### PR TITLE
fix: strip trailing newlines from shell stdout by default

### DIFF
--- a/scratchpads/stdout-newline-bug/README.md
+++ b/scratchpads/stdout-newline-bug/README.md
@@ -1,0 +1,288 @@
+# Bug Report: Shell stdout trailing newlines corrupt filenames
+
+## Summary
+
+When shell command output is used in `file_path` parameters via template variables like `${node.stdout}`, trailing newlines from shell output are **not stripped**, resulting in filenames containing literal newline characters (e.g., `myfile.md\n`).
+
+This creates files that:
+- Appear to exist in `find` and `ls` output
+- Cannot be accessed via normal shell commands or file APIs
+- Cause workflows to report "success" while producing unusable output
+
+**Severity: High** - Silent data corruption with no error indication.
+
+---
+
+## The Problem
+
+### Expected Behavior (per documentation)
+
+From `pflow instructions create --part 2`:
+
+> **What gets parsed:**
+> - All JSON types: objects `{}`, arrays `[]`, numbers, booleans, strings, null
+> - **Shell output with trailing `\n` is automatically stripped**
+> - Plain text and invalid JSON gracefully stay as strings
+
+### Actual Behavior
+
+Trailing newlines are **only** stripped during JSON parsing for path traversal. Raw `stdout` access preserves the newline:
+
+| Template Pattern | Newline Stripped? | Behavior |
+|------------------|-------------------|----------|
+| `${node.stdout}` | ❌ **No** | Raw output including `\n` |
+| `${node.stdout.field}` | ✅ Yes | JSON parsed, newline stripped before parsing |
+| `"prefix${node.stdout}suffix"` | ❌ **No** | Newline embedded in string |
+| `{"key": "${node.stdout}"}` | ⚠️ Escaped | Becomes `\n` in JSON, jq converts back |
+
+---
+
+## Reproduction
+
+### Minimal Test Case
+
+**File: `test-newline-filename.json`**
+
+```json
+{
+  "inputs": {},
+  "nodes": [
+    {
+      "id": "generate-filename",
+      "type": "shell",
+      "params": {
+        "command": "echo 'test-file'"
+      }
+    },
+    {
+      "id": "save-file",
+      "type": "write-file",
+      "params": {
+        "file_path": "./${generate-filename.stdout}.txt",
+        "content": "hello world"
+      }
+    }
+  ],
+  "edges": [
+    {"from": "generate-filename", "to": "save-file"}
+  ]
+}
+```
+
+**Run:**
+```bash
+pflow test-newline-filename.json
+```
+
+**Result:**
+```
+✓ Workflow completed in 0.444s
+✓ save-file (0ms)
+```
+
+**Actual file created:**
+```python
+>>> import os
+>>> [repr(f) for f in os.listdir('.') if 'test-file' in f]
+["'test-file\\n.txt'"]  # Literal newline in filename!
+```
+
+**Symptoms:**
+```bash
+$ cat test-file.txt
+cat: test-file.txt: No such file or directory
+
+$ ls -la | grep test
+-rw-r--r--  1 user  staff  11 Jan  8 12:48 test-file
+.txt                                        # <-- newline visible here
+```
+
+---
+
+## Root Cause Analysis
+
+### Why This Happens
+
+1. **Shell commands always output trailing newlines** - This is standard Unix behavior. `echo 'foo'` outputs `foo\n`.
+
+2. **pflow's template resolution passes stdout as-is** - When resolving `${node.stdout}`, pflow returns the raw string including the trailing `\n`.
+
+3. **Newline stripping only happens during JSON parsing** - The documentation's claim about "automatic stripping" only applies when pflow parses stdout as JSON (for path traversal like `${node.stdout.field}`).
+
+4. **`write-file` accepts the corrupted path** - The node doesn't validate or sanitize the `file_path` parameter.
+
+### Hex Dump Evidence
+
+```json
+{
+  "id": "check-value",
+  "type": "shell",
+  "params": {
+    "command": "printf '%s' '${generate-name.stdout}' | xxd"
+  }
+}
+```
+
+**Output:**
+```
+00000000: 6d79 6669 6c65 0a                        myfile.
+                    ^^-- 0x0a = newline character
+```
+
+### JSON Context Escaping (Different Bug?)
+
+When stdout is used in an inline object:
+
+```json
+{"stdin": {"name": "${generate-name.stdout}"}}
+```
+
+The newline is **escaped** to `\n` (two characters: `0x5c 0x6e`):
+
+```
+00000000: 7b22 6e61 6d65 223a 2022 6d79 6669 6c65  {"name": "myfile
+00000010: 5c6e 227d                                \n"}
+```
+
+When jq processes this, it converts `\n` back to a real newline, so the problem persists.
+
+---
+
+## Impact Assessment
+
+### Why This Is Severe
+
+1. **Silent Failure** - Workflow reports success, no errors or warnings
+2. **Invisible Corruption** - Newlines look like line breaks in terminal output
+3. **File Inaccessibility** - Created files can't be opened by normal tools
+4. **Debugging Difficulty** - Requires `repr()` or hex dump to detect
+5. **Common Pattern** - Dynamic filenames from shell output is a standard use case
+
+### Real-World Example
+
+Building a `webpage-to-markdown` workflow:
+
+```json
+{
+  "id": "get-date",
+  "type": "shell",
+  "params": {"command": "date +%Y-%m-%d"}
+},
+{
+  "id": "save-file",
+  "type": "write-file",
+  "params": {
+    "file_path": "./${get-date.stdout}-article.md",
+    "content": "${markdown}"
+  }
+}
+```
+
+**Expected:** `./2026-01-08-article.md`
+**Actual:** `./2026-01-08\n-article.md` (corrupted, inaccessible)
+
+---
+
+## Proposed Solutions
+
+### Option 1: Auto-strip for `file_path` parameters (Recommended)
+
+The `write-file` node should strip leading/trailing whitespace from `file_path`:
+
+```python
+file_path = params["file_path"].strip()
+```
+
+**Pros:** Targeted fix, no breaking changes, handles the most dangerous case
+**Cons:** Doesn't fix other contexts
+
+### Option 2: Strip trailing newlines from all shell stdout
+
+When capturing shell output, strip trailing newlines:
+
+```python
+stdout = process.stdout.rstrip('\n')
+```
+
+**Pros:** Fixes all cases, matches user expectation
+**Cons:** Could break edge cases relying on preserved newlines (unlikely)
+
+### Option 3: Add explicit trim syntax
+
+Add template modifier syntax:
+
+```
+${node.stdout}        # raw
+${node.stdout|trim}   # stripped
+${node.stdout|strip}  # stripped
+```
+
+**Pros:** Explicit, no magic, user control
+**Cons:** Requires users to remember, doesn't fix existing workflows
+
+### Option 4: Update documentation only
+
+Clarify that stripping only happens during JSON parsing, and users must handle raw stdout manually.
+
+**Pros:** No code changes
+**Cons:** Poor UX, users will keep hitting this issue
+
+---
+
+## Current Workarounds
+
+### Workaround 1: Use `tr -d '\n'`
+
+```json
+{"command": "date +%Y-%m-%d | tr -d '\\n'"}
+```
+
+**Problem:** Easy to forget, verbose, must apply to every shell command.
+
+### Workaround 2: Use `jq -j` instead of `jq -r`
+
+```json
+{"command": "echo '{\"x\":1}' | jq -j '.x'"}
+```
+
+**Problem:** Only works for jq, doesn't help with other commands.
+
+### Workaround 3: Output JSON and use path traversal
+
+```json
+// Instead of:
+{"command": "echo 'myfile'"}
+{"file_path": "./${node.stdout}.txt"}
+
+// Use:
+{"command": "echo '{\"name\": \"myfile\"}'"}
+{"file_path": "./${node.stdout.name}.txt"}
+```
+
+**Problem:** Verbose, unnatural, requires restructuring workflows.
+
+---
+
+## Test Files
+
+See the following files in this directory for reproduction:
+
+- `test-raw-stdout.json` - Shows newline in raw stdout
+- `test-json-path.json` - Shows newline stripped via JSON path
+- `test-filename-corruption.json` - Demonstrates corrupted filename
+- `test-inline-object.json` - Shows escaping behavior in objects
+
+---
+
+## Appendix: Discovery Timeline
+
+This bug was discovered while building a `webpage-to-markdown` workflow:
+
+1. Workflow completed "successfully"
+2. Output file couldn't be accessed via `cat`, `Read` tool, or file APIs
+3. `find` showed the file existed
+4. `ls -la` showed weird line break in output
+5. Python `repr()` revealed `'filename.md\n'`
+6. Required 15+ minutes of debugging to identify
+
+The fix required adding `tr -d '\n'` to three separate shell commands and changing `jq -r` to `jq -rj` - none of which is intuitive or documented.

--- a/scratchpads/stdout-newline-bug/run-tests.sh
+++ b/scratchpads/stdout-newline-bug/run-tests.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Run all test cases and show results
+# Requires: pflow in PATH (or run with `uv run pflow` substituted)
+
+set -e
+cd "$(dirname "$0")"
+
+# Use uv run pflow if pflow not directly available
+if command -v pflow &> /dev/null; then
+    PFLOW="pflow"
+else
+    PFLOW="uv run pflow"
+fi
+
+echo "=========================================="
+echo "STDOUT NEWLINE BUG - REPRODUCTION TESTS"
+echo "=========================================="
+echo ""
+
+# Cleanup
+rm -f bugdemo*.txt testfile*.txt myfile*.txt 2>/dev/null || true
+
+echo "TEST 1: Raw stdout contains trailing newline"
+echo "----------------------------------------------"
+$PFLOW test-raw-stdout.json 2>&1 | tail -5
+echo ""
+echo "Look for '0a' at the end - that's the newline byte (0x0a)"
+echo ""
+
+echo "TEST 2: JSON path traversal strips newline (WORKS)"
+echo "---------------------------------------------------"
+$PFLOW test-json-path.json 2>&1 | grep -E "✓|completed"
+echo ""
+echo "Checking created file:"
+python3 -c "import os; files = [f for f in os.listdir('.') if 'testfile' in f]; print('  Files:', [repr(f) for f in files])"
+echo "  ^ No newline in filename - JSON path traversal works!"
+echo ""
+
+echo "TEST 3: Raw stdout corrupts filename (THE BUG)"
+echo "-----------------------------------------------"
+$PFLOW test-filename-corruption.json 2>&1 | grep -E "✓|completed"
+echo ""
+echo "Checking created file:"
+python3 -c "import os; files = [f for f in os.listdir('.') if 'bugdemo' in f]; print('  Files:', [repr(f) for f in files])"
+echo "  ^ Notice the \\n in the filename - THIS IS THE BUG"
+echo ""
+echo "Try to access normally:"
+cat bugdemo.txt 2>&1 | sed 's/^/  /' || true
+echo ""
+
+echo "TEST 4: Inline object escapes then jq un-escapes"
+echo "-------------------------------------------------"
+$PFLOW test-inline-object.json 2>&1 | tail -10
+echo ""
+
+echo "=========================================="
+echo "SUMMARY"
+echo "=========================================="
+echo "- Raw \${node.stdout} preserves trailing newline"
+echo "- \${node.stdout.field} strips newline (JSON parsing)"
+echo "- Using raw stdout in file_path creates corrupted filenames"
+echo "- Workaround: Use JSON output + path traversal, or add 'tr -d \\n'"
+echo ""
+
+# Cleanup
+rm -f bugdemo*.txt testfile*.txt myfile*.txt 2>/dev/null || true

--- a/scratchpads/stdout-newline-bug/test-filename-corruption.json
+++ b/scratchpads/stdout-newline-bug/test-filename-corruption.json
@@ -1,0 +1,28 @@
+{
+  "inputs": {},
+  "nodes": [
+    {
+      "id": "generate-filename",
+      "type": "shell",
+      "purpose": "Simple echo - outputs 'bugdemo\\n'",
+      "params": {
+        "command": "echo 'bugdemo'"
+      }
+    },
+    {
+      "id": "save-file",
+      "type": "write-file",
+      "purpose": "Creates file with corrupted name 'bugdemo\\n.txt'",
+      "params": {
+        "file_path": "./${generate-filename.stdout}.txt",
+        "content": "This file exists but you cannot access it normally!\n\nTry: cat bugdemo.txt\nResult: No such file or directory\n\nThe actual filename has a newline character embedded in it."
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "generate-filename",
+      "to": "save-file"
+    }
+  ]
+}

--- a/scratchpads/stdout-newline-bug/test-inline-object.json
+++ b/scratchpads/stdout-newline-bug/test-inline-object.json
@@ -1,0 +1,45 @@
+{
+  "inputs": {},
+  "nodes": [
+    {
+      "id": "generate-name",
+      "type": "shell",
+      "purpose": "Output simple string with trailing newline",
+      "params": {
+        "command": "echo 'myfile'"
+      }
+    },
+    {
+      "id": "show-escaped",
+      "type": "shell",
+      "purpose": "Show that inline object escapes newline to literal backslash-n",
+      "params": {
+        "stdin": {
+          "name": "${generate-name.stdout}"
+        },
+        "command": "cat | xxd | head -2"
+      }
+    },
+    {
+      "id": "extract-and-show",
+      "type": "shell",
+      "purpose": "Show that jq converts escaped \\n back to real newline",
+      "params": {
+        "stdin": {
+          "name": "${generate-name.stdout}"
+        },
+        "command": "jq -r '.name' | xxd"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "generate-name",
+      "to": "show-escaped"
+    },
+    {
+      "from": "show-escaped",
+      "to": "extract-and-show"
+    }
+  ]
+}

--- a/scratchpads/stdout-newline-bug/test-json-path.json
+++ b/scratchpads/stdout-newline-bug/test-json-path.json
@@ -1,0 +1,28 @@
+{
+  "inputs": {},
+  "nodes": [
+    {
+      "id": "generate-json",
+      "type": "shell",
+      "purpose": "Output JSON (will have trailing newline after the closing brace)",
+      "params": {
+        "command": "echo '{\"name\": \"testfile\"}'"
+      }
+    },
+    {
+      "id": "save-file",
+      "type": "write-file",
+      "purpose": "Use JSON path traversal - this WORKS correctly",
+      "params": {
+        "file_path": "./${generate-json.stdout.name}.txt",
+        "content": "This file was created correctly because we used .stdout.name"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "generate-json",
+      "to": "save-file"
+    }
+  ]
+}

--- a/scratchpads/stdout-newline-bug/test-raw-stdout.json
+++ b/scratchpads/stdout-newline-bug/test-raw-stdout.json
@@ -1,0 +1,27 @@
+{
+  "inputs": {},
+  "nodes": [
+    {
+      "id": "generate-name",
+      "type": "shell",
+      "purpose": "Output a simple string (will have trailing newline)",
+      "params": {
+        "command": "echo 'myfile'"
+      }
+    },
+    {
+      "id": "show-hex",
+      "type": "shell",
+      "purpose": "Display hex dump of stdout to reveal newline",
+      "params": {
+        "command": "printf '%s' '${generate-name.stdout}' | xxd"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "generate-name",
+      "to": "show-hex"
+    }
+  ]
+}

--- a/src/pflow/cli/resources/cli-agent-instructions.md
+++ b/src/pflow/cli/resources/cli-agent-instructions.md
@@ -880,7 +880,7 @@ Example of using in nodes: `"Authorization": "Bearer ${api_token}"`
 
 **What gets parsed:**
 - All JSON types: objects `{}`, arrays `[]`, numbers, booleans, strings, null
-- Shell output with trailing `\n` is automatically stripped (disable with `strip_newline: false`)
+- Shell **stdout** with trailing `\n` is automatically stripped (disable with `strip_newline: false`). stderr is never modified.
 - Plain text and invalid JSON gracefully stay as strings
 
 **Concrete examples** (inline object context):

--- a/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
@@ -1179,7 +1179,7 @@ llm keys set anthropic --key "sk-ant-..."
 **Parsing Rules**:
 - ✅ **Auto-parsed**: Simple templates like `${node.output}` when target expects dict/list
 - ❌ **NOT parsed**: Complex templates like `"text ${var}"` always stay as strings (escape hatch)
-- ✅ **Handles newlines**: Shell output with trailing `\n` is automatically stripped (disable with `strip_newline: false`)
+- ✅ **Handles newlines**: Shell **stdout** with trailing `\n` is automatically stripped (disable with `strip_newline: false`). stderr is never modified.
 - ✅ **Type-safe**: Only uses parsed result if type matches (array→list, object→dict)
 - ✅ **Graceful fallback**: Invalid JSON stays as string (Pydantic validation catches it)
 

--- a/tests/test_nodes/test_shell/test_shell.py
+++ b/tests/test_nodes/test_shell/test_shell.py
@@ -733,3 +733,14 @@ class TestStripNewline:
 
         # All trailing newlines stripped
         assert shared["stdout"] == "data"
+
+    def test_empty_stdout_unchanged(self):
+        """Empty stdout remains empty after stripping.
+
+        Common scenario: commands with conditional output or no matches.
+        """
+        shared = {}
+        run_shell_node(shared, command="printf ''")  # Empty output
+
+        assert shared["stdout"] == ""
+        assert shared["stdout_is_binary"] is False

--- a/tests/test_nodes/test_shell/test_shell_binary.py
+++ b/tests/test_nodes/test_shell/test_shell_binary.py
@@ -391,3 +391,35 @@ class TestPartialUTF8Sequences:
             assert shared["stdout_is_binary"] is True
             expected_b64 = base64.b64encode(b"\xc3\x28").decode("ascii")
             assert shared["stdout"] == expected_b64
+
+
+class TestStripNewlineWithBinary:
+    """Test that strip_newline has no effect on binary data."""
+
+    def test_strip_newline_ignored_for_binary_stdout(self):
+        """Binary data is never modified by strip_newline parameter.
+
+        This guards against future refactoring accidentally applying
+        string operations to binary data.
+        """
+        node = ShellNode()
+        # Explicit strip_newline=True, should have no effect on binary
+        node.set_params({"command": "cat binary.bin", "strip_newline": True})
+
+        with patch("subprocess.run") as mock_run:
+            # Binary data ending with 0x0a (newline byte)
+            binary_with_newline = b"\x89PNG\r\n\x1a\n"  # PNG-like header ending with newline
+            mock_result = Mock()
+            mock_result.stdout = binary_with_newline
+            mock_result.stderr = b""
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
+            shared = {}
+            node.run(shared)
+
+            # Binary data unchanged - newline byte preserved
+            assert shared["stdout_is_binary"] is True
+            decoded = base64.b64decode(shared["stdout"])
+            assert decoded == binary_with_newline, "Binary data was modified by strip_newline"
+            assert decoded.endswith(b"\n"), "Binary newline byte was stripped"


### PR DESCRIPTION
## Summary

Shell commands like `echo`, `date`, `hostname` add trailing newlines for terminal formatting. When using `${node.stdout}` in file paths, this creates **silently corrupted filenames** with embedded newlines (e.g., `myfile\n.txt`).

This fix adds a `strip_newline` parameter to the shell node (default: `true`) that strips trailing newlines from text stdout, matching bash `$()` convention.

## Changes

- Add `strip_newline` parameter to shell node (default: `true`)
- Strip trailing newlines from text stdout in `post()` 
- Extract `_store_output()` helper to reduce cyclomatic complexity
- Update 3 tests that expected trailing newlines
- Add 4 high-value tests for `strip_newline` behavior
- Update agent instructions documentation with opt-out note

```
 src/pflow/cli/resources/cli-agent-instructions.md  |  2 +-
 .../instructions/mcp-agent-instructions.md         |  2 +-
 src/pflow/nodes/shell/shell.py                     | 58 +++++++++++++++-------
 tests/test_nodes/test_shell/test_shell.py          | 56 +++++++++++++++++++++
 tests/test_nodes/test_shell/test_shell_binary.py   |  6 +--
 5 files changed, 100 insertions(+), 24 deletions(-)
```

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `echo hello` → `${node.stdout}` | `hello\n` | `hello` |
| File path `${node.stdout}.txt` | `hello\n.txt` (corrupted) | `hello.txt` |
| `strip_newline: false` | N/A | `hello\n` (opt-out) |
| Multi-line output | N/A | Internal `\n` preserved |

## Testing

- `make test` - All 3857 tests pass
- `make check` - All linting/type checks pass
- Manual CLI verification with hex dump confirms fix

Fixes #48