### PR TITLE
fix: allow shell commands to use union types containing str/any (fixes #60)

### DIFF
--- a/src/pflow/runtime/template_validator.py
+++ b/src/pflow/runtime/template_validator.py
@@ -46,7 +46,12 @@ MAX_FLATTEN_DEPTH = 5  # Prevent infinite recursion on circular refs
 
 # Pattern to detect templates exactly wrapped in single quotes: '${var}'
 # This is an escape hatch for structured types in shell commands.
+#
+# Matches:   '${var}', '${node.field}', '${data.items[0].name}'
 # Does NOT match: '${a} ${b}', 'prefix ${var}', '$${var}' (escaped)
+#
+# Note: Array indices use [] not {}, so [^}]+ correctly captures paths
+# like 'data.items[0].value' without stopping at brackets.
 _QUOTED_TEMPLATE_PATTERN = re.compile(r"'\$\{([^}]+)\}'")
 
 # Types that are safe in shell commands (string-like or unknown type)


### PR DESCRIPTION
## Summary

The shell command type validator was blocking `dict|str` unions even though runtime coercion handles dict → JSON string correctly. This caused unnecessary friction when using HTTP responses in shell commands.

Fixes #60

## Changes

### Three-tier validation system:

1. **Tier 1 (auto-allow)**: Unions containing safe types (`str`, `string`, `any`) are now allowed automatically
2. **Tier 2 (quote escape)**: `'${var}'` syntax allows explicit opt-in for pure structured types
3. **Bug fix**: Extract base types from generics (`list[dict]` → `list`) before checking

### Behavior Matrix

| Type | `${x}` (unquoted) | `'${x}'` (quoted) |
|------|-------------------|-------------------|
| `dict\|str` | ✅ allowed (Tier 1) | ✅ allowed |
| `list\|any` | ✅ allowed (Tier 1) | ✅ allowed |
| `dict\|list` | ❌ blocked | ✅ allowed (Tier 2) |
| `dict` | ❌ blocked | ✅ allowed (Tier 2) |
| `list[dict]` | ❌ blocked (bug fix) | ✅ allowed (Tier 2) |

### Files Changed

- `src/pflow/runtime/template_validator.py` - Added validation logic, helper functions, error message updates
- `tests/test_runtime/test_template_validator_types.py` - Added 4 new test classes with comprehensive coverage

## Testing

```bash
make test   # 3946 tests pass
make check  # Linting and type checks pass
```

New test classes added:
- `TestShellCommandUnionTypes` - Tier 1 tests
- `TestShellCommandGenericTypes` - Fix 0 tests  
- `TestShellCommandQuoteEscape` - Tier 2 tests
- `TestShellCommandRegressions` - Regression tests