### PR TITLE
feat: unified reasoning/thinking control for LLM node (closes #98)

### DIFF
--- a/src/pflow/nodes/llm/llm.py
+++ b/src/pflow/nodes/llm/llm.py
@@ -122,7 +122,7 @@ class LLMNode(Node):
     - Params: output_schema: dict  # JSON Schema for structured output (optional)
     - Params: reasoning_effort: str  # Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params)
     - Params: reasoning_max_tokens: int  # Direct reasoning token budget, mutually exclusive with reasoning_effort (optional)
-    - Params: model_options: dict  # Additional provider-specific model options passed as kwargs (optional)
+    - Params: model_options: dict  # Additional provider-specific model options passed as kwargs (optional, overrides reasoning params if keys overlap)
     - Writes: shared["response"]: str|dict  # Text (str), or parsed JSON (dict) when output_schema is set
     - Writes: shared["llm_usage"]: dict  # Token usage metrics (empty dict {} if unavailable)
         - model: str  # Model identifier used
@@ -281,8 +281,10 @@ class LLMNode(Node):
         # Apply any additional provider-specific model options (escape hatch)
         kwargs.update(prep_res.get("model_options") or {})
 
-        # Catch validation errors (bad model_options, unsupported params) immediately —
-        # these are deterministic and retrying won't help
+        # PATTERN EXCEPTION: try/except in exec() is normally an anti-pattern (prevents
+        # retries), but ValidationError from Pydantic Options is deterministic — retrying
+        # won't help. We catch it here to avoid 3 wasted attempts on bad model_options.
+        # Long-term fix: add NonRetriableError support to PocketFlow's _exec loop (#100).
         try:
             response = model.prompt(prep_res["prompt"], **kwargs)
         except ValidationError as e:

--- a/tests/test_nodes/test_llm/test_llm_reasoning.py
+++ b/tests/test_nodes/test_llm/test_llm_reasoning.py
@@ -261,6 +261,7 @@ class TestReasoningValidation:
         # Should fail with error, and model.prompt called only ONCE (no retries)
         assert shared.get("error")
         assert "Invalid model options" in shared["error"]
+        assert shared.get("response") == ""
         assert mock_model.prompt.call_count == 1
 
 


### PR DESCRIPTION
## Summary

Add a unified interface for controlling model reasoning/thinking depth across all LLM providers, modeled after OpenRouter's approach. An agent writing a workflow uses the same `reasoning_effort: high` regardless of whether the model is Claude, OpenAI, or Gemini — pflow maps it to the right provider-specific parameter.

## Changes

- Add `reasoning_effort` (xhigh/high/medium/low/minimal/none), `reasoning_max_tokens` (direct token budget), and `model_options` (escape hatch dict) params to the LLM node
- Implement provider mapping via Options class introspection — detects which params a model accepts without hardcoded model names
- Use OpenRouter's effort-to-token-budget formula (`budget = clamp(max_tokens * ratio, 1024, 128000)`) for providers that need concrete token counts (Claude, Gemini 2.5)
- Validate `reasoning_effort` in `prep()` — invalid values fail immediately (no retries) with actionable error listing valid options
- Catch Pydantic `ValidationError` from bad `model_options` on first attempt — no pointless retry loop for deterministic errors
- Contract tests against real installed plugin Options classes (`llm-anthropic`, `llm-gemini`, OpenAI built-in) to catch silent breakage from upstream plugin updates

## Explanation

Each LLM provider uses different parameter names for the same concept (reasoning depth): Claude uses `thinking`/`thinking_budget`, OpenAI uses `reasoning_effort`, Gemini 3 uses `thinking_level`, etc. Without a unified interface, an AI agent writing pflow workflows needs provider-specific knowledge for every model.

The solution introspects the `llm` library model's Pydantic Options class at runtime to determine what the model accepts, then maps pflow's unified params accordingly. This works with all current plugins and future ones without code changes.

Provider detection priority (handles models with multiple fields like Opus 4.5):
1. `thinking_effort` → Anthropic Opus 4.5 (maps xhigh→high, minimal→low)
2. `reasoning_effort` → OpenAI / OpenRouter (pass-through)
3. `thinking_level` → Gemini 3 (maps xhigh→high)
4. `thinking_budget` → Anthropic older / Gemini 2.5 (token budget formula)
5. `thinking` → thinking-only models (no budget control)

## Testing

- 44 unit tests covering all provider mappings, edge cases, effort levels, budget clamping, case insensitivity
- 8 contract tests against real plugin Options classes (validated kwargs are accepted by real Pydantic models)
- 3 integration tests verifying params flow through LLMNode.exec()
- 3 validation tests (prep rejection, no-retry on ValidationError, call count assertion)
- Manually tested with real API calls: Gemini 3 (high/low/none), Claude Haiku 4.5 (medium, direct budget)

Run `make test` to verify all tests pass.

```
src/pflow/nodes/llm/llm.py                      | 137 +++++++-
tests/test_nodes/test_llm/test_llm_reasoning.py  | 430 ++++++++++++++++++++++++
2 files changed, 564 insertions(+), 3 deletions(-)
```