### PR TITLE
fix: MCP timeout config preserved, add CLI flags, remove unused registry run --timeout (closes #105)

### DIFF
--- a/src/pflow/cli/mcp.py
+++ b/src/pflow/cli/mcp.py
@@ -79,9 +79,65 @@ def _add_from_json_string(manager: MCPServerManager, json_str: str) -> list[str]
     )
 
 
+def _validate_timeout_flags(timeout: Optional[int], sse_timeout: Optional[int]) -> None:
+    """Validate timeout CLI flags before any config is saved.
+
+    Args:
+        timeout: HTTP connection timeout in seconds
+        sse_timeout: SSE read timeout in seconds
+
+    Raises:
+        click.BadParameter: If timeout values are invalid
+    """
+    if timeout is not None:
+        if timeout <= 0:
+            raise click.BadParameter("Timeout must be a positive number", param_hint="'--timeout'")
+        if timeout > 600:
+            raise click.BadParameter("Timeout cannot exceed 600 seconds (10 minutes)", param_hint="'--timeout'")
+    if sse_timeout is not None and sse_timeout <= 0:
+        raise click.BadParameter("SSE timeout must be a positive number", param_hint="'--sse-timeout'")
+
+
+def _apply_http_timeouts(
+    manager: MCPServerManager,
+    server_names: list[str],
+    timeout: Optional[int],
+    sse_timeout: Optional[int],
+) -> None:
+    """Apply timeout overrides to newly added HTTP servers.
+
+    Args:
+        manager: MCPServerManager instance
+        server_names: Names of servers to update
+        timeout: HTTP connection timeout in seconds
+        sse_timeout: SSE read timeout in seconds
+    """
+    config = manager.load()
+    servers = config.get("mcpServers", {})
+    updated = False
+    for name in server_names:
+        server = servers.get(name, {})
+        if server.get("type") == "http":
+            if timeout is not None:
+                server["timeout"] = timeout
+            if sse_timeout is not None:
+                server["sse_timeout"] = sse_timeout
+            updated = True
+    if updated:
+        manager.save(config)
+    else:
+        click.echo("⚠ --timeout/--sse-timeout flags only apply to HTTP servers, ignored for stdio servers", err=True)
+
+
 @mcp.command(name="add")
 @click.argument("config_sources", nargs=-1, required=True)
-def add(config_sources: tuple) -> None:
+@click.option(
+    "--timeout", type=int, default=None, help="HTTP connection timeout in seconds (applies to HTTP servers only)"
+)
+@click.option(
+    "--sse-timeout", type=int, default=None, help="SSE read timeout in seconds (applies to HTTP servers only)"
+)
+def add(config_sources: tuple, timeout: Optional[int], sse_timeout: Optional[int]) -> None:
     """Add MCP servers from config files or raw JSON.
 
     Examples:
@@ -91,8 +147,8 @@ def add(config_sources: tuple) -> None:
         # Add from raw JSON (simple format):
         pflow mcp add '{"github": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]}}'
 
-        # Add HTTP server:
-        pflow mcp add '{"slack": {"type": "http", "url": "https://mcp.example.com/slack"}}'
+        # Add HTTP server with custom timeout:
+        pflow mcp add '{"slack": {"type": "http", "url": "https://mcp.example.com/slack"}}' --timeout 60
 
         # Add from raw JSON (full MCP format, compatible with Claude Desktop):
         pflow mcp add '{"mcpServers": {"github": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]}}}'
@@ -105,6 +161,9 @@ def add(config_sources: tuple) -> None:
         {"mcpServers": {"server-name": {...}}}
     """
     from pathlib import Path
+
+    # Validate timeout flags before saving anything
+    _validate_timeout_flags(timeout, sse_timeout)
 
     manager = MCPServerManager()
     total_added = []
@@ -141,6 +200,10 @@ def add(config_sources: tuple) -> None:
             click.echo(f"Error: Failed to add servers: {e}", err=True)
             sys.exit(1)
 
+    # Apply timeout overrides to newly added HTTP servers
+    if total_added and (timeout is not None or sse_timeout is not None):
+        _apply_http_timeouts(manager, total_added, timeout, sse_timeout)
+
     if total_added:
         click.echo(f"\nSuccessfully configured {len(total_added)} MCP server(s).")
         click.echo("Run 'pflow mcp sync --all' to discover available tools from all servers.")
@@ -170,6 +233,8 @@ def _format_http_server(config: dict) -> list[str]:
 
     if config.get("timeout"):
         lines.append(f"    Timeout: {config['timeout']}s")
+    if config.get("sse_timeout"):
+        lines.append(f"    SSE Timeout: {config['sse_timeout']}s")
 
     return lines
 

--- a/src/pflow/cli/registry.py
+++ b/src/pflow/cli/registry.py
@@ -646,13 +646,11 @@ def discover_nodes(query: str) -> None:
     default=None,
     help="Output format: json bypasses structure mode for raw output",
 )
-@click.option("--timeout", type=int, default=60, help="Execution timeout in seconds")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed execution information")
 def run_node(
     node_type: str,
     params: tuple[str, ...],
     output_format: str | None,
-    timeout: int,
     verbose: bool,
 ) -> None:
     """Run a single node with provided parameters for testing.
@@ -692,7 +690,6 @@ def run_node(
         params=params,
         output_format=output_format or "text",  # Default to text for formatter
         show_structure=(output_format != "json"),  # Structure mode unless --output-format json
-        timeout=timeout,
         verbose=verbose,
     )
 

--- a/src/pflow/cli/registry_run.py
+++ b/src/pflow/cli/registry_run.py
@@ -21,7 +21,6 @@ def execute_single_node(
     params: tuple[str, ...],
     output_format: str,
     show_structure: bool,
-    timeout: int,
     verbose: bool,
 ) -> None:
     """Execute a single node with provided parameters.
@@ -31,7 +30,6 @@ def execute_single_node(
         params: Tuple of parameter strings in key=value format
         output_format: Output format - "text" or "json"
         show_structure: Whether to show flattened structure for templates
-        timeout: Execution timeout in seconds (currently unused)
         verbose: Whether to show detailed execution information
     """
     # Step 1: Parse and validate parameters

--- a/src/pflow/mcp/manager.py
+++ b/src/pflow/mcp/manager.py
@@ -285,7 +285,12 @@ class MCPServerManager:
         if env:
             config["env"] = env
 
-        # Note: timeout fields are not part of the standard, skip them
+        # Add timeout fields if provided (used by streamablehttp_client)
+        if timeout is not None:
+            config["timeout"] = timeout
+        if sse_timeout is not None:
+            config["sse_timeout"] = sse_timeout
+
         return config
 
     def _log_server_action(

--- a/tests/test_cli/test_mcp_add_json.py
+++ b/tests/test_cli/test_mcp_add_json.py
@@ -1,8 +1,16 @@
-"""Tests for pflow mcp add JSON input parsing."""
+"""Tests for pflow mcp add JSON input parsing and CLI flags."""
 
+import click.testing
 import pytest
 
-from pflow.cli.mcp import _add_from_json_string, _is_json_string, _is_server_config
+from pflow.cli.mcp import (
+    _add_from_json_string,
+    _apply_http_timeouts,
+    _is_json_string,
+    _is_server_config,
+    _validate_timeout_flags,
+    mcp,
+)
 from pflow.mcp import MCPServerManager
 
 
@@ -81,3 +89,199 @@ class TestAddFromJsonString:
         # Dict without command/url fields - not a valid server config
         with pytest.raises(ValueError, match="Invalid JSON format"):
             _add_from_json_string(manager, '{"name": {"invalid": "config"}}')
+
+
+class TestApplyHttpTimeouts:
+    """Test _apply_http_timeouts helper that applies --timeout/--sse-timeout to HTTP servers."""
+
+    def test_applies_timeout_to_http_server(self, tmp_path):
+        """--timeout 60 on an HTTP server should persist timeout: 60."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path)
+        _add_from_json_string(manager, '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}')
+
+        _apply_http_timeouts(manager, ["api"], timeout=60, sse_timeout=None)
+
+        config = manager.load()
+        assert config["mcpServers"]["api"]["timeout"] == 60
+        assert "sse_timeout" not in config["mcpServers"]["api"]
+
+    def test_applies_sse_timeout_to_http_server(self, tmp_path):
+        """--sse-timeout 120 on an HTTP server should persist sse_timeout: 120."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path)
+        _add_from_json_string(manager, '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}')
+
+        _apply_http_timeouts(manager, ["api"], timeout=None, sse_timeout=120)
+
+        config = manager.load()
+        assert config["mcpServers"]["api"]["sse_timeout"] == 120
+        assert "timeout" not in config["mcpServers"]["api"]
+
+    def test_applies_both_timeouts(self, tmp_path):
+        """Both --timeout and --sse-timeout should persist on HTTP servers."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path)
+        _add_from_json_string(manager, '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}')
+
+        _apply_http_timeouts(manager, ["api"], timeout=30, sse_timeout=300)
+
+        config = manager.load()
+        assert config["mcpServers"]["api"]["timeout"] == 30
+        assert config["mcpServers"]["api"]["sse_timeout"] == 300
+
+    def test_warns_for_stdio_server(self, tmp_path, capsys):
+        """--timeout on a stdio server should show a warning, not crash."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path)
+        _add_from_json_string(manager, '{"local": {"command": "npx", "args": ["server"]}}')
+
+        _apply_http_timeouts(manager, ["local"], timeout=60, sse_timeout=None)
+
+        # The warning is written to stderr via click.echo(err=True)
+        # capsys doesn't capture click.echo(err=True) directly, but we can check
+        # that no timeout was added to the stdio config
+        config = manager.load()
+        assert "timeout" not in config["mcpServers"]["local"]
+
+
+class TestMcpAddCliTimeoutFlags:
+    """Test --timeout and --sse-timeout CLI flags on `pflow mcp add`.
+
+    Note: The autouse `isolate_pflow_config` fixture automatically patches
+    MCPServerManager to use a temp config path. We read from the same
+    manager instance the command uses.
+    """
+
+    @pytest.fixture
+    def runner(self):
+        return click.testing.CliRunner()
+
+    def test_add_http_server_with_timeout_flag(self, runner):
+        """pflow mcp add '...' --timeout 60 should apply timeout to HTTP server."""
+        result = runner.invoke(
+            mcp,
+            [
+                "add",
+                '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}',
+                "--timeout",
+                "60",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        # Read from same isolated config the command wrote to
+        manager = MCPServerManager()
+        config = manager.load()
+        assert config["mcpServers"]["api"]["timeout"] == 60
+
+    def test_add_http_server_with_sse_timeout_flag(self, runner):
+        """pflow mcp add '...' --sse-timeout 120 should apply sse_timeout to HTTP server."""
+        result = runner.invoke(
+            mcp,
+            [
+                "add",
+                '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}',
+                "--sse-timeout",
+                "120",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        manager = MCPServerManager()
+        config = manager.load()
+        assert config["mcpServers"]["api"]["sse_timeout"] == 120
+
+    def test_timeout_on_stdio_server_shows_warning(self, runner):
+        """--timeout on a stdio server should warn the user."""
+        result = runner.invoke(
+            mcp,
+            [
+                "add",
+                '{"local": {"command": "npx", "args": ["server"]}}',
+                "--timeout",
+                "60",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Should show warning about timeout only applying to HTTP servers
+        assert "only apply to HTTP" in result.output or "ignored for stdio" in result.output
+
+    def test_invalid_timeout_does_not_persist_server(self, runner):
+        """Invalid --timeout must fail before saving anything to disk."""
+        result = runner.invoke(
+            mcp,
+            [
+                "add",
+                '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}',
+                "--timeout",
+                "-5",
+            ],
+        )
+
+        assert result.exit_code != 0
+        # Server must NOT be in config
+        manager = MCPServerManager()
+        config = manager.load()
+        assert "api" not in config.get("mcpServers", {})
+
+    def test_invalid_sse_timeout_does_not_persist_server(self, runner):
+        """Invalid --sse-timeout must fail before saving anything to disk."""
+        result = runner.invoke(
+            mcp,
+            [
+                "add",
+                '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}',
+                "--sse-timeout",
+                "-1",
+            ],
+        )
+
+        assert result.exit_code != 0
+        manager = MCPServerManager()
+        config = manager.load()
+        assert "api" not in config.get("mcpServers", {})
+
+    def test_timeout_exceeding_max_does_not_persist_server(self, runner):
+        """--timeout > 600 must fail before saving anything to disk."""
+        result = runner.invoke(
+            mcp,
+            [
+                "add",
+                '{"api": {"type": "http", "url": "https://api.example.com/mcp"}}',
+                "--timeout",
+                "999",
+            ],
+        )
+
+        assert result.exit_code != 0
+        manager = MCPServerManager()
+        config = manager.load()
+        assert "api" not in config.get("mcpServers", {})
+
+
+class TestValidateTimeoutFlags:
+    """Test early validation of timeout CLI flags."""
+
+    def test_valid_timeout_passes(self):
+        _validate_timeout_flags(timeout=60, sse_timeout=300)
+
+    def test_none_values_pass(self):
+        _validate_timeout_flags(timeout=None, sse_timeout=None)
+
+    def test_negative_timeout_raises(self):
+        with pytest.raises(click.BadParameter, match="positive number"):
+            _validate_timeout_flags(timeout=-1, sse_timeout=None)
+
+    def test_zero_timeout_raises(self):
+        with pytest.raises(click.BadParameter, match="positive number"):
+            _validate_timeout_flags(timeout=0, sse_timeout=None)
+
+    def test_timeout_exceeds_max_raises(self):
+        with pytest.raises(click.BadParameter, match="600 seconds"):
+            _validate_timeout_flags(timeout=601, sse_timeout=None)
+
+    def test_negative_sse_timeout_raises(self):
+        with pytest.raises(click.BadParameter, match="positive number"):
+            _validate_timeout_flags(timeout=None, sse_timeout=-1)

--- a/tests/test_cli/test_registry_run.py
+++ b/tests/test_cli/test_registry_run.py
@@ -829,3 +829,48 @@ def test_multiple_parameters_are_parsed_correctly(runner, tmp_path):
         # File should be created
         assert test_file.exists()
         assert test_file.read_text() == "Hello"
+
+
+# ==============================================================================
+# 8. --timeout flag removal (no longer accepted)
+# ==============================================================================
+
+
+def test_timeout_flag_is_rejected(runner, mock_registry):
+    """Passing --timeout to registry run should fail because the flag was removed.
+
+    The --timeout option was removed from `pflow registry run` because node
+    execution timeout is not a CLI concern. This test ensures the flag is
+    not silently accepted.
+    """
+    _MockRegistry, _instance = mock_registry
+
+    result = runner.invoke(registry, ["run", "read-file", "file_path=/tmp/x", "--timeout", "30"])
+
+    assert result.exit_code != 0
+    assert "No such option" in result.output or "no such option" in result.output.lower()
+
+
+def test_registry_run_works_without_timeout(runner, tmp_path):
+    """Registry run succeeds without any --timeout flag.
+
+    Confirms that the removal of --timeout did not break basic execution.
+    """
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello")
+
+    from pflow.nodes.file.read_file import ReadFileNode
+
+    with (
+        patch("pflow.cli.registry_run.import_node_class") as mock_import,
+        patch("pflow.cli.registry_run.Registry") as MockRegistry,
+    ):
+        instance = MagicMock()
+        instance.load.return_value = {"read-file": {}}
+        MockRegistry.return_value = instance
+        mock_import.return_value = ReadFileNode
+
+        result = runner.invoke(registry, ["run", "read-file", f"file_path={test_file}"])
+
+        assert result.exit_code == 0
+        assert "Node executed successfully" in result.output

--- a/tests/test_mcp/test_http_transport.py
+++ b/tests/test_mcp/test_http_transport.py
@@ -184,6 +184,120 @@ class TestHTTPConfiguration:
         assert config["mcpServers"]["composio"]["type"] == "http"
 
 
+class TestHTTPTimeoutPersistence:
+    """Test that timeout and sse_timeout are persisted in HTTP server config.
+
+    These tests verify that add_server(transport="http", ...) correctly stores
+    timeout fields in the config file, which was previously broken (they were
+    discarded by _build_http_config).
+    """
+
+    def test_add_http_server_persists_timeout(self, tmp_path):
+        """add_server with timeout=60 should store timeout: 60 in config."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        manager.add_server(
+            name="api-server",
+            transport="http",
+            url="https://api.example.com/mcp",
+            timeout=60,
+        )
+
+        config = manager.load()
+        server = config["mcpServers"]["api-server"]
+        assert server["timeout"] == 60
+
+    def test_add_http_server_persists_sse_timeout(self, tmp_path):
+        """add_server with sse_timeout=120 should store sse_timeout: 120 in config."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        manager.add_server(
+            name="streaming-server",
+            transport="http",
+            url="https://stream.example.com/mcp",
+            sse_timeout=120,
+        )
+
+        config = manager.load()
+        server = config["mcpServers"]["streaming-server"]
+        assert server["sse_timeout"] == 120
+
+    def test_add_http_server_persists_both_timeouts(self, tmp_path):
+        """add_server with both timeout and sse_timeout stores both."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        manager.add_server(
+            name="dual-timeout",
+            transport="http",
+            url="https://api.example.com/mcp",
+            timeout=60,
+            sse_timeout=120,
+        )
+
+        config = manager.load()
+        server = config["mcpServers"]["dual-timeout"]
+        assert server["timeout"] == 60
+        assert server["sse_timeout"] == 120
+
+    def test_add_http_server_no_timeout_omits_keys(self, tmp_path):
+        """add_server without timeout args should not include timeout keys."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        manager.add_server(
+            name="no-timeout",
+            transport="http",
+            url="https://api.example.com/mcp",
+        )
+
+        config = manager.load()
+        server = config["mcpServers"]["no-timeout"]
+        assert "timeout" not in server
+        assert "sse_timeout" not in server
+
+    def test_timeout_validation_rejects_negative(self, tmp_path):
+        """Negative timeout should be rejected during add_server."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        with pytest.raises(ValueError, match="Timeout must be a positive"):
+            manager.add_server(
+                name="bad-timeout",
+                transport="http",
+                url="https://api.example.com/mcp",
+                timeout=-5,
+            )
+
+    def test_timeout_validation_rejects_too_large(self, tmp_path):
+        """Timeout exceeding 600s should be rejected during add_server."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        with pytest.raises(ValueError, match="Timeout cannot exceed 600"):
+            manager.add_server(
+                name="huge-timeout",
+                transport="http",
+                url="https://api.example.com/mcp",
+                timeout=999,
+            )
+
+    def test_sse_timeout_validation_rejects_negative(self, tmp_path):
+        """Negative sse_timeout should be rejected during add_server."""
+        config_path = tmp_path / "mcp-servers.json"
+        manager = MCPServerManager(config_path=config_path)
+
+        with pytest.raises(ValueError, match="SSE timeout must be a positive"):
+            manager.add_server(
+                name="bad-sse",
+                transport="http",
+                url="https://api.example.com/mcp",
+                sse_timeout=-10,
+            )
+
+
 class TestHTTPTransportExecution:
     """Test HTTP transport execution in MCPNode."""
 


### PR DESCRIPTION
## Summary

Fixes three related timeout configuration issues: MCP server timeout silently discarded on save, no CLI path to set it, and a dead `--timeout` flag on `registry run`.

## Changes

- **`src/pflow/mcp/manager.py`** — `_build_http_config()` now includes `timeout`/`sse_timeout` in the config dict instead of discarding them. Downstream consumers (`MCPNode`, `MCPConnectionPool`, `MCPDiscovery`) already read these values with `config.get("timeout", 30)`.
- **`src/pflow/cli/mcp.py`** — Added `--timeout` and `--sse-timeout` flags to `pflow mcp add`. Flags are validated early (before any config is saved) to prevent partial-save on invalid values. Added `_validate_timeout_flags()` and `_apply_http_timeouts()` helpers. `_format_http_server()` now displays `sse_timeout`.
- **`src/pflow/cli/registry.py`** + **`registry_run.py`** — Removed unused `--timeout` flag from `pflow registry run`. It was accepted, forwarded, and dropped — the docstring said "currently unused". Per-node `timeout=N` param already works for all supporting node types.

## Explanation

**Why timeout was discarded**: The comment said "not part of the standard" but pflow's config format isn't the MCP standard anyway (uses `type` instead of `transport`, has `auth`, etc.). Three consumers already read these fields from config, they just always got defaults because the values were never persisted.

**Why remove `--timeout` from registry run**: It was redundant. Users can already pass `timeout=30` as a key=value param, which goes directly into `node.params` and is respected by all 5 node types that support timeout (shell, http, mcp, code, claude-code). The CLI flag would have needed to do the same injection, adding complexity for no benefit.

**Partial-save bug**: The code review caught that `pflow mcp add '...' --timeout -5` would save the server first, then crash on validation — leaving an orphaned entry. Fixed by validating flags at the top of `add()` before any config sources are processed.

## Testing

- 25 new tests across 3 files covering timeout persistence, CLI flags, early validation, and regression for the partial-save bug
- `make check` and `make test` pass clean (3942 passed, 485 skipped)

```
 src/pflow/cli/mcp.py                  |  71 +++++++++++-
 src/pflow/cli/registry.py             |   3 -
 src/pflow/cli/registry_run.py         |   2 -
 src/pflow/mcp/manager.py              |   7 +-
 tests/test_cli/test_mcp_add_json.py   | 208 +++++++++++++++++++++++++++++++-
 tests/test_cli/test_registry_run.py   |  45 ++++++++
 tests/test_mcp/test_http_transport.py | 114 +++++++++++++++++++
 7 files changed, 439 insertions(+), 11 deletions(-)
```