### PR TITLE
fix: coalesce (??) operator in output sources and batch items — fixes #111

### DIFF
--- a/.taskmaster/tasks/task_128/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_128/implementation/progress-log.md
@@ -415,3 +415,53 @@ Added `TestCoalesceErrorMessages` class (2 tests) to `test_node_wrapper_template
 
 - `make test`: 4066 passed, 485 skipped, 0 failures
 - `make check`: all clean
+
+## 2026-03-15 — Post-Merge Bug: Coalesce Doesn't Work in Output Sources or Batch Items
+
+### Discovery
+
+Bug report (`scratchpads/coalesce-operator-outputs-bug/bug-report.md`): `??` coalesce in `## Outputs` `- source:` declarations silently drops the output. No error, no warning — the output just vanishes. Non-coalesced outputs in the same workflow resolve fine.
+
+### Root Cause
+
+Two files bypassed `TemplateResolver.resolve_template()` by manually stripping `${...}` and calling `resolve_value()` directly — a low-level path traversal function with zero coalesce support:
+
+1. **`output_resolver.py:28-34`** — `source_expr[2:-1]` + `resolve_value()`. The `??` characters cause path traversal to fail, returning `None`. The `if value is not None` guard then silently skips the output.
+
+2. **`batch_node.py:258-260`** — same pattern for batch `items` template. `${a.items ?? b.items}` would raise `ValueError("resolved to None")`.
+
+### Why Phase 2 Impact Analysis Missed These
+
+The Phase 2 impact analysis searched for regex definitions and `TEMPLATE_PATTERN` usage across the codebase — 14 regex definitions across 8 files. But `output_resolver.py` uses no regex at all. It does manual `startswith("${")` + string slicing. `batch_node.py` does the same with `.strip()[2:-1]`. Both were invisible to a regex-focused scan.
+
+### Fix
+
+Both files now delegate to `TemplateResolver.resolve_template()` instead of manual stripping + `resolve_value()`. This is the same single resolution entry point that step parameters use.
+
+**`output_resolver.py`**: Normalizes `$node.output` and `node.output` formats to `${node.output}`, then calls `resolve_template()`. Returns `None` if the result equals the input (unresolved).
+
+**`batch_node.py`**: Calls `resolve_template(self.items_template.strip(), shared)` directly. Sets `items = None` if unresolved (same error path as before).
+
+### Audit of Other `resolve_value()` Call Sites
+
+Checked all 6 remaining direct `resolve_value()` callers — all are fine:
+
+- `cli/read_fields.py`, `mcp_server/services/field_service.py` — raw field paths from CLI/API, not template expressions
+- `execution/formatters/node_output_formatter.py` — display formatting with pre-extracted paths
+- `core/workflow_validator.py` — validation only, already coalesce-aware
+- `template_validator.py` — display formatting in warning messages
+
+### Tests
+
+**`test_output_resolver.py`** — Added `TestCoalesceInOutputSource` class (7 tests): first branch present, second branch present, all absent, three-way chain, type preservation, end-to-end via `populate_declared_outputs`, all-absent doesn't populate.
+
+**`test_batch_node.py`** — Added `TestItemsCoalesce` class (3 tests): first branch, second branch, all absent raises ValueError.
+
+### Lesson Learned
+
+When adding new syntax to the template system, audit ALL consumers — not just those using shared regex patterns. Ad-hoc consumers that do their own string manipulation are the ones that break silently.
+
+### Verification
+
+- `make test`: 4087 passed, 485 skipped, 0 failures
+- `make check`: all clean

--- a/src/pflow/runtime/batch_node.py
+++ b/src/pflow/runtime/batch_node.py
@@ -255,9 +255,12 @@ class PflowBatchNode(Node):
             # Task 103's resolve_nested() preserves types in nested structures
             items = TemplateResolver.resolve_nested(self.items_template, shared)
         else:
-            # Template reference - extract variable path: "${x.y}" -> "x.y"
-            var_path = self.items_template.strip()[2:-1]
-            items = TemplateResolver.resolve_value(var_path, shared)
+            # Template reference - use resolve_template for full syntax support
+            # (coalesce ??, nested indices, type preservation)
+            items = TemplateResolver.resolve_template(self.items_template.strip(), shared)
+            # resolve_template returns original string if unresolved
+            if items == self.items_template.strip():
+                items = None
 
             # Auto-parse JSON strings (enables shell → batch patterns)
             # Shell nodes output text; if that text is valid JSON array, parse it

--- a/src/pflow/runtime/output_resolver.py
+++ b/src/pflow/runtime/output_resolver.py
@@ -17,6 +17,9 @@ def resolve_output_source(source_expr: str, shared_storage: dict[str, Any]) -> O
     - $node.output - Dollar prefix format
     - node.output - Plain format
 
+    Uses TemplateResolver.resolve_template() to support the full template syntax
+    including coalesce (??), nested index templates, and type preservation.
+
     Args:
         source_expr: Template expression like "${node.output}" or "node.output"
         shared_storage: The shared storage dictionary
@@ -24,14 +27,18 @@ def resolve_output_source(source_expr: str, shared_storage: dict[str, Any]) -> O
     Returns:
         The resolved value or None if not found
     """
-    # Strip template syntax wrappers (${...} or $...)
-    if source_expr.startswith("${") and source_expr.endswith("}"):
-        source_expr = source_expr[2:-1]
-    elif source_expr.startswith("$"):
-        source_expr = source_expr[1:]
+    # Normalize to ${...} format so resolve_template() can handle it
+    if not source_expr.startswith("${"):
+        source_expr = "${" + source_expr[1:] + "}" if source_expr.startswith("$") else "${" + source_expr + "}"
 
-    # Use existing TemplateResolver.resolve_value which handles path traversal
-    return TemplateResolver.resolve_value(source_expr, shared_storage)
+    # Use resolve_template() which handles coalesce (??), nested indices,
+    # type preservation, and all other template syntax
+    result = TemplateResolver.resolve_template(source_expr, shared_storage)
+
+    # resolve_template returns the original string if unresolved
+    if result == source_expr:
+        return None
+    return result
 
 
 def populate_declared_outputs(

--- a/tests/test_integration/test_branch_convergence.py
+++ b/tests/test_integration/test_branch_convergence.py
@@ -434,6 +434,45 @@ class TestBranchConvergenceCoalesce:
 
 
 # ===========================================================================
+# TestCoalesceInWorkflowOutputs — Coalesce in ## Outputs source declarations
+# ===========================================================================
+
+
+class TestCoalesceInWorkflowOutputs:
+    """Test coalesce in workflow output source declarations (full compile+execute).
+
+    This tests the complete chain: compiler monkey-patches flow.run →
+    populate_declared_outputs → resolve_output_source → resolve_template.
+    The output resolver previously bypassed resolve_template, silently
+    dropping coalesced outputs.
+    """
+
+    def test_coalesced_output_resolves_to_executed_branch(self) -> None:
+        """Workflow output with ?? resolves to whichever branch ran."""
+        ir = _make_coalesce_ir(route_to_low=True)
+        ir["outputs"] = {
+            "content": {"source": "${branch-low.stdout ?? branch-high.stdout}"},
+        }
+
+        shared = compile_and_run_ir(ir)
+
+        assert "content" in shared, "Coalesced output was not populated"
+        assert "LOW-VALUE" in shared["content"]
+
+    def test_coalesced_output_other_branch(self) -> None:
+        """Same test, opposite branch — ensures both directions work."""
+        ir = _make_coalesce_ir(route_to_low=False)
+        ir["outputs"] = {
+            "content": {"source": "${branch-high.stdout ?? branch-low.stdout}"},
+        }
+
+        shared = compile_and_run_ir(ir)
+
+        assert "content" in shared, "Coalesced output was not populated"
+        assert "HIGH-VALUE" in shared["content"]
+
+
+# ===========================================================================
 # TestCoalesceWithOptionalInputs — Interaction between Phase 1 and Phase 2
 # ===========================================================================
 

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -537,6 +537,40 @@ class TestItemsResolution:
             batch.prep(shared)
 
 
+class TestItemsCoalesce:
+    """Tests for coalesce (??) operator in batch items template."""
+
+    def test_items_coalesce_first_branch(self):
+        """Batch items resolved via coalesce when first branch executed."""
+        inner = MockInnerNode("test_node")
+        batch = PflowBatchNode(inner, "test_node", {"items": "${source_a.items ?? source_b.items}"})
+
+        shared = {"source_a": {"items": ["x", "y"]}}
+        items = batch.prep(shared)
+
+        assert items == ["x", "y"]
+
+    def test_items_coalesce_second_branch(self):
+        """Batch items resolved via coalesce when second branch executed."""
+        inner = MockInnerNode("test_node")
+        batch = PflowBatchNode(inner, "test_node", {"items": "${source_a.items ?? source_b.items}"})
+
+        shared = {"source_b": {"items": ["a", "b", "c"]}}
+        items = batch.prep(shared)
+
+        assert items == ["a", "b", "c"]
+
+    def test_items_coalesce_all_absent_raises(self):
+        """ValueError when all coalesce operands are absent."""
+        inner = MockInnerNode("test_node")
+        batch = PflowBatchNode(inner, "test_node", {"items": "${source_a.items ?? source_b.items}"})
+
+        shared = {}
+
+        with pytest.raises(ValueError, match="resolved to None"):
+            batch.prep(shared)
+
+
 class TestItemsJsonAutoParsing:
     """Tests for JSON string auto-parsing in batch.items.
 

--- a/tests/test_runtime/test_output_resolver.py
+++ b/tests/test_runtime/test_output_resolver.py
@@ -210,6 +210,73 @@ class TestPopulateDeclaredOutputs:
         assert shared["output1"] == "value1"
 
 
+class TestCoalesceInOutputSource:
+    """Tests for coalesce (??) operator in output source expressions."""
+
+    def test_coalesce_resolves_first_present_branch(self):
+        """When first branch executed, coalesce returns its value."""
+        shared = {"branch_a": {"stdout": "hello from A"}}
+
+        result = resolve_output_source("${branch_a.stdout ?? branch_b.stdout}", shared)
+        assert result == "hello from A"
+
+    def test_coalesce_resolves_second_when_first_absent(self):
+        """When first branch absent, coalesce falls through to second."""
+        shared = {"branch_b": {"stdout": "hello from B"}}
+
+        result = resolve_output_source("${branch_b.stdout ?? branch_a.stdout}", shared)
+        assert result == "hello from B"
+
+    def test_coalesce_returns_none_when_all_absent(self):
+        """When no branch executed, coalesce returns None."""
+        shared = {}
+
+        result = resolve_output_source("${branch_a.stdout ?? branch_b.stdout}", shared)
+        assert result is None
+
+    def test_coalesce_three_operands(self):
+        """Three-way coalesce resolves to whichever branch ran."""
+        shared = {"branch_c": {"result": "from C"}}
+
+        result = resolve_output_source("${branch_a.result ?? branch_b.result ?? branch_c.result}", shared)
+        assert result == "from C"
+
+    def test_coalesce_preserves_type(self):
+        """Coalesce preserves non-string types (list, dict, int)."""
+        shared = {"node": {"data": [1, 2, 3]}}
+
+        result = resolve_output_source("${node.data ?? other.data}", shared)
+        assert result == [1, 2, 3]
+
+    def test_coalesce_in_populate_declared_outputs(self):
+        """End-to-end: coalesce in output source populates shared storage."""
+        shared = {"branch_a": {"stdout": "hello from A"}}
+
+        workflow_ir = {
+            "outputs": {
+                "content": {"source": "${branch_a.stdout ?? branch_b.stdout}"},
+            }
+        }
+
+        populate_declared_outputs(shared, workflow_ir)
+
+        assert shared["content"] == "hello from A"
+
+    def test_coalesce_all_absent_does_not_populate(self):
+        """When all coalesce operands absent, output is not written to shared."""
+        shared = {"unrelated": "data"}
+
+        workflow_ir = {
+            "outputs": {
+                "content": {"source": "${branch_a.stdout ?? branch_b.stdout}"},
+            }
+        }
+
+        populate_declared_outputs(shared, workflow_ir)
+
+        assert "content" not in shared
+
+
 class TestEdgeCases:
     """Test edge cases and error conditions."""
 


### PR DESCRIPTION
## Summary

The `??` coalesce operator silently failed in workflow `## Outputs` `- source:` declarations and batch `items` templates. Both code paths bypassed `TemplateResolver.resolve_template()` by manually stripping `${...}` and calling `resolve_value()` — a low-level path traversal function with no coalesce support.

## Task

Task 128 (Branch Convergence) — this is a post-implementation bug fix for Phase 2.

## Changes

- **`output_resolver.py`**: Replaced manual `${...}` stripping + `resolve_value()` with `resolve_template()`. Normalizes legacy formats (`$node.output`, `node.output`) to `${node.output}` before resolution.
- **`batch_node.py`**: Same fix for batch items template resolution.
- **Tests**: 10 new unit tests (7 output resolver, 3 batch node) + 2 integration tests that compile and run a full branching workflow with coalesced `## Outputs`.
- **Progress log**: Updated Task 128 progress log with root cause analysis and lesson learned.

## Explanation

Task 128 added `??` coalesce to `TemplateResolver.resolve_template()` and updated all consumers found via regex pattern analysis. But `output_resolver.py` and `batch_node.py` don't use regex — they do manual string slicing (`source_expr[2:-1]`) and call `resolve_value()` directly. This made them invisible to the impact scan.

The fix is minimal: both files now delegate to the same `resolve_template()` that step parameters use, getting coalesce, nested indices, and type preservation for free.

A codebase audit confirmed 6 other `resolve_value()` call sites are fine (CLI field access, MCP field service, display formatters, validation-only code).

## Created Docs

- `.taskmaster/tasks/task_128/implementation/progress-log.md` (updated with post-merge bug section)

## Testing

Run `make test` to verify all tests pass — 4089 passed, 485 skipped.