### PR TITLE
refactor: split template_validator.py by validation concern (closes #118)

### DIFF
--- a/src/pflow/core/workflow_validator.py
+++ b/src/pflow/core/workflow_validator.py
@@ -179,10 +179,10 @@ class WorkflowValidator:
             - errors: List of template validation errors
             - warnings: List of ValidationWarning objects
         """
-        from pflow.runtime.template_validator import TemplateValidator
+        from pflow.runtime.template_validator import validate_workflow_templates
 
         try:
-            errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, extracted_params, registry)
+            errors, warnings = validate_workflow_templates(workflow_ir, extracted_params, registry)
             return (errors, warnings)
         except Exception as e:
             return ([f"Template validation error: {e!s}"], [])

--- a/src/pflow/execution/executor_service.py
+++ b/src/pflow/execution/executor_service.py
@@ -343,7 +343,7 @@ class WorkflowExecutorService:
 
                 # For template errors, capture available fields (use same limit as template validator)
                 if category == "template_error":
-                    from pflow.runtime.template_validator import MAX_DISPLAYED_FIELDS
+                    from pflow.runtime.validation_utils import MAX_DISPLAYED_FIELDS
 
                     # Defensive: ensure node_output is dict-like and convert keys to strings
                     # This handles edge cases where node_output might not be a dict or keys aren't strings

--- a/src/pflow/execution/formatters/node_output_formatter.py
+++ b/src/pflow/execution/formatters/node_output_formatter.py
@@ -25,7 +25,7 @@ from typing import Any, Optional
 
 from pflow.registry import Registry
 from pflow.runtime.template_resolver import TemplateResolver
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.validation_utils import flatten_output_structure
 
 # Constants
 MAX_DISPLAYED_FIELDS = 500  # Allow up to 500 template paths
@@ -393,9 +393,7 @@ def extract_metadata_paths(node_type: str, registry: Registry) -> tuple[list[tup
 
             # Flatten nested structure if present
             if structure:
-                nested_paths = TemplateValidator._flatten_output_structure(
-                    base_key=key, base_type=output_type, structure=structure
-                )
+                nested_paths = flatten_output_structure(base_key=key, base_type=output_type, structure=structure)
                 # Skip first as it's the base key we already added
                 all_paths.extend(nested_paths[1:])
 

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -14,7 +14,11 @@ src/pflow/runtime/
 ├── namespaced_wrapper.py    # Collision prevention wrapper (~95 lines)
 ├── namespaced_store.py      # Namespaced store proxy (~156 lines)
 ├── template_resolver.py     # Template variable resolution engine
-├── template_validator.py    # Pre-execution template validation with rich errors
+├── template_validator.py    # Validation orchestrator + output extraction (~500 lines)
+├── template_path_validation.py  # Pass 5: path existence, nested path traversal (~650 lines)
+├── template_type_validation.py  # Passes 6+7: type matching, shell command types (~350 lines)
+├── batch_item_validation.py     # Pass 8: ${item.field} validation (~250 lines)
+├── validation_utils.py          # Shared validation infrastructure (~250 lines)
 ├── workflow_executor.py     # Nested workflow executor node
 ├── workflow_trace.py        # Trace collection with thread-safe LLM interception
 ├── workflow_validator.py    # IR validation and input preparation
@@ -164,15 +168,39 @@ Batch processing wrapper. **Inherits from `Node`, not PocketFlow's `BatchNode`**
 
 > For JSON auto-parsing and type coercion details, see `architecture/core-concepts/data-type-coercion.md`.
 
-### TemplateValidator (`template_validator.py`)
+### Template Validation (split across 5 files)
 
-Pre-execution validation with rich error suggestions:
+Pre-execution validation with rich error suggestions, split by validation concern. Each file owns both detection logic AND error formatting for its concern.
+
+**Entry point**: `validate_workflow_templates()` in `template_validator.py` — orchestrates all passes.
+
+**File structure**:
+- `template_validator.py` — Orchestrator, output extraction, template extraction, simple passes (malformed, unused inputs)
+- `template_path_validation.py` — Pass 5: path existence, namespaced output, nested path traversal + all path error formatting
+- `template_type_validation.py` — Passes 6+7: type matching + shell command type safety
+- `batch_item_validation.py` — Pass 8: `${item.field}` validation against inferred item structure
+- `validation_utils.py` — Shared: `split_template_path`, `sanitize_for_display`, `find_similar_paths`, `flatten_output_structure`, `build_paths_from_entries`, `get_node_ids`, `ValidationWarning`, display constants
+
+**Dependency graph** (no cycles):
+```
+template_validator.py (orchestrator)
+  ├── template_path_validation → validation_utils
+  ├── template_type_validation → type_checker
+  └── batch_item_validation → template_path_validation, validation_utils
+```
+
+**Public API**:
+- `validate_workflow_templates(workflow_ir, available_params, registry)` — main entry point
+- `extract_node_outputs(workflow_ir, registry)` — builds node_outputs dict (also used by compiler.py)
+- `ValidationWarning` — re-exported from validation_utils for backward compat
+
+**Key behaviors**:
 - Validates all templates have sources using registry metadata for node outputs
 - Detects unused declared inputs
 - Flattens nested output structures showing array access patterns
 - "Did you mean X?" suggestions for typos (substring matching)
 - Shows all available paths (limit 20) with types
-- **Shell command validation**: Blocks dict/list templates in shell `command` params (would break shell parsing). Fix options: access specific fields, use stdin, or use the **single-quote escape hatch**: `'${var}'` signals user accepts runtime JSON coercion to string.
+- **Shell command validation**: Blocks dict/list templates in shell `command` params. Fix options: access specific fields, use stdin, or use the **single-quote escape hatch**: `'${var}'`
 
 **Error format example**:
 ```

--- a/src/pflow/runtime/batch_item_validation.py
+++ b/src/pflow/runtime/batch_item_validation.py
@@ -1,0 +1,280 @@
+"""Batch item field validation (Pass 8).
+
+Validates ${item.field} references against inferred item structure.
+When batch items come from an upstream node's results array, checks
+that referenced fields actually exist on each item.
+"""
+
+from typing import Any, Optional
+
+from pflow.runtime.template_path_validation import validate_nested_path
+from pflow.runtime.template_resolver import TemplateResolver
+from pflow.runtime.validation_utils import (
+    find_similar_paths,
+    sanitize_for_display,
+)
+
+
+def validate_batch_item_fields(
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+) -> list[str]:
+    """Validate ${item.field} references against inferred item structure.
+
+    For batch nodes where items come from an upstream batch node's results,
+    validates that referenced fields actually exist on each item.
+
+    Falls back to permissive (no validation) when item structure cannot
+    be inferred (e.g., items from workflow input, inline array, or
+    non-batch source).
+    """
+    errors: list[str] = []
+
+    for node in workflow_ir.get("nodes", []):
+        node_id = node.get("id")
+        batch_config = node.get("batch")
+        if not batch_config or not node_id:
+            continue
+
+        item_alias = batch_config.get("as", "item")
+        items_template = batch_config.get("items")
+        if not items_template:
+            continue
+
+        item_structure = _infer_batch_item_structure(items_template, node_outputs)
+        if not item_structure:
+            continue
+
+        field_refs = _extract_item_field_refs(node.get("params", {}), item_alias)
+
+        seen_errors: set[str] = set()  # Mutated by _check_batch_item_ref to dedup
+        for field_path, full_template in field_refs:
+            error = _check_batch_item_ref(
+                field_path, full_template, item_structure, item_alias, items_template, node_id, seen_errors
+            )
+            if error:
+                errors.append(error)
+
+    return errors
+
+
+def _infer_batch_item_structure(
+    items_template: Any,
+    node_outputs: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Infer the structure of batch items from the items template.
+
+    When items: ${upstream.results}, looks up the upstream node's results
+    output and extracts the per-item structure (inner node outputs + 'item').
+
+    Returns:
+        Dict mapping field names to type info, or None if structure cannot be inferred.
+    """
+    if not isinstance(items_template, str):
+        return None
+
+    # Extract template references preserving left-to-right ?? order.
+    # extract_variables() returns a set (loses order), so we parse directly.
+    matches = TemplateResolver.TEMPLATE_PATTERN.findall(items_template)
+    if not matches:
+        return None
+
+    operands: list[str] = []
+    for match in matches:
+        operands.extend(TemplateResolver.split_coalesce_operands(match))
+
+    for operand in operands:
+        source_output = node_outputs.get(operand)
+        if source_output and isinstance(source_output, dict):
+            items_info = source_output.get("items")
+            if isinstance(items_info, dict) and "structure" in items_info:
+                structure = items_info["structure"]
+                if isinstance(structure, dict):
+                    return structure
+
+    return None
+
+
+def _collect_templates_from_value(
+    value: Any,
+) -> set[str]:
+    """Recursively collect template variables from a parameter value."""
+    templates: set[str] = set()
+    if isinstance(value, str) and TemplateResolver.has_templates(value):
+        templates.update(TemplateResolver.extract_variables(value))
+    elif isinstance(value, dict):
+        for val in value.values():
+            templates.update(_collect_templates_from_value(val))
+    elif isinstance(value, list):
+        for list_item in value:
+            templates.update(_collect_templates_from_value(list_item))
+    return templates
+
+
+def _extract_item_field_refs(
+    params: dict[str, Any],
+    item_alias: str,
+) -> list[tuple[str, str]]:
+    """Extract ${item.field} references from a node's params.
+
+    Returns:
+        List of (field_path, full_template) tuples.
+        field_path is everything after the alias (e.g., "response" from "item.response").
+    """
+    prefix = f"{item_alias}."
+    refs: list[tuple[str, str]] = []
+
+    for param_value in params.values():
+        for template in _collect_templates_from_value(param_value):
+            if template.startswith(prefix):
+                field_path = template[len(prefix) :]
+                if field_path:
+                    refs.append((field_path, template))
+
+    return refs
+
+
+def _check_batch_item_ref(
+    field_path: str,
+    full_template: str,
+    item_structure: dict[str, Any],
+    item_alias: str,
+    items_template: Any,
+    node_id: str,
+    seen_errors: set[str],
+) -> Optional[str]:
+    """Check a single ${item.field} reference against item structure. Returns error or None."""
+    parts = field_path.split(".")
+    first_field = parts[0].split("[")[0]
+
+    if first_field not in item_structure:
+        if first_field in seen_errors:
+            return None
+        seen_errors.add(first_field)
+        return _format_batch_item_field_error(
+            node_id, item_alias, items_template, first_field, full_template, item_structure
+        )
+
+    # First field exists — validate deeper path if any
+    if len(parts) > 1:
+        field_info = item_structure[first_field]
+        if isinstance(field_info, dict):
+            is_valid, _ = validate_nested_path(parts[1:], field_info, f"${{{full_template}}}", item_alias)
+            if not is_valid and full_template not in seen_errors:
+                seen_errors.add(full_template)
+                return _format_batch_item_nested_error(node_id, item_alias, parts, full_template, field_info)
+
+    return None
+
+
+def _format_batch_item_field_error(
+    node_id: str,
+    item_alias: str,
+    items_template: Any,
+    first_field: str,
+    full_template: str,
+    item_structure: dict[str, Any],
+) -> str:
+    """Format error message for invalid batch item field access."""
+    safe_node_id = sanitize_for_display(node_id)
+    safe_alias = sanitize_for_display(item_alias)
+    items_source = items_template if isinstance(items_template, str) else str(items_template)
+    safe_source = sanitize_for_display(items_source)
+
+    available_paths = [
+        (f"{safe_alias}.{field}", info.get("type", "any") if isinstance(info, dict) else "any")
+        for field, info in item_structure.items()
+    ]
+    suggestions = find_similar_paths(first_field, available_paths)
+
+    lines = [
+        f"Node '{safe_node_id}': ${{{full_template}}} references "
+        f"field '{first_field}' which is not available on batch items.",
+        "",
+        f"Items come from: {safe_source}",
+        f"Available fields on ${{{safe_alias}}}:",
+    ]
+
+    for field_name, field_info in item_structure.items():
+        field_type = field_info.get("type", "any") if isinstance(field_info, dict) else "any"
+        lines.append(f"  ${{{safe_alias}.{field_name}}} ({field_type})")
+
+    if suggestions:
+        lines.append("")
+        if len(suggestions) == 1:
+            sugg_path, _ = suggestions[0]
+            lines.append(f"Did you mean: ${{{sugg_path}}}?")
+        else:
+            lines.append("Did you mean one of these?")
+            for sugg_path, _ in suggestions:
+                lines.append(f"  - ${{{sugg_path}}}")
+
+    return "\n".join(lines)
+
+
+def _format_batch_item_nested_error(
+    node_id: str,
+    item_alias: str,
+    parts: list[str],
+    full_template: str,
+    field_info: dict[str, Any],
+) -> str:
+    """Format error for invalid nested path on a batch item field.
+
+    Example: ${item.llm_usage.nope} where llm_usage has known structure.
+    """
+    safe_node_id = sanitize_for_display(node_id)
+    safe_alias = sanitize_for_display(item_alias)
+
+    # Walk through intermediate parts to find where validation actually fails.
+    # For ${item.a.b.c} where c doesn't exist on b, we need to identify b as
+    # the parent — not a — so the error message and available fields are correct.
+    current_info = field_info
+    valid_depth = 0
+    for part in parts[1:-1]:
+        sub = current_info.get("structure", {}) if isinstance(current_info, dict) else {}
+        if part in sub and isinstance(sub[part], dict):
+            current_info = sub[part]
+            valid_depth += 1
+        else:
+            break
+
+    parent_path = f"{safe_alias}.{'.'.join(parts[: 1 + valid_depth])}"
+    bad_field = parts[1 + valid_depth].split("[")[0]
+    parent_name = parts[valid_depth]
+    parent_type = current_info.get("type", "any") if isinstance(current_info, dict) else "any"
+    nested_structure = current_info.get("structure", {}) if isinstance(current_info, dict) else {}
+
+    lines = [
+        f"Node '{safe_node_id}': ${{{full_template}}} \u2014 "
+        f"'{bad_field}' does not exist on '{parent_name}' ({parent_type}).",
+    ]
+
+    if nested_structure:
+        lines.append("")
+        lines.append(f"Available fields on ${{{parent_path}}}:")
+        for field_name, sub_info in nested_structure.items():
+            sub_type = sub_info.get("type", "any") if isinstance(sub_info, dict) else "any"
+            lines.append(f"  ${{{parent_path}.{field_name}}} ({sub_type})")
+
+        available_paths = [
+            (f"{parent_path}.{f}", i.get("type", "any") if isinstance(i, dict) else "any")
+            for f, i in nested_structure.items()
+        ]
+        suggestions = find_similar_paths(bad_field, available_paths)
+        if suggestions:
+            lines.append("")
+            if len(suggestions) == 1:
+                sugg_path, _ = suggestions[0]
+                lines.append(f"Did you mean: ${{{sugg_path}}}?")
+            else:
+                lines.append("Did you mean one of these?")
+                for sugg_path, _ in suggestions:
+                    lines.append(f"  - ${{{sugg_path}}}")
+    else:
+        lines.append("")
+        lines.append(
+            f"'{parent_name}' has type '{parent_type}' with no known sub-fields. Nested access may fail at runtime."
+        )
+
+    return "\n".join(lines)

--- a/src/pflow/runtime/compiler.py
+++ b/src/pflow/runtime/compiler.py
@@ -23,7 +23,7 @@ from pflow.registry import Registry
 from .namespaced_wrapper import NamespacedNodeWrapper
 from .node_wrapper import TemplateAwareNodeWrapper
 from .template_resolver import TemplateResolver
-from .template_validator import TemplateValidator, ValidationWarning
+from .template_validator import ValidationWarning, extract_node_outputs, validate_workflow_templates
 from .workflow_validator import prepare_inputs, validate_ir_structure
 
 # Set up module logger
@@ -1092,9 +1092,7 @@ def _validate_workflow(
     # Step 5: Validate templates if requested
     if validate_templates:
         logger.debug("Validating template variables", extra={"phase": "template_validation"})
-        template_errors, template_warnings = TemplateValidator.validate_workflow_templates(
-            ir_dict, initial_params, registry
-        )
+        template_errors, template_warnings = validate_workflow_templates(ir_dict, initial_params, registry)
 
         # Display warnings if present (non-blocking)
         if template_warnings:
@@ -1148,7 +1146,7 @@ def _validate_outputs(workflow_ir: dict[str, Any], registry: Registry) -> None:
             )
 
     # Get all possible outputs from nodes in the workflow
-    all_node_outputs = TemplateValidator._extract_node_outputs(workflow_ir, registry)
+    all_node_outputs = extract_node_outputs(workflow_ir, registry)
 
     logger.debug(
         f"Found {len(all_node_outputs)} possible outputs from nodes",

--- a/src/pflow/runtime/template_path_validation.py
+++ b/src/pflow/runtime/template_path_validation.py
@@ -1,0 +1,720 @@
+"""Template path existence validation (Pass 5).
+
+Validates that template references point to real outputs — node outputs,
+workflow inputs, or initial parameters. Owns both the detection logic
+and all error formatting for path-related issues.
+"""
+
+import logging
+from typing import Any, Optional
+
+from pflow.registry import Registry
+from pflow.runtime.validation_utils import (
+    MAX_DISPLAYED_FIELDS,
+    ValidationWarning,
+    build_paths_from_entries,
+    find_similar_paths,
+    get_node_ids,
+    sanitize_for_display,
+    split_template_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Main pass function
+# ---------------------------------------------------------------------------
+
+
+def validate_template_paths(
+    all_templates: set[str],
+    available_params: dict[str, Any],
+    node_outputs: dict[str, Any],
+    workflow_ir: dict[str, Any],
+    registry: Registry,
+) -> tuple[list[str], list[ValidationWarning]]:
+    """Validate each template path exists in available sources.
+
+    Wraps the per-template loop: for every template, checks existence
+    and generates an error message if missing.
+
+    Args:
+        all_templates: Set of all template variable names found
+        available_params: Parameters available from planner or CLI
+        node_outputs: Pre-computed node outputs from extraction
+        workflow_ir: The workflow IR
+        registry: Registry instance
+
+    Returns:
+        Tuple of (errors, warnings)
+    """
+    errors: list[str] = []
+    warnings: list[ValidationWarning] = []
+
+    for template in sorted(all_templates):
+        is_valid, warning = validate_template_path(template, available_params, node_outputs, workflow_ir, registry)
+
+        if warning:
+            warnings.append(warning)
+
+        if not is_valid:
+            error = create_template_error(template, available_params, workflow_ir, node_outputs, registry)
+            errors.append(error)
+
+    return (errors, warnings)
+
+
+# ---------------------------------------------------------------------------
+# Path validation (detection)
+# ---------------------------------------------------------------------------
+
+
+def validate_template_path(
+    template: str,
+    initial_params: dict[str, Any],
+    node_outputs: dict[str, Any],
+    workflow_ir: dict[str, Any],
+    registry: Registry,
+) -> tuple[bool, Optional[ValidationWarning]]:
+    """Validate a template path exists in available sources.
+
+    With namespacing enabled, we need to distinguish between:
+    1. Node output references (e.g., ${node_id.output_key})
+    2. Root-level references (e.g., ${input_file} or ${config.nested.path})
+
+    Args:
+        template: Template string like "var" or "var.field.subfield"
+        initial_params: Parameters provided by planner
+        node_outputs: Full structure info from node interfaces
+        workflow_ir: The workflow IR to check for node IDs
+        registry: Registry instance (passed through for consistency)
+
+    Returns:
+        Tuple of (is_valid, optional_warning)
+    """
+    # Use smart split to preserve dots inside nested templates like ${item.field}
+    parts = split_template_path(template)
+    base_var = parts[0]
+    enable_namespacing = workflow_ir.get("enable_namespacing", True)
+
+    # When namespacing is enabled, check if base_var is a node ID
+    if enable_namespacing:
+        node_ids = get_node_ids(workflow_ir)
+
+        if base_var in node_ids:
+            # This is a namespaced node output reference
+            return validate_namespaced_output(parts, base_var, node_outputs, template)
+
+    # Not a node ID reference (or namespacing disabled), check as root-level reference
+
+    # Check initial_params first (higher priority)
+    if base_var in initial_params:
+        # For nested paths in initial_params, we can't validate at compile time
+        # since values are runtime-dependent. This is a limitation.
+        return (True, None)
+
+    # Check node outputs (for backward compatibility when namespacing is disabled)
+    if base_var in node_outputs:
+        if len(parts) == 1:
+            return (True, None)
+
+        # Validate nested path in structure
+        output_key = base_var  # For non-namespaced, base_var is the output key
+        return validate_nested_path(parts[1:], node_outputs[base_var], full_template=template, output_key=output_key)
+
+    return (False, None)
+
+
+def validate_namespaced_output(
+    parts: list[str],
+    base_var: str,
+    node_outputs: dict[str, Any],
+    template: str,
+) -> tuple[bool, Optional[ValidationWarning]]:
+    """Validate a namespaced node output reference with array index support.
+
+    Handles patterns like:
+    - node_id.output_key
+    - node_id.results[0]
+    - node_id.results[0].field
+    """
+    if len(parts) == 1:
+        # Just the node ID without output key - invalid
+        return (False, None)
+
+    # Handle array indexing: parts[1] might be "results[0]" → base="results", index=0
+    output_part = parts[1]
+    array_index = None
+    if "[" in output_part and output_part.endswith("]"):
+        bracket_pos = output_part.index("[")
+        base_output = output_part[:bracket_pos]
+        array_index = output_part[bracket_pos + 1 : -1]
+    else:
+        base_output = output_part
+
+    node_output_key = f"{base_var}.{base_output}"
+    if node_output_key not in node_outputs:
+        # Dynamic workflow nodes (outputs unknown at validation time) accept any output
+        is_dynamic = base_var in node_outputs and node_outputs[base_var].get("is_workflow_dynamic")
+        return (True, None) if is_dynamic else (False, None)
+
+    output_info = node_outputs[node_output_key]
+
+    # If array access, check if output has items structure
+    if array_index is not None:
+        items_info = output_info.get("items", {})
+        if items_info:
+            # Use items structure for nested validation
+            if len(parts) == 2:
+                return (True, None)
+            return validate_nested_path(parts[2:], items_info, full_template=template, output_key=base_output)
+        # No items info but array access requested
+        output_type = output_info.get("type", "any")
+        # Allow if type is array (native array access)
+        if output_type == "array":
+            return (True, None)
+        # Also allow str types - they may contain JSON that gets auto-parsed at runtime
+        # This matches the behavior of check_type_allows_traversal for field access
+        if output_type in ["str", "string"]:
+            # Generate warning about JSON auto-parsing requirement
+            nested_path = f"[{array_index}]" + (".".join(parts[2:]) if len(parts) > 2 else "")
+            warning = ValidationWarning(
+                template=template if template.startswith("${") else f"${{{template}}}",
+                node_id=output_info.get("node_id", "unknown"),
+                node_type=output_info.get("node_type", "unknown"),
+                output_key=base_output,
+                output_type=output_type,
+                reason=(
+                    f"Array access on '{output_type}' requires valid JSON array at runtime. "
+                    f"Non-JSON strings cause 'Unresolved variables' error."
+                ),
+                nested_path=nested_path,
+            )
+            return (True, warning)
+        return (False, None)
+
+    if len(parts) == 2:
+        return (True, None)
+
+    # Validate deeper nested path
+    return validate_nested_path(parts[2:], output_info, full_template=template, output_key=base_output)
+
+
+def validate_nested_path(
+    path_parts: list[str], output_info: dict[str, Any], full_template: str = "", output_key: str = ""
+) -> tuple[bool, Optional[ValidationWarning]]:
+    """Validate a nested path exists in the output structure.
+
+    Args:
+        path_parts: List of path components after the base variable
+        output_info: Output info dict with type and structure
+        full_template: Full template string for warning context
+        output_key: The output key being accessed (for warning)
+
+    Returns:
+        Tuple of (is_valid, optional_warning)
+    """
+    current_structure = output_info.get("structure", {})
+
+    # If no structure info, check if type allows traversal
+    if not current_structure:
+        output_type = output_info.get("type", "any")
+        return check_type_allows_traversal(output_type, path_parts, output_info, full_template, output_key)
+
+    # Traverse the structure
+    for i, part in enumerate(path_parts):
+        if part not in current_structure:
+            return (False, None)
+
+        next_item = current_structure[part]
+        if isinstance(next_item, dict):
+            # Check if this is a type definition or nested structure
+            if "type" in next_item:
+                # This is a field definition
+                if i < len(path_parts) - 1:
+                    # More parts to traverse
+                    current_structure = next_item.get("structure", {})
+                    if not current_structure:
+                        # Can't traverse further unless type allows it
+                        # str/string allowed for JSON auto-parsing at runtime
+                        field_type = next_item.get("type", "any").lower()
+                        return (field_type in ["dict", "object", "any", "str", "string"], None)
+                else:
+                    # This is the final part - valid
+                    return (True, None)
+            else:
+                # Direct nested structure
+                current_structure = next_item
+        else:
+            # Reached a leaf type string, no more traversal possible
+            return (i == len(path_parts) - 1, None)
+
+    return (True, None)
+
+
+def check_type_allows_traversal(
+    output_type: str, path_parts: list[str], output_info: dict[str, Any], full_template: str, output_key: str
+) -> tuple[bool, Optional[ValidationWarning]]:
+    """Check if output type allows traversal and generate warning if needed.
+
+    Args:
+        output_type: The output type string (may be union like "dict|str")
+        path_parts: List of path components for warning context
+        output_info: Output info dict for warning context
+        full_template: Full template string for warning context
+        output_key: The output key being accessed
+
+    Returns:
+        Tuple of (is_valid, optional_warning)
+    """
+    # Parse union types (e.g., "dict|str" → ["dict", "str"])
+    types_in_union = [t.strip().lower() for t in output_type.split("|")]
+
+    # Check if ANY type in the union allows traversal
+    # - dict/object: structured data, traversable (trusted, no warning)
+    # - any: explicit "could be anything" declaration (trusted, no warning)
+    # - str/string: might contain JSON, defer to runtime via JSON auto-parsing (WARNING)
+    traversable_types = [t for t in types_in_union if t in ["dict", "object", "any", "str", "string"]]
+
+    if not traversable_types:
+        return (False, None)
+
+    # dict/object and any types are trusted - no warning needed
+    # - dict/object: structured data
+    # - any: node author explicitly declared "this could be anything"
+    trusted_types = [t for t in traversable_types if t in ["dict", "object", "any"]]
+    if trusted_types:
+        # At least one trusted type - allow without warning
+        return (True, None)
+
+    # Only str/string types remain - warn about JSON auto-parsing
+    # This is the "surprising" case where nested access works via implicit parsing
+    string_types = [t for t in traversable_types if t in ["str", "string"]]
+    warning = None
+
+    if string_types and len(path_parts) > 0:
+        warning = ValidationWarning(
+            template=full_template if full_template.startswith("${") else f"${{{full_template}}}",
+            node_id=output_info.get("node_id", "unknown"),
+            node_type=output_info.get("node_type", "unknown"),
+            output_key=output_key,
+            output_type=output_type,
+            reason=(
+                f"Nested access on '{output_type}' requires valid JSON at runtime. "
+                f"Non-JSON strings cause 'Unresolved variables' error."
+            ),
+            nested_path=".".join(path_parts),
+        )
+
+    return (True, warning)
+
+
+# ---------------------------------------------------------------------------
+# Error dispatching
+# ---------------------------------------------------------------------------
+
+
+def create_template_error(
+    template: str,
+    available_params: dict[str, Any],
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+    registry: Registry,
+) -> str:
+    """Create appropriate error message for missing template variable.
+
+    Args:
+        template: Template variable name
+        available_params: Available parameters
+        workflow_ir: The workflow IR
+        node_outputs: Full structure info from node interfaces
+        registry: Registry instance
+
+    Returns:
+        Error message string
+    """
+    # Use smart split to preserve dots inside nested templates like ${item.field}
+    parts = split_template_path(template)
+    base_var = parts[0]
+    enable_namespacing = workflow_ir.get("enable_namespacing", True)
+
+    # Check if this is a node ID reference when namespacing is enabled
+    if enable_namespacing and "." in template:
+        node_ids = get_node_ids(workflow_ir)
+        if base_var in node_ids:
+            return _create_node_reference_error(base_var, parts, template, workflow_ir, node_outputs, registry)
+
+    # Handle path templates (with dots)
+    if "." in template:
+        return _create_path_template_error(template, base_var, available_params, workflow_ir)
+
+    # Handle simple templates
+    return _create_simple_template_error(template, workflow_ir)
+
+
+# ---------------------------------------------------------------------------
+# Error formatting helpers (internal)
+# ---------------------------------------------------------------------------
+
+
+def _get_input_description(variable: str, workflow_ir: dict[str, Any]) -> str:
+    """Get description for an input variable if available.
+
+    Args:
+        variable: The variable name to look up
+        workflow_ir: The workflow IR containing input declarations
+
+    Returns:
+        A descriptive string with input info, or empty string if not a declared input
+    """
+    inputs = workflow_ir.get("inputs", {})
+    if variable in inputs:
+        input_def = inputs[variable]
+        desc = input_def.get("description", "")
+        required = input_def.get("required", True)
+        default = input_def.get("default")
+
+        parts = []
+        if desc:
+            parts.append(desc)
+        if not required and default is not None:
+            parts.append(f"(optional, default: {default})")
+        elif required:
+            parts.append("(required)")
+
+        return " - " + " ".join(parts) if parts else ""
+    return ""
+
+
+def _create_node_reference_error(
+    base_var: str,
+    parts: list[str],
+    template: str,
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+    registry: Registry,
+) -> str:
+    """Create error for node output references.
+
+    Args:
+        base_var: The base variable (node ID)
+        parts: Template parts split by dot
+        template: Full template string
+        workflow_ir: Workflow IR
+        node_outputs: Pre-computed node outputs from validation
+        registry: Registry instance
+
+    Returns:
+        Error message for node reference issues
+    """
+    # Missing output key
+    if len(parts) == 1:
+        return f"Invalid template ${{{template}}} - node ID '{base_var}' requires an output key (e.g., ${{{base_var}}}.output_key)"
+
+    output_key = parts[1]
+
+    # Find the node to get better error message
+    node = next((n for n in workflow_ir.get("nodes", []) if n.get("id") == base_var), None)
+    if node:
+        return _get_node_outputs_description(node, output_key, node_outputs, registry)
+
+    return f"Node '{base_var}' does not output '{output_key}'"
+
+
+def _create_path_template_error(
+    template: str, base_var: str, available_params: dict[str, Any], workflow_ir: dict[str, Any]
+) -> str:
+    """Create error for path templates (with dots) that aren't node references.
+
+    Args:
+        template: Full template string
+        base_var: Base variable name
+        available_params: Available parameters
+        workflow_ir: Workflow IR
+
+    Returns:
+        Error message for path template issues
+    """
+    if base_var in available_params:
+        return f"Template path ${{{template}}} cannot be validated - initial_params values are runtime-dependent"
+
+    # Check if base variable is a declared input
+    input_desc = _get_input_description(base_var, workflow_ir)
+    path_component = template[len(base_var) + 1 :]
+
+    if input_desc:
+        return (
+            f"Required input '${{{base_var}}}' not provided{input_desc} - attempted to access path '{path_component}'"
+        )
+
+    enable_namespacing = workflow_ir.get("enable_namespacing", True)
+    if enable_namespacing:
+        return (
+            f"Template variable ${{{template}}} has no valid source - "
+            f"'${{{base_var}}}' is neither a workflow input nor a node ID in this workflow"
+        )
+    else:
+        return (
+            f"Template variable ${{{template}}} has no valid source - "
+            f"not provided in initial_params and path '{path_component}' "
+            f"not found in outputs from any node in the workflow"
+        )
+
+
+def _create_simple_template_error(template: str, workflow_ir: dict[str, Any]) -> str:
+    """Create error for simple templates without dots.
+
+    Args:
+        template: Template variable name
+        workflow_ir: Workflow IR
+
+    Returns:
+        Error message for simple template issues
+    """
+    input_desc = _get_input_description(template, workflow_ir)
+
+    if input_desc:
+        return f"Required input '${{{template}}}' not provided{input_desc}"
+
+    # Check if it might be a node ID used incorrectly
+    enable_namespacing = workflow_ir.get("enable_namespacing", True)
+    if enable_namespacing:
+        node_ids = get_node_ids(workflow_ir)
+        if template in node_ids:
+            return (
+                f"Invalid template ${{{template}}} - this is a node ID. "
+                f"To reference node outputs, use ${{{template}}}.output_key format"
+            )
+
+    return (
+        f"Template variable ${{{template}}} has no valid source - "
+        f"not provided in initial_params and not written by any node"
+    )
+
+
+def format_enhanced_node_error(
+    node_id: str, node_type: str, attempted_key: str, available_paths: list[tuple[str, str]], base_var: str
+) -> str:
+    """Create multi-section error with available outputs and suggestions.
+
+    Args:
+        node_id: Node ID where error occurred
+        node_type: Type of the node
+        attempted_key: The output key that was attempted
+        available_paths: List of (path, type) tuples
+        base_var: Base variable (node ID) for template construction
+
+    Returns:
+        Multi-line error message with sections for problem, available outputs, and suggestions
+    """
+    # Sanitize all user-controlled values to prevent template injection
+    safe_node_id = sanitize_for_display(node_id)
+    safe_node_type = sanitize_for_display(node_type)
+    safe_attempted_key = sanitize_for_display(attempted_key)
+    safe_base_var = sanitize_for_display(base_var)
+
+    # Section 1: Problem statement
+    lines = [f"Node '{safe_node_id}' (type: {safe_node_type}) does not output '{safe_attempted_key}'"]
+
+    # Section 2: Available outputs (limit to 20 to avoid overwhelming)
+    if available_paths:
+        lines.append("")
+        lines.append(f"Available outputs from '{safe_node_id}':")
+
+        display_paths = available_paths[:MAX_DISPLAYED_FIELDS]  # Limit display
+        for path, type_str in display_paths:
+            # Sanitize path components for safety
+            safe_path = sanitize_for_display(path)
+            safe_type = sanitize_for_display(type_str)
+
+            # Format with checkmark and type
+            full_path = f"{safe_base_var}.{safe_path}" if safe_base_var not in safe_path else safe_path
+            lines.append(f"  \u2713 ${{{full_path}}} ({safe_type})")
+
+        # Show truncation message if needed
+        if len(available_paths) > 20:
+            remaining = len(available_paths) - 20
+            lines.append(f"  ... and {remaining} more outputs")
+
+    # Section 3: Suggestions (find similar paths)
+    suggestions = find_similar_paths(attempted_key, available_paths)
+    if suggestions:
+        lines.append("")
+        if len(suggestions) == 1:
+            sugg_path, _ = suggestions[0]
+            safe_sugg_path = sanitize_for_display(sugg_path)
+            full_sugg = f"{safe_base_var}.{safe_sugg_path}" if safe_base_var not in safe_sugg_path else safe_sugg_path
+            lines.append(f"Did you mean: ${{{full_sugg}}}?")
+        else:
+            lines.append("Did you mean one of these?")
+            for sugg_path, _ in suggestions:
+                safe_sugg_path = sanitize_for_display(sugg_path)
+                full_sugg = (
+                    f"{safe_base_var}.{safe_sugg_path}" if safe_base_var not in safe_sugg_path else safe_sugg_path
+                )
+                lines.append(f"  - ${{{full_sugg}}}")
+
+    # Section 4: Common fix (use first suggestion if available, otherwise first available path)
+    if suggestions:
+        fix_path, _ = suggestions[0]
+        full_fix = f"{base_var}.{fix_path}" if base_var not in fix_path else fix_path
+        lines.append("")
+        lines.append(f"Common fix: Change ${{{base_var}.{attempted_key}}} to ${{{full_fix}}}")
+    elif available_paths:
+        # No suggestions, but we have paths - suggest the first one as generic fix
+        first_path, _ = available_paths[0]
+        full_first = f"{base_var}.{first_path}" if base_var not in first_path else first_path
+        lines.append("")
+        lines.append(f"Tip: Try using ${{{full_first}}} instead")
+
+    return "\n".join(lines)
+
+
+def _get_node_outputs_description(
+    node: dict[str, Any], output_key: str, node_outputs: dict[str, Any], registry: Registry
+) -> str:
+    """Get error message for missing node output with enhanced suggestions.
+
+    Uses the pre-computed node_outputs dict (same source of truth as validation)
+    to build accurate error messages. For batch nodes, detects whether the
+    attempted key exists in the inner node's interface and provides targeted guidance.
+
+    Args:
+        node: Node dictionary from workflow IR
+        output_key: The output key being accessed
+        node_outputs: Pre-computed node outputs from validation
+        registry: Registry instance for metadata lookup (fallback only)
+
+    Returns:
+        Error message describing what outputs are available with suggestions
+    """
+    node_type = node.get("type", "unknown")
+    node_id = node.get("id")
+    node_id_str = str(node_id) if node_id else "unknown"
+
+    # Build available paths from pre-computed node_outputs (single source of truth)
+    node_prefix = f"{node_id_str}."
+    node_entries = {k[len(node_prefix) :]: v for k, v in node_outputs.items() if k.startswith(node_prefix)}
+
+    if not node_entries:
+        # Fallback to registry if node_outputs has no entries (shouldn't happen)
+        return _get_node_outputs_from_registry(node, output_key, registry)
+
+    # Detect batch: check if any entry has is_batch_output flag
+    is_batch = any(entry.get("is_batch_output") for entry in node_entries.values())
+
+    if is_batch:
+        return _create_batch_error(node_id_str, node_type, output_key, node_entries)
+
+    # Non-batch node: build available paths and use standard error formatter
+    all_paths = build_paths_from_entries(node_entries)
+
+    if all_paths:
+        return format_enhanced_node_error(
+            node_id=node_id_str,
+            node_type=node_type,
+            attempted_key=output_key,
+            available_paths=all_paths,
+            base_var=node_id_str,
+        )
+
+    return f"Node '{node_id_str}' (type: {node_type}) does not produce any outputs"
+
+
+def _get_node_outputs_from_registry(node: dict[str, Any], output_key: str, registry: Registry) -> str:
+    """Fallback when node_outputs has no entries for a node.
+
+    This is a defensive fallback that should not be reached in practice —
+    _extract_node_outputs() runs before error generation and registers
+    outputs for all nodes. Intentionally simple to avoid re-introducing
+    the registry-vs-batch divergence bug.
+    """
+    node_id = node.get("id", "unknown")
+    logger.warning(
+        f"node_outputs fallback reached for node '{node_id}' — this is unexpected",
+        extra={"node_id": node_id, "output_key": output_key},
+    )
+    return f"Node '{node_id}' does not output '{output_key}'"
+
+
+def _create_batch_error(node_id: str, node_type: str, attempted_key: str, node_entries: dict[str, Any]) -> str:
+    """Create error message for batch node output access.
+
+    Two cases:
+    1. The attempted key exists in the inner node's interface (e.g., llm_usage for LLM nodes)
+       → Show targeted "exists inside results" message with corrected path
+    2. The attempted key doesn't exist at all
+       → Show standard "not found" with actual batch outputs
+
+    Args:
+        node_id: Node ID
+        node_type: Inner node type (e.g., "llm")
+        attempted_key: The output key that was attempted
+        node_entries: Dict of output_key -> output_info for this batch node
+
+    Returns:
+        Error message string
+    """
+    safe_node_id = sanitize_for_display(node_id)
+    safe_key = sanitize_for_display(attempted_key)
+
+    # Check if the attempted key exists in the inner node's output structure
+    # The results entry has items.structure containing inner outputs
+    results_entry = node_entries.get("results", {})
+    items_info = results_entry.get("items", {})
+    inner_structure = items_info.get("structure", {}) if isinstance(items_info, dict) else {}
+
+    inner_field_exists = attempted_key in inner_structure
+
+    if inner_field_exists:
+        return _format_batch_inner_field_error(safe_node_id, safe_key, node_entries)
+
+    # Field doesn't exist in inner interface either — show standard batch outputs
+    all_paths = build_paths_from_entries(node_entries)
+    return format_enhanced_node_error(
+        node_id=safe_node_id,
+        node_type=f"{node_type}, batch",
+        attempted_key=attempted_key,
+        available_paths=all_paths,
+        base_var=safe_node_id,
+    )
+
+
+def _format_batch_inner_field_error(node_id: str, attempted_key: str, node_entries: dict[str, Any]) -> str:
+    """Format error for accessing an inner node field on a batch node.
+
+    This is the targeted message shown when an agent writes ${node.llm_usage}
+    but the node has batch processing — the field exists, just nested inside results.
+
+    Args:
+        node_id: Sanitized node ID
+        attempted_key: Sanitized output key that was attempted
+        node_entries: Dict of output_key -> output_info for this batch node
+
+    Returns:
+        Multi-line error message with corrected path
+    """
+    results_path = f"${{{node_id}.results}}"
+    item_path = f"${{{node_id}.results[0].{attempted_key}}}"
+    col_width = max(len(results_path), len(item_path)) + 2
+
+    lines = [
+        f"Node '{node_id}' uses batch processing.",
+        f"'{attempted_key}' is not available at the top level — batch wraps outputs in a 'results' array.",
+        "",
+        f"  {results_path:<{col_width}} \u2192 list of all results",
+        f"  {item_path:<{col_width}} \u2192 first item's {attempted_key}",
+        "",
+        f"To aggregate across items, pass {results_path} to a code node and iterate.",
+    ]
+
+    # Also show all actual batch outputs for reference
+    lines.append("")
+    lines.append(f"Available top-level outputs from '{node_id}':")
+    for key, info in node_entries.items():
+        safe_key = sanitize_for_display(key)
+        safe_type = sanitize_for_display(info.get("type", "any"))
+        lines.append(f"  \u2713 ${{{node_id}.{safe_key}}} ({safe_type})")
+
+    return "\n".join(lines)

--- a/src/pflow/runtime/template_type_validation.py
+++ b/src/pflow/runtime/template_type_validation.py
@@ -1,0 +1,374 @@
+"""Template type validation (Passes 6 and 7).
+
+Pass 6: Validates template variable types match parameter expectations.
+Pass 7: Blocks structured data (dict/list) in shell command parameters.
+"""
+
+import re
+from typing import Any, Optional
+
+from pflow.registry import Registry
+from pflow.runtime.template_resolver import TemplateResolver
+from pflow.runtime.type_checker import (
+    get_parameter_type,
+    infer_template_type,
+    is_type_compatible,
+)
+
+# Pattern to detect templates exactly wrapped in single quotes: '${var}'
+# This is an escape hatch for structured types in shell commands.
+#
+# Matches:   '${var}', '${node.field}', '${data.items[0].name}'
+# Does NOT match: '${a} ${b}', 'prefix ${var}', '$${var}' (escaped)
+#
+# Note: Array indices use [] not {}, so [^}]+ correctly captures paths
+# like 'data.items[0].value' without stopping at brackets.
+_QUOTED_TEMPLATE_PATTERN = re.compile(r"'\$\{([^}]+)\}'")
+
+# Types that are safe in shell commands (string-like or unknown type)
+# When a union contains one of these, runtime coercion to string is acceptable.
+_SHELL_SAFE_TYPES = {"str", "string", "any"}
+
+
+def _extract_base_type(type_str: str) -> str:
+    """Extract base type from generic type string.
+
+    Generic types like list[dict] or dict[str, any] have a base type
+    (list, dict) that determines their shell command compatibility.
+
+    Examples:
+        list[dict] -> list
+        dict[str, any] -> dict
+        str -> str
+        list -> list
+
+    Args:
+        type_str: Type string, possibly with generic parameters
+
+    Returns:
+        Base type without generic parameters
+    """
+    return type_str.split("[")[0]
+
+
+def _is_shell_safe_type(inferred_type: str, blocked_types: set[str]) -> tuple[bool, str | None]:
+    """Check if a type is safe for shell command embedding.
+
+    Args:
+        inferred_type: The inferred type string (may be union like "dict|str")
+        blocked_types: Set of blocked type names
+
+    Returns:
+        Tuple of (is_safe, blocked_type_if_not_safe)
+        - (True, None) if type is safe
+        - (False, "dict") if blocked, with the first blocked type
+    """
+    # Split union and get base type for each component
+    type_parts = [t.strip() for t in inferred_type.split("|")]
+    base_types = [_extract_base_type(t) for t in type_parts]
+
+    # Tier 1: If union contains a safe base type (str, string, any), allow it
+    if any(t in _SHELL_SAFE_TYPES for t in base_types):
+        return (True, None)
+
+    # Check if any base type is blocked
+    blocked_parts = [t for t in base_types if t in blocked_types]
+    if blocked_parts:
+        return (False, blocked_parts[0])
+
+    return (True, None)
+
+
+# ---------------------------------------------------------------------------
+# Pass 6: Type matching
+# ---------------------------------------------------------------------------
+
+
+def validate_template_types(workflow_ir: dict[str, Any], node_outputs: dict[str, Any], registry: Registry) -> list[str]:
+    """Validate template variable types match parameter expectations.
+
+    Args:
+        workflow_ir: Workflow IR
+        node_outputs: Node output metadata from registry
+        registry: Registry instance
+
+    Returns:
+        List of type mismatch errors
+    """
+    errors: list[str] = []
+
+    for node in workflow_ir.get("nodes", []):
+        node_type = node.get("type")
+        node_id = node.get("id")
+        params = node.get("params", {})
+
+        for param_name, param_value in params.items():
+            expected_type = get_parameter_type(node_type, param_name, registry)
+            _check_param_type(param_name, param_value, expected_type, node_id, workflow_ir, node_outputs, errors)
+
+    return errors
+
+
+def _check_param_type(
+    param_name: str,
+    value: Any,
+    expected_type: Optional[str],
+    node_id: str,
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+    errors: list[str],
+) -> None:
+    """Recursively validate template types in a parameter value."""
+    if isinstance(value, str) and TemplateResolver.has_templates(value):
+        if expected_type and expected_type != "any":
+            _check_string_template_types(param_name, value, expected_type, node_id, workflow_ir, node_outputs, errors)
+    elif isinstance(value, dict):
+        for val in value.values():
+            _check_param_type(param_name, val, None, node_id, workflow_ir, node_outputs, errors)
+    elif isinstance(value, list):
+        for item in value:
+            _check_param_type(param_name, item, None, node_id, workflow_ir, node_outputs, errors)
+
+
+def _check_string_template_types(
+    param_name: str,
+    value: str,
+    expected_type: str,
+    node_id: str,
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+    errors: list[str],
+) -> None:
+    """Validate template types in a string parameter value."""
+    templates = TemplateResolver.extract_variables(value)
+    for template in templates:
+        inferred_type = infer_template_type(template, workflow_ir, node_outputs)
+        if not inferred_type or inferred_type == "any":
+            continue
+        if not is_type_compatible(inferred_type, expected_type):
+            error_msg = (
+                f"Type mismatch in node '{node_id}' parameter '{param_name}': "
+                f"template ${{{template}}} has type '{inferred_type}' "
+                f"but parameter expects '{expected_type}'"
+            )
+            if inferred_type in ["dict", "list", "object"] and expected_type in ["str", "string"]:
+                error_msg += _generate_type_fix_suggestion(template, node_outputs, expected_type)
+            errors.append(error_msg)
+
+
+# ---------------------------------------------------------------------------
+# Pass 7: Shell command types
+# ---------------------------------------------------------------------------
+
+
+def validate_shell_command_types(workflow_ir: dict[str, Any], node_outputs: dict[str, Any]) -> list[str]:
+    """Block dict/list types in shell command parameters.
+
+    Shell commands cannot safely handle JSON embedded in command strings
+    due to shell escaping issues. This check runs BEFORE template resolution
+    to catch the problem at validation time rather than runtime.
+
+    The general type checker allows dict/list → str (for LLM prompts, HTTP bodies),
+    but shell commands are special - embedded JSON breaks shell parsing.
+
+    Validation has three tiers:
+    1. Fix 0: Extract base types from generics (list[dict] → list) before checking
+    2. Tier 1: Auto-allow unions containing safe types (str, string, any)
+    3. Tier 2: Allow templates wrapped in single quotes '${var}' as an escape hatch
+
+    Args:
+        workflow_ir: Workflow IR
+        node_outputs: Node output metadata from registry
+
+    Returns:
+        List of errors for structured data in shell commands
+    """
+    errors = []
+    # Types that cannot be safely embedded in shell command strings.
+    # Includes both Python type names (dict, list) and JSON Schema names (object, array)
+    # since workflow IR may use either convention.
+    SHELL_BLOCKED_TYPES = {"dict", "object", "list", "array"}
+
+    for node in workflow_ir.get("nodes", []):
+        node_type = node.get("type")
+        node_id = node.get("id")
+
+        # Only check shell nodes
+        if node_type != "shell":
+            continue
+
+        params = node.get("params", {})
+        command = params.get("command", "")
+
+        # Skip if command has no templates
+        if not isinstance(command, str) or not TemplateResolver.has_templates(command):
+            continue
+
+        # Tier 2: Find templates exactly wrapped in single quotes (escape hatch)
+        # Pattern '${var}' signals user accepts runtime coercion to string
+        quoted_templates = {match.group(1) for match in _QUOTED_TEMPLATE_PATTERN.finditer(command)}
+
+        # Check each template in the command and collect blocked ones
+        templates = TemplateResolver.extract_variables(command)
+        blocked_templates: list[tuple[str, str]] = []  # (template, type)
+
+        for template in templates:
+            # Tier 2: Skip if template is quoted (user accepts coercion)
+            if template in quoted_templates:
+                continue
+
+            inferred_type = infer_template_type(template, workflow_ir, node_outputs)
+
+            # Skip if cannot infer type (will be caught by path validation)
+            if not inferred_type:
+                continue
+
+            # Check if type is safe (handles Fix 0 and Tier 1)
+            is_safe, blocked_type = _is_shell_safe_type(inferred_type, SHELL_BLOCKED_TYPES)
+            if not is_safe and blocked_type:
+                blocked_templates.append((template, blocked_type))
+
+        # Generate a single consolidated error if any templates are blocked
+        if blocked_templates:
+            display_cmd = command if len(command) <= 60 else command[:57] + "..."
+
+            if len(blocked_templates) == 1:
+                # Single template - simple case
+                template, blocked_type = blocked_templates[0]
+                errors.append(
+                    f"Shell node '{node_id}': cannot use ${{{template}}} (type: {blocked_type}) "
+                    f"in command parameter.\n\n"
+                    f"PROBLEM: {blocked_type} data embedded in shell commands breaks parsing "
+                    f"(quotes, backticks, $() cause errors).\n\n"
+                    f"CURRENT (breaks):\n"
+                    f'  "command": "{display_cmd}"\n\n'
+                    f"FIX OPTIONS:\n\n"
+                    f"1. Access specific fields (if they're strings/numbers):\n"
+                    f"   ${{{template}.fieldname}}, ${{{template}.count}}, etc.\n\n"
+                    f"2. Use stdin for the whole object:\n"
+                    f'   {{"stdin": "${{{template}}}", "command": "jq \'.field\'"}}\n\n'
+                    f"3. Quote the template to accept JSON coercion (if you've verified it's safe):\n"
+                    f"   '${{{template}}}' - wrapping in single quotes signals you accept runtime coercion"
+                )
+            else:
+                # Multiple templates - need different approach
+                template_list = ", ".join(f"${{{t}}} ({typ})" for t, typ in blocked_templates)
+                errors.append(
+                    f"Shell node '{node_id}': multiple structured data templates in command: "
+                    f"{template_list}\n\n"
+                    f"PROBLEM: Shell commands can only receive ONE data source via stdin.\n\n"
+                    f"CURRENT (breaks):\n"
+                    f'  "command": "{display_cmd}"\n\n'
+                    f"FIX OPTIONS:\n\n"
+                    f"1. Use temp files - write each data source to a file, then read in shell:\n"
+                    f"   ### save-a\n"
+                    f"   - type: write-file\n"
+                    f"   - file_path: /tmp/a.json\n"
+                    f"   - content: ${{data-a}}\n\n"
+                    f"   ### save-b\n"
+                    f"   - type: write-file\n"
+                    f"   - file_path: /tmp/b.json\n"
+                    f"   - content: ${{data-b}}\n\n"
+                    f"   ### process\n"
+                    f"   - type: shell\n"
+                    f"   ```shell command\n"
+                    f"   jq -s '.[0] * .[1]' /tmp/a.json /tmp/b.json\n"
+                    f"   ```\n\n"
+                    f"2. Process each data source in separate shell nodes, combine results after\n\n"
+                    f"3. Pass one via stdin, reference another via file\n\n"
+                    f"4. Quote templates to accept JSON coercion (if you've verified they're safe):\n"
+                    f"   '${{template}}' - wrapping in single quotes signals you accept runtime coercion"
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Type fix suggestions
+# ---------------------------------------------------------------------------
+
+
+def _generate_type_fix_suggestion(  # noqa: C901
+    template: str, node_outputs: dict[str, Any], expected_type: str
+) -> str:
+    """Generate helpful suggestions for type mismatches with actual available fields.
+
+    Args:
+        template: The template variable that has the wrong type
+        node_outputs: Node output metadata from registry
+        expected_type: The type that was expected
+
+    Returns:
+        Suggestion string with available fields
+    """
+    # For nested templates like node.output.field, we need to traverse to find structure
+    # Find the structure for this template by traversing
+    structure = None
+    for key in node_outputs:
+        if template.startswith(key + ".") or template == key:
+            output_info = node_outputs[key]
+            remaining_path = template[len(key) :].lstrip(".")
+
+            if not remaining_path:
+                # This IS the base output
+                structure = output_info.get("structure", {})
+                break
+            else:
+                # Need to traverse nested structure
+                structure = _traverse_to_structure(output_info.get("structure", {}), remaining_path)
+                if structure:
+                    break
+
+    if not structure:
+        # Generic fallback
+        return f"\n  \U0001f4a1 Suggestion: Access a specific field (e.g., ${{{template}.field}}) or serialize to JSON"
+
+    # Find fields that match the expected type
+    matching_fields = []
+    for field_name, field_info in structure.items():
+        if isinstance(field_info, dict) and "type" in field_info:
+            field_type = field_info["type"]
+            # Check if this field matches the expected type
+            if field_type in [expected_type, "str", "string"] and expected_type in ["str", "string"]:
+                matching_fields.append(field_name)
+
+    if matching_fields:
+        suggestion = "\n  \U0001f4a1 Available fields with correct type:"
+        for field in matching_fields[:5]:  # Show up to 5
+            suggestion += f"\n     - ${{{template}.{field}}}"
+        if len(matching_fields) > 5:
+            suggestion += f"\n     ... and {len(matching_fields) - 5} more"
+        return suggestion
+    else:
+        return "\n  \U0001f4a1 Suggestion: Access a nested field or serialize to JSON"
+
+
+def _traverse_to_structure(structure: dict[str, Any], path: str) -> Optional[dict[str, Any]]:
+    """Traverse nested structure to find the structure at a given path.
+
+    Args:
+        structure: The structure dict to traverse
+        path: Dot-separated path like "author.login"
+
+    Returns:
+        The structure dict at that path, or None if not found
+    """
+    if not path or not structure:
+        return structure
+
+    path_parts = path.split(".")
+    current = structure
+
+    for part in path_parts:
+        if part in current:
+            field_info = current[part]
+            if isinstance(field_info, dict):
+                current = field_info.get("structure", {})
+                if not current:
+                    return None
+            else:
+                return None
+        else:
+            return None
+
+    return current

--- a/src/pflow/runtime/template_validator.py
+++ b/src/pflow/runtime/template_validator.py
@@ -1,1232 +1,656 @@
 """Template variable validation for workflow execution.
 
-This module provides validation functionality to ensure all required
-template variables have corresponding parameters available before
-workflow execution begins.
+This module is the orchestrator for template validation. It runs all
+validation passes in sequence and aggregates errors/warnings.
+
+Validation passes are split by concern into separate modules:
+- template_path_validation: Pass 5 (path existence)
+- template_type_validation: Passes 6+7 (type matching, shell command types)
+- batch_item_validation: Pass 8 (${item.field} validation)
+- validation_utils: Shared infrastructure
+
+This module owns:
+- The main entry point (validate_workflow_templates)
+- Output extraction (building the node_outputs dict)
+- Template extraction
+- Simple passes (malformed syntax, unused inputs)
 """
 
 import logging
 import re
-from dataclasses import dataclass
-from typing import Any, ClassVar, Optional
+from typing import Any, Optional
 
 from pflow.registry import Registry
+from pflow.runtime.batch_item_validation import validate_batch_item_fields
+from pflow.runtime.template_path_validation import validate_template_paths
 from pflow.runtime.template_resolver import TemplateResolver
-from pflow.runtime.type_checker import (
-    get_parameter_type,
-    infer_template_type,
-    is_type_compatible,
+from pflow.runtime.template_type_validation import (
+    validate_shell_command_types,
+    validate_template_types,
+)
+from pflow.runtime.validation_utils import (
+    ValidationWarning,
+    get_node_ids,
 )
 
-
-@dataclass
-class ValidationWarning:
-    """Warning about runtime-validated template access.
-
-    Emitted when static validation cannot verify a template path
-    (e.g., accessing nested fields on outputs with type 'Any').
-    These templates will be validated at runtime during execution.
-    """
-
-    template: str  # Full template with ${}
-    node_id: str  # Node producing the output
-    node_type: str  # Node type (often MCP)
-    output_key: str  # Output key being accessed
-    output_type: str  # Type causing runtime validation
-    reason: str  # Human-readable explanation
-    nested_path: str  # Nested portion: "data.field[0]"
-
+# Re-export for backward compatibility (imported by compiler.py, tests)
+__all__ = ["ValidationWarning", "extract_node_outputs", "validate_workflow_templates"]
 
 logger = logging.getLogger(__name__)
 
-# Display limits for error messages - balances information vs overwhelming output
-MAX_DISPLAYED_FIELDS = 20  # Fits in ~25 terminal lines with formatting
-MAX_DISPLAYED_SUGGESTIONS = 3  # Cognitive limit for processing alternatives
-MAX_FLATTEN_DEPTH = 5  # Prevent infinite recursion on circular refs
+# More permissive pattern to catch malformed templates for validation
+# Supports array notation: ${node[0].field}, ${node.field[0].subfield}
+# Also supports nested index templates: ${node[${__index__}].field}
+# Also supports coalesce operator: ${a.field ?? b.field}
+_PERM_VAR = r"[a-zA-Z_][\w-]*(?:(?:\[(?:[\d]+|\$\{[^}]+\})\])?(?:\.[\w-]*(?:\[(?:[\d]+|\$\{[^}]+\})\])?)*)?"
+_PERMISSIVE_PATTERN = re.compile(rf"\$\{{({_PERM_VAR}(?:\s*\?\?\s*{_PERM_VAR})*)\}}")
 
-# Pattern to detect templates exactly wrapped in single quotes: '${var}'
-# This is an escape hatch for structured types in shell commands.
-#
-# Matches:   '${var}', '${node.field}', '${data.items[0].name}'
-# Does NOT match: '${a} ${b}', 'prefix ${var}', '$${var}' (escaped)
-#
-# Note: Array indices use [] not {}, so [^}]+ correctly captures paths
-# like 'data.items[0].value' without stopping at brackets.
-_QUOTED_TEMPLATE_PATTERN = re.compile(r"'\$\{([^}]+)\}'")
-
-# Types that are safe in shell commands (string-like or unknown type)
-# When a union contains one of these, runtime coercion to string is acceptable.
-_SHELL_SAFE_TYPES = {"str", "string", "any"}
+# Batch output definitions matching PflowBatchNode.post() structure
+BATCH_OUTPUTS: list[dict[str, str]] = [
+    {"key": "results", "type": "array", "description": "Array of results in input order"},
+    {"key": "count", "type": "number", "description": "Total items processed"},
+    {"key": "success_count", "type": "number", "description": "Items that succeeded"},
+    {"key": "error_count", "type": "number", "description": "Items that failed"},
+    {"key": "errors", "type": "array", "description": "Error details (null if none)"},
+    {"key": "batch_metadata", "type": "dict", "description": "Execution statistics"},
+]
 
 
-def _extract_base_type(type_str: str) -> str:
-    """Extract base type from generic type string.
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
 
-    Generic types like list[dict] or dict[str, any] have a base type
-    (list, dict) that determines their shell command compatibility.
 
-    Examples:
-        list[dict] -> list
-        dict[str, any] -> dict
-        str -> str
-        list -> list
+def validate_workflow_templates(
+    workflow_ir: dict[str, Any], available_params: dict[str, Any], registry: Registry
+) -> tuple[list[str], list[ValidationWarning]]:
+    """
+    Validates all template variables in a workflow.
+
+    Uses the registry to determine which variables are written by nodes
+    and validates that all template paths exist in the node outputs.
+    Also validates that all declared inputs are actually used.
 
     Args:
-        type_str: Type string, possibly with generic parameters
+        workflow_ir: The workflow IR containing nodes with template parameters
+        available_params: Parameters available from planner or CLI
+        registry: Registry instance with parsed node metadata
 
     Returns:
-        Base type without generic parameters
+        Tuple of (errors, warnings):
+        - errors: List of validation errors that prevent execution
+        - warnings: List of ValidationWarning objects for runtime-validated templates
     """
-    return type_str.split("[")[0]
+    errors: list[str] = []
+    warnings: list[ValidationWarning] = []
 
+    # Check for malformed template syntax FIRST
+    malformed_errors = _validate_malformed_templates(workflow_ir)
+    errors.extend(malformed_errors)
 
-def _is_shell_safe_type(inferred_type: str, blocked_types: set[str]) -> tuple[bool, str | None]:
-    """Check if a type is safe for shell command embedding.
-
-    Args:
-        inferred_type: The inferred type string (may be union like "dict|str")
-        blocked_types: Set of blocked type names
-
-    Returns:
-        Tuple of (is_safe, blocked_type_if_not_safe)
-        - (True, None) if type is safe
-        - (False, "dict") if blocked, with the first blocked type
-    """
-    # Split union and get base type for each component
-    type_parts = [t.strip() for t in inferred_type.split("|")]
-    base_types = [_extract_base_type(t) for t in type_parts]
-
-    # Tier 1: If union contains a safe base type (str, string, any), allow it
-    if any(t in _SHELL_SAFE_TYPES for t in base_types):
-        return (True, None)
-
-    # Check if any base type is blocked
-    blocked_parts = [t for t in base_types if t in blocked_types]
-    if blocked_parts:
-        return (False, blocked_parts[0])
-
-    return (True, None)
-
-
-def _split_template_path(template: str) -> list[str]:
-    """Split template path on dots, preserving dots inside ${...}.
-
-    Standard str.split(".") breaks nested templates like ${item.field}
-    inside array brackets. This function correctly handles:
-
-    - drafts.results[${item.draft_index}].response
-      -> ['drafts', 'results[${item.draft_index}]', 'response']
-
-    - node.data[${__index__}].field
-      -> ['node', 'data[${__index__}]', 'field']
-
-    Args:
-        template: Template path string (without ${} wrapper)
-
-    Returns:
-        List of path components with nested templates preserved
-    """
-    parts: list[str] = []
-    current = ""
-    depth = 0  # Track nesting level of ${...}
-
-    i = 0
-    while i < len(template):
-        if template[i : i + 2] == "${":
-            depth += 1
-            current += template[i : i + 2]
-            i += 2
-        elif template[i] == "}" and depth > 0:
-            depth -= 1
-            current += template[i]
-            i += 1
-        elif template[i] == "." and depth == 0:
-            if current:
-                parts.append(current)
-            current = ""
-            i += 1
-        else:
-            current += template[i]
-            i += 1
-
-    if current:
-        parts.append(current)
-
-    return parts
-
-
-class TemplateValidator:
-    """Validates template variables before workflow execution."""
-
-    @staticmethod
-    def _get_input_description(variable: str, workflow_ir: dict[str, Any]) -> str:
-        """Get description for an input variable if available.
-
-        Args:
-            variable: The variable name to look up
-            workflow_ir: The workflow IR containing input declarations
-
-        Returns:
-            A descriptive string with input info, or empty string if not a declared input
-        """
-        inputs = workflow_ir.get("inputs", {})
-        if variable in inputs:
-            input_def = inputs[variable]
-            desc = input_def.get("description", "")
-            required = input_def.get("required", True)
-            default = input_def.get("default")
-
-            parts = []
-            if desc:
-                parts.append(desc)
-            if not required and default is not None:
-                parts.append(f"(optional, default: {default})")
-            elif required:
-                parts.append("(required)")
-
-            return " - " + " ".join(parts) if parts else ""
-        return ""
-
-    @staticmethod
-    def _get_node_ids(workflow_ir: dict[str, Any]) -> set[str]:
-        """Extract all node IDs from the workflow.
-
-        Args:
-            workflow_ir: The workflow IR
-
-        Returns:
-            Set of all node IDs in the workflow
-        """
-        return {node.get("id") for node in workflow_ir.get("nodes", []) if node.get("id")}
-
-    @staticmethod
-    def validate_workflow_templates(
-        workflow_ir: dict[str, Any], available_params: dict[str, Any], registry: Registry
-    ) -> tuple[list[str], list[ValidationWarning]]:
-        """
-        Validates all template variables in a workflow.
-
-        Uses the registry to determine which variables are written by nodes
-        and validates that all template paths exist in the node outputs.
-        Also validates that all declared inputs are actually used.
-
-        Args:
-            workflow_ir: The workflow IR containing nodes with template parameters
-            available_params: Parameters available from planner or CLI
-            registry: Registry instance with parsed node metadata
-
-        Returns:
-            Tuple of (errors, warnings):
-            - errors: List of validation errors that prevent execution
-            - warnings: List of ValidationWarning objects for runtime-validated templates
-        """
-        errors: list[str] = []
-        warnings: list[ValidationWarning] = []
-
-        # Check for malformed template syntax FIRST
-        malformed_errors = TemplateValidator._validate_malformed_templates(workflow_ir)
-        errors.extend(malformed_errors)
-
-        # If malformed syntax found, return early with those errors
-        if malformed_errors:
-            logger.error(f"Found {len(malformed_errors)} malformed template(s)", extra={"errors": malformed_errors})
-            return (errors, warnings)
-
-        # Extract all templates from workflow
-        all_templates = TemplateValidator._extract_all_templates(workflow_ir)
-
-        if all_templates:
-            logger.debug(
-                f"Found {len(all_templates)} template variables to validate", extra={"templates": sorted(all_templates)}
-            )
-        else:
-            logger.debug("No template variables found in workflow")
-
-        # Check for unused inputs
-        unused_input_errors = TemplateValidator._validate_unused_inputs(workflow_ir, all_templates)
-        errors.extend(unused_input_errors)
-
-        # If no templates, we can return early (after checking for unused inputs)
-        if not all_templates:
-            return (errors, warnings)
-
-        # Get full output structure from nodes
-        node_outputs = TemplateValidator._extract_node_outputs(workflow_ir, registry, available_params)
-
-        logger.debug(
-            f"Extracted outputs from {len(node_outputs)} node variables", extra={"outputs": sorted(node_outputs.keys())}
-        )
-
-        # Validate each template path
-        for template in sorted(all_templates):
-            is_valid, warning = TemplateValidator._validate_template_path(
-                template, available_params, node_outputs, workflow_ir, registry
-            )
-
-            # Collect warning if present
-            if warning:
-                warnings.append(warning)
-
-            # Collect error if invalid
-            if not is_valid:
-                error = TemplateValidator._create_template_error(
-                    template, available_params, workflow_ir, node_outputs, registry
-                )
-                errors.append(error)
-
-        # NEW: Validate template types match parameter expectations
-        type_errors = TemplateValidator._validate_template_types(workflow_ir, node_outputs, registry)
-        errors.extend(type_errors)
-
-        # Block structured data (dict/list) in shell command parameters
-        shell_errors = TemplateValidator._validate_shell_command_types(workflow_ir, node_outputs)
-        errors.extend(shell_errors)
-
-        # Validate batch item field access (${item.field} against inferred structure)
-        batch_item_errors = TemplateValidator._validate_batch_item_fields(workflow_ir, node_outputs)
-        errors.extend(batch_item_errors)
-
-        if errors:
-            logger.warning(
-                f"Template validation found {len(errors)} errors", extra={"error_count": len(errors), "errors": errors}
-            )
-        elif warnings:
-            logger.info(
-                f"Template validation passed with {len(warnings)} runtime-validated template(s)",
-                extra={"warning_count": len(warnings)},
-            )
-        else:
-            logger.info("Template validation passed")
-
+    # If malformed syntax found, return early with those errors
+    if malformed_errors:
+        logger.error(f"Found {len(malformed_errors)} malformed template(s)", extra={"errors": malformed_errors})
         return (errors, warnings)
 
-    @staticmethod
-    def _validate_unused_inputs(workflow_ir: dict[str, Any], all_templates: set[str]) -> list[str]:
-        """Validate that all declared inputs are actually used.
-
-        Args:
-            workflow_ir: The workflow IR
-            all_templates: Set of all template variables found
-
-        Returns:
-            List of error messages for unused inputs
-        """
-        errors: list[str] = []
-        declared_inputs = set(workflow_ir.get("inputs", {}).keys())
-
-        if declared_inputs:
-            enable_namespacing = workflow_ir.get("enable_namespacing", True)
-            node_ids = TemplateValidator._get_node_ids(workflow_ir) if enable_namespacing else set()
-
-            # Extract base variable names from templates (before any dots)
-            # But exclude node IDs when namespacing is enabled
-            used_inputs = set()
-            for var in all_templates:
-                base_var = var.split(".")[0]
-                # Only count as used input if it's actually a declared input
-                # and not a node ID (when namespacing is enabled)
-                if base_var in declared_inputs and (not enable_namespacing or base_var not in node_ids):
-                    used_inputs.add(base_var)
-
-            unused_inputs = declared_inputs - used_inputs
-            if unused_inputs:
-                errors.append(f"Declared input(s) never used as template variable: {', '.join(sorted(unused_inputs))}")
-                logger.warning(f"Found {len(unused_inputs)} unused inputs", extra={"unused": sorted(unused_inputs)})
-
-        return errors
-
-    @staticmethod
-    def _sanitize_for_display(value: str, max_length: int = 100) -> str:
-        """Sanitize string for safe display in error messages.
-
-        Removes control characters and limits length to prevent:
-        - Terminal escape sequences
-        - Log injection (newlines, carriage returns)
-        - Information disclosure
-
-        Args:
-            value: String to sanitize (node_id, template variable, etc.)
-            max_length: Maximum length before truncation
-
-        Returns:
-            Sanitized string safe for error messages
-        """
-        # Remove non-printable characters AND newlines/carriage returns
-        # Allow only printable characters, excluding control chars that enable log injection
-        sanitized = "".join(c for c in value if c.isprintable() and c not in ("\n", "\r", "\t", "\x0b", "\x0c"))
-
-        # Truncate if too long
-        if len(sanitized) > max_length:
-            sanitized = sanitized[:max_length] + "..."
-
-        return sanitized
-
-    @staticmethod
-    def _flatten_output_structure(  # noqa: C901
-        base_key: str,
-        base_type: str,
-        structure: dict[str, Any],
-        _current_path: str = "",
-        _paths: list[tuple[str, str]] | None = None,
-        _depth: int = 0,
-        _max_depth: int = MAX_FLATTEN_DEPTH,
-    ) -> list[tuple[str, str]]:
-        """Recursively flatten output structure to list of (path, type) tuples.
-
-        Note: This function has inherent complexity (noqa: C901) due to recursive
-        tree traversal of arbitrary nested structures. Refactoring would require
-        breaking the recursion pattern, which could reduce readability without
-        meaningful benefit. The complexity is managed through:
-        - Clear function boundaries (prep/traverse/handle)
-        - Depth limiting to prevent infinite recursion
-        - Comprehensive docstrings
-        - Type hints for all parameters
-
-        Args:
-            base_key: The base output key (e.g., "result")
-            base_type: Type of the base key (e.g., "dict")
-            structure: Nested structure dictionary
-            _current_path: Current path during recursion (internal)
-            _paths: Accumulated paths (internal)
-            _depth: Current recursion depth (internal)
-            _max_depth: Maximum recursion depth to prevent infinite loops
-
-        Returns:
-            List of (path, type) tuples representing all accessible paths
-
-        Example:
-            Input: base_key="result", base_type="dict", structure={
-                "messages": {"type": "array", "items": {"type": "dict", "structure": {...}}}
-            }
-            Output: [
-                ("result", "dict"),
-                ("result.messages", "array"),
-                ("result.messages[0].text", "string"),
-                ...
-            ]
-        """
-        if _paths is None:
-            _paths = []
-
-        # Prevent infinite recursion on malformed structures
-        if _depth > _max_depth:
-            return _paths
-
-        # Add the base path first
-        if _current_path == "":
-            _paths.append((base_key, base_type))
-            _current_path = base_key
-
-        # Recursively traverse structure
-        if structure and isinstance(structure, dict):
-            for field_name, field_info in structure.items():
-                field_path = f"{_current_path}.{field_name}"
-
-                if isinstance(field_info, dict):
-                    field_type = field_info.get("type", "any")
-                    _paths.append((field_path, field_type))
-
-                    # Handle arrays with example index
-                    if field_type == "array" and "items" in field_info:
-                        items = field_info["items"]
-                        if isinstance(items, dict):
-                            item_type = items.get("type", "any")
-                            item_path = f"{field_path}[0]"
-                            _paths.append((item_path, item_type))
-
-                            # Recurse into array item structure
-                            if "structure" in items and isinstance(items["structure"], dict):
-                                TemplateValidator._flatten_output_structure(
-                                    base_key="",  # Not used in recursion
-                                    base_type="",
-                                    structure=items["structure"],
-                                    _current_path=item_path,
-                                    _paths=_paths,
-                                    _depth=_depth + 1,
-                                    _max_depth=_max_depth,
-                                )
-
-                    # Recurse into nested dict structure
-                    elif "structure" in field_info and isinstance(field_info["structure"], dict):
-                        TemplateValidator._flatten_output_structure(
-                            base_key="",
-                            base_type="",
-                            structure=field_info["structure"],
-                            _current_path=field_path,
-                            _paths=_paths,
-                            _depth=_depth + 1,
-                            _max_depth=_max_depth,
-                        )
-                elif isinstance(field_info, str):
-                    # Direct type string (legacy format)
-                    _paths.append((field_path, field_info))
-
-        return _paths
-
-    @staticmethod
-    def _find_similar_paths(attempted_key: str, available_paths: list[tuple[str, str]]) -> list[tuple[str, str]]:
-        """Find paths similar to the attempted key.
-
-        Uses simple substring matching for MVP.
-
-        Args:
-            attempted_key: The key user tried to access (e.g., "msg")
-            available_paths: List of (path, type) tuples
-
-        Returns:
-            List of (path, type) tuples that match, sorted by relevance
-
-        Example:
-            attempted_key="msg"
-            available_paths=[("result", "dict"), ("result.messages", "array")]
-            returns=[("result.messages", "array")]
-        """
-        attempted_lower = attempted_key.lower()
-        matches = []
-
-        for path, path_type in available_paths:
-            # Extract just the last component of the path for matching
-            last_component = path.split(".")[-1].split("[")[0]  # Handle array notation
-
-            # Substring match (case-insensitive)
-            if attempted_lower in last_component.lower():
-                # Calculate match quality (longer substring match = better)
-                match_quality = len(attempted_lower) / len(last_component) if last_component else 0
-                matches.append((path, path_type, match_quality))
-
-        # Sort by match quality (best matches first), then alphabetically
-        matches.sort(key=lambda x: (-x[2], x[0]))
-
-        # Return just the (path, type) tuples, top 3 matches
-        return [(path, path_type) for path, path_type, _ in matches[:MAX_DISPLAYED_SUGGESTIONS]]
-
-    @staticmethod
-    def _format_enhanced_node_error(
-        node_id: str, node_type: str, attempted_key: str, available_paths: list[tuple[str, str]], base_var: str
-    ) -> str:
-        """Create multi-section error with available outputs and suggestions.
-
-        Args:
-            node_id: Node ID where error occurred
-            node_type: Type of the node
-            attempted_key: The output key that was attempted
-            available_paths: List of (path, type) tuples
-            base_var: Base variable (node ID) for template construction
-
-        Returns:
-            Multi-line error message with sections for problem, available outputs, and suggestions
-        """
-        # Sanitize all user-controlled values to prevent template injection
-        safe_node_id = TemplateValidator._sanitize_for_display(node_id)
-        safe_node_type = TemplateValidator._sanitize_for_display(node_type)
-        safe_attempted_key = TemplateValidator._sanitize_for_display(attempted_key)
-        safe_base_var = TemplateValidator._sanitize_for_display(base_var)
-
-        # Section 1: Problem statement
-        lines = [f"Node '{safe_node_id}' (type: {safe_node_type}) does not output '{safe_attempted_key}'"]
-
-        # Section 2: Available outputs (limit to 20 to avoid overwhelming)
-        if available_paths:
-            lines.append("")
-            lines.append(f"Available outputs from '{safe_node_id}':")
-
-            display_paths = available_paths[:MAX_DISPLAYED_FIELDS]  # Limit display
-            for path, type_str in display_paths:
-                # Sanitize path components for safety
-                safe_path = TemplateValidator._sanitize_for_display(path)
-                safe_type = TemplateValidator._sanitize_for_display(type_str)
-
-                # Format with checkmark and type
-                full_path = f"{safe_base_var}.{safe_path}" if safe_base_var not in safe_path else safe_path
-                lines.append(f"  ✓ ${{{full_path}}} ({safe_type})")
-
-            # Show truncation message if needed
-            if len(available_paths) > 20:
-                remaining = len(available_paths) - 20
-                lines.append(f"  ... and {remaining} more outputs")
-
-        # Section 3: Suggestions (find similar paths)
-        suggestions = TemplateValidator._find_similar_paths(attempted_key, available_paths)
-        if suggestions:
-            lines.append("")
-            if len(suggestions) == 1:
-                sugg_path, _ = suggestions[0]
-                safe_sugg_path = TemplateValidator._sanitize_for_display(sugg_path)
-                full_sugg = (
-                    f"{safe_base_var}.{safe_sugg_path}" if safe_base_var not in safe_sugg_path else safe_sugg_path
-                )
-                lines.append(f"Did you mean: ${{{full_sugg}}}?")
-            else:
-                lines.append("Did you mean one of these?")
-                for sugg_path, _ in suggestions:
-                    safe_sugg_path = TemplateValidator._sanitize_for_display(sugg_path)
-                    full_sugg = (
-                        f"{safe_base_var}.{safe_sugg_path}" if safe_base_var not in safe_sugg_path else safe_sugg_path
-                    )
-                    lines.append(f"  - ${{{full_sugg}}}")
-
-        # Section 4: Common fix (use first suggestion if available, otherwise first available path)
-        if suggestions:
-            fix_path, _ = suggestions[0]
-            full_fix = f"{base_var}.{fix_path}" if base_var not in fix_path else fix_path
-            lines.append("")
-            lines.append(f"Common fix: Change ${{{base_var}.{attempted_key}}} to ${{{full_fix}}}")
-        elif available_paths:
-            # No suggestions, but we have paths - suggest the first one as generic fix
-            first_path, _ = available_paths[0]
-            full_first = f"{base_var}.{first_path}" if base_var not in first_path else first_path
-            lines.append("")
-            lines.append(f"Tip: Try using ${{{full_first}}} instead")
-
-        return "\n".join(lines)
-
-    @staticmethod
-    def _get_node_outputs_description(
-        node: dict[str, Any], output_key: str, node_outputs: dict[str, Any], registry: Registry
-    ) -> str:
-        """Get error message for missing node output with enhanced suggestions.
-
-        Uses the pre-computed node_outputs dict (same source of truth as validation)
-        to build accurate error messages. For batch nodes, detects whether the
-        attempted key exists in the inner node's interface and provides targeted guidance.
-
-        Args:
-            node: Node dictionary from workflow IR
-            output_key: The output key being accessed
-            node_outputs: Pre-computed node outputs from validation
-            registry: Registry instance for metadata lookup (fallback only)
-
-        Returns:
-            Error message describing what outputs are available with suggestions
-        """
-        node_type = node.get("type", "unknown")
-        node_id = node.get("id")
-        node_id_str = str(node_id) if node_id else "unknown"
-
-        # Build available paths from pre-computed node_outputs (single source of truth)
-        node_prefix = f"{node_id_str}."
-        node_entries = {k[len(node_prefix) :]: v for k, v in node_outputs.items() if k.startswith(node_prefix)}
-
-        if not node_entries:
-            # Fallback to registry if node_outputs has no entries (shouldn't happen)
-            return TemplateValidator._get_node_outputs_from_registry(node, output_key, registry)
-
-        # Detect batch: check if any entry has is_batch_output flag
-        is_batch = any(entry.get("is_batch_output") for entry in node_entries.values())
-
-        if is_batch:
-            return TemplateValidator._create_batch_error(node_id_str, node_type, output_key, node_entries)
-
-        # Non-batch node: build available paths and use standard error formatter
-        all_paths = TemplateValidator._build_paths_from_entries(node_entries)
-
-        if all_paths:
-            return TemplateValidator._format_enhanced_node_error(
-                node_id=node_id_str,
-                node_type=node_type,
-                attempted_key=output_key,
-                available_paths=all_paths,
-                base_var=node_id_str,
-            )
-
-        return f"Node '{node_id_str}' (type: {node_type}) does not produce any outputs"
-
-    @staticmethod
-    def _build_paths_from_entries(node_entries: dict[str, Any]) -> list[tuple[str, str]]:
-        """Build flattened (path, type) list from node_outputs entries.
-
-        Args:
-            node_entries: Dict of output_key -> output_info for a single node
-
-        Returns:
-            List of (path, type) tuples for display
-        """
-        all_paths: list[tuple[str, str]] = []
-        for key, info in node_entries.items():
-            output_type = info.get("type", "any")
-            all_paths.append((key, output_type))
-
-            # Flatten nested structure if present
-            structure = info.get("structure", {})
-            if structure and isinstance(structure, dict):
-                nested = TemplateValidator._flatten_output_structure(
-                    base_key=key, base_type=output_type, structure=structure
-                )
-                # Skip first entry (base key already added)
-                all_paths.extend(nested[1:])
-
-            # Flatten items structure for arrays (e.g., results array)
-            items_info = info.get("items", {})
-            if items_info and isinstance(items_info, dict):
-                item_type = items_info.get("type", "any")
-                item_path = f"{key}[0]"
-                all_paths.append((item_path, item_type))
-
-                items_structure = items_info.get("structure", {})
-                if items_structure and isinstance(items_structure, dict):
-                    nested = TemplateValidator._flatten_output_structure(
-                        base_key="",
-                        base_type="",
-                        structure=items_structure,
-                        _current_path=item_path,
-                        _paths=[],
-                        _depth=0,
-                    )
-                    all_paths.extend(nested)
-
-        return all_paths
-
-    @staticmethod
-    def _create_batch_error(node_id: str, node_type: str, attempted_key: str, node_entries: dict[str, Any]) -> str:
-        """Create error message for batch node output access.
-
-        Two cases:
-        1. The attempted key exists in the inner node's interface (e.g., llm_usage for LLM nodes)
-           → Show targeted "exists inside results" message with corrected path
-        2. The attempted key doesn't exist at all
-           → Show standard "not found" with actual batch outputs
-
-        Args:
-            node_id: Node ID
-            node_type: Inner node type (e.g., "llm")
-            attempted_key: The output key that was attempted
-            node_entries: Dict of output_key -> output_info for this batch node
-
-        Returns:
-            Error message string
-        """
-        safe_node_id = TemplateValidator._sanitize_for_display(node_id)
-        safe_key = TemplateValidator._sanitize_for_display(attempted_key)
-
-        # Check if the attempted key exists in the inner node's output structure
-        # The results entry has items.structure containing inner outputs
-        results_entry = node_entries.get("results", {})
-        items_info = results_entry.get("items", {})
-        inner_structure = items_info.get("structure", {}) if isinstance(items_info, dict) else {}
-
-        inner_field_exists = attempted_key in inner_structure
-
-        if inner_field_exists:
-            return TemplateValidator._format_batch_inner_field_error(safe_node_id, safe_key, node_entries)
-
-        # Field doesn't exist in inner interface either — show standard batch outputs
-        all_paths = TemplateValidator._build_paths_from_entries(node_entries)
-        return TemplateValidator._format_enhanced_node_error(
-            node_id=safe_node_id,
-            node_type=f"{node_type}, batch",
-            attempted_key=attempted_key,
-            available_paths=all_paths,
-            base_var=safe_node_id,
+    # Extract all templates from workflow
+    all_templates = _extract_all_templates(workflow_ir)
+
+    if all_templates:
+        logger.debug(
+            f"Found {len(all_templates)} template variables to validate", extra={"templates": sorted(all_templates)}
         )
+    else:
+        logger.debug("No template variables found in workflow")
 
-    @staticmethod
-    def _format_batch_inner_field_error(node_id: str, attempted_key: str, node_entries: dict[str, Any]) -> str:
-        """Format error for accessing an inner node field on a batch node.
+    # Check for unused inputs
+    unused_input_errors = _validate_unused_inputs(workflow_ir, all_templates)
+    errors.extend(unused_input_errors)
 
-        This is the targeted message shown when an agent writes ${node.llm_usage}
-        but the node has batch processing — the field exists, just nested inside results.
+    # If no templates, we can return early (after checking for unused inputs)
+    if not all_templates:
+        return (errors, warnings)
 
-        Args:
-            node_id: Sanitized node ID
-            attempted_key: Sanitized output key that was attempted
-            node_entries: Dict of output_key -> output_info for this batch node
+    # Get full output structure from nodes
+    node_outputs = extract_node_outputs(workflow_ir, registry, available_params)
 
-        Returns:
-            Multi-line error message with corrected path
-        """
-        results_path = f"${{{node_id}.results}}"
-        item_path = f"${{{node_id}.results[0].{attempted_key}}}"
-        col_width = max(len(results_path), len(item_path)) + 2
+    logger.debug(
+        f"Extracted outputs from {len(node_outputs)} node variables", extra={"outputs": sorted(node_outputs.keys())}
+    )
 
-        lines = [
-            f"Node '{node_id}' uses batch processing.",
-            f"'{attempted_key}' is not available at the top level — batch wraps outputs in a 'results' array.",
-            "",
-            f"  {results_path:<{col_width}} → list of all results",
-            f"  {item_path:<{col_width}} → first item's {attempted_key}",
-            "",
-            f"To aggregate across items, pass {results_path} to a code node and iterate.",
-        ]
+    # Pass 5: Validate each template path
+    path_errors, path_warnings = validate_template_paths(
+        all_templates, available_params, node_outputs, workflow_ir, registry
+    )
+    errors.extend(path_errors)
+    warnings.extend(path_warnings)
 
-        # Also show all actual batch outputs for reference
-        lines.append("")
-        lines.append(f"Available top-level outputs from '{node_id}':")
-        for key, info in node_entries.items():
-            safe_key = TemplateValidator._sanitize_for_display(key)
-            safe_type = TemplateValidator._sanitize_for_display(info.get("type", "any"))
-            lines.append(f"  ✓ ${{{node_id}.{safe_key}}} ({safe_type})")
+    # Pass 6: Validate template types match parameter expectations
+    type_errors = validate_template_types(workflow_ir, node_outputs, registry)
+    errors.extend(type_errors)
 
-        return "\n".join(lines)
+    # Pass 7: Block structured data (dict/list) in shell command parameters
+    shell_errors = validate_shell_command_types(workflow_ir, node_outputs)
+    errors.extend(shell_errors)
 
-    @staticmethod
-    def _get_node_outputs_from_registry(node: dict[str, Any], output_key: str, registry: Registry) -> str:
-        """Fallback when node_outputs has no entries for a node.
+    # Pass 8: Validate batch item field access (${item.field} against inferred structure)
+    batch_item_errors = validate_batch_item_fields(workflow_ir, node_outputs)
+    errors.extend(batch_item_errors)
 
-        This is a defensive fallback that should not be reached in practice —
-        _extract_node_outputs() runs before error generation and registers
-        outputs for all nodes. Intentionally simple to avoid re-introducing
-        the registry-vs-batch divergence bug.
-        """
-        node_id = node.get("id", "unknown")
+    if errors:
         logger.warning(
-            f"node_outputs fallback reached for node '{node_id}' — this is unexpected",
-            extra={"node_id": node_id, "output_key": output_key},
+            f"Template validation found {len(errors)} errors", extra={"error_count": len(errors), "errors": errors}
         )
-        return f"Node '{node_id}' does not output '{output_key}'"
-
-    @staticmethod
-    def _create_node_reference_error(
-        base_var: str,
-        parts: list[str],
-        template: str,
-        workflow_ir: dict[str, Any],
-        node_outputs: dict[str, Any],
-        registry: Registry,
-    ) -> str:
-        """Create error for node output references.
-
-        Args:
-            base_var: The base variable (node ID)
-            parts: Template parts split by dot
-            template: Full template string
-            workflow_ir: Workflow IR
-            node_outputs: Pre-computed node outputs from validation
-            registry: Registry instance
-
-        Returns:
-            Error message for node reference issues
-        """
-        # Missing output key
-        if len(parts) == 1:
-            return f"Invalid template ${{{template}}} - node ID '{base_var}' requires an output key (e.g., ${{{base_var}}}.output_key)"
-
-        output_key = parts[1]
-
-        # Find the node to get better error message
-        node = next((n for n in workflow_ir.get("nodes", []) if n.get("id") == base_var), None)
-        if node:
-            return TemplateValidator._get_node_outputs_description(node, output_key, node_outputs, registry)
-
-        return f"Node '{base_var}' does not output '{output_key}'"
-
-    @staticmethod
-    def _create_path_template_error(
-        template: str, base_var: str, available_params: dict[str, Any], workflow_ir: dict[str, Any]
-    ) -> str:
-        """Create error for path templates (with dots) that aren't node references.
-
-        Args:
-            template: Full template string
-            base_var: Base variable name
-            available_params: Available parameters
-            workflow_ir: Workflow IR
-
-        Returns:
-            Error message for path template issues
-        """
-        if base_var in available_params:
-            return f"Template path ${{{template}}} cannot be validated - initial_params values are runtime-dependent"
-
-        # Check if base variable is a declared input
-        input_desc = TemplateValidator._get_input_description(base_var, workflow_ir)
-        path_component = template[len(base_var) + 1 :]
-
-        if input_desc:
-            return f"Required input '${{{base_var}}}' not provided{input_desc} - attempted to access path '{path_component}'"
-
-        enable_namespacing = workflow_ir.get("enable_namespacing", True)
-        if enable_namespacing:
-            return (
-                f"Template variable ${{{template}}} has no valid source - "
-                f"'${{{base_var}}}' is neither a workflow input nor a node ID in this workflow"
-            )
-        else:
-            return (
-                f"Template variable ${{{template}}} has no valid source - "
-                f"not provided in initial_params and path '{path_component}' "
-                f"not found in outputs from any node in the workflow"
-            )
-
-    @staticmethod
-    def _create_simple_template_error(template: str, workflow_ir: dict[str, Any]) -> str:
-        """Create error for simple templates without dots.
-
-        Args:
-            template: Template variable name
-            workflow_ir: Workflow IR
-
-        Returns:
-            Error message for simple template issues
-        """
-        input_desc = TemplateValidator._get_input_description(template, workflow_ir)
-
-        if input_desc:
-            return f"Required input '${{{template}}}' not provided{input_desc}"
-
-        # Check if it might be a node ID used incorrectly
-        enable_namespacing = workflow_ir.get("enable_namespacing", True)
-        if enable_namespacing:
-            node_ids = TemplateValidator._get_node_ids(workflow_ir)
-            if template in node_ids:
-                return (
-                    f"Invalid template ${{{template}}} - this is a node ID. "
-                    f"To reference node outputs, use ${{{template}}}.output_key format"
-                )
-
-        return (
-            f"Template variable ${{{template}}} has no valid source - "
-            f"not provided in initial_params and not written by any node"
+    elif warnings:
+        logger.info(
+            f"Template validation passed with {len(warnings)} runtime-validated template(s)",
+            extra={"warning_count": len(warnings)},
         )
+    else:
+        logger.info("Template validation passed")
 
-    @staticmethod
-    def _create_template_error(
-        template: str,
-        available_params: dict[str, Any],
-        workflow_ir: dict[str, Any],
-        node_outputs: dict[str, Any],
-        registry: Registry,
-    ) -> str:
-        """Create appropriate error message for missing template variable.
+    return (errors, warnings)
 
-        Args:
-            template: Template variable name
-            available_params: Available parameters
-            workflow_ir: The workflow IR
-            node_outputs: Full structure info from node interfaces
-            registry: Registry instance
 
-        Returns:
-            Error message string
-        """
-        # Use smart split to preserve dots inside nested templates like ${item.field}
-        parts = _split_template_path(template)
-        base_var = parts[0]
+# ---------------------------------------------------------------------------
+# Simple passes (too small for own file)
+# ---------------------------------------------------------------------------
+
+
+def _validate_unused_inputs(workflow_ir: dict[str, Any], all_templates: set[str]) -> list[str]:
+    """Validate that all declared inputs are actually used.
+
+    Args:
+        workflow_ir: The workflow IR
+        all_templates: Set of all template variables found
+
+    Returns:
+        List of error messages for unused inputs
+    """
+    errors: list[str] = []
+    declared_inputs = set(workflow_ir.get("inputs", {}).keys())
+
+    if declared_inputs:
         enable_namespacing = workflow_ir.get("enable_namespacing", True)
+        node_ids = get_node_ids(workflow_ir) if enable_namespacing else set()
 
-        # Check if this is a node ID reference when namespacing is enabled
-        if enable_namespacing and "." in template:
-            node_ids = TemplateValidator._get_node_ids(workflow_ir)
-            if base_var in node_ids:
-                return TemplateValidator._create_node_reference_error(
-                    base_var, parts, template, workflow_ir, node_outputs, registry
-                )
+        # Extract base variable names from templates (before any dots)
+        # But exclude node IDs when namespacing is enabled
+        used_inputs = set()
+        for var in all_templates:
+            base_var = var.split(".")[0]
+            # Only count as used input if it's actually a declared input
+            # and not a node ID (when namespacing is enabled)
+            if base_var in declared_inputs and (not enable_namespacing or base_var not in node_ids):
+                used_inputs.add(base_var)
 
-        # Handle path templates (with dots)
-        if "." in template:
-            return TemplateValidator._create_path_template_error(template, base_var, available_params, workflow_ir)
+        unused_inputs = declared_inputs - used_inputs
+        if unused_inputs:
+            errors.append(f"Declared input(s) never used as template variable: {', '.join(sorted(unused_inputs))}")
+            logger.warning(f"Found {len(unused_inputs)} unused inputs", extra={"unused": sorted(unused_inputs)})
 
-        # Handle simple templates
-        return TemplateValidator._create_simple_template_error(template, workflow_ir)
+    return errors
 
-    # More permissive pattern to catch malformed templates for validation
-    # Supports array notation: ${node[0].field}, ${node.field[0].subfield}
-    # Also supports nested index templates: ${node[${__index__}].field}
-    # Also supports coalesce operator: ${a.field ?? b.field}
-    _PERM_VAR = r"[a-zA-Z_][\w-]*(?:(?:\[(?:[\d]+|\$\{[^}]+\})\])?(?:\.[\w-]*(?:\[(?:[\d]+|\$\{[^}]+\})\])?)*)?"
-    _PERMISSIVE_PATTERN = re.compile(rf"\$\{{({_PERM_VAR}(?:\s*\?\?\s*{_PERM_VAR})*)\}}")
 
-    # Batch output definitions matching PflowBatchNode.post() structure
-    _BATCH_OUTPUTS: ClassVar[list[dict[str, str]]] = [
-        {"key": "results", "type": "array", "description": "Array of results in input order"},
-        {"key": "count", "type": "number", "description": "Total items processed"},
-        {"key": "success_count", "type": "number", "description": "Items that succeeded"},
-        {"key": "error_count", "type": "number", "description": "Items that failed"},
-        {"key": "errors", "type": "array", "description": "Error details (null if none)"},
-        {"key": "batch_metadata", "type": "dict", "description": "Execution statistics"},
-    ]
+def _validate_malformed_templates(workflow_ir: dict[str, Any]) -> list[str]:
+    """Detect malformed template syntax by counting ${ vs valid template matches.
 
-    @staticmethod
-    def _extract_node_outputs(
-        workflow_ir: dict[str, Any],
-        registry: Registry,
-        initial_params: Optional[dict[str, Any]] = None,
-    ) -> dict[str, Any]:
-        """Extract full output structures from nodes using interface metadata.
+    A malformed template is one where we find ${ but it doesn't form a valid template.
+    Examples: ${unclosed, ${}, ${ }
 
-        When namespacing is enabled, outputs are registered under both:
-        - The original key (for backward compatibility checks)
-        - The namespaced path "node_id.output_key"
+    Args:
+        workflow_ir: The workflow IR
 
-        For batch nodes, registers batch-specific outputs (results, count, etc.)
-        instead of the inner node's normal outputs, and adds the item alias
-        as an available variable.
+    Returns:
+        List of error messages for malformed templates
+    """
+    errors: list[str] = []
 
-        Returns:
-            Dict mapping variable names to their full structure/type info
-        """
-        node_outputs: dict[str, dict[str, Any]] = {}
-        enable_namespacing = workflow_ir.get("enable_namespacing", True)
+    for node in workflow_ir.get("nodes", []):
+        node_id = node.get("id", "unknown")
+        params = node.get("params", {})
 
-        for node in workflow_ir.get("nodes", []):
-            node_id = node.get("id")
-            node_type = node.get("type")
-            if not node_type or not node_id:
-                continue
+        def check_value(value: Any, node_id: str, param_path: str = "") -> None:
+            """Recursively check for malformed templates in any value type."""
+            if isinstance(value, str) and "${" in value:
+                # Count how many ${ we have
+                dollar_brace_count = value.count("${")
 
-            # Workflow nodes: resolve child outputs for validation.
-            if node_type in ("workflow", "pflow.runtime.workflow_executor"):
-                TemplateValidator._register_workflow_node_outputs(
-                    node_outputs,
-                    node,
-                    node_id,
-                    node_type,
-                    enable_namespacing,
-                    registry,
-                    initial_params,
-                )
-                continue
+                # Count how many valid templates we matched
+                valid_matches = _PERMISSIVE_PATTERN.findall(value)
 
-            # Check for batch configuration
-            batch_config = node.get("batch")
+                # Account for nested templates inside brackets - they're part of
+                # outer templates and shouldn't be counted separately.
+                # Example: ${results[${__index__}]} has 2 '${' but is 1 logical template
+                # - valid_matches = ['results[${__index__}]', '__index__'] (2 matches)
+                # - nested_count = 1 (one match contains '[${')
+                # - dollar_brace_count = 2
+                # - len(valid_matches) + nested_count = 3 >= 2 ✓ (no error)
+                nested_count = sum(f"${{{m}}}".count("[${") for m in valid_matches)
 
-            if batch_config:
-                # Batch node: register batch outputs instead of normal outputs
-                TemplateValidator._register_batch_outputs(
-                    node_outputs, node_id, node_type, enable_namespacing, registry
-                )
-                TemplateValidator._register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
-            else:
-                # Non-batch node: extract outputs from registry interface
-                TemplateValidator._register_node_outputs_from_registry(
-                    node_outputs, node_id, node_type, enable_namespacing, registry
-                )
+                # If mismatch (accounting for nested), we have malformed syntax
+                if len(valid_matches) + nested_count < dollar_brace_count:
+                    location = f"node '{node_id}' parameter '{param_path}'" if param_path else f"node '{node_id}'"
+                    errors.append(
+                        f"Malformed template syntax in {location}: "
+                        f"Found {dollar_brace_count} '${{' but only {len(valid_matches)} valid template(s). "
+                        f"Check for missing '}}' or empty templates like '${{}}'"
+                    )
+            elif isinstance(value, dict):
+                for key, val in value.items():
+                    check_value(val, node_id, f"{param_path}.{key}" if param_path else key)
+            elif isinstance(value, list):
+                for idx, item in enumerate(value):
+                    check_value(item, node_id, f"{param_path}[{idx}]")
 
-        return node_outputs
+        for param_key, param_value in params.items():
+            check_value(param_value, node_id, param_key)
 
-    @staticmethod
-    def _register_workflow_node_outputs(
-        node_outputs: dict[str, Any],
-        node: dict[str, Any],
-        node_id: str,
-        node_type: str,
-        enable_namespacing: bool,
-        registry: Registry,
-        initial_params: Optional[dict[str, Any]],
-    ) -> None:
-        """Register outputs for a workflow node, handling both batch and non-batch cases.
+    return errors
 
-        Resolves the child workflow's declared outputs. When the node has batch config,
-        wraps those outputs in the batch structure (results, count, etc.) instead of
-        exposing them directly.
-        """
-        child_outputs = TemplateValidator._resolve_child_workflow_outputs(node, initial_params)
+
+# ---------------------------------------------------------------------------
+# Template extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_all_templates(workflow_ir: dict[str, Any]) -> set[str]:  # noqa: C901
+    """Extract all template variables from workflow.
+
+    Scans all node parameters for template variables.
+    Uses a more permissive pattern than TemplateResolver to catch
+    malformed templates that need syntax validation.
+
+    Args:
+        workflow_ir: The workflow IR
+
+    Returns:
+        Set of all template variable names found
+    """
+    templates = set()
+
+    for node in workflow_ir.get("nodes", []):
+        node_id = node.get("id", "unknown")
+        params = node.get("params", {})
+
+        def extract_from_value(value: Any, node_id: str, path: str = "") -> None:
+            """Recursively extract templates from any value type."""
+            if isinstance(value, str) and "$" in value:
+                # Use permissive pattern to catch malformed templates
+                matches = _PERMISSIVE_PATTERN.findall(value)
+                # Split coalesce operands so each is validated individually
+                split_matches: list[str] = []
+                for match in matches:
+                    if "??" in match:
+                        split_matches.extend(TemplateResolver.split_coalesce_operands(match))
+                    else:
+                        split_matches.append(match)
+                templates.update(split_matches)
+
+                if matches:
+                    logger.debug(
+                        f"Found templates in node '{node_id}' at path '{path}'",
+                        extra={"node_id": node_id, "path": path, "templates": sorted(matches)},
+                    )
+            elif isinstance(value, dict):
+                for key, val in value.items():
+                    extract_from_value(val, node_id, f"{path}.{key}" if path else key)
+            elif isinstance(value, list):
+                for idx, item in enumerate(value):
+                    extract_from_value(item, node_id, f"{path}[{idx}]")
+
+        for param_key, param_value in params.items():
+            extract_from_value(param_value, node_id, param_key)
+
+        # Also extract templates from batch.items if present
+        batch_config = node.get("batch")
+        if batch_config:
+            items_template = batch_config.get("items")
+            if items_template:
+                extract_from_value(items_template, node_id, "batch.items")
+
+    return templates
+
+
+# ---------------------------------------------------------------------------
+# Output extraction (builds node_outputs dict used by all passes)
+# ---------------------------------------------------------------------------
+
+
+def extract_node_outputs(
+    workflow_ir: dict[str, Any],
+    registry: Registry,
+    initial_params: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Extract full output structures from nodes using interface metadata.
+
+    When namespacing is enabled, outputs are registered under both:
+    - The original key (for backward compatibility checks)
+    - The namespaced path "node_id.output_key"
+
+    For batch nodes, registers batch-specific outputs (results, count, etc.)
+    instead of the inner node's normal outputs, and adds the item alias
+    as an available variable.
+
+    Returns:
+        Dict mapping variable names to their full structure/type info
+    """
+    node_outputs: dict[str, dict[str, Any]] = {}
+    enable_namespacing = workflow_ir.get("enable_namespacing", True)
+
+    for node in workflow_ir.get("nodes", []):
+        node_id = node.get("id")
+        node_type = node.get("type")
+        if not node_type or not node_id:
+            continue
+
+        # Workflow nodes: resolve child outputs for validation.
+        if node_type in ("workflow", "pflow.runtime.workflow_executor"):
+            _register_workflow_node_outputs(
+                node_outputs,
+                node,
+                node_id,
+                node_type,
+                enable_namespacing,
+                registry,
+                initial_params,
+            )
+            continue
+
+        # Check for batch configuration
         batch_config = node.get("batch")
 
         if batch_config:
-            # Batch workflow: wrap child outputs in batch structure
-            if child_outputs is not None:
-                inner_outputs: dict[str, Any] = {}
-                for output_name, output_spec in child_outputs.items():
-                    output_type = output_spec.get("type", "any") if isinstance(output_spec, dict) else "any"
-                    inner_outputs[output_name] = {"type": output_type}
-                TemplateValidator._register_batch_outputs(
-                    node_outputs,
-                    node_id,
-                    node_type,
-                    enable_namespacing,
-                    registry,
-                    inner_outputs_override=inner_outputs,
-                )
-            else:
-                # Child unresolvable: register batch outputs without inner structure.
-                # skip_results_structure=True lets the validator accept any results[N].* path
-                # (falls through to permissive "array type" check).
-                TemplateValidator._register_batch_outputs(
-                    node_outputs,
-                    node_id,
-                    node_type,
-                    enable_namespacing,
-                    registry,
-                    skip_results_structure=True,
-                )
-            TemplateValidator._register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
-        elif child_outputs is not None:
-            # Non-batch workflow with resolvable outputs
+            # Batch node: register batch outputs instead of normal outputs
+            _register_batch_outputs(node_outputs, node_id, node_type, enable_namespacing, registry)
+            _register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
+        else:
+            # Non-batch node: extract outputs from registry interface
+            _register_node_outputs_from_registry(node_outputs, node_id, node_type, enable_namespacing, registry)
+
+    return node_outputs
+
+
+def _register_workflow_node_outputs(
+    node_outputs: dict[str, Any],
+    node: dict[str, Any],
+    node_id: str,
+    node_type: str,
+    enable_namespacing: bool,
+    registry: Registry,
+    initial_params: Optional[dict[str, Any]],
+) -> None:
+    """Register outputs for a workflow node, handling both batch and non-batch cases.
+
+    Resolves the child workflow's declared outputs. When the node has batch config,
+    wraps those outputs in the batch structure (results, count, etc.) instead of
+    exposing them directly.
+    """
+    child_outputs = _resolve_child_workflow_outputs(node, initial_params)
+    batch_config = node.get("batch")
+
+    if batch_config:
+        # Batch workflow: wrap child outputs in batch structure
+        if child_outputs is not None:
+            inner_outputs: dict[str, Any] = {}
             for output_name, output_spec in child_outputs.items():
                 output_type = output_spec.get("type", "any") if isinstance(output_spec, dict) else "any"
-                output_info = {"type": output_type, "node_id": node_id, "node_type": node_type}
-                node_outputs[output_name] = output_info
-                if enable_namespacing:
-                    node_outputs[f"{node_id}.{output_name}"] = output_info
+                inner_outputs[output_name] = {"type": output_type}
+            _register_batch_outputs(
+                node_outputs,
+                node_id,
+                node_type,
+                enable_namespacing,
+                registry,
+                inner_outputs_override=inner_outputs,
+            )
         else:
-            # Can't resolve child outputs — mark as dynamic
-            node_outputs[node_id] = {
-                "type": "any",
-                "node_id": node_id,
-                "node_type": node_type,
-                "is_workflow_dynamic": True,
-            }
-
-    @staticmethod
-    def _register_batch_item_variables(
-        node_outputs: dict[str, Any],
-        node_id: str,
-        node_type: str,
-        batch_config: dict[str, Any],
-    ) -> None:
-        """Register the item alias and __index__ as available variables for batch nodes."""
-        item_alias = batch_config.get("as", "item")
-        node_outputs[item_alias] = {
+            # Child unresolvable: register batch outputs without inner structure.
+            # skip_results_structure=True lets the validator accept any results[N].* path
+            # (falls through to permissive "array type" check).
+            _register_batch_outputs(
+                node_outputs,
+                node_id,
+                node_type,
+                enable_namespacing,
+                registry,
+                skip_results_structure=True,
+            )
+        _register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
+    elif child_outputs is not None:
+        # Non-batch workflow with resolvable outputs
+        for output_name, output_spec in child_outputs.items():
+            output_type = output_spec.get("type", "any") if isinstance(output_spec, dict) else "any"
+            output_info = {"type": output_type, "node_id": node_id, "node_type": node_type}
+            node_outputs[output_name] = output_info
+            if enable_namespacing:
+                node_outputs[f"{node_id}.{output_name}"] = output_info
+    else:
+        # Can't resolve child outputs — mark as dynamic
+        node_outputs[node_id] = {
             "type": "any",
-            "description": f"Current batch item during iteration (from node '{node_id}')",
             "node_id": node_id,
             "node_type": node_type,
-            "is_batch_item": True,
-        }
-        node_outputs["__index__"] = {
-            "type": "int",
-            "description": f"Current batch item index (0-based) during iteration (from node '{node_id}')",
-            "node_id": node_id,
-            "node_type": node_type,
-            "is_batch_item": True,
+            "is_workflow_dynamic": True,
         }
 
-    @staticmethod
-    def _resolve_child_workflow_outputs(
-        node: dict[str, Any],
-        initial_params: Optional[dict[str, Any]],
-    ) -> Optional[dict[str, Any]]:
-        """Try to resolve a workflow node's child outputs for validation.
 
-        Returns the child's declared outputs dict if resolvable, or None if
-        the child can't be loaded (dynamic reference, missing file, etc.).
-        """
-        params = node.get("params", {})
+def _register_batch_item_variables(
+    node_outputs: dict[str, Any],
+    node_id: str,
+    node_type: str,
+    batch_config: dict[str, Any],
+) -> None:
+    """Register the item alias and __index__ as available variables for batch nodes."""
+    item_alias = batch_config.get("as", "item")
+    node_outputs[item_alias] = {
+        "type": "any",
+        "description": f"Current batch item during iteration (from node '{node_id}')",
+        "node_id": node_id,
+        "node_type": node_type,
+        "is_batch_item": True,
+    }
+    node_outputs["__index__"] = {
+        "type": "int",
+        "description": f"Current batch item index (0-based) during iteration (from node '{node_id}')",
+        "node_id": node_id,
+        "node_type": node_type,
+        "is_batch_item": True,
+    }
 
-        # Inline workflow_ir — read outputs directly
-        workflow_ir = params.get("workflow_ir")
-        if isinstance(workflow_ir, dict):
-            outputs = workflow_ir.get("outputs", {})
-            return outputs if outputs else None
 
-        # File or saved name reference
-        workflow_ref = params.get("workflow")
-        if not workflow_ref or not isinstance(workflow_ref, str):
-            return None
+def _resolve_child_workflow_outputs(
+    node: dict[str, Any],
+    initial_params: Optional[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """Try to resolve a workflow node's child outputs for validation.
 
-        # Skip template references — can't resolve at validation time
-        if "${" in workflow_ref:
-            return None
+    Returns the child's declared outputs dict if resolvable, or None if
+    the child can't be loaded (dynamic reference, missing file, etc.).
+    """
+    params = node.get("params", {})
 
-        from pflow.runtime.workflow_executor import WorkflowExecutor
+    # Inline workflow_ir — read outputs directly
+    workflow_ir = params.get("workflow_ir")
+    if isinstance(workflow_ir, dict):
+        outputs = workflow_ir.get("outputs", {})
+        return outputs if outputs else None
 
-        if WorkflowExecutor._is_file_reference(workflow_ref):
-            # File reference — try to load
-            try:
-                from pathlib import Path
+    # File or saved name reference
+    workflow_ref = params.get("workflow")
+    if not workflow_ref or not isinstance(workflow_ref, str):
+        return None
 
-                from pflow.core.markdown_parser import parse_markdown
+    # Skip template references — can't resolve at validation time
+    if "${" in workflow_ref:
+        return None
 
-                path = Path(workflow_ref)
-                if not path.is_absolute() and initial_params:
-                    parent_file = initial_params.get("_pflow_workflow_file")
-                    base_dir = Path(parent_file).parent if parent_file else Path.cwd()
-                    path = base_dir / path
-                path = path.resolve()
-                if not path.exists():
-                    return None
-                content = path.read_text(encoding="utf-8")
-                result = parse_markdown(content)
-                outputs = result.ir.get("outputs", {})
-                return outputs if outputs else None
-            except Exception:
-                logger.debug("Could not resolve child workflow outputs for '%s'", workflow_ref, exc_info=True)
-                return None
-        else:
-            # Saved workflow name — try to load via WorkflowManager
-            try:
-                from pflow.core.workflow_manager import WorkflowManager
+    from pflow.runtime.workflow_executor import WorkflowExecutor
 
-                wm = WorkflowManager()
-                child_ir = wm.load_ir(workflow_ref)
-                outputs = child_ir.get("outputs", {})
-                return outputs if outputs else None
-            except Exception:
-                logger.debug("Could not resolve child workflow outputs for '%s'", workflow_ref, exc_info=True)
-                return None
-
-    @staticmethod
-    def _get_inner_outputs_from_registry(node_type: str, registry: Registry) -> dict[str, Any]:
-        """Look up a node type's output structure from the registry.
-
-        Returns a dict mapping output key → {type, description, structure}.
-        Returns empty dict if node type is not found.
-        """
-        inner_outputs: dict[str, Any] = {}
+    if WorkflowExecutor._is_file_reference(workflow_ref):
+        # File reference — try to load
         try:
-            nodes_metadata = registry.get_nodes_metadata([node_type])
-            if node_type in nodes_metadata:
-                interface = nodes_metadata[node_type]["interface"]
-                for output in interface.get("outputs", []):
-                    if isinstance(output, str):
-                        inner_outputs[output] = {"type": "any"}
-                    else:
-                        key = output.get("key", "")
-                        if key:
-                            inner_outputs[key] = {
-                                "type": output.get("type", "any"),
-                                "description": output.get("description", ""),
-                                "structure": output.get("structure", {}),
-                            }
-        except (ValueError, KeyError):
-            pass
-        return inner_outputs
+            from pathlib import Path
 
-    @staticmethod
-    def _register_batch_outputs(
-        node_outputs: dict[str, Any],
-        node_id: str,
-        node_type: str,
-        enable_namespacing: bool,
-        registry: Registry,
-        inner_outputs_override: Optional[dict[str, Any]] = None,
-        skip_results_structure: bool = False,
-    ) -> None:
-        """Register batch-specific outputs for a node with batch configuration.
+            from pflow.core.markdown_parser import parse_markdown
 
-        Batch nodes wrap their inner node's outputs in a structured result with:
-        - results: Array of per-item results (with inner node's output structure)
-        - count: Total items processed
-        - success_count/error_count: Success/failure counts
-        - errors: Error details if any
-        - batch_metadata: Execution statistics
+            path = Path(workflow_ref)
+            if not path.is_absolute() and initial_params:
+                parent_file = initial_params.get("_pflow_workflow_file")
+                base_dir = Path(parent_file).parent if parent_file else Path.cwd()
+                path = base_dir / path
+            path = path.resolve()
+            if not path.exists():
+                return None
+            content = path.read_text(encoding="utf-8")
+            result = parse_markdown(content)
+            outputs = result.ir.get("outputs", {})
+            return outputs if outputs else None
+        except Exception:
+            logger.debug("Could not resolve child workflow outputs for '%s'", workflow_ref, exc_info=True)
+            return None
+    else:
+        # Saved workflow name — try to load via WorkflowManager
+        try:
+            from pflow.core.workflow_manager import WorkflowManager
 
-        Args:
-            inner_outputs_override: Pre-resolved inner output structure (e.g., from
-                child workflow outputs). When provided, skips registry lookup.
-            skip_results_structure: When True, don't attach items structure to results.
-                Used when inner outputs are unknown (e.g., dynamic workflow child ref)
-                so the validator accepts any results[N].* path at validation time.
-        """
-        if skip_results_structure:
-            inner_outputs_structure: dict[str, Any] = {}
-        elif inner_outputs_override is not None:
-            inner_outputs_structure = inner_outputs_override
-        else:
-            inner_outputs_structure = TemplateValidator._get_inner_outputs_from_registry(node_type, registry)
+            wm = WorkflowManager()
+            child_ir = wm.load_ir(workflow_ref)
+            outputs = child_ir.get("outputs", {})
+            return outputs if outputs else None
+        except Exception:
+            logger.debug("Could not resolve child workflow outputs for '%s'", workflow_ref, exc_info=True)
+            return None
 
-        for output in TemplateValidator._BATCH_OUTPUTS:
-            key = output["key"]
-            output_info: dict[str, Any] = {
-                "type": output["type"],
-                "description": output["description"],
-                "node_id": node_id,
-                "node_type": node_type,
-                "is_batch_output": True,
+
+def _get_inner_outputs_from_registry(node_type: str, registry: Registry) -> dict[str, Any]:
+    """Look up a node type's output structure from the registry.
+
+    Returns a dict mapping output key → {type, description, structure}.
+    Returns empty dict if node type is not found.
+    """
+    inner_outputs: dict[str, Any] = {}
+    try:
+        nodes_metadata = registry.get_nodes_metadata([node_type])
+        if node_type in nodes_metadata:
+            interface = nodes_metadata[node_type]["interface"]
+            for output in interface.get("outputs", []):
+                if isinstance(output, str):
+                    inner_outputs[output] = {"type": "any"}
+                else:
+                    key = output.get("key", "")
+                    if key:
+                        inner_outputs[key] = {
+                            "type": output.get("type", "any"),
+                            "description": output.get("description", ""),
+                            "structure": output.get("structure", {}),
+                        }
+    except (ValueError, KeyError):
+        pass
+    return inner_outputs
+
+
+def _register_batch_outputs(
+    node_outputs: dict[str, Any],
+    node_id: str,
+    node_type: str,
+    enable_namespacing: bool,
+    registry: Registry,
+    inner_outputs_override: Optional[dict[str, Any]] = None,
+    skip_results_structure: bool = False,
+) -> None:
+    """Register batch-specific outputs for a node with batch configuration.
+
+    Batch nodes wrap their inner node's outputs in a structured result with:
+    - results: Array of per-item results (with inner node's output structure)
+    - count: Total items processed
+    - success_count/error_count: Success/failure counts
+    - errors: Error details if any
+    - batch_metadata: Execution statistics
+
+    Args:
+        inner_outputs_override: Pre-resolved inner output structure (e.g., from
+            child workflow outputs). When provided, skips registry lookup.
+        skip_results_structure: When True, don't attach items structure to results.
+            Used when inner outputs are unknown (e.g., dynamic workflow child ref)
+            so the validator accepts any results[N].* path at validation time.
+    """
+    if skip_results_structure:
+        inner_outputs_structure: dict[str, Any] = {}
+    elif inner_outputs_override is not None:
+        inner_outputs_structure = inner_outputs_override
+    else:
+        inner_outputs_structure = _get_inner_outputs_from_registry(node_type, registry)
+
+    for output in BATCH_OUTPUTS:
+        key = output["key"]
+        output_info: dict[str, Any] = {
+            "type": output["type"],
+            "description": output["description"],
+            "node_id": node_id,
+            "node_type": node_type,
+            "is_batch_output": True,
+        }
+
+        # For 'results' array, add inner node's output structure plus 'item'.
+        # When skip_results_structure is True, omit items so the validator
+        # falls through to permissive array-type access for unknown inner outputs.
+        if key == "results" and not skip_results_structure:
+            # Each result always contains 'item' (original batch input)
+            result_structure = {"item": {"type": "any", "description": "Original batch input"}}
+            if inner_outputs_structure:
+                result_structure.update(inner_outputs_structure)
+            output_info["items"] = {
+                "type": "dict",
+                "structure": result_structure,
             }
 
-            # For 'results' array, add inner node's output structure plus 'item'.
-            # When skip_results_structure is True, omit items so the validator
-            # falls through to permissive array-type access for unknown inner outputs.
-            if key == "results" and not skip_results_structure:
-                # Each result always contains 'item' (original batch input)
-                result_structure = {"item": {"type": "any", "description": "Original batch input"}}
-                if inner_outputs_structure:
-                    result_structure.update(inner_outputs_structure)
-                output_info["items"] = {
-                    "type": "dict",
-                    "structure": result_structure,
-                }
+        # Register under original key for backward compatibility
+        node_outputs[key] = output_info
+
+        # If namespacing is enabled, also register under node_id.output
+        if enable_namespacing:
+            namespaced_key = f"{node_id}.{key}"
+            node_outputs[namespaced_key] = output_info
+
+
+def _register_node_outputs_from_registry(
+    node_outputs: dict[str, Any],
+    node_id: str,
+    node_type: str,
+    enable_namespacing: bool,
+    registry: Registry,
+) -> None:
+    """Register outputs from registry interface metadata for non-batch nodes."""
+    # Get node metadata from registry
+    nodes_metadata = registry.get_nodes_metadata([node_type])
+    if node_type not in nodes_metadata:
+        raise ValueError(f"Unknown node type: {node_type}")
+
+    interface = nodes_metadata[node_type]["interface"]
+
+    # Extract outputs with full structure
+    for output in interface["outputs"]:
+        if isinstance(output, str):
+            # Simple format: just the key, no structure
+            output_info = {"type": "any", "node_id": node_id, "node_type": node_type}
+
+            # Register under original key for backward compatibility
+            node_outputs[output] = output_info
+
+            # If namespacing is enabled, also register under node_id.output
+            if enable_namespacing:
+                namespaced_key = f"{node_id}.{output}"
+                node_outputs[namespaced_key] = output_info
+        else:
+            # Rich format: includes type and structure
+            key = output["key"]
+            output_info = {
+                "type": output.get("type", "any"),
+                "structure": output.get("structure", {}),
+                "node_id": node_id,
+                "node_type": node_type,
+            }
 
             # Register under original key for backward compatibility
             node_outputs[key] = output_info
@@ -1235,1011 +659,3 @@ class TemplateValidator:
             if enable_namespacing:
                 namespaced_key = f"{node_id}.{key}"
                 node_outputs[namespaced_key] = output_info
-
-    @staticmethod
-    def _register_node_outputs_from_registry(
-        node_outputs: dict[str, Any],
-        node_id: str,
-        node_type: str,
-        enable_namespacing: bool,
-        registry: Registry,
-    ) -> None:
-        """Register outputs from registry interface metadata for non-batch nodes."""
-        # Get node metadata from registry
-        nodes_metadata = registry.get_nodes_metadata([node_type])
-        if node_type not in nodes_metadata:
-            raise ValueError(f"Unknown node type: {node_type}")
-
-        interface = nodes_metadata[node_type]["interface"]
-
-        # Extract outputs with full structure
-        for output in interface["outputs"]:
-            if isinstance(output, str):
-                # Simple format: just the key, no structure
-                output_info = {"type": "any", "node_id": node_id, "node_type": node_type}
-
-                # Register under original key for backward compatibility
-                node_outputs[output] = output_info
-
-                # If namespacing is enabled, also register under node_id.output
-                if enable_namespacing:
-                    namespaced_key = f"{node_id}.{output}"
-                    node_outputs[namespaced_key] = output_info
-            else:
-                # Rich format: includes type and structure
-                key = output["key"]
-                output_info = {
-                    "type": output.get("type", "any"),
-                    "structure": output.get("structure", {}),
-                    "node_id": node_id,
-                    "node_type": node_type,
-                }
-
-                # Register under original key for backward compatibility
-                node_outputs[key] = output_info
-
-                # If namespacing is enabled, also register under node_id.output
-                if enable_namespacing:
-                    namespaced_key = f"{node_id}.{key}"
-                    node_outputs[namespaced_key] = output_info
-
-    @staticmethod
-    def _validate_namespaced_output(
-        parts: list[str],
-        base_var: str,
-        node_outputs: dict[str, Any],
-        template: str,
-    ) -> tuple[bool, Optional[ValidationWarning]]:
-        """Validate a namespaced node output reference with array index support.
-
-        Handles patterns like:
-        - node_id.output_key
-        - node_id.results[0]
-        - node_id.results[0].field
-        """
-        if len(parts) == 1:
-            # Just the node ID without output key - invalid
-            return (False, None)
-
-        # Handle array indexing: parts[1] might be "results[0]" → base="results", index=0
-        output_part = parts[1]
-        array_index = None
-        if "[" in output_part and output_part.endswith("]"):
-            bracket_pos = output_part.index("[")
-            base_output = output_part[:bracket_pos]
-            array_index = output_part[bracket_pos + 1 : -1]
-        else:
-            base_output = output_part
-
-        node_output_key = f"{base_var}.{base_output}"
-        if node_output_key not in node_outputs:
-            # Dynamic workflow nodes (outputs unknown at validation time) accept any output
-            is_dynamic = base_var in node_outputs and node_outputs[base_var].get("is_workflow_dynamic")
-            return (True, None) if is_dynamic else (False, None)
-
-        output_info = node_outputs[node_output_key]
-
-        # If array access, check if output has items structure
-        if array_index is not None:
-            items_info = output_info.get("items", {})
-            if items_info:
-                # Use items structure for nested validation
-                if len(parts) == 2:
-                    return (True, None)
-                return TemplateValidator._validate_nested_path(
-                    parts[2:], items_info, full_template=template, output_key=base_output
-                )
-            # No items info but array access requested
-            output_type = output_info.get("type", "any")
-            # Allow if type is array (native array access)
-            if output_type == "array":
-                return (True, None)
-            # Also allow str types - they may contain JSON that gets auto-parsed at runtime
-            # This matches the behavior of _check_type_allows_traversal for field access
-            if output_type in ["str", "string"]:
-                # Generate warning about JSON auto-parsing requirement
-                nested_path = f"[{array_index}]" + (".".join(parts[2:]) if len(parts) > 2 else "")
-                warning = ValidationWarning(
-                    template=template if template.startswith("${") else f"${{{template}}}",
-                    node_id=output_info.get("node_id", "unknown"),
-                    node_type=output_info.get("node_type", "unknown"),
-                    output_key=base_output,
-                    output_type=output_type,
-                    reason=(
-                        f"Array access on '{output_type}' requires valid JSON array at runtime. "
-                        f"Non-JSON strings cause 'Unresolved variables' error."
-                    ),
-                    nested_path=nested_path,
-                )
-                return (True, warning)
-            return (False, None)
-
-        if len(parts) == 2:
-            return (True, None)
-
-        # Validate deeper nested path
-        return TemplateValidator._validate_nested_path(
-            parts[2:], output_info, full_template=template, output_key=base_output
-        )
-
-    @staticmethod
-    def _validate_template_path(
-        template: str,
-        initial_params: dict[str, Any],
-        node_outputs: dict[str, Any],
-        workflow_ir: dict[str, Any],
-        registry: Registry,
-    ) -> tuple[bool, Optional[ValidationWarning]]:
-        """Validate a template path exists in available sources.
-
-        With namespacing enabled, we need to distinguish between:
-        1. Node output references (e.g., ${node_id.output_key})
-        2. Root-level references (e.g., ${input_file} or ${config.nested.path})
-
-        Args:
-            template: Template string like "var" or "var.field.subfield"
-            initial_params: Parameters provided by planner
-            node_outputs: Full structure info from node interfaces
-            workflow_ir: The workflow IR to check for node IDs
-            registry: Registry instance (passed through for consistency)
-
-        Returns:
-            Tuple of (is_valid, optional_warning)
-        """
-        # Use smart split to preserve dots inside nested templates like ${item.field}
-        parts = _split_template_path(template)
-        base_var = parts[0]
-        enable_namespacing = workflow_ir.get("enable_namespacing", True)
-
-        # When namespacing is enabled, check if base_var is a node ID
-        if enable_namespacing:
-            node_ids = TemplateValidator._get_node_ids(workflow_ir)
-
-            if base_var in node_ids:
-                # This is a namespaced node output reference
-                return TemplateValidator._validate_namespaced_output(parts, base_var, node_outputs, template)
-
-        # Not a node ID reference (or namespacing disabled), check as root-level reference
-
-        # Check initial_params first (higher priority)
-        if base_var in initial_params:
-            # For nested paths in initial_params, we can't validate at compile time
-            # since values are runtime-dependent. This is a limitation.
-            return (True, None)
-
-        # Check node outputs (for backward compatibility when namespacing is disabled)
-        if base_var in node_outputs:
-            if len(parts) == 1:
-                return (True, None)
-
-            # Validate nested path in structure
-            output_key = base_var  # For non-namespaced, base_var is the output key
-            return TemplateValidator._validate_nested_path(
-                parts[1:], node_outputs[base_var], full_template=template, output_key=output_key
-            )
-
-        return (False, None)
-
-    @staticmethod
-    def _check_type_allows_traversal(
-        output_type: str, path_parts: list[str], output_info: dict[str, Any], full_template: str, output_key: str
-    ) -> tuple[bool, Optional[ValidationWarning]]:
-        """Check if output type allows traversal and generate warning if needed.
-
-        Args:
-            output_type: The output type string (may be union like "dict|str")
-            path_parts: List of path components for warning context
-            output_info: Output info dict for warning context
-            full_template: Full template string for warning context
-            output_key: The output key being accessed
-
-        Returns:
-            Tuple of (is_valid, optional_warning)
-        """
-        # Parse union types (e.g., "dict|str" → ["dict", "str"])
-        types_in_union = [t.strip().lower() for t in output_type.split("|")]
-
-        # Check if ANY type in the union allows traversal
-        # - dict/object: structured data, traversable (trusted, no warning)
-        # - any: explicit "could be anything" declaration (trusted, no warning)
-        # - str/string: might contain JSON, defer to runtime via JSON auto-parsing (WARNING)
-        traversable_types = [t for t in types_in_union if t in ["dict", "object", "any", "str", "string"]]
-
-        if not traversable_types:
-            return (False, None)
-
-        # dict/object and any types are trusted - no warning needed
-        # - dict/object: structured data
-        # - any: node author explicitly declared "this could be anything"
-        trusted_types = [t for t in traversable_types if t in ["dict", "object", "any"]]
-        if trusted_types:
-            # At least one trusted type - allow without warning
-            return (True, None)
-
-        # Only str/string types remain - warn about JSON auto-parsing
-        # This is the "surprising" case where nested access works via implicit parsing
-        string_types = [t for t in traversable_types if t in ["str", "string"]]
-        warning = None
-
-        if string_types and len(path_parts) > 0:
-            warning = ValidationWarning(
-                template=full_template if full_template.startswith("${") else f"${{{full_template}}}",
-                node_id=output_info.get("node_id", "unknown"),
-                node_type=output_info.get("node_type", "unknown"),
-                output_key=output_key,
-                output_type=output_type,
-                reason=(
-                    f"Nested access on '{output_type}' requires valid JSON at runtime. "
-                    f"Non-JSON strings cause 'Unresolved variables' error."
-                ),
-                nested_path=".".join(path_parts),
-            )
-
-        return (True, warning)
-
-    @staticmethod
-    def _validate_nested_path(
-        path_parts: list[str], output_info: dict[str, Any], full_template: str = "", output_key: str = ""
-    ) -> tuple[bool, Optional[ValidationWarning]]:
-        """Validate a nested path exists in the output structure.
-
-        Args:
-            path_parts: List of path components after the base variable
-            output_info: Output info dict with type and structure
-            full_template: Full template string for warning context
-            output_key: The output key being accessed (for warning)
-
-        Returns:
-            Tuple of (is_valid, optional_warning)
-        """
-        current_structure = output_info.get("structure", {})
-
-        # If no structure info, check if type allows traversal
-        if not current_structure:
-            output_type = output_info.get("type", "any")
-            return TemplateValidator._check_type_allows_traversal(
-                output_type, path_parts, output_info, full_template, output_key
-            )
-
-        # Traverse the structure
-        for i, part in enumerate(path_parts):
-            if part not in current_structure:
-                return (False, None)
-
-            next_item = current_structure[part]
-            if isinstance(next_item, dict):
-                # Check if this is a type definition or nested structure
-                if "type" in next_item:
-                    # This is a field definition
-                    if i < len(path_parts) - 1:
-                        # More parts to traverse
-                        current_structure = next_item.get("structure", {})
-                        if not current_structure:
-                            # Can't traverse further unless type allows it
-                            # str/string allowed for JSON auto-parsing at runtime
-                            field_type = next_item.get("type", "any").lower()
-                            return (field_type in ["dict", "object", "any", "str", "string"], None)
-                    else:
-                        # This is the final part - valid
-                        return (True, None)
-                else:
-                    # Direct nested structure
-                    current_structure = next_item
-            else:
-                # Reached a leaf type string, no more traversal possible
-                return (i == len(path_parts) - 1, None)
-
-        return (True, None)
-
-    @staticmethod
-    def _validate_malformed_templates(workflow_ir: dict[str, Any]) -> list[str]:
-        """Detect malformed template syntax by counting ${ vs valid template matches.
-
-        A malformed template is one where we find ${ but it doesn't form a valid template.
-        Examples: ${unclosed, ${}, ${ }
-
-        Args:
-            workflow_ir: The workflow IR
-
-        Returns:
-            List of error messages for malformed templates
-        """
-        errors: list[str] = []
-
-        for node in workflow_ir.get("nodes", []):
-            node_id = node.get("id", "unknown")
-            params = node.get("params", {})
-
-            def check_value(value: Any, node_id: str, param_path: str = "") -> None:
-                """Recursively check for malformed templates in any value type."""
-                if isinstance(value, str) and "${" in value:
-                    # Count how many ${ we have
-                    dollar_brace_count = value.count("${")
-
-                    # Count how many valid templates we matched
-                    valid_matches = TemplateValidator._PERMISSIVE_PATTERN.findall(value)
-
-                    # Account for nested templates inside brackets - they're part of
-                    # outer templates and shouldn't be counted separately.
-                    # Example: ${results[${__index__}]} has 2 '${' but is 1 logical template
-                    # - valid_matches = ['results[${__index__}]', '__index__'] (2 matches)
-                    # - nested_count = 1 (one match contains '[${')
-                    # - dollar_brace_count = 2
-                    # - len(valid_matches) + nested_count = 3 >= 2 ✓ (no error)
-                    nested_count = sum(f"${{{m}}}".count("[${") for m in valid_matches)
-
-                    # If mismatch (accounting for nested), we have malformed syntax
-                    if len(valid_matches) + nested_count < dollar_brace_count:
-                        location = f"node '{node_id}' parameter '{param_path}'" if param_path else f"node '{node_id}'"
-                        errors.append(
-                            f"Malformed template syntax in {location}: "
-                            f"Found {dollar_brace_count} '${{' but only {len(valid_matches)} valid template(s). "
-                            f"Check for missing '}}' or empty templates like '${{}}'"
-                        )
-                elif isinstance(value, dict):
-                    for key, val in value.items():
-                        check_value(val, node_id, f"{param_path}.{key}" if param_path else key)
-                elif isinstance(value, list):
-                    for idx, item in enumerate(value):
-                        check_value(item, node_id, f"{param_path}[{idx}]")
-
-            for param_key, param_value in params.items():
-                check_value(param_value, node_id, param_key)
-
-        return errors
-
-    @staticmethod
-    def _extract_all_templates(workflow_ir: dict[str, Any]) -> set[str]:  # noqa: C901
-        """Extract all template variables from workflow.
-
-        Scans all node parameters for template variables.
-        Uses a more permissive pattern than TemplateResolver to catch
-        malformed templates that need syntax validation.
-
-        Args:
-            workflow_ir: The workflow IR
-
-        Returns:
-            Set of all template variable names found
-        """
-        templates = set()
-
-        for node in workflow_ir.get("nodes", []):
-            node_id = node.get("id", "unknown")
-            params = node.get("params", {})
-
-            def extract_from_value(value: Any, node_id: str, path: str = "") -> None:
-                """Recursively extract templates from any value type."""
-                if isinstance(value, str) and "$" in value:
-                    # Use permissive pattern to catch malformed templates
-                    matches = TemplateValidator._PERMISSIVE_PATTERN.findall(value)
-                    # Split coalesce operands so each is validated individually
-                    split_matches: list[str] = []
-                    for match in matches:
-                        if "??" in match:
-                            split_matches.extend(TemplateResolver.split_coalesce_operands(match))
-                        else:
-                            split_matches.append(match)
-                    templates.update(split_matches)
-
-                    if matches:
-                        logger.debug(
-                            f"Found templates in node '{node_id}' at path '{path}'",
-                            extra={"node_id": node_id, "path": path, "templates": sorted(matches)},
-                        )
-                elif isinstance(value, dict):
-                    for key, val in value.items():
-                        extract_from_value(val, node_id, f"{path}.{key}" if path else key)
-                elif isinstance(value, list):
-                    for idx, item in enumerate(value):
-                        extract_from_value(item, node_id, f"{path}[{idx}]")
-
-            for param_key, param_value in params.items():
-                extract_from_value(param_value, node_id, param_key)
-
-            # Also extract templates from batch.items if present
-            batch_config = node.get("batch")
-            if batch_config:
-                items_template = batch_config.get("items")
-                if items_template:
-                    extract_from_value(items_template, node_id, "batch.items")
-
-        return templates
-
-    @staticmethod
-    def _is_valid_syntax(template: str) -> bool:
-        """Check if template syntax is valid.
-
-        Validates:
-        - No double dots (..)
-        - No leading/trailing dots
-        - Valid identifier characters
-
-        Args:
-            template: Template variable name (without $)
-
-        Returns:
-            True if syntax is valid
-        """
-        # Check for empty template
-        if not template:
-            return False
-
-        # Check for double dots
-        if ".." in template:
-            return False
-
-        # Check for leading/trailing dots
-        if template.startswith(".") or template.endswith("."):
-            return False
-
-        # Check that all parts are valid identifiers
-        parts = template.split(".")
-        for part in parts:
-            if not part:  # Empty part between dots
-                return False
-            # Check valid identifier characters (alphanumeric + underscore)
-            if not all(c.isalnum() or c == "_" for c in part):
-                return False
-            # Identifiers shouldn't start with a digit
-            if part[0].isdigit():
-                return False
-
-        return True
-
-    @staticmethod
-    def _check_string_template_types(
-        param_name: str,
-        value: str,
-        expected_type: str,
-        node_id: str,
-        workflow_ir: dict[str, Any],
-        node_outputs: dict[str, Any],
-        errors: list[str],
-    ) -> None:
-        """Validate template types in a string parameter value."""
-        templates = TemplateResolver.extract_variables(value)
-        for template in templates:
-            inferred_type = infer_template_type(template, workflow_ir, node_outputs)
-            if not inferred_type or inferred_type == "any":
-                continue
-            if not is_type_compatible(inferred_type, expected_type):
-                error_msg = (
-                    f"Type mismatch in node '{node_id}' parameter '{param_name}': "
-                    f"template ${{{template}}} has type '{inferred_type}' "
-                    f"but parameter expects '{expected_type}'"
-                )
-                if inferred_type in ["dict", "list", "object"] and expected_type in ["str", "string"]:
-                    error_msg += TemplateValidator._generate_type_fix_suggestion(template, node_outputs, expected_type)
-                errors.append(error_msg)
-
-    @staticmethod
-    def _check_param_type(
-        param_name: str,
-        value: Any,
-        expected_type: Optional[str],
-        node_id: str,
-        workflow_ir: dict[str, Any],
-        node_outputs: dict[str, Any],
-        errors: list[str],
-    ) -> None:
-        """Recursively validate template types in a parameter value."""
-        if isinstance(value, str) and TemplateResolver.has_templates(value):
-            if expected_type and expected_type != "any":
-                TemplateValidator._check_string_template_types(
-                    param_name, value, expected_type, node_id, workflow_ir, node_outputs, errors
-                )
-        elif isinstance(value, dict):
-            for val in value.values():
-                TemplateValidator._check_param_type(param_name, val, None, node_id, workflow_ir, node_outputs, errors)
-        elif isinstance(value, list):
-            for item in value:
-                TemplateValidator._check_param_type(param_name, item, None, node_id, workflow_ir, node_outputs, errors)
-
-    @staticmethod
-    def _validate_template_types(
-        workflow_ir: dict[str, Any], node_outputs: dict[str, Any], registry: Registry
-    ) -> list[str]:
-        """Validate template variable types match parameter expectations.
-
-        Args:
-            workflow_ir: Workflow IR
-            node_outputs: Node output metadata from registry
-            registry: Registry instance
-
-        Returns:
-            List of type mismatch errors
-        """
-        errors: list[str] = []
-
-        for node in workflow_ir.get("nodes", []):
-            node_type = node.get("type")
-            node_id = node.get("id")
-            params = node.get("params", {})
-
-            for param_name, param_value in params.items():
-                expected_type = get_parameter_type(node_type, param_name, registry)
-                TemplateValidator._check_param_type(
-                    param_name, param_value, expected_type, node_id, workflow_ir, node_outputs, errors
-                )
-
-        return errors
-
-    @staticmethod
-    def _validate_shell_command_types(workflow_ir: dict[str, Any], node_outputs: dict[str, Any]) -> list[str]:
-        """Block dict/list types in shell command parameters.
-
-        Shell commands cannot safely handle JSON embedded in command strings
-        due to shell escaping issues. This check runs BEFORE template resolution
-        to catch the problem at validation time rather than runtime.
-
-        The general type checker allows dict/list → str (for LLM prompts, HTTP bodies),
-        but shell commands are special - embedded JSON breaks shell parsing.
-
-        Validation has three tiers:
-        1. Fix 0: Extract base types from generics (list[dict] → list) before checking
-        2. Tier 1: Auto-allow unions containing safe types (str, string, any)
-        3. Tier 2: Allow templates wrapped in single quotes '${var}' as an escape hatch
-
-        Args:
-            workflow_ir: Workflow IR
-            node_outputs: Node output metadata from registry
-
-        Returns:
-            List of errors for structured data in shell commands
-        """
-        errors = []
-        # Types that cannot be safely embedded in shell command strings.
-        # Includes both Python type names (dict, list) and JSON Schema names (object, array)
-        # since workflow IR may use either convention.
-        SHELL_BLOCKED_TYPES = {"dict", "object", "list", "array"}
-
-        for node in workflow_ir.get("nodes", []):
-            node_type = node.get("type")
-            node_id = node.get("id")
-
-            # Only check shell nodes
-            if node_type != "shell":
-                continue
-
-            params = node.get("params", {})
-            command = params.get("command", "")
-
-            # Skip if command has no templates
-            if not isinstance(command, str) or not TemplateResolver.has_templates(command):
-                continue
-
-            # Tier 2: Find templates exactly wrapped in single quotes (escape hatch)
-            # Pattern '${var}' signals user accepts runtime coercion to string
-            quoted_templates = {match.group(1) for match in _QUOTED_TEMPLATE_PATTERN.finditer(command)}
-
-            # Check each template in the command and collect blocked ones
-            templates = TemplateResolver.extract_variables(command)
-            blocked_templates: list[tuple[str, str]] = []  # (template, type)
-
-            for template in templates:
-                # Tier 2: Skip if template is quoted (user accepts coercion)
-                if template in quoted_templates:
-                    continue
-
-                inferred_type = infer_template_type(template, workflow_ir, node_outputs)
-
-                # Skip if cannot infer type (will be caught by path validation)
-                if not inferred_type:
-                    continue
-
-                # Check if type is safe (handles Fix 0 and Tier 1)
-                is_safe, blocked_type = _is_shell_safe_type(inferred_type, SHELL_BLOCKED_TYPES)
-                if not is_safe and blocked_type:
-                    blocked_templates.append((template, blocked_type))
-
-            # Generate a single consolidated error if any templates are blocked
-            if blocked_templates:
-                display_cmd = command if len(command) <= 60 else command[:57] + "..."
-
-                if len(blocked_templates) == 1:
-                    # Single template - simple case
-                    template, blocked_type = blocked_templates[0]
-                    errors.append(
-                        f"Shell node '{node_id}': cannot use ${{{template}}} (type: {blocked_type}) "
-                        f"in command parameter.\n\n"
-                        f"PROBLEM: {blocked_type} data embedded in shell commands breaks parsing "
-                        f"(quotes, backticks, $() cause errors).\n\n"
-                        f"CURRENT (breaks):\n"
-                        f'  "command": "{display_cmd}"\n\n'
-                        f"FIX OPTIONS:\n\n"
-                        f"1. Access specific fields (if they're strings/numbers):\n"
-                        f"   ${{{template}.fieldname}}, ${{{template}.count}}, etc.\n\n"
-                        f"2. Use stdin for the whole object:\n"
-                        f'   {{"stdin": "${{{template}}}", "command": "jq \'.field\'"}}\n\n'
-                        f"3. Quote the template to accept JSON coercion (if you've verified it's safe):\n"
-                        f"   '${{{template}}}' - wrapping in single quotes signals you accept runtime coercion"
-                    )
-                else:
-                    # Multiple templates - need different approach
-                    template_list = ", ".join(f"${{{t}}} ({typ})" for t, typ in blocked_templates)
-                    errors.append(
-                        f"Shell node '{node_id}': multiple structured data templates in command: "
-                        f"{template_list}\n\n"
-                        f"PROBLEM: Shell commands can only receive ONE data source via stdin.\n\n"
-                        f"CURRENT (breaks):\n"
-                        f'  "command": "{display_cmd}"\n\n'
-                        f"FIX OPTIONS:\n\n"
-                        f"1. Use temp files - write each data source to a file, then read in shell:\n"
-                        f"   ### save-a\n"
-                        f"   - type: write-file\n"
-                        f"   - file_path: /tmp/a.json\n"
-                        f"   - content: ${{data-a}}\n\n"
-                        f"   ### save-b\n"
-                        f"   - type: write-file\n"
-                        f"   - file_path: /tmp/b.json\n"
-                        f"   - content: ${{data-b}}\n\n"
-                        f"   ### process\n"
-                        f"   - type: shell\n"
-                        f"   ```shell command\n"
-                        f"   jq -s '.[0] * .[1]' /tmp/a.json /tmp/b.json\n"
-                        f"   ```\n\n"
-                        f"2. Process each data source in separate shell nodes, combine results after\n\n"
-                        f"3. Pass one via stdin, reference another via file\n\n"
-                        f"4. Quote templates to accept JSON coercion (if you've verified they're safe):\n"
-                        f"   '${{template}}' - wrapping in single quotes signals you accept runtime coercion"
-                    )
-
-        return errors
-
-    @staticmethod
-    def _infer_batch_item_structure(
-        items_template: Any,
-        node_outputs: dict[str, Any],
-    ) -> Optional[dict[str, Any]]:
-        """Infer the structure of batch items from the items template.
-
-        When items: ${upstream.results}, looks up the upstream node's results
-        output and extracts the per-item structure (inner node outputs + 'item').
-
-        Returns:
-            Dict mapping field names to type info, or None if structure cannot be inferred.
-        """
-        if not isinstance(items_template, str):
-            return None
-
-        # Extract template references preserving left-to-right ?? order.
-        # extract_variables() returns a set (loses order), so we parse directly.
-        matches = TemplateResolver.TEMPLATE_PATTERN.findall(items_template)
-        if not matches:
-            return None
-
-        operands: list[str] = []
-        for match in matches:
-            operands.extend(TemplateResolver.split_coalesce_operands(match))
-
-        for operand in operands:
-            source_output = node_outputs.get(operand)
-            if source_output and isinstance(source_output, dict):
-                items_info = source_output.get("items")
-                if isinstance(items_info, dict) and "structure" in items_info:
-                    structure = items_info["structure"]
-                    if isinstance(structure, dict):
-                        return structure
-
-        return None
-
-    @staticmethod
-    def _collect_templates_from_value(
-        value: Any,
-    ) -> set[str]:
-        """Recursively collect template variables from a parameter value."""
-        templates: set[str] = set()
-        if isinstance(value, str) and TemplateResolver.has_templates(value):
-            templates.update(TemplateResolver.extract_variables(value))
-        elif isinstance(value, dict):
-            for val in value.values():
-                templates.update(TemplateValidator._collect_templates_from_value(val))
-        elif isinstance(value, list):
-            for list_item in value:
-                templates.update(TemplateValidator._collect_templates_from_value(list_item))
-        return templates
-
-    @staticmethod
-    def _extract_item_field_refs(
-        params: dict[str, Any],
-        item_alias: str,
-    ) -> list[tuple[str, str]]:
-        """Extract ${item.field} references from a node's params.
-
-        Returns:
-            List of (field_path, full_template) tuples.
-            field_path is everything after the alias (e.g., "response" from "item.response").
-        """
-        prefix = f"{item_alias}."
-        refs: list[tuple[str, str]] = []
-
-        for param_value in params.values():
-            for template in TemplateValidator._collect_templates_from_value(param_value):
-                if template.startswith(prefix):
-                    field_path = template[len(prefix) :]
-                    if field_path:
-                        refs.append((field_path, template))
-
-        return refs
-
-    @staticmethod
-    def _format_batch_item_field_error(
-        node_id: str,
-        item_alias: str,
-        items_template: Any,
-        first_field: str,
-        full_template: str,
-        item_structure: dict[str, Any],
-    ) -> str:
-        """Format error message for invalid batch item field access."""
-        safe_node_id = TemplateValidator._sanitize_for_display(node_id)
-        safe_alias = TemplateValidator._sanitize_for_display(item_alias)
-        items_source = items_template if isinstance(items_template, str) else str(items_template)
-        safe_source = TemplateValidator._sanitize_for_display(items_source)
-
-        available_paths = [
-            (f"{safe_alias}.{field}", info.get("type", "any") if isinstance(info, dict) else "any")
-            for field, info in item_structure.items()
-        ]
-        suggestions = TemplateValidator._find_similar_paths(first_field, available_paths)
-
-        lines = [
-            f"Node '{safe_node_id}': ${{{full_template}}} references "
-            f"field '{first_field}' which is not available on batch items.",
-            "",
-            f"Items come from: {safe_source}",
-            f"Available fields on ${{{safe_alias}}}:",
-        ]
-
-        for field_name, field_info in item_structure.items():
-            field_type = field_info.get("type", "any") if isinstance(field_info, dict) else "any"
-            lines.append(f"  ${{{safe_alias}.{field_name}}} ({field_type})")
-
-        if suggestions:
-            lines.append("")
-            if len(suggestions) == 1:
-                sugg_path, _ = suggestions[0]
-                lines.append(f"Did you mean: ${{{sugg_path}}}?")
-            else:
-                lines.append("Did you mean one of these?")
-                for sugg_path, _ in suggestions:
-                    lines.append(f"  - ${{{sugg_path}}}")
-
-        return "\n".join(lines)
-
-    @staticmethod
-    def _format_batch_item_nested_error(
-        node_id: str,
-        item_alias: str,
-        parts: list[str],
-        full_template: str,
-        field_info: dict[str, Any],
-    ) -> str:
-        """Format error for invalid nested path on a batch item field.
-
-        Example: ${item.llm_usage.nope} where llm_usage has known structure.
-        """
-        safe_node_id = TemplateValidator._sanitize_for_display(node_id)
-        safe_alias = TemplateValidator._sanitize_for_display(item_alias)
-
-        # Walk through intermediate parts to find where validation actually fails.
-        # For ${item.a.b.c} where c doesn't exist on b, we need to identify b as
-        # the parent — not a — so the error message and available fields are correct.
-        current_info = field_info
-        valid_depth = 0
-        for part in parts[1:-1]:
-            sub = current_info.get("structure", {}) if isinstance(current_info, dict) else {}
-            if part in sub and isinstance(sub[part], dict):
-                current_info = sub[part]
-                valid_depth += 1
-            else:
-                break
-
-        parent_path = f"{safe_alias}.{'.'.join(parts[: 1 + valid_depth])}"
-        bad_field = parts[1 + valid_depth].split("[")[0]
-        parent_name = parts[valid_depth]
-        parent_type = current_info.get("type", "any") if isinstance(current_info, dict) else "any"
-        nested_structure = current_info.get("structure", {}) if isinstance(current_info, dict) else {}
-
-        lines = [
-            f"Node '{safe_node_id}': ${{{full_template}}} — "
-            f"'{bad_field}' does not exist on '{parent_name}' ({parent_type}).",
-        ]
-
-        if nested_structure:
-            lines.append("")
-            lines.append(f"Available fields on ${{{parent_path}}}:")
-            for field_name, sub_info in nested_structure.items():
-                sub_type = sub_info.get("type", "any") if isinstance(sub_info, dict) else "any"
-                lines.append(f"  ${{{parent_path}.{field_name}}} ({sub_type})")
-
-            available_paths = [
-                (f"{parent_path}.{f}", i.get("type", "any") if isinstance(i, dict) else "any")
-                for f, i in nested_structure.items()
-            ]
-            suggestions = TemplateValidator._find_similar_paths(bad_field, available_paths)
-            if suggestions:
-                lines.append("")
-                if len(suggestions) == 1:
-                    sugg_path, _ = suggestions[0]
-                    lines.append(f"Did you mean: ${{{sugg_path}}}?")
-                else:
-                    lines.append("Did you mean one of these?")
-                    for sugg_path, _ in suggestions:
-                        lines.append(f"  - ${{{sugg_path}}}")
-        else:
-            lines.append("")
-            lines.append(
-                f"'{parent_name}' has type '{parent_type}' with no known sub-fields. Nested access may fail at runtime."
-            )
-
-        return "\n".join(lines)
-
-    @staticmethod
-    def _validate_batch_item_fields(
-        workflow_ir: dict[str, Any],
-        node_outputs: dict[str, Any],
-    ) -> list[str]:
-        """Validate ${item.field} references against inferred item structure.
-
-        For batch nodes where items come from an upstream batch node's results,
-        validates that referenced fields actually exist on each item.
-
-        Falls back to permissive (no validation) when item structure cannot
-        be inferred (e.g., items from workflow input, inline array, or
-        non-batch source).
-        """
-        errors: list[str] = []
-
-        for node in workflow_ir.get("nodes", []):
-            node_id = node.get("id")
-            batch_config = node.get("batch")
-            if not batch_config or not node_id:
-                continue
-
-            item_alias = batch_config.get("as", "item")
-            items_template = batch_config.get("items")
-            if not items_template:
-                continue
-
-            item_structure = TemplateValidator._infer_batch_item_structure(items_template, node_outputs)
-            if not item_structure:
-                continue
-
-            field_refs = TemplateValidator._extract_item_field_refs(node.get("params", {}), item_alias)
-
-            seen_errors: set[str] = set()  # Mutated by _check_batch_item_ref to dedup
-            for field_path, full_template in field_refs:
-                error = TemplateValidator._check_batch_item_ref(
-                    field_path, full_template, item_structure, item_alias, items_template, node_id, seen_errors
-                )
-                if error:
-                    errors.append(error)
-
-        return errors
-
-    @staticmethod
-    def _check_batch_item_ref(
-        field_path: str,
-        full_template: str,
-        item_structure: dict[str, Any],
-        item_alias: str,
-        items_template: Any,
-        node_id: str,
-        seen_errors: set[str],
-    ) -> Optional[str]:
-        """Check a single ${item.field} reference against item structure. Returns error or None."""
-        parts = field_path.split(".")
-        first_field = parts[0].split("[")[0]
-
-        if first_field not in item_structure:
-            if first_field in seen_errors:
-                return None
-            seen_errors.add(first_field)
-            return TemplateValidator._format_batch_item_field_error(
-                node_id, item_alias, items_template, first_field, full_template, item_structure
-            )
-
-        # First field exists — validate deeper path if any
-        if len(parts) > 1:
-            field_info = item_structure[first_field]
-            if isinstance(field_info, dict):
-                is_valid, _ = TemplateValidator._validate_nested_path(
-                    parts[1:], field_info, f"${{{full_template}}}", item_alias
-                )
-                if not is_valid and full_template not in seen_errors:
-                    seen_errors.add(full_template)
-                    return TemplateValidator._format_batch_item_nested_error(
-                        node_id, item_alias, parts, full_template, field_info
-                    )
-
-        return None
-
-    @staticmethod
-    def _generate_type_fix_suggestion(  # noqa: C901
-        template: str, node_outputs: dict[str, Any], expected_type: str
-    ) -> str:
-        """Generate helpful suggestions for type mismatches with actual available fields.
-
-        Args:
-            template: The template variable that has the wrong type
-            node_outputs: Node output metadata from registry
-            expected_type: The type that was expected
-
-        Returns:
-            Suggestion string with available fields
-        """
-        # For nested templates like node.output.field, we need to traverse to find structure
-        # Find the structure for this template by traversing
-        structure = None
-        for key in node_outputs:
-            if template.startswith(key + ".") or template == key:
-                output_info = node_outputs[key]
-                remaining_path = template[len(key) :].lstrip(".")
-
-                if not remaining_path:
-                    # This IS the base output
-                    structure = output_info.get("structure", {})
-                    break
-                else:
-                    # Need to traverse nested structure
-                    structure = TemplateValidator._traverse_to_structure(
-                        output_info.get("structure", {}), remaining_path
-                    )
-                    if structure:
-                        break
-
-        if not structure:
-            # Generic fallback
-            return f"\n  💡 Suggestion: Access a specific field (e.g., ${{{template}.field}}) or serialize to JSON"
-
-        # Find fields that match the expected type
-        matching_fields = []
-        for field_name, field_info in structure.items():
-            if isinstance(field_info, dict) and "type" in field_info:
-                field_type = field_info["type"]
-                # Check if this field matches the expected type
-                if field_type in [expected_type, "str", "string"] and expected_type in ["str", "string"]:
-                    matching_fields.append(field_name)
-
-        if matching_fields:
-            suggestion = "\n  💡 Available fields with correct type:"
-            for field in matching_fields[:5]:  # Show up to 5
-                suggestion += f"\n     - ${{{template}.{field}}}"
-            if len(matching_fields) > 5:
-                suggestion += f"\n     ... and {len(matching_fields) - 5} more"
-            return suggestion
-        else:
-            return "\n  💡 Suggestion: Access a nested field or serialize to JSON"
-
-    @staticmethod
-    def _traverse_to_structure(structure: dict[str, Any], path: str) -> Optional[dict[str, Any]]:
-        """Traverse nested structure to find the structure at a given path.
-
-        Args:
-            structure: The structure dict to traverse
-            path: Dot-separated path like "author.login"
-
-        Returns:
-            The structure dict at that path, or None if not found
-        """
-        if not path or not structure:
-            return structure
-
-        path_parts = path.split(".")
-        current = structure
-
-        for part in path_parts:
-            if part in current:
-                field_info = current[part]
-                if isinstance(field_info, dict):
-                    current = field_info.get("structure", {})
-                    if not current:
-                        return None
-                else:
-                    return None
-            else:
-                return None
-
-        return current

--- a/src/pflow/runtime/validation_utils.py
+++ b/src/pflow/runtime/validation_utils.py
@@ -1,0 +1,304 @@
+"""Shared validation utilities for template validation.
+
+Provides common infrastructure used across multiple validation modules:
+- ValidationWarning dataclass
+- Display constants
+- Path splitting, sanitization, and suggestion matching
+- Output structure flattening
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Display limits for error messages - balances information vs overwhelming output
+MAX_DISPLAYED_FIELDS = 20  # Fits in ~25 terminal lines with formatting
+MAX_DISPLAYED_SUGGESTIONS = 3  # Cognitive limit for processing alternatives
+MAX_FLATTEN_DEPTH = 5  # Prevent infinite recursion on circular refs
+
+
+@dataclass
+class ValidationWarning:
+    """Warning about runtime-validated template access.
+
+    Emitted when static validation cannot verify a template path
+    (e.g., accessing nested fields on outputs with type 'Any').
+    These templates will be validated at runtime during execution.
+    """
+
+    template: str  # Full template with ${}
+    node_id: str  # Node producing the output
+    node_type: str  # Node type (often MCP)
+    output_key: str  # Output key being accessed
+    output_type: str  # Type causing runtime validation
+    reason: str  # Human-readable explanation
+    nested_path: str  # Nested portion: "data.field[0]"
+
+
+def split_template_path(template: str) -> list[str]:
+    """Split template path on dots, preserving dots inside ${...}.
+
+    Standard str.split(".") breaks nested templates like ${item.field}
+    inside array brackets. This function correctly handles:
+
+    - drafts.results[${item.draft_index}].response
+      -> ['drafts', 'results[${item.draft_index}]', 'response']
+
+    - node.data[${__index__}].field
+      -> ['node', 'data[${__index__}]', 'field']
+
+    Args:
+        template: Template path string (without ${} wrapper)
+
+    Returns:
+        List of path components with nested templates preserved
+    """
+    parts: list[str] = []
+    current = ""
+    depth = 0  # Track nesting level of ${...}
+
+    i = 0
+    while i < len(template):
+        if template[i : i + 2] == "${":
+            depth += 1
+            current += template[i : i + 2]
+            i += 2
+        elif template[i] == "}" and depth > 0:
+            depth -= 1
+            current += template[i]
+            i += 1
+        elif template[i] == "." and depth == 0:
+            if current:
+                parts.append(current)
+            current = ""
+            i += 1
+        else:
+            current += template[i]
+            i += 1
+
+    if current:
+        parts.append(current)
+
+    return parts
+
+
+def get_node_ids(workflow_ir: dict[str, Any]) -> set[str]:
+    """Extract all node IDs from the workflow.
+
+    Args:
+        workflow_ir: The workflow IR
+
+    Returns:
+        Set of all node IDs in the workflow
+    """
+    return {node.get("id") for node in workflow_ir.get("nodes", []) if node.get("id")}
+
+
+def sanitize_for_display(value: str, max_length: int = 100) -> str:
+    """Sanitize string for safe display in error messages.
+
+    Removes control characters and limits length to prevent:
+    - Terminal escape sequences
+    - Log injection (newlines, carriage returns)
+    - Information disclosure
+
+    Args:
+        value: String to sanitize (node_id, template variable, etc.)
+        max_length: Maximum length before truncation
+
+    Returns:
+        Sanitized string safe for error messages
+    """
+    # Remove non-printable characters AND newlines/carriage returns
+    # Allow only printable characters, excluding control chars that enable log injection
+    sanitized = "".join(c for c in value if c.isprintable() and c not in ("\n", "\r", "\t", "\x0b", "\x0c"))
+
+    # Truncate if too long
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "..."
+
+    return sanitized
+
+
+def flatten_output_structure(  # noqa: C901
+    base_key: str,
+    base_type: str,
+    structure: dict[str, Any],
+    _current_path: str = "",
+    _paths: list[tuple[str, str]] | None = None,
+    _depth: int = 0,
+    _max_depth: int = MAX_FLATTEN_DEPTH,
+) -> list[tuple[str, str]]:
+    """Recursively flatten output structure to list of (path, type) tuples.
+
+    Note: This function has inherent complexity (noqa: C901) due to recursive
+    tree traversal of arbitrary nested structures. Refactoring would require
+    breaking the recursion pattern, which could reduce readability without
+    meaningful benefit. The complexity is managed through:
+    - Clear function boundaries (prep/traverse/handle)
+    - Depth limiting to prevent infinite recursion
+    - Comprehensive docstrings
+    - Type hints for all parameters
+
+    Args:
+        base_key: The base output key (e.g., "result")
+        base_type: Type of the base key (e.g., "dict")
+        structure: Nested structure dictionary
+        _current_path: Current path during recursion (internal)
+        _paths: Accumulated paths (internal)
+        _depth: Current recursion depth (internal)
+        _max_depth: Maximum recursion depth to prevent infinite loops
+
+    Returns:
+        List of (path, type) tuples representing all accessible paths
+
+    Example:
+        Input: base_key="result", base_type="dict", structure={
+            "messages": {"type": "array", "items": {"type": "dict", "structure": {...}}}
+        }
+        Output: [
+            ("result", "dict"),
+            ("result.messages", "array"),
+            ("result.messages[0].text", "string"),
+            ...
+        ]
+    """
+    if _paths is None:
+        _paths = []
+
+    # Prevent infinite recursion on malformed structures
+    if _depth > _max_depth:
+        return _paths
+
+    # Add the base path first
+    if _current_path == "":
+        _paths.append((base_key, base_type))
+        _current_path = base_key
+
+    # Recursively traverse structure
+    if structure and isinstance(structure, dict):
+        for field_name, field_info in structure.items():
+            field_path = f"{_current_path}.{field_name}"
+
+            if isinstance(field_info, dict):
+                field_type = field_info.get("type", "any")
+                _paths.append((field_path, field_type))
+
+                # Handle arrays with example index
+                if field_type == "array" and "items" in field_info:
+                    items = field_info["items"]
+                    if isinstance(items, dict):
+                        item_type = items.get("type", "any")
+                        item_path = f"{field_path}[0]"
+                        _paths.append((item_path, item_type))
+
+                        # Recurse into array item structure
+                        if "structure" in items and isinstance(items["structure"], dict):
+                            flatten_output_structure(
+                                base_key="",  # Not used in recursion
+                                base_type="",
+                                structure=items["structure"],
+                                _current_path=item_path,
+                                _paths=_paths,
+                                _depth=_depth + 1,
+                                _max_depth=_max_depth,
+                            )
+
+                # Recurse into nested dict structure
+                elif "structure" in field_info and isinstance(field_info["structure"], dict):
+                    flatten_output_structure(
+                        base_key="",
+                        base_type="",
+                        structure=field_info["structure"],
+                        _current_path=field_path,
+                        _paths=_paths,
+                        _depth=_depth + 1,
+                        _max_depth=_max_depth,
+                    )
+            elif isinstance(field_info, str):
+                # Direct type string (legacy format)
+                _paths.append((field_path, field_info))
+
+    return _paths
+
+
+def find_similar_paths(attempted_key: str, available_paths: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Find paths similar to the attempted key.
+
+    Uses simple substring matching for MVP.
+
+    Args:
+        attempted_key: The key user tried to access (e.g., "msg")
+        available_paths: List of (path, type) tuples
+
+    Returns:
+        List of (path, type) tuples that match, sorted by relevance
+
+    Example:
+        attempted_key="msg"
+        available_paths=[("result", "dict"), ("result.messages", "array")]
+        returns=[("result.messages", "array")]
+    """
+    attempted_lower = attempted_key.lower()
+    matches = []
+
+    for path, path_type in available_paths:
+        # Extract just the last component of the path for matching
+        last_component = path.split(".")[-1].split("[")[0]  # Handle array notation
+
+        # Substring match (case-insensitive)
+        if attempted_lower in last_component.lower():
+            # Calculate match quality (longer substring match = better)
+            match_quality = len(attempted_lower) / len(last_component) if last_component else 0
+            matches.append((path, path_type, match_quality))
+
+    # Sort by match quality (best matches first), then alphabetically
+    matches.sort(key=lambda x: (-x[2], x[0]))
+
+    # Return just the (path, type) tuples, top 3 matches
+    return [(path, path_type) for path, path_type, _ in matches[:MAX_DISPLAYED_SUGGESTIONS]]
+
+
+def build_paths_from_entries(node_entries: dict[str, Any]) -> list[tuple[str, str]]:
+    """Build flattened (path, type) list from node_outputs entries.
+
+    Args:
+        node_entries: Dict of output_key -> output_info for a single node
+
+    Returns:
+        List of (path, type) tuples for display
+    """
+    all_paths: list[tuple[str, str]] = []
+    for key, info in node_entries.items():
+        output_type = info.get("type", "any")
+        all_paths.append((key, output_type))
+
+        # Flatten nested structure if present
+        structure = info.get("structure", {})
+        if structure and isinstance(structure, dict):
+            nested = flatten_output_structure(base_key=key, base_type=output_type, structure=structure)
+            # Skip first entry (base key already added)
+            all_paths.extend(nested[1:])
+
+        # Flatten items structure for arrays (e.g., results array)
+        items_info = info.get("items", {})
+        if items_info and isinstance(items_info, dict):
+            item_type = items_info.get("type", "any")
+            item_path = f"{key}[0]"
+            all_paths.append((item_path, item_type))
+
+            items_structure = items_info.get("structure", {})
+            if items_structure and isinstance(items_structure, dict):
+                nested = flatten_output_structure(
+                    base_key="",
+                    base_type="",
+                    structure=items_structure,
+                    _current_path=item_path,
+                    _paths=[],
+                    _depth=0,
+                )
+                all_paths.extend(nested)
+
+    return all_paths

--- a/tests/test_cli/test_workflow_save_security.py
+++ b/tests/test_cli/test_workflow_save_security.py
@@ -11,16 +11,16 @@ import pytest
 
 from pflow.core.exceptions import WorkflowValidationError
 from pflow.core.workflow_manager import WorkflowManager
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.validation_utils import sanitize_for_display
 
 
 class TestSanitizeForDisplay:
-    """Test _sanitize_for_display prevents log injection attacks."""
+    """Test sanitize_for_display prevents log injection attacks."""
 
     def test_sanitize_blocks_newline_injection(self):
         """Newlines must be stripped to prevent log injection."""
         malicious = "fake\n[INFO] admin logged in\n"
-        result = TemplateValidator._sanitize_for_display(malicious)
+        result = sanitize_for_display(malicious)
         assert "\n" not in result
         assert "\r" not in result
         assert result == "fake[INFO] admin logged in"
@@ -28,42 +28,42 @@ class TestSanitizeForDisplay:
     def test_sanitize_blocks_carriage_return(self):
         """Carriage returns must be stripped."""
         malicious = "node\rmalicious_override"
-        result = TemplateValidator._sanitize_for_display(malicious)
+        result = sanitize_for_display(malicious)
         assert "\r" not in result
         assert result == "nodemalicious_override"
 
     def test_sanitize_blocks_tab_characters(self):
         """Tab characters must be stripped."""
         malicious = "node\tmalicious"
-        result = TemplateValidator._sanitize_for_display(malicious)
+        result = sanitize_for_display(malicious)
         assert "\t" not in result
         assert result == "nodemalicious"
 
     def test_sanitize_blocks_vertical_tab(self):
         """Vertical tabs (\x0b) must be stripped."""
         malicious = "node\x0bmalicious"
-        result = TemplateValidator._sanitize_for_display(malicious)
+        result = sanitize_for_display(malicious)
         assert "\x0b" not in result
         assert result == "nodemalicious"
 
     def test_sanitize_blocks_form_feed(self):
         """Form feeds (\x0c) must be stripped."""
         malicious = "node\x0cmalicious"
-        result = TemplateValidator._sanitize_for_display(malicious)
+        result = sanitize_for_display(malicious)
         assert "\x0c" not in result
         assert result == "nodemalicious"
 
     def test_sanitize_truncates_long_strings(self):
         """Long strings should be truncated with ellipsis."""
         long_string = "a" * 200
-        result = TemplateValidator._sanitize_for_display(long_string, max_length=100)
+        result = sanitize_for_display(long_string, max_length=100)
         assert len(result) == 103  # 100 chars + "..."
         assert result.endswith("...")
 
     def test_sanitize_preserves_safe_characters(self):
         """Safe characters should pass through unchanged."""
         safe = "node-123_abc.xyz"
-        result = TemplateValidator._sanitize_for_display(safe)
+        result = sanitize_for_display(safe)
         assert result == safe
 
 

--- a/tests/test_core/test_workflow_validator.py
+++ b/tests/test_core/test_workflow_validator.py
@@ -242,9 +242,9 @@ Do something.
         }
 
         # The template validator should resolve ${process.result} successfully
-        from pflow.runtime.template_validator import TemplateValidator
+        from pflow.runtime.template_validator import validate_workflow_templates
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry_with_nodes)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry_with_nodes)
 
         template_errors = [e for e in errors if "process" in e and "result" in e]
         assert len(template_errors) == 0, f"Unexpected errors for workflow output: {template_errors}"
@@ -273,9 +273,9 @@ Do something.
             "edges": [{"from": "process", "to": "use_output"}],
         }
 
-        from pflow.runtime.template_validator import TemplateValidator
+        from pflow.runtime.template_validator import validate_workflow_templates
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry_with_nodes)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry_with_nodes)
 
         # Dynamic workflow should NOT produce errors for any output reference
         template_errors = [e for e in errors if "process" in e and "anything" in e]

--- a/tests/test_integration/test_unused_inputs.py
+++ b/tests/test_integration/test_unused_inputs.py
@@ -7,7 +7,7 @@ a realistic scenario where a workflow declares inputs but doesn't use them all.
 import pytest
 
 from pflow.registry import Registry
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import validate_workflow_templates
 
 
 class MockRegistry(Registry):
@@ -112,7 +112,7 @@ def test_unused_inputs_detected_before_execution(tmp_path):
         # Note: unused_option and another_unused are not provided but have defaults or are optional
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, registry)
 
     # Should detect the unused inputs
     assert len(errors) == 1
@@ -177,7 +177,7 @@ def test_workflow_with_all_inputs_used(tmp_path):
         "backup_file": str(tmp_path / "backup.txt"),
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, registry)
 
     # Should have no errors since all inputs are used
     assert len(errors) == 0
@@ -224,7 +224,7 @@ def test_unused_inputs_with_nested_workflows(tmp_path):
 
     initial_params = {"config_path": str(tmp_path / "config.json")}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(parent_workflow, initial_params, registry)
+    errors, _warnings = validate_workflow_templates(parent_workflow, initial_params, registry)
 
     # Should detect the unused debug flag
     assert any("unused_debug_flag" in error for error in errors)

--- a/tests/test_planning/unit/test_validation.py
+++ b/tests/test_planning/unit/test_validation.py
@@ -84,9 +84,9 @@ class TestValidatorNode:
         # Mock validate_ir to pass
         with (
             patch("pflow.core.ir_schema.validate_ir"),
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            mock_validate.return_value = ([], [])
 
             prep_res = validator_node.prep(shared)
             exec_res = validator_node.exec(prep_res)
@@ -104,8 +104,8 @@ class TestValidatorNode:
         # Mock validate_ir to raise ValidationError
         with patch("pflow.core.ir_schema.validate_ir") as mock_validate:
             mock_validate.side_effect = Exception("Missing required field: ir_version")
-            with patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator:
-                MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            with patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate:
+                mock_validate.return_value = ([], [])
 
                 prep_res = validator_node.prep(shared)
                 exec_res = validator_node.exec(prep_res)
@@ -123,8 +123,8 @@ class TestValidatorNode:
         # Mock validate_ir to raise error
         with patch("pflow.core.ir_schema.validate_ir") as mock_validate:
             mock_validate.side_effect = Exception("Missing required field: ir_version")
-            with patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator:
-                MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            with patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate:
+                mock_validate.return_value = ([], [])
 
                 prep_res = validator_node.prep(shared)
                 exec_res = validator_node.exec(prep_res)
@@ -149,8 +149,8 @@ class TestValidatorNode:
 
             mock_validate.side_effect = ValidationError()
 
-            with patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator:
-                MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            with patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate:
+                mock_validate.return_value = ([], [])
 
                 prep_res = validator_node.prep(shared)
                 exec_res = validator_node.exec(prep_res)
@@ -165,9 +165,9 @@ class TestValidatorNode:
 
         with (
             patch("pflow.core.ir_schema.validate_ir"),
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.return_value = (
+            mock_validate.return_value = (
                 [
                     "Template error: Unknown variable {{unknown_var}}",
                     "Unused input: input_file",
@@ -188,9 +188,9 @@ class TestValidatorNode:
 
         with (
             patch("pflow.core.ir_schema.validate_ir"),
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            mock_validate.return_value = ([], [])
 
             prep_res = validator_node.prep(shared)
             exec_res = validator_node.exec(prep_res)
@@ -215,9 +215,9 @@ class TestValidatorNode:
 
         with (
             patch("pflow.core.ir_schema.validate_ir"),
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            mock_validate.return_value = ([], [])
 
             prep_res = validator_node.prep(shared)
             exec_res = validator_node.exec(prep_res)
@@ -256,9 +256,9 @@ class TestValidatorNode:
 
         with (
             patch("pflow.core.ir_schema.validate_ir"),
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.return_value = ([], [])
+            mock_validate.return_value = ([], [])
 
             prep_res = validator_node.prep(shared)
             exec_res = validator_node.exec(prep_res)
@@ -272,9 +272,9 @@ class TestValidatorNode:
 
         with (
             patch("pflow.core.ir_schema.validate_ir"),
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.side_effect = Exception("Template parsing failed")
+            mock_validate.side_effect = Exception("Template parsing failed")
 
             prep_res = validator_node.prep(shared)
             exec_res = validator_node.exec(prep_res)
@@ -297,9 +297,9 @@ class TestValidatorNode:
 
         with (
             patch("pflow.core.ir_schema.validate_ir"),  # Mock passes
-            patch("pflow.runtime.template_validator.TemplateValidator") as MockTemplateValidator,
+            patch("pflow.runtime.template_validator.validate_workflow_templates") as mock_validate,
         ):
-            MockTemplateValidator.validate_workflow_templates.return_value = ([], [])  # No errors
+            mock_validate.return_value = ([], [])  # No errors
 
             prep_res = validator_node.prep(shared)
             exec_res = validator_node.exec(prep_res)

--- a/tests/test_runtime/test_nested_templates.py
+++ b/tests/test_runtime/test_nested_templates.py
@@ -77,54 +77,54 @@ class TestSplitTemplatePath:
 
     def test_simple_path(self):
         """Simple paths split normally."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        assert _split_template_path("node.field") == ["node", "field"]
-        assert _split_template_path("a.b.c") == ["a", "b", "c"]
+        assert split_template_path("node.field") == ["node", "field"]
+        assert split_template_path("a.b.c") == ["a", "b", "c"]
 
     def test_single_component(self):
         """Single component returns list with one element."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        assert _split_template_path("node") == ["node"]
+        assert split_template_path("node") == ["node"]
 
     def test_nested_template_preserved(self):
         """Dots inside ${...} are not split points."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        result = _split_template_path("drafts.results[${item.draft_index}].response")
+        result = split_template_path("drafts.results[${item.draft_index}].response")
         assert result == ["drafts", "results[${item.draft_index}]", "response"]
 
     def test_dunder_index_preserved(self):
         """${__index__} is preserved correctly."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        result = _split_template_path("node.data[${__index__}].field")
+        result = split_template_path("node.data[${__index__}].field")
         assert result == ["node", "data[${__index__}]", "field"]
 
     def test_multiple_nested_templates(self):
         """Multiple nested templates in one path."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        result = _split_template_path("a[${x.y}].b[${z.w}].c")
+        result = split_template_path("a[${x.y}].b[${z.w}].c")
         assert result == ["a[${x.y}]", "b[${z.w}]", "c"]
 
     def test_complex_nested_path(self):
         """Complex nested path with multiple dots inside template."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        result = _split_template_path("node.results[${item.data.index}].value")
+        result = split_template_path("node.results[${item.data.index}].value")
         assert result == ["node", "results[${item.data.index}]", "value"]
 
     def test_empty_string(self):
         """Empty string returns empty list."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        assert _split_template_path("") == []
+        assert split_template_path("") == []
 
     def test_trailing_nested_template(self):
         """Nested template at end of path."""
-        from pflow.runtime.template_validator import _split_template_path
+        from pflow.runtime.validation_utils import split_template_path
 
-        result = _split_template_path("node.data[${idx}]")
+        result = split_template_path("node.data[${idx}]")
         assert result == ["node", "data[${idx}]"]

--- a/tests/test_runtime/test_template_array_notation.py
+++ b/tests/test_runtime/test_template_array_notation.py
@@ -1,7 +1,7 @@
 """Test the enhancement to TemplateValidator for array notation support.
 
 This module tests that:
-- TemplateValidator._extract_all_templates() finds array notation patterns
+- _extract_all_templates() finds array notation patterns
 - TemplateResolver.TEMPLATE_PATTERN matches array notation correctly
 - Workflows with array templates work end-to-end
 """
@@ -10,14 +10,17 @@ from unittest.mock import patch
 
 from pflow.registry import Registry
 from pflow.runtime.template_resolver import TemplateResolver
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import (
+    _extract_all_templates,
+    validate_workflow_templates,
+)
 
 
 class TestTemplateArrayNotation:
     """Test array notation support in template validation and resolution."""
 
     def test_template_validator_finds_simple_array_notation(self):
-        """Test that TemplateValidator._extract_all_templates() finds ${node[0].field} patterns."""
+        """Test that _extract_all_templates() finds ${node[0].field} patterns."""
         workflow_ir = {
             "nodes": [
                 {
@@ -28,7 +31,7 @@ class TestTemplateArrayNotation:
             ]
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
 
         # Should find both array notation templates
         assert "api.items[0].name" in templates
@@ -53,7 +56,7 @@ class TestTemplateArrayNotation:
             ]
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
 
         # Should find all nested array templates
         assert "github.repos[0].issues[0].title" in templates
@@ -75,7 +78,7 @@ class TestTemplateArrayNotation:
             ]
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
 
         # Should find all templates in list
         assert "data[0].value" in templates
@@ -158,7 +161,7 @@ class TestTemplateArrayNotation:
             mock_metadata.side_effect = get_metadata
 
             # Should validate - array notation is in templates
-            errors, _warnings = TemplateValidator.validate_workflow_templates(
+            errors, _warnings = validate_workflow_templates(
                 workflow_ir,
                 {},  # No external params needed
                 registry,
@@ -185,7 +188,7 @@ class TestTemplateArrayNotation:
             ]
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
 
         # Should extract both, validation happens at runtime
         assert "api.data[0]" in templates
@@ -208,7 +211,7 @@ class TestTemplateArrayNotation:
             ]
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
 
         # Should find all template types
         assert "node.field.subfield" in templates

--- a/tests/test_runtime/test_template_validator.py
+++ b/tests/test_runtime/test_template_validator.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import Mock
 
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import (
+    _extract_all_templates,
+    validate_workflow_templates,
+)
 
 
 def create_mock_registry():
@@ -142,7 +145,7 @@ class TestTemplateExtraction:
             "edges": [],
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
         assert templates == {"url"}
 
     def test_extracts_templates_from_multiple_nodes(self):
@@ -156,7 +159,7 @@ class TestTemplateExtraction:
             "edges": [],
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
         assert templates == {"var1", "var2", "var3"}
 
     def test_extracts_path_templates(self):
@@ -172,7 +175,7 @@ class TestTemplateExtraction:
             "edges": [],
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
         assert templates == {"data.title", "data.metadata.author"}
 
     def test_handles_nodes_without_params(self):
@@ -185,7 +188,7 @@ class TestTemplateExtraction:
             "edges": [],
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
         assert templates == set()
 
     def test_deduplicates_templates(self):
@@ -198,51 +201,8 @@ class TestTemplateExtraction:
             "edges": [],
         }
 
-        templates = TemplateValidator._extract_all_templates(workflow_ir)
+        templates = _extract_all_templates(workflow_ir)
         assert templates == {"url"}
-
-
-class TestSyntaxValidation:
-    """Test template syntax validation."""
-
-    def test_valid_syntax(self):
-        """Test valid template syntax."""
-        assert TemplateValidator._is_valid_syntax("url")
-        assert TemplateValidator._is_valid_syntax("issue_number")
-        assert TemplateValidator._is_valid_syntax("data.field")
-        assert TemplateValidator._is_valid_syntax("a.b.c.d")
-        assert TemplateValidator._is_valid_syntax("user_info.name_field")
-
-    def test_invalid_syntax_double_dots(self):
-        """Test that double dots are invalid."""
-        assert not TemplateValidator._is_valid_syntax("data..field")
-        assert not TemplateValidator._is_valid_syntax("a...b")
-
-    def test_invalid_syntax_leading_trailing_dots(self):
-        """Test that leading/trailing dots are invalid."""
-        assert not TemplateValidator._is_valid_syntax(".field")
-        assert not TemplateValidator._is_valid_syntax("field.")
-        assert not TemplateValidator._is_valid_syntax(".field.subfield.")
-
-    def test_invalid_syntax_empty_parts(self):
-        """Test that empty parts are invalid."""
-        assert not TemplateValidator._is_valid_syntax("")
-        assert not TemplateValidator._is_valid_syntax("a..b")  # Empty part between dots
-
-    def test_invalid_syntax_bad_characters(self):
-        """Test that invalid characters are rejected."""
-        assert not TemplateValidator._is_valid_syntax("var-name")  # Hyphen
-        assert not TemplateValidator._is_valid_syntax("var name")  # Space
-        assert not TemplateValidator._is_valid_syntax("var@field")  # Special char
-        assert not TemplateValidator._is_valid_syntax("123var")  # Starts with digit
-
-    def test_valid_identifiers(self):
-        """Test valid identifier patterns."""
-        assert TemplateValidator._is_valid_syntax("_private")
-        assert TemplateValidator._is_valid_syntax("var123")
-        assert TemplateValidator._is_valid_syntax("CONSTANT")
-        assert TemplateValidator._is_valid_syntax("camelCase")
-        assert TemplateValidator._is_valid_syntax("snake_case")
 
 
 class TestWorkflowValidation:
@@ -270,7 +230,7 @@ class TestWorkflowValidation:
         params = {"url": "https://youtube.com/watch?v=xyz"}
         registry = create_mock_registry()
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 0
 
     def test_missing_cli_parameter(self):
@@ -287,7 +247,7 @@ class TestWorkflowValidation:
         params = {}
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 1
         assert "Template variable ${url} has no valid source" in errors[0]
 
@@ -305,7 +265,7 @@ class TestWorkflowValidation:
         params = {}
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 3
         assert any("${param1}" in e for e in errors)
         assert any("${param2}" in e for e in errors)
@@ -331,7 +291,7 @@ class TestWorkflowValidation:
         params = {"url": "https://youtube.com/watch?v=xyz"}
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 0  # No errors - transcript_data is from shared store
 
     def test_invalid_syntax_in_shared_vars(self):
@@ -345,7 +305,7 @@ class TestWorkflowValidation:
 
         params = {}
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 1
         assert "Template variable ${data..field} has no valid source" in errors[0]
 
@@ -369,7 +329,7 @@ class TestWorkflowValidation:
         params = {"config": {"setting": "value1", "other": "value2"}}
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 0  # config is provided
 
     def test_no_templates_in_workflow(self):
@@ -384,7 +344,7 @@ class TestWorkflowValidation:
 
         params = {}
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 0  # No templates, no errors
 
 
@@ -412,14 +372,12 @@ class TestRealWorldScenarios:
 
         # Test with missing URL
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
         assert len(errors) == 1
         assert "Template variable ${url} has no valid source" in errors[0]
 
         # Test with URL provided
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
-            workflow_ir, {"url": "https://youtube.com"}, registry
-        )
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"url": "https://youtube.com"}, registry)
         assert len(errors) == 0  # transcript_data and summary are from shared store
 
     def test_github_issue_workflow(self):
@@ -442,19 +400,19 @@ class TestRealWorldScenarios:
 
         # Test with no params
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
         assert len(errors) == 2
         assert any("${repo}" in e for e in errors)
         assert any("${issue_number}" in e for e in errors)
 
         # Test with partial params
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"repo": "pflow"}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"repo": "pflow"}, registry)
         assert len(errors) == 1
         assert "${issue_number}" in errors[0]
 
         # Test with all params
         params = {"repo": "pflow", "issue_number": "123"}
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, params, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, params, registry)
         assert len(errors) == 0
 
 
@@ -477,9 +435,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
-            workflow_ir, {"items": ["a", "b", "c"]}, registry
-        )
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b", "c"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_batch_item_alias_custom_recognized(self):
@@ -498,9 +454,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
-            workflow_ir, {"records": ["a", "b"]}, registry
-        )
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"records": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_batch_outputs_recognized(self):
@@ -524,7 +478,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_all_batch_outputs_available(self):
@@ -557,7 +511,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": []}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": []}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_batch_items_template_validated(self):
@@ -578,7 +532,7 @@ class TestBatchTemplateValidation:
         registry = create_mock_registry()
 
         # With data provided - should pass (data is used in batch.items)
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_batch_items_invalid_template_fails(self):
@@ -596,7 +550,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
         assert len(errors) > 0
         assert any("nonexistent_array" in e for e in errors)
 
@@ -622,7 +576,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
 
         # Should fail with batch-specific error message
         assert len(errors) == 1, f"Expected exactly 1 error, got {len(errors)}: {errors}"
@@ -661,7 +615,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
 
         # Should have exactly one error
         assert len(errors) == 1, f"Expected exactly 1 error, got {len(errors)}: {errors}"
@@ -700,7 +654,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
 
         # Should have exactly one error
         assert len(errors) == 1, f"Expected exactly 1 error, got {len(errors)}: {errors}"
@@ -739,7 +693,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
 
         assert len(errors) == 1, f"Expected exactly 1 error, got {len(errors)}: {errors}"
         error = errors[0]
@@ -767,7 +721,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should have errors (missing input_text and invalid foobar)
         assert len(errors) >= 1, f"Expected at least 1 error, got {len(errors)}: {errors}"
@@ -801,9 +755,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
-            workflow_ir, {"url": "https://youtube.com"}, registry
-        )
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"url": "https://youtube.com"}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_mixed_batch_and_non_batch_nodes(self):
@@ -834,7 +786,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
+        errors, _warnings = validate_workflow_templates(
             workflow_ir, {"url": "https://youtube.com", "items": ["a", "b"]}, registry
         )
         assert len(errors) == 0, f"Unexpected errors: {errors}"
@@ -863,7 +815,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
         # Should NOT produce an error - results[0].response is valid
         assert len(errors) == 0, f"Unexpected errors for nested batch access: {errors}"
 
@@ -891,7 +843,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
         # Should NOT produce an error - results[0].item is valid (original batch input)
         assert len(errors) == 0, f"Unexpected errors for batch item field access: {errors}"
 
@@ -919,7 +871,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
         # Should NOT produce an error - deeply nested path is valid
         assert len(errors) == 0, f"Unexpected errors for deeply nested batch access: {errors}"
 
@@ -947,7 +899,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
         # Should produce an error - typo_field is not a valid output
         assert len(errors) == 1, f"Expected 1 error for invalid path, got: {errors}"
         assert "typo_field" in errors[0] or "results[0]" in errors[0]
@@ -978,9 +930,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
-            workflow_ir, {"items": ["a", "b", "c"]}, registry
-        )
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b", "c"]}, registry)
         # Should NOT produce any "malformed template" errors
         malformed_errors = [e for e in errors if "Malformed template" in e]
         assert len(malformed_errors) == 0, f"Unexpected malformed template errors: {malformed_errors}"
@@ -1031,7 +981,7 @@ class TestBatchTemplateValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # CRITICAL: Should NOT fail with "does not output 'results[${item'"
         bad_errors = [e for e in errors if "results[${item" in e]
@@ -1073,7 +1023,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_workflow_batch_all_outputs_available(self):
@@ -1107,7 +1057,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": []}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": []}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_workflow_batch_inner_outputs_in_results(self):
@@ -1134,7 +1084,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_workflow_batch_blocks_direct_child_outputs(self):
@@ -1159,7 +1109,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
         # Should fail because 'content' is inside results, not at top level
         assert len(errors) > 0, "Should reject direct child output access on batched workflow"
         assert any("content" in e for e in errors), f"Error should mention 'content': {errors}"
@@ -1181,7 +1131,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"items": ["a"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_workflow_batch_unresolvable_child_dynamic(self):
@@ -1208,7 +1158,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
+        errors, _warnings = validate_workflow_templates(
             workflow_ir, {"items": ["a"], "wf_path": "./child.pflow.md"}, registry
         )
         # Should pass — batch outputs are known even if child outputs aren't
@@ -1238,7 +1188,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
+        errors, _warnings = validate_workflow_templates(
             workflow_ir, {"items": ["a"], "wf_path": "./child.pflow.md"}, registry
         )
         # Should pass — unknown inner outputs should be permissive, not strict
@@ -1265,7 +1215,7 @@ class TestBatchWorkflowNodeValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"text": "hello"}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"text": "hello"}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
 
@@ -1294,7 +1244,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_invalid_field_caught(self):
@@ -1319,7 +1269,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "nonexistent" in errors[0]
         assert "not available on batch items" in errors[0]
@@ -1347,7 +1297,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "Did you mean" in errors[0]
         assert "item.response" in errors[0]
@@ -1368,7 +1318,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_permissive_when_items_is_inline_array(self):
@@ -1387,7 +1337,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_permissive_when_items_from_non_batch_source(self):
@@ -1411,7 +1361,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_multiple_batch_nodes_validated_independently(self):
@@ -1451,7 +1401,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_multiple_batch_nodes_wrong_field_caught(self):
@@ -1476,7 +1426,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "stdout" in errors[0]
         assert "not available on batch items" in errors[0]
@@ -1503,7 +1453,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_custom_alias_invalid_field_caught(self):
@@ -1528,7 +1478,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "nonexistent" in errors[0]
 
@@ -1569,7 +1519,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_bare_item_not_checked(self):
@@ -1594,7 +1544,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_item_field_original_input_accessible(self):
@@ -1619,7 +1569,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_error_shows_available_fields(self):
@@ -1644,7 +1594,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         # Should show available shell output fields
         assert "${item.stdout}" in errors[0]
@@ -1672,7 +1622,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "${fetch.results}" in errors[0]
         # Must NOT double-wrap: ${${fetch.results}} would be wrong
@@ -1700,7 +1650,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
 
     def test_workflow_batch_item_fields_validated(self):
@@ -1738,7 +1688,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"sources": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"sources": ["a"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_workflow_batch_item_invalid_field_caught(self):
@@ -1771,7 +1721,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"sources": ["a"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"sources": ["a"]}, registry)
         assert len(errors) == 1
         assert "stdout" in errors[0]
         assert "not available on batch items" in errors[0]
@@ -1804,7 +1754,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
+        errors, _warnings = validate_workflow_templates(
             workflow_ir, {"sources": ["a"], "workflow_path": "some.pflow.md"}, registry
         )
         # Should NOT produce item field errors — structure is unknown
@@ -1833,7 +1783,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
 
     def test_nested_item_path_invalid_caught(self):
@@ -1858,7 +1808,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "nope" in errors[0]
         assert "llm_usage" in errors[0]
@@ -1887,7 +1837,7 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 1
         assert "Did you mean" in errors[0]
         assert "item.llm_usage.model" in errors[0]
@@ -1914,5 +1864,5 @@ class TestBatchItemFieldValidation:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"data": ["a", "b"]}, registry)
         assert len(errors) == 0, f"Unexpected errors: {errors}"

--- a/tests/test_runtime/test_template_validator_enhanced_errors.py
+++ b/tests/test_runtime/test_template_validator_enhanced_errors.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock
 
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import validate_workflow_templates
 
 
 def create_mock_registry():
@@ -77,7 +77,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert errors[0] == "Required input '${issue_number}' not provided - GitHub issue number to fix (required)"
@@ -103,7 +103,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert (
@@ -130,7 +130,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert "Required input '${config}' not provided - API configuration object (required)" in errors[0]
@@ -158,7 +158,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should have 2 errors: one for missing required input, one for undeclared variable
         assert len(errors) == 2
@@ -183,7 +183,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert "Template variable ${some_var} has no valid source" in errors[0]
@@ -215,7 +215,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 2
         # Check both errors are present (order not guaranteed)
@@ -243,7 +243,7 @@ class TestEnhancedTemplateErrors:
         }
 
         registry = create_mock_registry()
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert errors[0] == "Required input '${my_input}' not provided - (required)"
@@ -269,8 +269,6 @@ class TestEnhancedTemplateErrors:
 
         registry = create_mock_registry()
         # Provide the required input
-        errors, _warnings = TemplateValidator.validate_workflow_templates(
-            workflow_ir, {"issue_number": "123"}, registry
-        )
+        errors, _warnings = validate_workflow_templates(workflow_ir, {"issue_number": "123"}, registry)
 
         assert len(errors) == 0

--- a/tests/test_runtime/test_template_validator_malformed.py
+++ b/tests/test_runtime/test_template_validator_malformed.py
@@ -7,7 +7,7 @@ like unclosed braces, empty templates, etc.
 from unittest.mock import Mock
 
 from pflow.registry import Registry
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import validate_workflow_templates
 
 
 def create_mock_registry(nodes_metadata):
@@ -44,7 +44,7 @@ class TestMalformedTemplateDetection:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1, f"Expected 1 error but got {len(errors)}: {errors}"
         assert "Malformed template syntax" in errors[0]
@@ -66,7 +66,7 @@ class TestMalformedTemplateDetection:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert "Malformed template syntax" in errors[0]
@@ -87,7 +87,7 @@ class TestMalformedTemplateDetection:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert "Malformed template syntax" in errors[0]
@@ -114,7 +114,7 @@ class TestMalformedTemplateDetection:
             "shell": {"interface": {"inputs": [], "outputs": [{"key": "result", "type": "str"}], "params": []}}
         })
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should detect the malformed template
         assert any("Malformed template syntax" in err for err in errors)
@@ -142,7 +142,7 @@ class TestMalformedTemplateDetection:
             "shell": {"interface": {"inputs": [], "outputs": [{"key": "result", "type": "str"}], "params": []}}
         })
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should NOT have malformed template errors
         assert not any("Malformed template syntax" in err for err in errors)
@@ -170,7 +170,7 @@ class TestMalformedTemplateDetection:
             "shell": {"interface": {"inputs": [], "outputs": [], "params": []}},
         })
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should NOT have malformed template errors
         assert not any("Malformed template syntax" in err for err in errors)
@@ -190,7 +190,7 @@ class TestMalformedTemplateDetection:
 
         registry = create_mock_registry({"http": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert "Malformed template syntax" in errors[0]
@@ -211,7 +211,7 @@ class TestMalformedTemplateDetection:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should detect malformed template in the list
         malformed_errors = [err for err in errors if "Malformed template syntax" in err]
@@ -233,7 +233,7 @@ class TestMalformedTemplateDetection:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should have no errors
         assert len(errors) == 0
@@ -257,7 +257,7 @@ class TestMalformedTemplateEdgeCases:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Double ${{ means 2 ${, but only 1 valid template
         assert any("Malformed template syntax" in err for err in errors)
@@ -277,7 +277,7 @@ class TestMalformedTemplateEdgeCases:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 1
         assert "Found 2 '${' but only 0 valid template(s)" in errors[0]
@@ -302,7 +302,7 @@ class TestMalformedTemplateEdgeCases:
 
         registry = create_mock_registry({"shell": {"interface": {"inputs": [], "outputs": [], "params": []}}})
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should NOT flag as malformed — it's a valid coalesce with nested indices
         assert not any("Malformed template syntax" in err for err in errors)

--- a/tests/test_runtime/test_template_validator_types.py
+++ b/tests/test_runtime/test_template_validator_types.py
@@ -3,7 +3,7 @@
 import pytest
 
 from pflow.registry.registry import Registry
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import validate_workflow_templates
 
 
 @pytest.fixture
@@ -175,7 +175,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 0
@@ -196,7 +196,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 0  # No error - dict serializes to JSON string
@@ -217,7 +217,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 1
@@ -241,7 +241,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 0
@@ -262,7 +262,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 1
@@ -281,7 +281,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 0
@@ -302,7 +302,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "llm", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         # dict|str → str now passes because both dict and str can serialize to str
@@ -324,7 +324,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "llm", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         # dict|str → int should fail because neither dict nor str can convert to int
@@ -360,7 +360,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 0
@@ -390,7 +390,7 @@ class TestTypeValidationIntegration:
             ],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 2  # str→int and dict→int both fail
@@ -411,7 +411,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "consumer"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         type_errors = [e for e in errors if "Type mismatch" in e]
         assert len(type_errors) == 1
@@ -441,7 +441,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should have error about dict in shell command
         shell_errors = [e for e in errors if "Shell node" in e or "stdin" in e.lower()]
@@ -467,7 +467,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should have error about list in shell command
         shell_errors = [e for e in errors if "Shell node" in e or "stdin" in e.lower()]
@@ -494,7 +494,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # No shell-specific errors for stdin
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -516,7 +516,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # No errors for string in command
         assert len(errors) == 0
@@ -542,7 +542,7 @@ class TestTypeValidationIntegration:
             "edges": [],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should block dict workflow input in shell command
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -569,7 +569,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # No errors - accessing string field from dict is safe
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -598,7 +598,7 @@ class TestTypeValidationIntegration:
             "edges": [{"from": "llm-node", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should pass - dict|str contains str, which is a safe type
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -624,7 +624,7 @@ class TestShellCommandUnionTypes:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0
@@ -645,7 +645,7 @@ class TestShellCommandUnionTypes:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0
@@ -666,7 +666,7 @@ class TestShellCommandUnionTypes:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1
@@ -688,7 +688,7 @@ class TestShellCommandUnionTypes:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0
@@ -717,7 +717,7 @@ class TestShellCommandGenericTypes:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should block - base type "list" is blocked
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -741,7 +741,7 @@ class TestShellCommandGenericTypes:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should pass - quoted template bypasses type check
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -771,7 +771,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0
@@ -792,7 +792,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1
@@ -814,7 +814,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0
@@ -841,7 +841,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         # Should pass - quoted template with nested path is escaped
         shell_errors = [e for e in errors if "Shell node" in e]
@@ -864,7 +864,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1  # Still blocked
@@ -886,7 +886,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1  # Still blocked
@@ -912,7 +912,7 @@ class TestShellCommandQuoteEscape:
             ],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0  # Both escaped
@@ -938,7 +938,7 @@ class TestShellCommandQuoteEscape:
             ],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1  # Only unquoted one blocked
@@ -960,7 +960,7 @@ class TestShellCommandQuoteEscape:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1
@@ -987,7 +987,7 @@ class TestShellCommandRegressions:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1
@@ -1008,7 +1008,7 @@ class TestShellCommandRegressions:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 1
@@ -1029,7 +1029,7 @@ class TestShellCommandRegressions:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0
@@ -1051,7 +1051,7 @@ class TestShellCommandRegressions:
             "edges": [{"from": "producer", "to": "shell-node"}],
         }
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, test_registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, test_registry)
 
         shell_errors = [e for e in errors if "Shell node" in e]
         assert len(shell_errors) == 0

--- a/tests/test_runtime/test_template_validator_union_types.py
+++ b/tests/test_runtime/test_template_validator_union_types.py
@@ -10,7 +10,7 @@ Related to Issue #66: Validator should allow nested template access for typed di
 from unittest.mock import Mock
 
 from pflow.registry import Registry
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import validate_workflow_templates
 
 
 def create_mock_registry(nodes_metadata):
@@ -73,7 +73,7 @@ class TestUnionTypeValidation:
         })
 
         # Validate - should pass without errors
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         assert len(warnings) == 0, "dict|str union should not generate warnings"
@@ -113,7 +113,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # No errors - str allows nested access via JSON auto-parsing
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -152,7 +152,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         assert len(warnings) == 0, "dict|object union should not generate warnings"
@@ -188,7 +188,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         assert len(warnings) == 0, "dict|str|int union should not generate warnings"
@@ -224,7 +224,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         # any is trusted (explicit declaration) - no warning even with str in union
@@ -261,7 +261,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         # dict and any are both trusted - no warning
@@ -298,7 +298,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         assert len(warnings) == 0, "Case-insensitive Dict|Str should work"
@@ -334,7 +334,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         assert len(warnings) == 0, "Whitespace handling should work"
@@ -370,7 +370,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Single dict type should allow nested access without warnings
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -407,7 +407,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
         # any is an explicit declaration - node author knows what they're doing
@@ -448,7 +448,7 @@ class TestUnionTypeValidation:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # No nested access, so no warnings even for union types
         # dict|str is compatible with str (auto-serialization)
@@ -490,7 +490,7 @@ class TestUnionTypeEdgeCases:
             },
         })
 
-        errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, _warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should still work - empty string after strip is ignored
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -530,7 +530,7 @@ class TestUnionTypeEdgeCases:
             },
         })
 
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # dict|str is compatible with str (auto-serialization)
         assert len(errors) == 0, f"Expected no errors but got: {errors}"

--- a/tests/test_runtime/test_template_validator_unused_inputs.py
+++ b/tests/test_runtime/test_template_validator_unused_inputs.py
@@ -7,7 +7,7 @@ declared inputs are never used as template variables in the workflow.
 import pytest
 
 from pflow.registry import Registry
-from pflow.runtime.template_validator import TemplateValidator
+from pflow.runtime.template_validator import validate_workflow_templates
 
 
 class MockRegistry(Registry):
@@ -110,7 +110,7 @@ def test_unused_input_single_unused(mock_registry, tmp_path):
 
     initial_params = {"input_path": input_path}  # unused_param not provided
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have exactly one error about unused input
     assert len(errors) == 1
@@ -142,7 +142,7 @@ def test_all_inputs_used(mock_registry, tmp_path):
 
     initial_params = {"input_path": input_path, "output_path": output_path}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors
     assert len(errors) == 0
@@ -163,7 +163,7 @@ def test_empty_inputs_field(mock_registry, tmp_path):
         ],
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, {}, mock_registry)
     assert len(errors) == 0
 
     # Test with missing inputs field
@@ -177,7 +177,7 @@ def test_empty_inputs_field(mock_registry, tmp_path):
         ]
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir_no_inputs, {}, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir_no_inputs, {}, mock_registry)
     assert len(errors) == 0
 
 
@@ -209,7 +209,7 @@ def test_input_used_in_nested_path(mock_registry, tmp_path):
         "api_settings": {"endpoint": {"url": output_path}},
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - both inputs are used even though with nested paths
     assert len(errors) == 0
@@ -235,7 +235,7 @@ def test_multiple_unused_inputs(mock_registry, tmp_path):
 
     initial_params = {"used_param": str(tmp_path / "file.txt")}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have exactly one error listing all unused inputs
     assert len(errors) == 1
@@ -276,7 +276,7 @@ def test_node_output_not_flagged_as_unused_input(mock_registry, tmp_path):
 
     initial_params = {"input_file": input_path}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - outputs aren't inputs
     assert len(errors) == 0
@@ -309,7 +309,7 @@ def test_input_used_multiple_times(mock_registry, tmp_path):
 
     initial_params = {"base_path": str(tmp_path)}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - input is used
     assert len(errors) == 0
@@ -340,7 +340,7 @@ def test_mixed_used_and_unused_inputs(mock_registry, tmp_path):
 
     initial_params = {"used1": str(tmp_path / "input.txt"), "used2": str(tmp_path / "output.txt")}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have one error about unused inputs
     assert len(errors) == 1
@@ -368,7 +368,7 @@ def test_input_only_used_in_concatenation(mock_registry, tmp_path):
 
     initial_params = {"prefix": "test", "suffix": "data"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - both inputs are used
     assert len(errors) == 0
@@ -393,7 +393,7 @@ def test_unused_input_with_missing_required_input(mock_registry):
     # Don't provide the required input
     initial_params = {}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have two errors: one for missing required, one for unused
     assert len(errors) == 2
@@ -421,7 +421,7 @@ def test_case_sensitivity_in_unused_detection(mock_registry, tmp_path):
 
     initial_params = {"MyInput": str(tmp_path / "file.txt")}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have one error about unused 'myinput' (lowercase)
     assert len(errors) == 1
@@ -461,7 +461,7 @@ def test_nested_headers_with_templates(mock_registry):
 
     initial_params = {"api_token": "token123", "channel_id": "C123", "api_key": "key456"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are used in nested headers
     assert len(errors) == 0
@@ -494,7 +494,7 @@ def test_nested_body_with_templates(mock_registry):
 
     initial_params = {"message": "Hello", "user_id": "user123", "timestamp": "2024-01-01T00:00:00Z"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are used in nested body
     assert len(errors) == 0
@@ -527,7 +527,7 @@ def test_nested_params_with_templates(mock_registry):
 
     initial_params = {"search_query": "test", "page_size": "10", "sort_order": "desc"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are used in nested params
     assert len(errors) == 0
@@ -573,7 +573,7 @@ def test_deeply_nested_templates(mock_registry):
 
     initial_params = {"api_key": "key", "user_name": "Bob", "project_id": "P1", "task_id": "T1"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are used even in deeply nested structures
     assert len(errors) == 0
@@ -608,7 +608,7 @@ def test_templates_in_lists(mock_registry):
 
     initial_params = {"item1": "a", "item2": "b", "item3": "c"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are used in lists
     assert len(errors) == 0
@@ -642,7 +642,7 @@ def test_mixed_nested_and_toplevel_templates(mock_registry):
 
     initial_params = {"direct_url": "https://api.com", "header_token": "token", "body_message": "hello"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have one error - unused_param is not used
     assert len(errors) == 1
@@ -690,7 +690,7 @@ def test_nested_templates_with_multiple_nodes(mock_registry):
 
     initial_params = {"auth_token": "token123", "api_key": "key456", "channel": "C789"}
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are used across different nodes
     assert len(errors) == 0
@@ -787,7 +787,7 @@ def test_slack_google_sheets_real_scenario(mock_registry):
         "sheet_name": "Sheet1",
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have no errors - all inputs are properly used in various nested structures
     assert len(errors) == 0
@@ -831,7 +831,7 @@ def test_partially_used_nested_inputs(mock_registry):
         "also_never_used": "a",
     }
 
-    errors, _warnings = TemplateValidator.validate_workflow_templates(workflow_ir, initial_params, mock_registry)
+    errors, _warnings = validate_workflow_templates(workflow_ir, initial_params, mock_registry)
 
     # Should have one error listing both unused inputs
     assert len(errors) == 1

--- a/tests/test_runtime/test_template_validator_warnings.py
+++ b/tests/test_runtime/test_template_validator_warnings.py
@@ -8,7 +8,7 @@ Warning behavior:
 
 from unittest.mock import Mock
 
-from pflow.runtime.template_validator import TemplateValidator, ValidationWarning
+from pflow.runtime.template_validator import ValidationWarning, validate_workflow_templates
 
 
 def create_mock_registry_with_str_output():
@@ -115,7 +115,7 @@ class TestValidationWarnings:
         }
 
         registry = create_mock_registry_with_str_output()
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should NOT error - str allows nested access via JSON auto-parsing
         assert len(errors) == 0, f"Expected no errors, got: {errors}"
@@ -149,7 +149,7 @@ class TestValidationWarnings:
         }
 
         registry = create_mock_registry_with_any_output()
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should NOT error
         assert len(errors) == 0, f"Expected no errors, got: {errors}"
@@ -174,7 +174,7 @@ class TestValidationWarnings:
         }
 
         registry = create_mock_registry_with_str_output()
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should not error or warn - direct access, no nesting
         assert len(errors) == 0
@@ -220,7 +220,7 @@ class TestValidationWarnings:
         }
 
         registry = create_mock_registry_with_str_output()
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0, f"Expected no errors, got: {errors}"
         assert len(warnings) == 2, f"Expected 2 warnings, got: {warnings}"
@@ -246,7 +246,7 @@ class TestValidationWarnings:
         }
 
         registry = create_mock_registry_with_str_output()
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         assert len(errors) == 0
         assert len(warnings) == 1
@@ -286,7 +286,7 @@ class TestWarningEdgeCases:
         }
 
         registry = create_mock_registry_with_str_output()
-        errors, warnings = TemplateValidator.validate_workflow_templates(workflow_ir, {}, registry)
+        errors, warnings = validate_workflow_templates(workflow_ir, {}, registry)
 
         # Should have error for nonexistent node
         assert len(errors) >= 1


### PR DESCRIPTION
## Summary

Split the 2,246-line `TemplateValidator` class into 5 focused modules organized by validation concern. Pure structural refactor — zero behavior change.

## Changes

- **Split `template_validator.py`** (2,246 → 660 lines) into 5 files by validation concern
  - `template_path_validation.py` (734 lines) — Pass 5: path existence + all path error formatting
  - `template_type_validation.py` (382 lines) — Passes 6+7: type matching + shell command types
  - `batch_item_validation.py` (284 lines) — Pass 8: `${item.field}` validation
  - `validation_utils.py` (306 lines) — Shared infrastructure
- **Dissolved `TemplateValidator` class** — was pure namespace (all `@staticmethod`, zero state), now module-level functions
- **Deleted dead code** — `_is_valid_syntax()` (defined but never called) and its 6 tests
- **Updated all 17 consumer files** — 4 production imports + 13 test files including 10 `mock.patch` string targets

## Explanation

The file was flagged during PR #117 (batch item validation) where we added ~260 lines to an already-large file. The split follows the principle: **split by concern, not by category**. Each file owns both its detection logic AND its error formatting — they change together, so they live together.

The dependency graph between new files is a clean DAG with no cycles:
```
template_validator.py (orchestrator)
  ├── template_path_validation → validation_utils
  ├── template_type_validation → type_checker (pre-existing)
  └── batch_item_validation → template_path_validation, validation_utils
```

Key decisions:
- Kept files flat in `runtime/` (subdirectory extraction deferred to follow-up)
- Dropped underscore prefixes on functions that became cross-module public API
- Re-exported `ValidationWarning` from `template_validator.py` for backward compat
- `_BATCH_OUTPUTS` changed from `ClassVar` to plain module-level list (mypy requirement)

## Testing

```
make test   → 4,128 passed (6 fewer = deleted dead code tests)
make check  → ruff + mypy + deptry all clean
grep -rn "TemplateValidator" src/ tests/ → 0 code references
```

Migration audit verified all 54 non-deleted items exist in exactly one target file with zero duplications.

---

23 files changed, 2509 insertions(+), 2440 deletions(-)