### PR TITLE
fix: propagate LLM costs and cross-cutting keys through nested workflows (fixes #125)

### DIFF
--- a/src/pflow/cli/main.py
+++ b/src/pflow/cli/main.py
@@ -1500,7 +1500,7 @@ def _handle_workflow_error(
 
     # Save trace even on error
     if workflow_trace:
-        trace_file = workflow_trace.save_to_file()
+        trace_file = workflow_trace.save_to_file(llm_calls=shared_storage.get("__llm_calls__"))
         _echo_trace(ctx, f"📊 Workflow trace saved: {trace_file}")
 
     ctx.exit(1)
@@ -1547,7 +1547,7 @@ def _handle_workflow_success(
 
     # Save trace if requested (AFTER handling output so JSON is included)
     if workflow_trace:
-        trace_file = workflow_trace.save_to_file()
+        trace_file = workflow_trace.save_to_file(llm_calls=shared_storage.get("__llm_calls__"))
         _echo_trace(ctx, f"📊 Workflow trace saved: {trace_file}")
 
     # Only show success message if we didn't produce output
@@ -1790,7 +1790,7 @@ def _handle_workflow_exception(
 
     # Save trace on error if requested
     if workflow_trace:
-        trace_file = workflow_trace.save_to_file()
+        trace_file = workflow_trace.save_to_file(llm_calls=shared_storage.get("__llm_calls__"))
         _echo_trace(ctx, f"📊 Workflow trace saved: {trace_file}")
 
     ctx.exit(1)

--- a/src/pflow/execution/executor_service.py
+++ b/src/pflow/execution/executor_service.py
@@ -180,7 +180,8 @@ class WorkflowExecutorService:
         # Note: stdin data is now routed to workflow inputs via stdin: true
         # in the workflow IR, handled by _validate_and_prepare_workflow_params
 
-        # Initialize metrics tracking
+        # Initialize cross-cutting accumulators
+        shared_store["__warnings__"] = {}
         if metrics_collector:
             shared_store["__llm_calls__"] = []
             metrics_collector.record_workflow_start()

--- a/src/pflow/mcp/CLAUDE.md
+++ b/src/pflow/mcp/CLAUDE.md
@@ -39,7 +39,7 @@ mcp-servers.json   lists tools+schemas   registry entries         for stateful s
 | Pool creation | `execution/executor_service.py:_initialize_shared_store` → `shared["__mcp_pool__"]` | Created unconditionally for every workflow, but background thread starts lazily on first `call_tool()` |
 | Pool consumption | `nodes/mcp/node.py:prep()` → `pool.call_tool()` | Falls back to `asyncio.run()` if no pool (e.g., `pflow registry run`) |
 | Pool shutdown | `execution/executor_service.py` finally block | Always runs; safe to call multiple times |
-| Nested workflows | Do NOT propagate `__mcp_pool__` | Each gets its own pool from its own `executor_service` call |
+| Nested workflows | `__mcp_pool__` propagated from parent | Child workflows reuse parent's pool via `WorkflowExecutor._PROPAGATED_KEYS` (thread-safe, no shutdown risk) |
 
 ## Critical Details
 

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -192,6 +192,7 @@ Downstream: `${process_title.result}`
 - **Max depth enforcement** via `_pflow_depth` (default 10)
 - **Relative paths resolve from parent workflow directory** via `_pflow_workflow_file`, not CWD
 - **Child input validation**: compares provided params against child's `## Inputs`, gives actionable error with "You provided X, Available inputs: Y"
+- **Cross-cutting key propagation**: `_PROPAGATED_KEYS` tuple defines which `__dunder__` keys flow from parent to child storage in mapped mode (`__registry__`, `__llm_calls__`, `__progress_callback__`, `__mcp_pool__`, `__warnings__`). Execution-scoped keys (`__execution__`, `__cache_hits__`, `__template_errors__`) are deliberately NOT propagated — children get their own.
 
 ### WorkflowTraceCollector (`workflow_trace.py`)
 

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -60,6 +60,17 @@ class WorkflowExecutor(BaseNode):
         "__registry__",
     })
 
+    # Cross-cutting infrastructure keys propagated from parent to child storage.
+    # These are accumulators/resources that must flow through workflow boundaries,
+    # NOT execution-scoped state (__execution__, __cache_hits__, __template_errors__).
+    _PROPAGATED_KEYS = (
+        "__registry__",
+        "__llm_calls__",
+        "__progress_callback__",
+        "__mcp_pool__",
+        "__warnings__",
+    )
+
     def prep(self, shared: dict[str, Any]) -> dict[str, Any]:
         """Load the sub-workflow and prepare child inputs."""
         max_depth = self.params.get("max_depth", self.MAX_DEPTH_DEFAULT)
@@ -328,7 +339,8 @@ class WorkflowExecutor(BaseNode):
         child_storage[f"{self.RESERVED_KEY_PREFIX}stack"] = child_stack
         child_storage[f"{self.RESERVED_KEY_PREFIX}workflow_file"] = prep_res["workflow_path"]
 
-        if "__registry__" in parent_shared:
-            child_storage["__registry__"] = parent_shared["__registry__"]
+        for key in self._PROPAGATED_KEYS:
+            if key in parent_shared:
+                child_storage[key] = parent_shared[key]
 
         return child_storage

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -385,8 +385,13 @@ class WorkflowTraceCollector:
 
         return "success"
 
-    def save_to_file(self) -> Path:
+    def save_to_file(self, llm_calls: list[dict[str, Any]] | None = None) -> Path:
         """Save trace to JSON file in ~/.pflow/debug/.
+
+        Args:
+            llm_calls: Authoritative LLM call data from shared["__llm_calls__"].
+                When provided, llm_summary is built from this instead of scanning
+                trace events. This ensures sub-workflow LLM calls are counted.
 
         Returns:
             Path to the saved trace file
@@ -433,15 +438,26 @@ class WorkflowTraceCollector:
             "nodes": self.events,
         }
 
-        # Add summary of LLM calls if present
-        llm_events = [e for e in self.events if "llm_call" in e]
-        if llm_events:
-            total_tokens = sum(e["llm_call"].get("total_tokens", 0) for e in llm_events)
-            trace_data["llm_summary"] = {
-                "total_calls": len(llm_events),
-                "total_tokens": total_tokens,
-                "models_used": list({e["llm_call"].get("model", "unknown") for e in llm_events}),
-            }
+        # Add summary of LLM calls if present.
+        # Prefer authoritative __llm_calls__ (includes sub-workflow calls),
+        # fall back to scanning trace events (backward compat).
+        if llm_calls is not None:
+            if llm_calls:
+                total_tokens = sum(c.get("total_tokens", 0) for c in llm_calls)
+                trace_data["llm_summary"] = {
+                    "total_calls": len(llm_calls),
+                    "total_tokens": total_tokens,
+                    "models_used": list({c.get("model", "unknown") for c in llm_calls}),
+                }
+        else:
+            llm_events = [e for e in self.events if "llm_call" in e]
+            if llm_events:
+                total_tokens = sum(e["llm_call"].get("total_tokens", 0) for e in llm_events)
+                trace_data["llm_summary"] = {
+                    "total_calls": len(llm_events),
+                    "total_tokens": total_tokens,
+                    "models_used": list({e["llm_call"].get("model", "unknown") for e in llm_events}),
+                }
 
         # Add JSON output if it was generated (e.g., when --output-format json was used)
         if self.json_output is not None:

--- a/tests/test_runtime/test_workflow_executor/test_metrics_propagation.py
+++ b/tests/test_runtime/test_workflow_executor/test_metrics_propagation.py
@@ -1,0 +1,590 @@
+"""Tests for cross-cutting key propagation from parent to child workflows.
+
+Verifies that infrastructure keys (__llm_calls__, __progress_callback__,
+__mcp_pool__, __warnings__) are propagated through workflow nesting boundaries
+via WorkflowExecutor._PROPAGATED_KEYS / _create_child_storage().
+
+This ensures LLM costs from sub-workflows are not silently dropped, progress
+callbacks reach nested nodes, and MCP connection pools are shared.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pflow.pocketflow import BaseNode
+from pflow.registry import Registry
+from pflow.runtime import compile_ir_to_flow
+from pflow.runtime.workflow_executor import WorkflowExecutor
+
+
+class MockLLMNode(BaseNode):
+    """Simulates an LLM node by writing llm_usage to the shared store.
+
+    InstrumentedNodeWrapper picks this up via _capture_llm_usage() and
+    appends it to shared["__llm_calls__"].
+    """
+
+    def prep(self, shared):
+        return None
+
+    def exec(self, prep_res):
+        return "mock response"
+
+    def post(self, shared, prep_res, exec_res):
+        shared["response"] = exec_res
+        shared["llm_usage"] = {
+            "model": "test-model",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+        }
+        return "default"
+
+
+class SourceNode(BaseNode):
+    """Provides a list of items for batch processing."""
+
+    def prep(self, shared):
+        return None
+
+    def exec(self, prep_res):
+        return None
+
+    def post(self, shared, prep_res, exec_res):
+        shared["result"] = ["alpha", "beta", "gamma"]
+        return "default"
+
+
+def _setup_mock_imports(mock_node_class=None):
+    """Setup mock imports for test nodes.
+
+    Follows the exact pattern from test_integration.py. The compiler uses
+    importlib.import_module to load node classes from registry metadata.
+    We mock this to provide test node implementations.
+    """
+    if mock_node_class is None:
+        mock_node_class = MockLLMNode
+
+    mock_llm_module = Mock()
+    mock_llm_module.ExampleNode = mock_node_class
+    mock_llm_module.WorkflowExecutor = WorkflowExecutor
+
+    mock_source_module = Mock()
+    mock_source_module.SourceNode = SourceNode
+
+    def side_effect(module_path):
+        if module_path == "pflow.nodes.test_node":
+            return mock_llm_module
+        elif module_path == "pflow.nodes.source_node":
+            return mock_source_module
+        elif module_path == "pflow.runtime.workflow_executor":
+            import pflow.runtime.workflow_executor
+
+            return pflow.runtime.workflow_executor
+        else:
+            return mock_llm_module
+
+    return patch("importlib.import_module", side_effect=side_effect)
+
+
+@pytest.fixture
+def mock_registry(tmp_path):
+    """Create a mock registry with test nodes and workflow executor."""
+    registry_path = tmp_path / "test_registry.json"
+    registry = Registry(registry_path)
+
+    registry_data = {
+        "pflow.nodes.test_node": {
+            "module": "pflow.nodes.test_node",
+            "class_name": "ExampleNode",
+            "docstring": "Test node for testing",
+            "file_path": "/mock/path/test_node.py",
+            "interface": {
+                "inputs": [],
+                "outputs": [{"key": "test_output", "type": "string"}],
+                "parameters": [],
+            },
+        },
+        "pflow.runtime.workflow_executor": {
+            "module": "pflow.runtime.workflow_executor",
+            "class_name": "WorkflowExecutor",
+            "docstring": "Runtime executor for nested workflow execution",
+            "file_path": "/mock/path/workflow_executor.py",
+            "interface": {
+                "inputs": [],
+                "outputs": [],
+                "parameters": [
+                    {"key": "workflow", "type": "string", "required": False},
+                    {"key": "workflow_ir", "type": "dict", "required": False},
+                    {"key": "storage_mode", "type": "string", "required": False},
+                    {"key": "max_depth", "type": "integer", "required": False},
+                    {"key": "error_action", "type": "string", "required": False},
+                ],
+            },
+        },
+        "pflow.nodes.source_node": {
+            "module": "pflow.nodes.source_node",
+            "class_name": "SourceNode",
+            "docstring": "Provides items for batch processing",
+            "file_path": "/mock/path/source_node.py",
+            "interface": {
+                "inputs": [],
+                "outputs": [{"key": "result", "type": "array"}],
+                "parameters": [],
+            },
+        },
+    }
+
+    registry.save(registry_data)
+    return registry
+
+
+# ------------------------------------------------------------------ #
+# Integration tests: full compile + run pipeline
+# ------------------------------------------------------------------ #
+
+
+class TestLLMCallsPropagation:
+    """Verify __llm_calls__ accumulator flows through workflow nesting."""
+
+    def test_single_sub_workflow_llm_calls_propagated(self, mock_registry):
+        """When parent and child each have an LLM node, both entries appear in __llm_calls__.
+
+        Parent runs "direct-llm" (MockLLMNode), then "child-call" (WorkflowExecutor
+        with inline IR containing one MockLLMNode). After execution, the shared
+        __llm_calls__ list should contain entries from both levels.
+        """
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "inner-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call inside child workflow",
+                }
+            ],
+            "edges": [],
+        }
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "direct-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call in parent workflow",
+                },
+                {
+                    "id": "child-call",
+                    "type": "pflow.runtime.workflow_executor",
+                    "params": {
+                        "workflow_ir": child_ir,
+                    },
+                    "purpose": "Execute child workflow with LLM node",
+                },
+            ],
+            "edges": [{"from": "direct-llm", "to": "child-call"}],
+        }
+
+        with _setup_mock_imports():
+            flow = compile_ir_to_flow(parent_ir, registry=mock_registry, validate=False)
+            shared: dict = {"__llm_calls__": []}
+            flow.run(shared)
+
+            assert len(shared["__llm_calls__"]) == 2
+            node_ids = [call["node_id"] for call in shared["__llm_calls__"]]
+            assert "direct-llm" in node_ids
+            assert "inner-llm" in node_ids
+
+            # Verify token counts are preserved
+            for call in shared["__llm_calls__"]:
+                assert call["total_tokens"] == 150
+                assert call["input_tokens"] == 100
+                assert call["output_tokens"] == 50
+
+    def test_nested_depth_2_llm_calls_propagated(self, mock_registry):
+        """When workflows nest 3 levels deep, all LLM calls from every level appear.
+
+        Grandparent -> parent -> child, each with one MockLLMNode.
+        After run, __llm_calls__ should contain exactly 3 entries.
+        """
+        grandchild_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "c-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call in grandchild workflow",
+                }
+            ],
+            "edges": [],
+        }
+
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "p-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call in child workflow",
+                },
+                {
+                    "id": "child-call",
+                    "type": "pflow.runtime.workflow_executor",
+                    "params": {
+                        "workflow_ir": grandchild_ir,
+                    },
+                    "purpose": "Execute grandchild workflow with LLM node",
+                },
+            ],
+            "edges": [{"from": "p-llm", "to": "child-call"}],
+        }
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "gp-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call in grandparent workflow",
+                },
+                {
+                    "id": "parent-call",
+                    "type": "pflow.runtime.workflow_executor",
+                    "params": {
+                        "workflow_ir": child_ir,
+                    },
+                    "purpose": "Execute child workflow containing grandchild",
+                },
+            ],
+            "edges": [{"from": "gp-llm", "to": "parent-call"}],
+        }
+
+        with _setup_mock_imports():
+            flow = compile_ir_to_flow(parent_ir, registry=mock_registry, validate=False)
+            shared: dict = {"__llm_calls__": []}
+            flow.run(shared)
+
+            assert len(shared["__llm_calls__"]) == 3
+            node_ids = [call["node_id"] for call in shared["__llm_calls__"]]
+            assert "gp-llm" in node_ids
+            assert "p-llm" in node_ids
+            assert "c-llm" in node_ids
+
+    def test_batched_sub_workflow_llm_calls_propagated(self, mock_registry):
+        """When a batched workflow node runs N children, all child LLM calls are tracked.
+
+        This is the highest-risk scenario: batch creates shallow copies of shared
+        (preserving __llm_calls__ reference), then each batch item runs a
+        WorkflowExecutor through the full wrapper chain (InstrumentedNodeWrapper ->
+        PflowBatchNode -> NamespacedNodeWrapper -> WorkflowExecutor). The child's
+        _create_child_storage propagates __llm_calls__ through the NamespacedSharedStore
+        proxy. Three layers of indirection must all work correctly.
+
+        Topology: source -> batch-children (3 items, each runs child workflow with 1 LLM)
+        Expected: 3 entries in __llm_calls__ (one per batch item's child LLM node).
+        """
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "child-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call inside batched child workflow",
+                }
+            ],
+            "edges": [],
+        }
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "source",
+                    "type": "pflow.nodes.source_node",
+                    "params": {},
+                    "purpose": "Provide items list for batch processing",
+                },
+                {
+                    "id": "batch-children",
+                    "type": "pflow.runtime.workflow_executor",
+                    "params": {
+                        "workflow_ir": child_ir,
+                    },
+                    "batch": {"items": "${source.result}"},
+                    "purpose": "Run child workflow for each item in batch",
+                },
+            ],
+            "edges": [{"from": "source", "to": "batch-children"}],
+        }
+
+        with _setup_mock_imports():
+            flow = compile_ir_to_flow(parent_ir, registry=mock_registry, validate=False)
+            shared: dict = {"__llm_calls__": []}
+            flow.run(shared)
+
+            # 3 batch items x 1 LLM call each = 3 total
+            assert len(shared["__llm_calls__"]) == 3
+            for call in shared["__llm_calls__"]:
+                assert call["node_id"] == "child-llm"
+                assert call["total_tokens"] == 150
+
+    def test_shared_mode_no_regression(self, mock_registry):
+        """When storage_mode is 'shared', LLM calls still propagate correctly.
+
+        Same topology as test_single_sub_workflow but with storage_mode: shared.
+        The child writes directly to parent storage, so propagation should work
+        without any special handling.
+        """
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "inner-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call inside shared-mode child",
+                }
+            ],
+            "edges": [],
+        }
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "direct-llm",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Simulate LLM call in parent workflow",
+                },
+                {
+                    "id": "child-call",
+                    "type": "pflow.runtime.workflow_executor",
+                    "params": {
+                        "workflow_ir": child_ir,
+                        "storage_mode": "shared",
+                    },
+                    "purpose": "Execute child workflow in shared storage mode",
+                },
+            ],
+            "edges": [{"from": "direct-llm", "to": "child-call"}],
+        }
+
+        with _setup_mock_imports():
+            flow = compile_ir_to_flow(parent_ir, registry=mock_registry, validate=False)
+            shared: dict = {"__llm_calls__": []}
+            flow.run(shared)
+
+            assert len(shared["__llm_calls__"]) == 2
+            node_ids = [call["node_id"] for call in shared["__llm_calls__"]]
+            assert "direct-llm" in node_ids
+            assert "inner-llm" in node_ids
+
+
+class TestProgressCallbackPropagation:
+    """Verify __progress_callback__ is propagated to child workflows."""
+
+    def test_progress_callback_propagated(self, mock_registry):
+        """When parent has a progress callback, child's InstrumentedNodeWrapper invokes it.
+
+        The progress callback is used for real-time execution feedback. If it's not
+        propagated, nested workflow execution appears silent to the user.
+        """
+        callback = Mock()
+
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "inner-node",
+                    "type": "pflow.nodes.test_node",
+                    "params": {},
+                    "purpose": "Node inside child that should trigger callback",
+                }
+            ],
+            "edges": [],
+        }
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "child-call",
+                    "type": "pflow.runtime.workflow_executor",
+                    "params": {
+                        "workflow_ir": child_ir,
+                    },
+                    "purpose": "Execute child workflow to test callback propagation",
+                },
+            ],
+            "edges": [],
+        }
+
+        with _setup_mock_imports():
+            flow = compile_ir_to_flow(parent_ir, registry=mock_registry, validate=False)
+            shared: dict = {"__progress_callback__": callback}
+            flow.run(shared)
+
+            # The callback should have been called at least once by the child's
+            # InstrumentedNodeWrapper (it calls on node start and completion)
+            assert callback.call_count > 0
+
+
+# ------------------------------------------------------------------ #
+# Unit tests: _create_child_storage directly
+# ------------------------------------------------------------------ #
+
+
+class TestCreateChildStorage:
+    """Unit tests for WorkflowExecutor._create_child_storage().
+
+    Tests the propagation mechanism directly without the full compilation
+    pipeline overhead.
+    """
+
+    def _make_prep_res(self, workflow_path="test.pflow.md"):
+        """Create a minimal prep_res dict for _create_child_storage."""
+        return {
+            "child_params": {"input1": "value1"},
+            "current_depth": 0,
+            "execution_stack": [],
+            "workflow_path": workflow_path,
+        }
+
+    def test_propagated_keys_in_child_storage(self):
+        """When parent has all propagated keys, child storage gets same object references.
+
+        This is the core invariant: propagated keys must be the SAME objects
+        (not copies), so that mutations in the child (e.g., appending to
+        __llm_calls__) are visible in the parent.
+        """
+        node = WorkflowExecutor()
+        node.set_params({"workflow_ir": {"nodes": [], "ir_version": "0.1.0"}})
+
+        llm_calls_list: list = []
+        progress_cb = Mock()
+        mcp_pool = Mock()
+        warnings_dict: dict = {}
+        registry = Mock()
+
+        parent_shared: dict = {
+            "__llm_calls__": llm_calls_list,
+            "__progress_callback__": progress_cb,
+            "__mcp_pool__": mcp_pool,
+            "__warnings__": warnings_dict,
+            "__registry__": registry,
+            "_pflow_depth": 0,
+            "_pflow_stack": [],
+        }
+
+        prep_res = self._make_prep_res()
+        child_storage = node._create_child_storage(parent_shared, "mapped", prep_res)
+
+        # All propagated keys present and are same object references
+        assert child_storage["__llm_calls__"] is llm_calls_list
+        assert child_storage["__progress_callback__"] is progress_cb
+        assert child_storage["__mcp_pool__"] is mcp_pool
+        assert child_storage["__warnings__"] is warnings_dict
+        assert child_storage["__registry__"] is registry
+
+        # Child params are present
+        assert child_storage["input1"] == "value1"
+
+        # Execution-scoped keys are NOT propagated (they are per-workflow)
+        assert "__execution__" not in child_storage
+        assert "__cache_hits__" not in child_storage
+        assert "__template_errors__" not in child_storage
+
+    def test_propagated_keys_not_present_in_parent(self):
+        """When parent lacks propagated keys, child simply does not have them.
+
+        No KeyError should occur. This handles the case where a workflow is
+        run without the full executor service (e.g., in tests).
+        """
+        node = WorkflowExecutor()
+        node.set_params({"workflow_ir": {"nodes": [], "ir_version": "0.1.0"}})
+
+        parent_shared: dict = {
+            "_pflow_depth": 0,
+            "_pflow_stack": [],
+        }
+
+        prep_res = self._make_prep_res()
+        child_storage = node._create_child_storage(parent_shared, "mapped", prep_res)
+
+        # None of the propagated keys should be present
+        assert "__llm_calls__" not in child_storage
+        assert "__progress_callback__" not in child_storage
+        assert "__mcp_pool__" not in child_storage
+        assert "__warnings__" not in child_storage
+        # __registry__ also not present since parent didn't have it
+        assert "__registry__" not in child_storage
+
+        # Should still have child params and execution context
+        assert child_storage["input1"] == "value1"
+        assert child_storage["_pflow_depth"] == 1
+
+    def test_shared_mode_propagation_is_noop(self):
+        """When storage_mode is 'shared', child_storage IS parent_shared (same object).
+
+        In shared mode, the child operates directly on the parent's storage.
+        Propagation is effectively a no-op because the keys are already there.
+        """
+        node = WorkflowExecutor()
+        node.set_params({"workflow_ir": {"nodes": [], "ir_version": "0.1.0"}})
+
+        llm_calls_list: list = []
+        parent_shared: dict = {
+            "__llm_calls__": llm_calls_list,
+            "__progress_callback__": Mock(),
+            "_pflow_depth": 0,
+            "_pflow_stack": [],
+        }
+
+        prep_res = self._make_prep_res()
+        child_storage = node._create_child_storage(parent_shared, "shared", prep_res)
+
+        # In shared mode, child_storage IS parent_shared
+        assert child_storage is parent_shared
+
+        # The propagated keys are naturally present since it's the same dict
+        assert child_storage["__llm_calls__"] is llm_calls_list
+
+    def test_mutation_in_child_visible_in_parent(self):
+        """When child appends to __llm_calls__, parent sees it immediately.
+
+        This is the critical behavior that the bug fix enables: because the
+        propagated list is the SAME object, not a copy, mutations in the child
+        flow back to the parent.
+        """
+        node = WorkflowExecutor()
+        node.set_params({"workflow_ir": {"nodes": [], "ir_version": "0.1.0"}})
+
+        llm_calls_list: list = []
+        parent_shared: dict = {
+            "__llm_calls__": llm_calls_list,
+            "_pflow_depth": 0,
+            "_pflow_stack": [],
+        }
+
+        prep_res = self._make_prep_res()
+        child_storage = node._create_child_storage(parent_shared, "mapped", prep_res)
+
+        # Simulate what InstrumentedNodeWrapper._capture_llm_usage does
+        child_storage["__llm_calls__"].append({
+            "node_id": "child-node",
+            "model": "test-model",
+            "total_tokens": 100,
+        })
+
+        # Parent sees the mutation because it's the same list
+        assert len(parent_shared["__llm_calls__"]) == 1
+        assert parent_shared["__llm_calls__"][0]["node_id"] == "child-node"

--- a/tests/test_runtime/test_workflow_trace.py
+++ b/tests/test_runtime/test_workflow_trace.py
@@ -636,3 +636,103 @@ class TestWorkflowTraceCollector:
         # Should be parseable as ISO format
         parsed = datetime.fromisoformat(timestamp)
         assert isinstance(parsed, datetime)
+
+    def test_llm_summary_from_llm_calls_parameter(self, collector, temp_home):
+        """Test that llm_summary is built from llm_calls param when provided.
+
+        This ensures sub-workflow LLM calls (tracked in __llm_calls__ but not
+        in trace events) are included in the trace file's llm_summary.
+        """
+        with patch("pathlib.Path.home", return_value=temp_home):
+            # Record a non-LLM node (no llm_call in trace events)
+            collector.record_node_execution(
+                node_id="workflow-node",
+                node_type="WorkflowExecutor",
+                duration_ms=500.0,
+                shared_before={},
+                shared_after={},
+                success=True,
+            )
+
+            # Provide authoritative llm_calls (e.g., from child workflows)
+            llm_calls = [
+                {
+                    "model": "gpt-4",
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                    "node_id": "parent-llm",
+                },
+                {
+                    "model": "gpt-4",
+                    "input_tokens": 200,
+                    "output_tokens": 100,
+                    "total_tokens": 300,
+                    "node_id": "child-llm",
+                },
+                {
+                    "model": "claude-sonnet",
+                    "input_tokens": 50,
+                    "output_tokens": 25,
+                    "total_tokens": 75,
+                    "node_id": "child-llm-2",
+                },
+            ]
+
+            filepath = collector.save_to_file(llm_calls=llm_calls)
+
+            with open(filepath) as f:
+                trace_data = json.load(f)
+
+            assert "llm_summary" in trace_data
+            summary = trace_data["llm_summary"]
+            assert summary["total_calls"] == 3
+            assert summary["total_tokens"] == 525
+            assert set(summary["models_used"]) == {"gpt-4", "claude-sonnet"}
+
+    def test_llm_summary_fallback_to_events(self, collector, temp_home):
+        """Test backward compat: llm_summary from events when llm_calls not provided."""
+        with patch("pathlib.Path.home", return_value=temp_home):
+            collector.record_node_execution(
+                node_id="llm-node",
+                node_type="LLMNode",
+                duration_ms=1000.0,
+                shared_before={},
+                shared_after={"llm_usage": {"model": "gpt-4", "total_tokens": 200}},
+                success=True,
+            )
+
+            # No llm_calls param — should fall back to event scanning
+            filepath = collector.save_to_file()
+
+            with open(filepath) as f:
+                trace_data = json.load(f)
+
+            assert "llm_summary" in trace_data
+            assert trace_data["llm_summary"]["total_calls"] == 1
+            assert trace_data["llm_summary"]["total_tokens"] == 200
+
+    def test_llm_summary_empty_llm_calls_means_no_calls(self, collector, temp_home):
+        """Test that empty llm_calls list is authoritative: zero calls, no summary.
+
+        An empty list means "we tracked LLM calls and there were none" — it should
+        NOT fall back to trace event scanning, even if events contain llm_call data.
+        """
+        with patch("pathlib.Path.home", return_value=temp_home):
+            collector.record_node_execution(
+                node_id="llm-node",
+                node_type="LLMNode",
+                duration_ms=1000.0,
+                shared_before={},
+                shared_after={"llm_usage": {"model": "gpt-4", "total_tokens": 100}},
+                success=True,
+            )
+
+            # Empty list is authoritative — no LLM calls happened
+            filepath = collector.save_to_file(llm_calls=[])
+
+            with open(filepath) as f:
+                trace_data = json.load(f)
+
+            # Empty authoritative list = no llm_summary in trace
+            assert "llm_summary" not in trace_data


### PR DESCRIPTION
## Summary

LLM costs from sub-workflows were silently dropped from metrics, trace files, and CLI cost display. Only direct top-level LLM calls were tracked. The more a workflow used composition, the worse the underreporting (real-world example: 3 calls reported vs ~32 actual, costs understated by ~10x).

## Changes

- **`workflow_executor.py`**: Added `_PROPAGATED_KEYS` class constant. `_create_child_storage()` now propagates cross-cutting infrastructure keys (`__llm_calls__`, `__progress_callback__`, `__mcp_pool__`, `__warnings__`, `__registry__`) from parent to child storage by reference. Child LLM calls append to the parent's list automatically at any nesting depth.
- **`executor_service.py`**: Pre-initialize `shared_store["__warnings__"] = {}` so it propagates to children (same pattern as `__llm_calls__`).
- **`workflow_trace.py`**: Added `llm_calls` parameter to `save_to_file()`. When provided, builds `llm_summary` from the authoritative `__llm_calls__` list (which includes sub-workflow calls) instead of scanning trace events. Uses `is not None` check to correctly handle empty lists.
- **`cli/main.py`**: Pass `shared_storage.get("__llm_calls__")` at 3 `save_to_file()` call sites.
- **CLAUDE.md docs**: Updated `runtime/CLAUDE.md` and `mcp/CLAUDE.md` to document `_PROPAGATED_KEYS` and corrected MCP pool propagation behavior.

## Explanation

The root cause was a missing distinction between two kinds of `__` keys in the shared store:

| Kind | Examples | Should isolate per-workflow? |
|------|---------|---|
| Execution-scoped | `__execution__`, `__cache_hits__` | Yes |
| Cross-cutting telemetry/infrastructure | `__llm_calls__`, `__progress_callback__`, `__mcp_pool__` | **No** |

`_create_child_storage()` treated all `__` keys the same (didn't propagate any except `__registry__`). The fix introduces `_PROPAGATED_KEYS` to explicitly list which keys flow through workflow boundaries by reference, so mutations in child workflows (e.g., appending to `__llm_calls__`) are immediately visible in the parent.

Key design decisions:
- **Reference sharing, not merging**: Child gets the same list/dict object as parent. No post-execution merge needed. Works recursively at any depth.
- **No double-counting risk**: Verified that `WorkflowExecutor` never writes `llm_usage`, so the parent's `InstrumentedNodeWrapper` finds nothing to capture. `PflowBatchNode._capture_item_llm_usage()` also finds nothing for workflow nodes.
- **Thread-safe**: `list.append()` under GIL is atomic. Already the established pattern for parallel batch items.

## Testing

**Automated (12 new tests):**
- 9 tests in `test_metrics_propagation.py`:
  - Single sub-workflow, depth-2 nesting, batch + workflow (3 items), shared mode
  - Progress callback propagation
  - `_create_child_storage()` unit tests (reference identity, missing keys, mutation visibility)
- 3 tests in `test_workflow_trace.py`:
  - `llm_calls` parameter-based summary, event fallback, empty list handling

**Manual verification** with real LLM calls (Gemini Flash):

| Test | Expected calls | Trace `total_calls` | CLI cost |
|------|---------------|---------------------|----------|
| 3 direct (baseline) | 3 | 3 ✅ | $0.0032 |
| 2 direct + 1 child | 3 | 3 ✅ | $0.0031 |
| 1 direct + 3 batched children | 4 | 4 ✅ | $0.0057 |
| Depth-2 nesting (3 levels) | 3 | 3 ✅ | $0.0034 |

Run `make test` — 4092 passed. Run `make check` — all clean.

```
 src/pflow/cli/main.py                              |   6 +-
 src/pflow/execution/executor_service.py            |   3 +-
 src/pflow/mcp/CLAUDE.md                            |   2 +-
 src/pflow/runtime/CLAUDE.md                        |   1 +
 src/pflow/runtime/workflow_executor.py             |  16 +-
 src/pflow/runtime/workflow_trace.py                |  36 +-
 .../test_metrics_propagation.py                    | 590 +++++++++++++++++++++
 tests/test_runtime/test_workflow_trace.py          | 100 ++++
 8 files changed, 737 insertions(+), 17 deletions(-)
```