### PR TITLE
fix: error on duplicate known section headings (closes #212)

### DIFF
--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -206,6 +206,7 @@ def parse_markdown(content: str) -> MarkdownParseResult:  # noqa: C901
     result = MarkdownParseResult(ir={}, source=content)
     warnings: list[str] = []
     orphaned_lines: dict[_SectionType, list[int]] = {}
+    seen_sections: dict[_SectionType, int] = {}  # section_type → first line number
 
     lines = content.splitlines()
     total_lines = len(lines)
@@ -305,6 +306,14 @@ def parse_markdown(content: str) -> MarkdownParseResult:  # noqa: C901
             current_entity = None
             section_name = stripped[3:].strip()
             current_section, is_steps, warning = _resolve_section(section_name, line_num)
+            if current_section in _KNOWN_SECTIONS and current_section in seen_sections:
+                raise MarkdownParseError(
+                    f"Duplicate '## {_SECTION_DISPLAY_NAMES[current_section]}' section.",
+                    line=line_num,
+                    suggestion=f"Merge with the existing '## {_SECTION_DISPLAY_NAMES[current_section]}' section at line {seen_sections[current_section]}.",
+                )
+            if current_section in _KNOWN_SECTIONS:
+                seen_sections[current_section] = line_num
             if is_steps:
                 steps_section_found = True
             if warning:

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -416,6 +416,153 @@ class TestEntityParsing:
         with pytest.raises(MarkdownParseError, match="Duplicate entity ID 'fetch'"):
             parse_markdown(content)
 
+    def test_duplicate_steps_section_raises(self) -> None:
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### hello
+
+            Says hello.
+
+            - type: shell
+
+            ## Steps
+
+            ### goodbye
+
+            Says goodbye.
+
+            - type: shell
+        """)
+        with pytest.raises(MarkdownParseError, match="Duplicate '## Steps' section") as exc_info:
+            parse_markdown(content)
+        assert "Merge with the existing" in str(exc_info.value.suggestion)
+        # Error line points to the duplicate (line 13), suggestion references the original (line 5)
+        assert exc_info.value.line == 13
+        assert "line 5" in str(exc_info.value.suggestion)
+
+    def test_duplicate_inputs_section_raises(self) -> None:
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Inputs
+
+            ### message
+
+            A message.
+
+            - type: str
+
+            ## Inputs
+
+            ### name
+
+            A name.
+
+            - type: str
+
+            ## Steps
+
+            ### hello
+
+            Says hello.
+
+            - type: shell
+        """)
+        with pytest.raises(MarkdownParseError, match="Duplicate '## Inputs' section"):
+            parse_markdown(content)
+
+    def test_duplicate_outputs_section_raises(self) -> None:
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### hello
+
+            Says hello.
+
+            - type: shell
+
+            ## Outputs
+
+            ### result
+
+            The result.
+
+            - from: hello
+
+            ## Outputs
+
+            ### other
+
+            Another output.
+
+            - from: hello
+        """)
+        with pytest.raises(MarkdownParseError, match="Duplicate '## Outputs' section"):
+            parse_markdown(content)
+
+    def test_duplicate_section_case_insensitive(self) -> None:
+        """## Steps and ## steps both resolve to STEPS — duplicate detected."""
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### hello
+
+            Says hello.
+
+            - type: shell
+
+            ## steps
+
+            ### goodbye
+
+            Says goodbye.
+
+            - type: shell
+        """)
+        with pytest.raises(MarkdownParseError, match="Duplicate '## Steps' section"):
+            parse_markdown(content)
+
+    def test_duplicate_unknown_sections_allowed(self) -> None:
+        """Unknown sections (not Inputs/Steps/Outputs) can repeat without error."""
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Notes
+
+            Some notes.
+
+            ## Steps
+
+            ### hello
+
+            Says hello.
+
+            - type: shell
+
+            ## Notes
+
+            More notes.
+        """)
+        result = parse_markdown(content)
+        assert len(result.ir["nodes"]) == 1
+
 
 # ===========================================================================
 # 4. YAML param parsing


### PR DESCRIPTION
## Summary

Duplicate `## Inputs`, `## Steps`, or `## Outputs` headings in a workflow file now raise a `MarkdownParseError` instead of silently merging entities from both occurrences.

## Changes

- **Parser** (`markdown_parser.py`): Track seen known sections in the H2 handler. Error on duplicates with actionable suggestion pointing to the first occurrence's line number.
- **Tests** (`test_markdown_parser.py`): 5 new tests — duplicate Steps/Inputs/Outputs raise, case-insensitive detection, unknown sections allowed to repeat.

## Explanation

The parser's H2 handler previously overwrote `current_section` without checking whether that section type was already seen. Two `## Inputs` sections would silently merge their entities. Worse, this partially defeated the orphaned content detection from #204 — a valid entity in the second section made the entity count > 0, downgrading what should be an error to a warning.

The fix is 8 lines: a `seen_sections` dict tracks the first line number of each known section type, and the H2 handler checks it before proceeding.

## Testing

- `make test` — 4513 tests pass
- `make check` — all quality checks pass
- Manual verification with 6 workflow files covering: basic duplicates, orphan interaction, non-adjacent duplicates, case variation, near-miss false positive, valid workflow