### PR TITLE
fix: make --output-format json orthogonal to stderr verbosity (fixes #229)

### DIFF
--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -157,7 +157,7 @@ Structured output on stdout for machine parsing:
 pflow --output-format json workflow.pflow.md
 ```
 
-All workflow results, metrics, and errors serialize to a single JSON object on stdout. Progress display is suppressed.
+All workflow results, metrics, and errors serialize to a single JSON object on stdout. Progress and execution summary go to stderr (suppressed with `-p`).
 
 <Expandable title="JSON output structure">
 

--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -116,7 +116,7 @@ CLI text mode emits a stderr warning when auto-detection is used (not in `--prin
 
 ### JSON/Text Duality
 
-Error output is unified: `output_error()` in `error_output.py` handles JSON/text branching for ALL error types. Success output still has parallel paths in `workflow_output.py`. The `--output-format json` flag gates which path executes. JSON mode suppresses all logging below ERROR level to prevent stdout contamination.
+Error output is unified: `output_error()` in `error_output.py` handles JSON/text branching for ALL error types. Success output still has parallel paths in `workflow_output.py`. The `--output-format json` flag gates which path executes. `--output-format` controls stdout format only; stderr verbosity is controlled solely by `-p`.
 
 ## workflow_output.py
 
@@ -179,7 +179,7 @@ Note: has its own copy of `_get_output_controller` (duplicated from main.py to a
 --version              # Show version
 --verbose, -v          # Detailed output (extra error context)
 --output-key, -o       # Extract specific shared store key instead of auto-detection
---output-format        # "text" (default) or "json" — json forces non-interactive
+--output-format        # "text" (default) or "json" — controls stdout format only
 --print, -p            # Minimal output: suppress stderr header/summary/warnings
 --no-trace             # Disable automatic workflow trace saving
 --cache/--no-cache     # Enable/disable memoization cache reads (default: --cache). Writes always happen.
@@ -237,9 +237,9 @@ Note: `commands/mcp.py` still uses inline formatting (not yet migrated to shared
 ## Interactive Mode
 
 `OutputController.is_interactive()` has exactly one caller: `cli/mcp_sync.py` for MCP discovery progress gating. It does NOT gate workflow-execution progress.
-- **Progress display**: always streams to stderr via `create_progress_callback()` (TTY and non-TTY alike). Suppressed in `-p` and `--output-format json` by the callsite gate `progress_enabled = not print_flag and output_format != "json"` in `main.py`, not by TTY detection. The one TTY-specific branch is `_handle_batch_progress`'s `\r` inline counter.
+- **Progress display**: always streams to stderr via `create_progress_callback()` (TTY and non-TTY alike). Suppressed in `-p` by the callsite gate `progress_enabled = not print_flag` in `main.py`, not by TTY detection. The one TTY-specific branch is `_handle_batch_progress`'s `\r` inline counter.
 - **Save prompts**: use `click.confirm(...)` directly. There is no `OutputController` method for this.
-- **Trace path echo**: `_echo_trace` suppresses the "📊 Workflow trace saved" line in `-p` and JSON mode.
+- **Trace path echo**: `_echo_trace` suppresses the "📊 Workflow trace saved" line in `-p` mode.
 
 ## Common Usage
 

--- a/src/pflow/cli/main.py
+++ b/src/pflow/cli/main.py
@@ -316,11 +316,8 @@ def execute_json_workflow(  # noqa: C901
         click.echo("\n✗ Workflow execution interrupted", err=True)
         ctx.exit(130)
     except Exception as e:
-        # Emit failure tag to stderr (mirrors _display_execution_result error path)
         metrics = result.metrics if result else None
-        if not print_flag and metrics:
-            duration_s = time.perf_counter() - metrics.start_time
-            click.echo(f"❌ Workflow failed after {duration_s:.3f}s", err=True)
+        _emit_failure_tag(ctx, metrics)
 
         output_error(
             ctx,
@@ -338,6 +335,18 @@ def execute_json_workflow(  # noqa: C901
         if trace and config.trace_enabled:
             _save_trace_and_report(ctx, trace)
         _cleanup_temp_files(stdin_data, effective_verbose)
+
+
+def _emit_failure_tag(ctx: click.Context, metrics: Any | None) -> None:
+    """Emit one-line failure tag to stderr for agent observability.
+
+    Mirrors the success path's ``✓ Workflow completed in Xs`` completion tag.
+    Suppressed by ``-p`` (same as all stderr diagnostics).
+    """
+    print_flag = ctx.obj.get("print_flag", False) if ctx.obj else False
+    if not print_flag and metrics:
+        duration_s = time.perf_counter() - metrics.start_time
+        click.echo(f"❌ Workflow failed after {duration_s:.3f}s", err=True)
 
 
 def _display_execution_result(
@@ -367,12 +376,7 @@ def _display_execution_result(
         if result.status == WorkflowStatus.DEGRADED:
             ctx.exit(2)
     else:
-        # Emit one-line failure tag to stderr so agents see status without
-        # parsing stdout (mirrors the success path's completion tag).
-        print_flag = ctx.obj.get("print_flag", False) if ctx.obj else False
-        if not print_flag and result.metrics:
-            duration_s = time.perf_counter() - result.metrics.start_time
-            click.echo(f"❌ Workflow failed after {duration_s:.3f}s", err=True)
+        _emit_failure_tag(ctx, result.metrics)
 
         output_error(
             ctx,

--- a/src/pflow/cli/main.py
+++ b/src/pflow/cli/main.py
@@ -7,6 +7,7 @@ import logging
 import os
 import signal
 import sys
+import time
 import warnings
 from pathlib import Path
 from typing import Any, cast
@@ -66,17 +67,13 @@ def _get_output_controller(ctx: click.Context) -> OutputController:
     # Fallback: create one if not in context (shouldn't happen normally)
     return OutputController(
         print_flag=ctx.obj.get("print_flag", False) if ctx.obj else False,
-        output_format=ctx.obj.get("output_format", "text") if ctx.obj else "text",
     )
 
 
 def _echo_trace(ctx: click.Context, message: str) -> None:
     """Output trace file location message.
 
-    Shown in all modes EXCEPT:
-    - -p (print) mode: user explicitly wants only raw output
-    - JSON output mode: structured output only
-
+    Suppressed in -p (print) mode where user explicitly wants only raw output.
     Trace files are valuable for debugging in non-interactive contexts
     like CI/CD, agents, and scripts.
 
@@ -85,8 +82,7 @@ def _echo_trace(ctx: click.Context, message: str) -> None:
         message: Trace message to display
     """
     output_controller = _get_output_controller(ctx)
-    # Suppress in -p (print) or JSON modes - user wants only structured output
-    if output_controller.print_flag or output_controller.output_format == "json":
+    if output_controller.print_flag:
         return
     click.echo(message, err=True)
 
@@ -135,7 +131,7 @@ def _handle_workflow_success(
     verbose: bool,
 ) -> None:
     """Handle successful workflow execution."""
-    if verbose and output_format != "json":
+    if verbose:
         click.echo("cli: Workflow execution completed", err=True)
 
     # Check for output from shared store (now with metrics)
@@ -274,7 +270,7 @@ def execute_json_workflow(  # noqa: C901
     # Build config
     verbose = ctx.obj.get("verbose", False)
     print_flag = ctx.obj.get("print_flag", False)
-    effective_verbose = verbose and not print_flag and output_format != "json"
+    effective_verbose = verbose and not print_flag
     config = RunnerConfig(
         trace_enabled=ctx.obj.get("trace", True),
         cache_enabled=ctx.obj.get("cache", True),
@@ -286,15 +282,11 @@ def execute_json_workflow(  # noqa: C901
     if not effective_verbose:
         warnings.filterwarnings("ignore", message="Flow ends:.*", module="pflow.core.node")
 
-    # Suppress logging in JSON mode (except CRITICAL) to keep output clean
-    if output_format == "json":
-        logging.getLogger().setLevel(logging.CRITICAL)
-
     # Store total nodes for --report
     ctx.obj["total_nodes"] = len(ir_data.get("nodes", []))
 
     output_controller = _get_output_controller(ctx)
-    progress_enabled = not print_flag and output_format != "json"
+    progress_enabled = not print_flag
 
     # Show execution starting
     if effective_verbose:
@@ -324,13 +316,19 @@ def execute_json_workflow(  # noqa: C901
         click.echo("\n✗ Workflow execution interrupted", err=True)
         ctx.exit(130)
     except Exception as e:
+        # Emit failure tag to stderr (mirrors _display_execution_result error path)
+        metrics = result.metrics if result else None
+        if not print_flag and metrics:
+            duration_s = time.perf_counter() - metrics.start_time
+            click.echo(f"❌ Workflow failed after {duration_s:.3f}s", err=True)
+
         output_error(
             ctx,
             exception=e,
             output_format=output_format,
             verbose=effective_verbose,
             workflow_metadata=ctx.obj.get("workflow_metadata") if ctx.obj else None,
-            metrics_collector=result.metrics if result else None,
+            metrics_collector=metrics,
             shared_storage=result.shared_after if result else {},
         )
         ctx.exit(1)
@@ -340,8 +338,6 @@ def execute_json_workflow(  # noqa: C901
         if trace and config.trace_enabled:
             _save_trace_and_report(ctx, trace)
         _cleanup_temp_files(stdin_data, effective_verbose)
-        if output_format == "json":
-            logging.getLogger().setLevel(logging.WARNING)
 
 
 def _display_execution_result(
@@ -371,6 +367,13 @@ def _display_execution_result(
         if result.status == WorkflowStatus.DEGRADED:
             ctx.exit(2)
     else:
+        # Emit one-line failure tag to stderr so agents see status without
+        # parsing stdout (mirrors the success path's completion tag).
+        print_flag = ctx.obj.get("print_flag", False) if ctx.obj else False
+        if not print_flag and result.metrics:
+            duration_s = time.perf_counter() - result.metrics.start_time
+            click.echo(f"❌ Workflow failed after {duration_s:.3f}s", err=True)
+
         output_error(
             ctx,
             result=result,
@@ -468,7 +471,6 @@ def _initialize_context(
     # Create OutputController once and store it for reuse
     ctx.obj["output_controller"] = OutputController(
         print_flag=print_flag,
-        output_format=output_format,
     )
 
 
@@ -773,12 +775,9 @@ def _handle_named_workflow(
 
     ctx.obj["execution_params"] = filter_user_params(params)
 
-    # Show what we're doing if verbose (but not in JSON mode).
-    # All `cli:` diagnostic lines go to stderr per the GH #194 fix
-    # convention (data → stdout, diagnostics → stderr) so that
-    # ``pflow -v workflow.pflow.md | jq`` does not mix CLI diagnostic
-    # noise with parseable workflow output on stdout.
-    if verbose and output_format != "json":
+    # All `cli:` diagnostic lines go to stderr (data → stdout,
+    # diagnostics → stderr) so they never contaminate stdout.
+    if verbose:
         if source == "library":
             click.echo(f"cli: Loading workflow '{first_arg}' from registry", err=True)
         else:
@@ -985,20 +984,6 @@ def workflow_command(
     # NOTE: Logging already configured in main_wrapper.py before routing
     # No need to configure again here
 
-    # Suppress WARNING logs in JSON mode to prevent stdout contamination
-    # Only ERROR and CRITICAL logs will be shown
-    original_log_levels = {}
-    if output_format == "json":
-        # Save and update root logger level
-        root_logger = logging.getLogger()
-        original_log_levels["root"] = root_logger.level
-        root_logger.setLevel(logging.ERROR)
-
-        # Also update pflow logger level (child loggers inherit from this)
-        pflow_logger = logging.getLogger("pflow")
-        original_log_levels["pflow"] = pflow_logger.level
-        pflow_logger.setLevel(logging.ERROR)
-
     try:
         # Inject API keys from pflow settings into environment
         # This must happen early, before any LLM operations
@@ -1025,7 +1010,7 @@ def workflow_command(
         # Only show MCP output if verbose AND not in print mode or JSON output
         print_flag = ctx.obj.get("print_flag", False)
         output_format = ctx.obj.get("output_format", "text")
-        effective_verbose = verbose and not print_flag and output_format != "json"
+        effective_verbose = verbose and not print_flag
         _auto_discover_mcp_servers(ctx, effective_verbose)
 
         # Handle stdin data
@@ -1060,12 +1045,6 @@ def workflow_command(
         wm = ctx.obj.get("workflow_metadata") if ctx.obj else None
         output_error(ctx, exception=e, output_format=of, verbose=vb, workflow_metadata=wm)
         ctx.exit(1)
-    finally:
-        # Restore original logging levels if we changed them
-        if "root" in original_log_levels:
-            logging.getLogger().setLevel(original_log_levels["root"])
-        if "pflow" in original_log_levels:
-            logging.getLogger("pflow").setLevel(original_log_levels["pflow"])
 
 
 # Alias for backward compatibility with tests that import main directly

--- a/src/pflow/cli/mcp_sync.py
+++ b/src/pflow/cli/mcp_sync.py
@@ -31,7 +31,6 @@ def _get_output_controller(ctx: click.Context) -> OutputController:
     # Fallback: create one if not in context (shouldn't happen normally)
     return OutputController(
         print_flag=ctx.obj.get("print_flag", False) if ctx.obj else False,
-        output_format=ctx.obj.get("output_format", "text") if ctx.obj else "text",
     )
 
 

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -405,7 +405,6 @@ def _emit_summary_or_only_indicator(
     warnings: list[Any] | None,
     verbose: bool,
     print_flag: bool,
-    precomputed_result: dict[str, Any] | None = None,
 ) -> None:
     """Dispatch between full summary, --only-only emission, or nothing.
 
@@ -427,21 +426,18 @@ def _emit_summary_or_only_indicator(
     if print_flag and not only_node:
         return  # -p mode without --only: nothing to emit
 
-    if precomputed_result is not None:
-        formatted = precomputed_result
-    else:
-        from pflow.execution.formatters.success_formatter import format_execution_success
+    from pflow.execution.formatters.success_formatter import format_execution_success
 
-        formatted = format_execution_success(
-            shared_storage=shared_storage,
-            workflow_ir=workflow_ir or {},
-            metrics_collector=metrics_collector,
-            workflow_metadata=workflow_metadata,
-            output_key=output_key,
-            trace_path=None,
-            status=status,
-            warnings=warnings,
-        )
+    formatted = format_execution_success(
+        shared_storage=shared_storage,
+        workflow_ir=workflow_ir or {},
+        metrics_collector=metrics_collector,
+        workflow_metadata=workflow_metadata,
+        output_key=output_key,
+        trace_path=None,
+        status=status,
+        warnings=warnings,
+    )
 
     if print_flag:
         # -p + --only: emit just the mode confirmation, nothing else
@@ -579,7 +575,6 @@ def _handle_json_output(
         warnings=warnings,
         verbose=verbose,
         print_flag=print_flag,
-        precomputed_result=result,
     )
 
     return _serialize_json_result(result, verbose)

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -405,6 +405,7 @@ def _emit_summary_or_only_indicator(
     warnings: list[Any] | None,
     verbose: bool,
     print_flag: bool,
+    precomputed_result: dict[str, Any] | None = None,
 ) -> None:
     """Dispatch between full summary, --only-only emission, or nothing.
 
@@ -426,18 +427,21 @@ def _emit_summary_or_only_indicator(
     if print_flag and not only_node:
         return  # -p mode without --only: nothing to emit
 
-    from pflow.execution.formatters.success_formatter import format_execution_success
+    if precomputed_result is not None:
+        formatted = precomputed_result
+    else:
+        from pflow.execution.formatters.success_formatter import format_execution_success
 
-    formatted = format_execution_success(
-        shared_storage=shared_storage,
-        workflow_ir=workflow_ir or {},
-        metrics_collector=metrics_collector,
-        workflow_metadata=workflow_metadata,
-        output_key=output_key,
-        trace_path=None,
-        status=status,
-        warnings=warnings,
-    )
+        formatted = format_execution_success(
+            shared_storage=shared_storage,
+            workflow_ir=workflow_ir or {},
+            metrics_collector=metrics_collector,
+            workflow_metadata=workflow_metadata,
+            output_key=output_key,
+            trace_path=None,
+            status=status,
+            warnings=warnings,
+        )
 
     if print_flag:
         # -p + --only: emit just the mode confirmation, nothing else
@@ -533,6 +537,7 @@ def _handle_json_output(
     output_key: str | None,
     workflow_ir: dict[str, Any] | None,
     verbose: bool,
+    print_flag: bool = False,
     metrics_collector: Any | None = None,
     workflow_metadata: dict[str, Any] | None = None,
     workflow_trace: Any | None = None,
@@ -542,6 +547,8 @@ def _handle_json_output(
     """Handle JSON formatted output.
 
     Returns all declared outputs or specified key as JSON, optionally with metrics.
+    Emits execution summary to stderr (same as text mode) — ``--output-format``
+    controls stdout format, ``-p`` controls stderr verbosity.
     """
     # Use shared formatter for consistency with MCP
     from pflow.execution.formatters.success_formatter import format_execution_success
@@ -560,6 +567,20 @@ def _handle_json_output(
     # Save JSON output to trace if available
     if workflow_trace and hasattr(workflow_trace, "set_json_output"):
         workflow_trace.set_json_output(result)
+
+    # Emit execution summary to stderr (same as text mode)
+    _emit_summary_or_only_indicator(
+        shared_storage=shared_storage,
+        workflow_ir=workflow_ir,
+        metrics_collector=metrics_collector,
+        workflow_metadata=workflow_metadata,
+        output_key=output_key,
+        status=status,
+        warnings=warnings,
+        verbose=verbose,
+        print_flag=print_flag,
+        precomputed_result=result,
+    )
 
     return _serialize_json_result(result, verbose)
 
@@ -650,9 +671,10 @@ def _handle_workflow_output(
             output_key,
             workflow_ir,
             verbose,
-            metrics_collector,
-            workflow_metadata,
-            workflow_trace,
+            print_flag=print_flag,
+            metrics_collector=metrics_collector,
+            workflow_metadata=workflow_metadata,
+            workflow_trace=workflow_trace,
             status=status,
             warnings=warnings,
         )

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -189,7 +189,7 @@ See `workflow/CLAUDE.md` for per-file details (storage format, validation pipeli
 
 ### output_controller.py
 
-**`is_interactive()`** (ALL must pass): no `-p/--print`, output format not `json`, stdin+stdout are TTY. Only `cli/mcp_sync.py` reads it (MCP discovery gating). **Progress during workflow execution is NOT TTY-gated** — `create_progress_callback()` always returns a callable; only `_handle_batch_progress`'s `\r` inline counter gates on `sys.stderr.isatty()` because `\r` renders as garbage in non-TTY capture.
+**`is_interactive()`** (ALL must pass): no `-p/--print`, stdin+stdout are TTY. Only `cli/mcp_sync.py` reads it (MCP discovery gating). **Progress during workflow execution is NOT TTY-gated** — `create_progress_callback()` always returns a callable; only `_handle_batch_progress`'s `\r` inline counter gates on `sys.stderr.isatty()` because `\r` renders as garbage in non-TTY capture.
 
 **Progress indicators**: ✓ success, ✗ Failed (non-batch fatal), ⚠️ warning, ↻ cached, `[no matches]`/`[not found]` smart-handled shell tags.
 

--- a/src/pflow/core/output_controller.py
+++ b/src/pflow/core/output_controller.py
@@ -51,16 +51,14 @@ class OutputController:
 
     Rules for interactive mode detection:
     1. If print_flag is True then is_interactive returns False
-    2. If output_format equals "json" then is_interactive returns False
-    3. If stdin_tty is False then is_interactive returns False
-    4. If stdout_tty is False then is_interactive returns False
-    5. Only if all conditions pass is the mode considered interactive
+    2. If stdin_tty is False then is_interactive returns False
+    3. If stdout_tty is False then is_interactive returns False
+    4. Only if all conditions pass is the mode considered interactive
     """
 
     def __init__(
         self,
         print_flag: bool = False,
-        output_format: str = "text",
         stdin_tty: Optional[bool] = None,
         stdout_tty: Optional[bool] = None,
     ):
@@ -68,12 +66,10 @@ class OutputController:
 
         Args:
             print_flag: CLI flag -p/--print to force non-interactive mode
-            output_format: Output format (text/json), json implies non-interactive
             stdin_tty: Override for sys.stdin.isatty() (for testing)
             stdout_tty: Override for sys.stdout.isatty() (for testing)
         """
         self.print_flag = print_flag
-        self.output_format = output_format
 
         # Handle Windows edge case where sys.stdin can be None
         if stdin_tty is not None:
@@ -127,11 +123,7 @@ class OutputController:
         if self.print_flag:
             return False
 
-        # Rule 2: JSON output format implies non-interactive
-        if self.output_format == "json":
-            return False
-
-        # Rules 3 & 4: Both stdin AND stdout must be TTY for interactive
+        # Rules 2 & 3: Both stdin AND stdout must be TTY for interactive
         return self.stdin_tty and self.stdout_tty
 
     def _close_partial_line(self) -> None:
@@ -342,8 +334,8 @@ class OutputController:
         Python's logging machinery running the filter before each emit.
 
         Only called from ``create_progress_callback`` so non-progress modes
-        (``-p``, ``--output-format json``, MCP server) never install the
-        filter and never pay its (negligible) cost.
+        (``-p``, MCP server) never install the filter and never pay its
+        (negligible) cost.
         """
         if self._log_filter_installed:
             return

--- a/src/pflow/execution/CLAUDE.md
+++ b/src/pflow/execution/CLAUDE.md
@@ -130,7 +130,7 @@ Diagnostic(
 
 ## Integration
 
-**CLI**: `cli/main.py:execute_json_workflow()` calls `WorkflowRunner().run()`, passing `progress_callback=output_controller.create_progress_callback()` when progress is enabled. Handles: stdin routing, logging suppression, trace saving, display.
+**CLI**: `cli/main.py:execute_json_workflow()` calls `WorkflowRunner().run()`, passing `progress_callback=output_controller.create_progress_callback()` when progress is enabled. Handles: stdin routing, trace saving, display.
 
 **MCP Server**: `mcp_server/services/execution_service.py` calls `WorkflowRunner().run()` without a progress callback (defaults to `None`). Three methods: `execute_workflow()`, `validate_workflow()`, `run_registry_node()`.
 

--- a/tests/test_cli/test_dual_mode_stdin.py
+++ b/tests/test_cli/test_dual_mode_stdin.py
@@ -710,7 +710,7 @@ class TestJSONOutputFormat:
 
         assert result.exit_code == 1
         # Output should be valid JSON
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert output["success"] is False
         assert "error" in output
         assert "Piped input cannot be routed" in output["error"]
@@ -740,7 +740,7 @@ class TestJSONOutputFormat:
         assert "stdin" in result.output.lower()
         # Should NOT be valid JSON
         with pytest.raises(json.JSONDecodeError):
-            json.loads(result.output)
+            json.loads(result.stdout)
 
     @patch("pflow.core.shell_integration.stdin_has_data", return_value=True)
     def test_multiple_stdin_error_json_output(self, mock_stdin, tmp_path):
@@ -764,7 +764,7 @@ class TestJSONOutputFormat:
 
         assert result.exit_code == 1
         # Output should be valid JSON
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert output["success"] is False
         assert "error" in output
         assert "errors" in output
@@ -806,4 +806,4 @@ class TestJSONOutputFormat:
         assert "Multiple inputs" in result.output or "stdin" in result.output.lower()
         # Should NOT be valid JSON
         with pytest.raises(json.JSONDecodeError):
-            json.loads(result.output)
+            json.loads(result.stdout)

--- a/tests/test_cli/test_enhanced_error_output.py
+++ b/tests/test_cli/test_enhanced_error_output.py
@@ -51,7 +51,7 @@ class TestEnhancedErrorOutput:
         assert result.exit_code != 0
 
         # Parse JSON output
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         # Verify execution state exists
         assert "execution" in output, "JSON output should include execution state"
@@ -101,7 +101,7 @@ class TestEnhancedErrorOutput:
 
         assert result.exit_code == 0
 
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         # Verify execution state exists in success case too
         assert "execution" in output
@@ -132,14 +132,14 @@ class TestEnhancedErrorOutput:
         # First run - no cache
         result1 = runner.invoke(main, ["--output-format", "json", str(workflow_path)])
         assert result1.exit_code == 0
-        output1 = json.loads(result1.output)
+        output1 = json.loads(result1.stdout)
         steps1 = output1["execution"]["steps"]
         assert steps1[0]["cached"] is False
 
         # Second run - should hit cache
         result2 = runner.invoke(main, ["--output-format", "json", str(workflow_path)])
         assert result2.exit_code == 0
-        output2 = json.loads(result2.output)
+        output2 = json.loads(result2.stdout)
         steps2 = output2["execution"]["steps"]
 
         # Verify cache field is tracked (value depends on cache config)
@@ -187,7 +187,7 @@ class TestEnhancedErrorOutput:
 
         assert result.exit_code != 0
 
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         # Verify required fields
         assert "success" in output
@@ -267,7 +267,7 @@ class TestEnhancedErrorOutput:
             assert result.exit_code != 0
 
             if output_format == "json":
-                output = json.loads(result.output)
+                output = json.loads(result.stdout)
                 assert output["success"] is False
             else:
                 assert "error" in result.output.lower() or "failed" in result.output.lower()
@@ -289,7 +289,7 @@ class TestEnhancedErrorOutput:
         result = runner.invoke(main, ["--output-format", "json", str(workflow_path)])
 
         assert result.exit_code == 0
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         steps = output["execution"]["steps"]
         assert len(steps) == 1
@@ -326,7 +326,7 @@ class TestEnhancedErrorOutput:
         result = runner.invoke(main, ["--output-format", "json", str(workflow_path)])
 
         assert result.exit_code != 0
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         steps = output["execution"]["steps"]
         step_map = {step["node_id"]: step for step in steps}

--- a/tests/test_cli/test_progress_streaming_subprocess.py
+++ b/tests/test_cli/test_progress_streaming_subprocess.py
@@ -874,25 +874,19 @@ class TestRealSubprocessProgressRendering:
                 proc.kill()
                 proc.wait()
 
-    def test_json_mode_keeps_stderr_silent(self, tmp_path, uv_exe, subprocess_env):
+    def test_json_mode_emits_summary_on_stderr(self, tmp_path, uv_exe, subprocess_env):
         """``pflow --output-format json foo.pflow.md`` must emit valid JSON on
-        stdout and zero bytes on stderr.
+        stdout and progress/summary on stderr.
 
-        JSON mode is the machine-clean invariant: agents consuming structured
-        output need stderr to be empty so any stderr content they observe is a
-        real error signal. The CLI enforces this by installing no progress
-        callback when ``output_format == "json"`` AND by routing the success
-        summary through ``_handle_json_output`` which never calls
-        ``_emit_summary_or_only_indicator``.
+        ``--output-format`` controls stdout format only; ``-p`` controls stderr
+        verbosity. JSON mode gets the same stderr diagnostics as text mode:
+        progress lines, completion tag, cost, and trace path. This matches
+        Unix conventions (curl, git, ffmpeg emit diagnostics to stderr
+        regardless of output format).
 
-        This subprocess test replaces a mocked predecessor in
-        ``test_workflow_output_handling.py`` that was test theater: the old
-        test used the ``mock_compile`` fixture whose ``ExecutionResult`` had
-        ``metrics=None``, so the summary code path could never fire regardless
-        of mode. The subprocess path exercises the real runner + real
-        MetricsCollector and would catch a regression where JSON mode starts
-        leaking stderr (e.g. someone removing the ``output_format != "json"``
-        clause from the ``progress_enabled`` gate in ``cli/main.py``).
+        stdout stays machine-clean JSON. stderr is human-readable diagnostics.
+        Agents piping ``| jq > file.md`` see the summary in their Bash tool
+        output without parsing JSON.
         """
         import json
 
@@ -924,7 +918,7 @@ class TestRealSubprocessProgressRendering:
             f"workflow failed unexpectedly\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
         )
 
-        # stdout must be valid JSON (the machine-clean contract)
+        # stdout must be valid JSON
         try:
             parsed = json.loads(result.stdout)
         except json.JSONDecodeError as exc:
@@ -932,10 +926,129 @@ class TestRealSubprocessProgressRendering:
 
         assert parsed.get("success") is True, f"Expected success=True in JSON output, got: {parsed}"
 
-        # stderr must be empty — this is the invariant agents rely on
+        # stderr must contain the completion summary (same as text mode)
+        assert "Workflow completed" in result.stderr, (
+            "JSON mode must emit completion summary to stderr. "
+            "Agents need to see status without parsing JSON.\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+        # stderr must NOT contain JSON — it's for human-readable diagnostics only
+        stderr_stripped = result.stderr.strip()
+        assert not stderr_stripped.startswith("{"), (
+            f"stderr must not contain JSON output — JSON goes to stdout only.\nstderr: {result.stderr!r}"
+        )
+
+        # stdout must NOT contain progress text — progress goes to stderr only
+        assert "Executing workflow" not in result.stdout, (
+            f"Progress text must not appear on stdout — it goes to stderr.\nstdout: {result.stdout!r}"
+        )
+
+    def test_json_print_mode_keeps_stderr_silent(self, tmp_path, uv_exe, subprocess_env):
+        """``pflow --output-format json -p foo.pflow.md`` must emit valid JSON
+        on stdout and zero bytes on stderr.
+
+        ``-p`` is the sole control for stderr verbosity. When active, all
+        stderr diagnostics are suppressed regardless of output format.
+        """
+        import json
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "echo_canary",
+                    "type": "shell",
+                    "cache": False,
+                    "params": {"command": "echo JSON_PRINT_CANARY"},
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "json_print_mode.pflow.md"
+        workflow_path.write_text(ir_to_markdown(workflow))
+
+        result = subprocess.run(  # noqa: S603
+            [uv_exe, "run", "pflow", "--output-format", "json", "-p", str(workflow_path)],
+            capture_output=True,
+            text=True,
+            shell=False,
+            env=subprocess_env,
+        )
+        _skip_if_uv_sandbox_panics(result)
+
+        assert result.returncode == 0, (
+            f"workflow failed unexpectedly\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+        # stdout must be valid JSON
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(f"JSON+print mode stdout is not valid JSON: {exc}\nstdout:\n{result.stdout}") from exc
+
+        assert parsed.get("success") is True, f"Expected success=True in JSON output, got: {parsed}"
+
+        # stderr must be empty — -p suppresses all diagnostics
         assert result.stderr.strip() == "", (
-            "JSON mode must keep stderr silent. Any stderr content contaminates "
-            "the machine-clean contract that agents rely on.\n"
+            "JSON mode with -p must keep stderr silent. "
+            "-p is the sole control for stderr verbosity.\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_json_mode_failure_emits_stderr_tag(self, tmp_path, uv_exe, subprocess_env):
+        """``pflow --output-format json`` with a failing workflow must emit
+        ``❌ Workflow failed after Xs`` on stderr and a valid JSON error
+        object on stdout.
+
+        Covers both the ``_display_execution_result`` error path (Runner
+        catches the failure) and ensures the failure tag mirrors the success
+        path's ``✓ Workflow completed in Xs`` completion tag.
+        """
+        import json
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "will_fail",
+                    "type": "shell",
+                    "cache": False,
+                    "params": {"command": "exit 1"},
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "json_fail.pflow.md"
+        workflow_path.write_text(ir_to_markdown(workflow))
+
+        result = subprocess.run(  # noqa: S603
+            [uv_exe, "run", "pflow", "--output-format", "json", str(workflow_path)],
+            capture_output=True,
+            text=True,
+            shell=False,
+            env=subprocess_env,
+        )
+        _skip_if_uv_sandbox_panics(result)
+
+        assert result.returncode != 0, (
+            f"workflow should have failed\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+        # stdout must be valid JSON error object
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"JSON mode failure stdout is not valid JSON: {exc}\nstdout:\n{result.stdout}"
+            ) from exc
+
+        assert parsed.get("success") is False, f"Expected success=False in JSON output, got: {parsed}"
+
+        # stderr must contain the failure completion tag
+        assert "Workflow failed after" in result.stderr, (
+            "JSON mode failure must emit '❌ Workflow failed after Xs' to stderr. "
+            "Agents need to see failure status without parsing JSON.\n"
             f"stderr: {result.stderr!r}"
         )
 

--- a/tests/test_cli/test_read_fields.py
+++ b/tests/test_cli/test_read_fields.py
@@ -101,7 +101,7 @@ class TestReadFieldsCommand:
         assert result.exit_code == 0
 
         # Parse JSON output
-        output_data = json.loads(result.output)
+        output_data = json.loads(result.stdout)
         assert output_data["status"] == "success"
         assert output_data["result[0].id"] == 1
 

--- a/tests/test_cli/test_registry_cli.py
+++ b/tests/test_cli/test_registry_cli.py
@@ -125,7 +125,7 @@ def test_list_json_output(runner, mock_registry):
     assert result.exit_code == 0
 
     # Parse and validate JSON
-    output = json.loads(result.output)
+    output = json.loads(result.stdout)
     assert "nodes" in output
     assert isinstance(output["nodes"], list)
 
@@ -276,7 +276,7 @@ def test_search_json_output(runner, mock_registry):
     assert result.exit_code == 0
 
     # Parse and validate JSON
-    output = json.loads(result.output)
+    output = json.loads(result.stdout)
     assert "query" in output
     assert output["query"] == "file"
     assert "results" in output
@@ -474,7 +474,7 @@ def test_scan_json_output(runner, mock_registry):
         assert result.exit_code == 0
 
         # Parse and validate JSON
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert "found" in output
         assert "added" in output
         assert "nodes" in output

--- a/tests/test_cli/test_registry_run.py
+++ b/tests/test_cli/test_registry_run.py
@@ -215,7 +215,7 @@ def test_json_output_format_produces_valid_json(runner, tmp_path):
         assert result.exit_code == 0
 
         # --output-format json should produce valid JSON with actual data
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert output["success"] is True
         assert output["node_type"] == "read-file"
         assert "outputs" in output
@@ -253,7 +253,7 @@ def test_json_output_bypasses_structure_formatting(runner, tmp_path):
         result = runner.invoke(registry, ["run", "read-file", f"file_path={test_file}", "--output-format", "json"])
 
         assert result.exit_code == 0
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         # JSON output should NOT contain structure mode formatting
         output_str = json.dumps(output)
@@ -801,7 +801,7 @@ def test_json_mode_error_response_is_valid(runner, mock_registry):
 
     # Should still be valid JSON
     try:
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         assert "error" in output or "success" in output
     except json.JSONDecodeError:
         # Error messages might not be JSON in error cases, that's acceptable

--- a/tests/test_cli/test_shell_stderr_display.py
+++ b/tests/test_cli/test_shell_stderr_display.py
@@ -75,7 +75,7 @@ class TestShellStderrDisplay:
         assert result.exit_code != 0
 
         # Parse JSON output
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         # Verify shell_stderr is in the error structure
         assert "errors" in output

--- a/tests/test_cli/test_shell_stderr_warnings.py
+++ b/tests/test_cli/test_shell_stderr_warnings.py
@@ -285,7 +285,7 @@ class TestStderrInJsonOutput:
 
         assert result.exit_code == 0
 
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
 
         # Verify the primary output is extracted (auto-detected stdout from namespace)
         assert "stdout" in output["result"]

--- a/tests/test_cli/test_unified_error_output.py
+++ b/tests/test_cli/test_unified_error_output.py
@@ -75,9 +75,9 @@ FORBIDDEN_FIELDS = frozenset({
 def _parse_json_output(result: Any) -> dict[str, Any]:
     """Parse JSON from CLI runner output, raising a clear error on failure."""
     try:
-        return json.loads(result.output)
+        return json.loads(result.stdout)
     except json.JSONDecodeError as exc:
-        raise AssertionError(f"Expected valid JSON output but got:\n{result.output[:500]}") from exc
+        raise AssertionError(f"Expected valid JSON output but got:\n{result.stdout[:500]}") from exc
 
 
 def _assert_unified_shape(output: dict[str, Any]) -> None:

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -638,7 +638,7 @@ class TestWorkflowOutputHandling:
 
             assert result.exit_code == 0
             # Parse the JSON output - it's now wrapped in a result structure
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             assert actual_result == {"summary": "Task completed successfully"}
@@ -680,7 +680,7 @@ class TestWorkflowOutputHandling:
 
             assert result.exit_code == 0
             # Parse the JSON output - it's now wrapped in a result structure
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             # Should include ALL declared outputs
@@ -726,7 +726,7 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--output-format", "json", "--output-key", "custom_key", workflow_file])
 
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             # Should only return the requested key
@@ -762,7 +762,7 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             # Should return empty JSON object
@@ -796,7 +796,7 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             # Should return first matching fallback key
@@ -844,7 +844,7 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
 
@@ -910,14 +910,14 @@ class TestWorkflowOutputHandling:
             # Test "JSON" (uppercase)
             result = runner.invoke(main, ["--output-format", "JSON", workflow_file])
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             actual_result = output_data.get("result", output_data)
             assert actual_result == {"data": "Test value"}
 
             # Test "Json" (mixed case)
             result = runner.invoke(main, ["--output-format", "Json", workflow_file])
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             actual_result = output_data.get("result", output_data)
             assert actual_result == {"data": "Test value"}
         finally:
@@ -947,22 +947,8 @@ class TestWorkflowOutputHandling:
 
             assert result.exit_code == 0
 
-            # The output should contain valid JSON, possibly with verbose messages
-            # Try to parse the whole output first
-            try:
-                # If it's pure JSON, this will work
-                json_output = json.loads(result.output)
-            except json.JSONDecodeError:
-                # If there are verbose messages mixed in, try to find JSON in the output
-                # Look for JSON-like structure (including nested objects)
-                import re
-
-                json_match = re.search(r"\{.*\}", result.output, re.DOTALL)
-                if json_match:
-                    json_output = json.loads(json_match.group())
-                else:
-                    # If still not found, fail with helpful message
-                    raise AssertionError(f"Could not find valid JSON in output:\n{result.output}") from None
+            # Verbose messages go to stderr; stdout has pure JSON
+            json_output = json.loads(result.stdout)
 
             # Extract the actual result from the wrapper
             actual_result = json_output.get("result", json_output)
@@ -1002,7 +988,7 @@ class TestWorkflowOutputHandling:
 
             assert result.exit_code == 0
             # Should handle binary data without crashing
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             actual_result = output_data.get("result", output_data)
             assert "binary_output" in actual_result
         finally:
@@ -1031,7 +1017,7 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             # Both fields should be present
@@ -1075,7 +1061,7 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output_data = json.loads(result.output)
+            output_data = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_data.get("result", output_data)
             # Should only include found outputs

--- a/tests/test_cli/test_workflow_output_source_simple.py
+++ b/tests/test_cli/test_workflow_output_source_simple.py
@@ -42,7 +42,7 @@ class TestWorkflowOutputSource:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
             actual_result = output.get("result", output)
 
             # Check that outputs were populated correctly
@@ -100,7 +100,7 @@ class TestWorkflowOutputSource:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
             actual_result = output.get("result", output)
 
             assert actual_result["first"] == "from A"
@@ -127,7 +127,7 @@ class TestWorkflowOutputSource:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
             actual_result = output.get("result", output)
             assert actual_result["result"] == "file test"
         finally:
@@ -157,7 +157,7 @@ class TestWorkflowOutputSource:
             result = runner.invoke(main, ["--output-format", "json", workflow_file])
 
             assert result.exit_code == 0
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
             actual_result = output.get("result", output)
 
             # Should find the echo output (either from root or from namespaced node)

--- a/tests/test_core/test_output_controller.py
+++ b/tests/test_core/test_output_controller.py
@@ -22,11 +22,6 @@ class TestOutputController:
         controller = OutputController(print_flag=True, stdin_tty=True, stdout_tty=True)
         assert controller.is_interactive() is False
 
-    def test_json_format_forces_non_interactive(self):
-        """Test requirement 2: output_format="json", stdin_tty=True, stdout_tty=True → is_interactive=False."""
-        controller = OutputController(output_format="json", stdin_tty=True, stdout_tty=True)
-        assert controller.is_interactive() is False
-
     def test_stdin_not_tty_forces_non_interactive(self):
         """Test requirement 3: stdin_tty=False, stdout_tty=True → is_interactive=False."""
         controller = OutputController(stdin_tty=False, stdout_tty=True)
@@ -169,14 +164,13 @@ class TestOutputController:
         with patch("sys.stdin.isatty", return_value=True), patch("sys.stdout.isatty", return_value=True):
             controller = OutputController()
             assert controller.print_flag is False
-            assert controller.output_format == "text"
             assert controller.stdin_tty is True
             assert controller.stdout_tty is True
             assert controller.is_interactive() is True
 
     def test_all_conditions_true_for_interactive(self):
         """Test that all conditions must be true for interactive mode."""
-        controller = OutputController(print_flag=False, output_format="text", stdin_tty=True, stdout_tty=True)
+        controller = OutputController(print_flag=False, stdin_tty=True, stdout_tty=True)
         assert controller.is_interactive() is True
 
     @patch("sys.stdout", None)
@@ -530,7 +524,7 @@ class TestOutputController:
 
     def test_multiple_flags_forcing_non_interactive(self):
         """Test multiple flags all forcing non-interactive mode."""
-        controller = OutputController(print_flag=True, output_format="json", stdin_tty=False, stdout_tty=False)
+        controller = OutputController(print_flag=True, stdin_tty=False, stdout_tty=False)
         assert controller.is_interactive() is False
 
     @patch("click.style", side_effect=mock_click_style)

--- a/tests/test_integration/test_metrics_integration.py
+++ b/tests/test_integration/test_metrics_integration.py
@@ -197,7 +197,7 @@ class TestMetricsCollection:
                 result = runner.invoke(cli, ["--output-format", "json", workflow_file], env={"HOME": str(temp_home)})
 
             assert result.exit_code == 0
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
 
             # Check new unified structure
             assert "success" in output
@@ -258,7 +258,7 @@ class TestMetricsCollection:
                 print(f"Exit code: {result.exit_code}")
                 print(f"Output: {result.output}")
             assert result.exit_code == 0
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
 
             # Check cost calculation
             # gpt-4o-mini: 20 tokens @ $0.15/M + 30 tokens @ $0.60/M = $0.000021
@@ -299,24 +299,13 @@ class TestMetricsCollection:
             # Should have non-zero exit code
             assert result.exit_code != 0
 
-            # Try to extract JSON from output (might be mixed with error messages)
-            output = None
-            lines = result.output.strip().split("\n")
+            # stdout has pure JSON even on error (stderr has error messages)
+            output = json.loads(result.stdout)
 
-            # Try to find JSON in the output (often at the end)
-            for line in reversed(lines):
-                if line.strip().startswith("{"):
-                    try:
-                        output = json.loads(line)
-                        break
-                    except json.JSONDecodeError:
-                        continue
-
-            # If we found JSON output, verify it has error info
-            if output:
-                assert output.get("success") is False or "error" in output
-                # Should have some metrics even on error
-                assert "duration_ms" in output or "metrics" in output
+            # Verify it has error info
+            assert output.get("success") is False or "error" in output
+            # Should have some metrics even on error
+            assert "duration_ms" in output or "metrics" in output
 
         finally:
             Path(workflow_file).unlink()
@@ -699,7 +688,7 @@ class TestCLIFlags:
             result = runner.invoke(cli, ["--output-format", "json", workflow_file])
             assert result.exit_code == 0
 
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
 
             # Metrics should be present at top level
             assert "duration_ms" in output
@@ -729,7 +718,7 @@ class TestJSONOutputStructure:
 
         try:
             result = runner.invoke(cli, ["--output-format", "json", workflow_file])
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
 
             # Top-level structure
             assert output["success"] is True
@@ -791,34 +780,16 @@ class TestJSONOutputStructure:
             # The workflow should fail
             assert result.exit_code != 0
 
-            # The output should be valid JSON even on error
-            try:
-                output = json.loads(result.output)
-                json_parsed = True
-            except json.JSONDecodeError:
-                json_parsed = False
-                # If JSON parsing fails, check if it's because of mixed output
-                # Look for JSON in the output
-                lines = result.output.strip().split("\n")
-                for line in reversed(lines):  # Check from end where JSON usually is
-                    try:
-                        output = json.loads(line)
-                        json_parsed = True
-                        break
-                    except (json.JSONDecodeError, ValueError):
-                        continue
+            # stdout has pure JSON even on error (stderr has error messages)
+            output = json.loads(result.stdout)
 
-            if json_parsed:
-                # Test behavior: Error information is present
-                assert output.get("success") is False
+            # Test behavior: Error information is present
+            assert output.get("success") is False
 
-                # Test behavior: Some metrics are available even on error
-                # At least one of these should be present
-                has_metrics = "duration_ms" in output or "metrics" in output or "num_nodes" in output
-                assert has_metrics, "Should have some metrics even on error"
-            else:
-                # If we can't parse JSON, at least verify error output exists
-                assert "error" in result.output.lower() or "fail" in result.output.lower()
+            # Test behavior: Some metrics are available even on error
+            # At least one of these should be present
+            has_metrics = "duration_ms" in output or "metrics" in output or "num_nodes" in output
+            assert has_metrics, "Should have some metrics even on error"
 
         finally:
             Path(workflow_file).unlink()
@@ -842,7 +813,7 @@ class TestMetricsAccuracy:
             result = runner.invoke(cli, ["--output-format", "json", workflow_file])
             elapsed = (time.time() - start) * 1000  # Convert to ms
 
-            output = json.loads(result.output)
+            output = json.loads(result.stdout)
             reported_duration = output["duration_ms"]
 
             # Duration should be positive and reasonable
@@ -934,7 +905,7 @@ class TestMetricsAccuracy:
                     result = runner.invoke(
                         cli, ["--output-format", "json", workflow_file], env={"HOME": str(temp_home)}
                     )
-                output = json.loads(result.output)
+                output = json.loads(result.stdout)
 
                 assert output.get("success", False), f"Workflow failed for {expected_count}-node: {output}"
                 assert output["nodes_executed"] == expected_count

--- a/tests/test_integration/test_workflow_outputs_namespaced.py
+++ b/tests/test_integration/test_workflow_outputs_namespaced.py
@@ -97,7 +97,7 @@ class TestWorkflowOutputsNamespaced:
             assert result.exit_code == 0, f"Failed with output: {result.output}"
 
             # Parse JSON output
-            output_json = json.loads(result.output)
+            output_json = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_json.get("result", output_json)
 
@@ -150,7 +150,7 @@ class TestWorkflowOutputsNamespaced:
             assert result.exit_code == 0, f"Failed with output: {result.output}"
 
             # Parse JSON and verify all outputs
-            output_json = json.loads(result.output)
+            output_json = json.loads(result.stdout)
             # Extract the actual result from the wrapper
             actual_result = output_json.get("result", output_json)
 

--- a/tests/test_nodes/test_shell_smart_handling.py
+++ b/tests/test_nodes/test_shell_smart_handling.py
@@ -330,7 +330,7 @@ class TestSmartHandlingJsonOutput:
 
         assert result.exit_code == 0
 
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         steps = output["execution"]["steps"]
         assert len(steps) == 1
         assert steps[0]["smart_handled"] is True
@@ -358,7 +358,7 @@ class TestSmartHandlingJsonOutput:
 
         assert result.exit_code == 0
 
-        output = json.loads(result.output)
+        output = json.loads(result.stdout)
         steps = output["execution"]["steps"]
         assert len(steps) == 1
         assert "smart_handled" not in steps[0]


### PR DESCRIPTION
## Summary

Remove JSON-mode stderr suppression so that `--output-format` controls stdout format only and `-p` is the sole control for stderr verbosity. Agents running `pflow --output-format json foo | jq > file.md` now see progress, completion status, and cost on stderr without parsing JSON.

## Changes

**Production (net -56 lines, +52 lines → simpler)**
- `main.py`: Delete 10 JSON-mode stderr suppression guards (logging CRITICAL/ERROR overrides, `progress_enabled` gate, `effective_verbose` gates, `_echo_trace` gate, verbose message gates). Add error-path `❌ Workflow failed after Xs` completion tag to both error paths.
- `workflow_output.py`: Emit stderr summary from `_handle_json_output` via `_emit_summary_or_only_indicator` with `precomputed_result` to avoid double `format_execution_success` call.
- `output_controller.py`: Remove dead `output_format` parameter and field. Remove JSON check from `is_interactive()`.
- `mcp_sync.py`: Remove `output_format` from `OutputController` constructor call.

**Tests (55 fixes across 16 files)**
- `json.loads(result.output)` → `json.loads(result.stdout)` for all CliRunner JSON tests (Click 8.3.1 always provides separate `result.stdout` / `result.stderr` streams).
- Rewrite `test_json_mode_keeps_stderr_silent` → `test_json_mode_emits_summary_on_stderr` (assert new contract: JSON on stdout, progress+summary on stderr).
- Add `test_json_print_mode_keeps_stderr_silent` (verify `-p` suppresses stderr in JSON mode).
- Add `test_json_mode_failure_emits_stderr_tag` (verify `❌ Workflow failed` appears on stderr for failed JSON-mode runs).
- Remove dead `output_format` assertions from `test_output_controller.py`.

**Documentation**
- `cli/CLAUDE.md`: Update JSON/Text Duality, Interactive Mode, Command Flags sections.
- `core/CLAUDE.md`: Update `is_interactive()` rule list.
- `execution/CLAUDE.md`: Remove "logging suppression" from `execute_json_workflow` description.
- `docs/reference/cli/index.mdx`: Update JSON mode description for users.

## Explanation

The original design conflated two orthogonal concerns — `--output-format` (stdout format) and stderr verbosity — via 10+ special-case guards. This contradicts Unix conventions (curl, git, ffmpeg, docker all emit diagnostics to stderr regardless of output format) and the Task 149 routing rule (data→stdout, diagnostics→stderr).

The fix removes the guards rather than adding new features. The codebase gets simpler:
- `--output-format json` → JSON on stdout, progress/summary/cost on stderr
- `--output-format json -p` → JSON on stdout, silent stderr
- `--output-format json foo | jq > file.md` → agent sees status on stderr, jq reads stdout

The error-path completion tag (`❌ Workflow failed after Xs`) is new — it mirrors the success path's `✓ Workflow completed in Xs` tag so agents see failure status without parsing JSON.

## Testing

```bash
make test    # 4792 passed, 9 skipped
make check   # ruff, mypy, deptry all clean
```

Manual verification:
```bash
# JSON mode: progress + summary on stderr, valid JSON on stdout
pflow --output-format json examples/simple-workflow.pflow.md 2>/tmp/stderr.txt > /tmp/stdout.txt

# JSON + -p: silent stderr
pflow --output-format json -p examples/simple-workflow.pflow.md 2>/tmp/stderr.txt

# Pipe through jq still works
pflow --output-format json examples/simple-workflow.pflow.md | jq '.success'
```