### PR TITLE
fix: wire WorkflowValidator into save path (task 150, fixes #236)

### DIFF
--- a/.taskmaster/tasks/task_150/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_150/implementation/implementation-plan.md
@@ -1,0 +1,373 @@
+# Fix: Wire WorkflowValidator into CLI Save Path (GH #236)
+
+## Context
+
+`pflow workflow save` only runs IR schema validation (`validate_ir()`), never the full 9-step `WorkflowValidator.validate()`. Broken workflows (unknown params, non-existent node refs, template errors) get silently accepted into `~/.pflow/workflows/` and only fail when the user tries to run them. The MCP save path correctly validates; the CLI save path doesn't. Root cause: `save_workflow_with_options` trusts callers to pre-validate — two callers (CLI, MCP) each implemented their own "prepare for save" logic, and the CLI one only did schema validation.
+
+Applying the Task 144 pattern ("delete the bypass, bring behavior into the unified pipeline"): `save_workflow_with_options` should own parse + validate + save as one atomic operation. Callers can't skip validation because it's inside the save function. This deletes 2 CLI helper functions, simplifies the MCP save method, and eliminates the bug class (not just the bug instance).
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/pflow/core/workflow/save_service.py` | `save_workflow_with_options` gains parse + validate; return type adds validated IR |
+| `src/pflow/cli/commands/workflow.py` | Delete `_load_and_parse_workflow`, delete `_save_with_overwrite_check`, rewrite `save_workflow` command |
+| `src/pflow/mcp_server/services/execution_service.py` | Simplify `save_workflow` + `_save_and_format_result` |
+| `tests/test_core/test_workflow_save_service.py` | Update for new return type + validation in save |
+| `tests/test_cli/test_workflow_save_cli.py` | Update error message assertions for rich diagnostic display |
+| `tests/test_mcp_server/test_workflow_save.py` | Update for simplified MCP save path |
+| `tests/test_integration/test_workflow_bundling.py` | Update 4 unpack sites for new return type; fix 1 test assertion (error source changes) |
+| `src/pflow/core/workflow/CLAUDE.md` | Update save_service documentation |
+| `src/pflow/cli/commands/CLAUDE.md` | Update workflow save documentation |
+
+## Implementation
+
+### Phase 1: `save_workflow_with_options` owns validation
+
+**File: `src/pflow/core/workflow/save_service.py`**
+
+1. Change return type from `tuple[Path, list[str]]` to `tuple[Path, list[str], dict[str, Any]]` (third element: validated IR)
+
+2. Add parse + validate at the top of `save_workflow_with_options`, before the existing existence check:
+
+```python
+def save_workflow_with_options(
+    name: str,
+    markdown_content: str,
+    *,
+    force: bool = False,
+    metadata: Optional[dict[str, Any]] = None,
+    source_path: Optional[Path] = None,
+) -> tuple[Path, list[str], dict[str, Any]]:
+    # --- NEW: parse + validate ---
+    result = parse_markdown(markdown_content)
+    validated_ir = _validate_and_normalize_ir(
+        result.ir,
+        auto_normalize=True,
+        source_desc=f"Invalid workflow '{name}'",
+        source_path=source_path,
+    )
+    # --- existing logic below (unchanged) ---
+    manager = WorkflowManager()
+    # ... existence check, deps, save ...
+    return Path(saved_path), bundled_files, validated_ir
+```
+
+3. New exceptions that can propagate from this function:
+   - `MarkdownParseError` — from `parse_markdown()` (new)
+   - `WorkflowValidationError` with `validation_errors` populated — from `_validate_and_normalize_ir()` (new)
+   - `FileExistsError`, `WorkflowValidationError` (summary-only) — from existing save mechanics (unchanged)
+
+4. Update the docstring: remove "pre-validated by caller", document that validation is internal. Update the Raises section.
+
+**`parse_markdown` is already imported** at the top of the file (line 15). `_validate_and_normalize_ir` is defined in the same file. No new imports needed.
+
+### Phase 2: Simplify CLI save command
+
+**File: `src/pflow/cli/commands/workflow.py`**
+
+1. **Delete `_load_and_parse_workflow`** (lines 225-273) — this bypass caused #236
+
+2. **Delete `_save_with_overwrite_check`** (lines 276-323) — thin wrapper with one caller, no abstraction value once `_load_and_parse_workflow` is gone
+
+3. **Rewrite `save_workflow` click command** (lines 351-397) as a single coherent flow:
+
+```python
+def save_workflow(file_path: str, name: str, delete_draft: bool, force: bool) -> None:
+    from pathlib import Path as PathLib
+    from pflow.core.workflow.save_service import save_workflow_with_options, validate_workflow_name
+
+    # Validate name
+    is_valid, error = validate_workflow_name(name)
+    if not is_valid:
+        click.echo(f"Error: {error}", err=True)
+        sys.exit(1)
+
+    # Reject JSON files (CLI-specific migration message)
+    path = PathLib(file_path)
+    if path.suffix == ".json":
+        click.echo(
+            "Error: JSON workflow format is no longer supported. "
+            "Use .pflow.md format instead.",
+            err=True,
+        )
+        sys.exit(1)
+
+    # Save (parse + validate + persist — all inside save_workflow_with_options)
+    try:
+        content = path.read_text(encoding="utf-8")
+        saved_path, bundled_files, workflow_ir = save_workflow_with_options(
+            name=name,
+            markdown_content=content,
+            force=force,
+            source_path=path,
+        )
+    except FileExistsError as e:
+        click.echo(f"Error: {e}", err=True)
+        click.echo("  Use --force to overwrite.", err=True)
+        sys.exit(1)
+    except WorkflowValidationError as e:
+        # Rich diagnostic display — same format as --validate-only
+        if e.validation_errors:
+            from pflow.execution.formatters.validation_formatter import (
+                format_validation_failure,
+            )
+            click.echo(format_validation_failure(e.validation_errors), err=True)
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except MarkdownParseError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except FileNotFoundError:
+        click.echo(f"Error: File not found: {file_path}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Error saving workflow: {e}", err=True)
+        sys.exit(1)
+
+    if force:
+        click.echo(f"✓ Overwritten existing workflow '{name}'")
+
+    _delete_draft_if_requested(file_path, delete_draft)
+
+    from pflow.execution.formatters.workflow_save_formatter import format_save_success
+    success_message = format_save_success(
+        name=name,
+        saved_path=str(saved_path),
+        workflow_ir=workflow_ir,
+        metadata=None,
+        bundled_files=bundled_files,
+    )
+    click.echo(success_message)
+```
+
+**Key display decision**: `WorkflowValidationError` with `validation_errors` uses `format_validation_failure()` — the same renderer as `--validate-only`. This gives the rich numbered format with suggestions, matching the acceptance criteria. `WorkflowValidationError` without `validation_errors` (I/O errors from save mechanics) falls back to the string message.
+
+**Edge case — JSON rejection**: Stays in the CLI command (not in `save_workflow_with_options`) because it's a CLI-specific migration message, not a validation concern.
+
+### Phase 3: Simplify MCP save
+
+**File: `src/pflow/mcp_server/services/execution_service.py`**
+
+1. **Simplify `save_workflow`** (lines 304-378): Delete the manual `parse_markdown` + `load_and_validate_workflow` block (lines 349-368). The validation now happens inside `save_workflow_with_options`.
+
+New flow:
+```python
+@classmethod
+@ensure_stateless
+def save_workflow(cls, workflow: str, name: str, force: bool = False) -> str:
+    from pflow.core.workflow.save_service import save_workflow_with_options, validate_workflow_name
+
+    # Validate name (unchanged)
+    is_valid, error = validate_workflow_name(name)
+    if not is_valid:
+        raise ValueError(f"Invalid workflow name: {error}")
+
+    # Determine content and source_path (unchanged logic, simplified)
+    if "\n" in workflow:
+        markdown_content = workflow
+        source_path = None
+    elif workflow.lower().endswith(".pflow.md") or Path(workflow).expanduser().exists():
+        file_path = Path(workflow).expanduser()
+        if not file_path.exists():
+            raise ValueError(f"Workflow file not found: {workflow}")
+        markdown_content = file_path.read_text(encoding="utf-8")
+        source_path = file_path
+    else:
+        raise ValueError(
+            f"Cannot save '{workflow}'. Pass raw .pflow.md content or a file path."
+        )
+
+    # Save (validation is internal) + format result
+    try:
+        return cls._save_and_format_result(name, markdown_content, force, source_path)
+    except WorkflowValidationError as e:
+        from pflow.execution.formatters.validation_formatter import format_validation_failure
+        rendered = (
+            format_validation_failure(e.validation_errors)
+            if e.validation_errors
+            else f"Invalid workflow: {e}"
+        )
+        raise ValueError(rendered) from e
+    except MarkdownParseError as e:
+        raise ValueError(f"Invalid workflow: {e}") from e
+```
+
+2. **Simplify `_save_and_format_result`** (lines 380-429): Remove the `workflow_ir` parameter — it comes from the save result now.
+
+```python
+@classmethod
+def _save_and_format_result(
+    cls,
+    name: str,
+    markdown_content: str,
+    force: bool,
+    source_path: Optional[Path] = None,
+) -> str:
+    from pflow.core.workflow.save_service import save_workflow_with_options
+    from pflow.execution.formatters.workflow_save_formatter import format_save_success
+
+    saved_path, bundled_files, workflow_ir = save_workflow_with_options(
+        name=name,
+        markdown_content=markdown_content,
+        force=force,
+        source_path=source_path,
+    )
+    return format_save_success(
+        name=name,
+        saved_path=str(saved_path),
+        workflow_ir=workflow_ir,
+        metadata=None,
+        bundled_files=bundled_files,
+    )
+```
+
+3. **Remove stale imports**: `parse_markdown` and `load_and_validate_workflow` are no longer needed in this file's save path. Check if they're used elsewhere in the file before removing.
+
+### Phase 4: Update tests
+
+**4a. `tests/test_core/test_workflow_save_service.py` — `TestSaveWorkflowWithOptions`**
+
+These 7 tests mock `WorkflowManager` and test save mechanics (force, overwrite, re-enrich). Since `save_workflow_with_options` now parses and validates internally:
+
+- Update all `path, bundled = save_workflow_with_options(...)` to `path, bundled, ir = ...`
+- Use `ir_to_markdown()` from `tests/shared/markdown_utils.py` to create valid workflow content that passes full validation (replace any minimal/invalid test fixtures)
+- For tests that specifically test save mechanics (force, delete, re-enrich), use a simple valid workflow: single shell node with `command` param
+- Verify existing assertions still hold after fixture updates
+
+**4b. `tests/test_cli/test_workflow_save_cli.py`**
+
+- `test_workflow_save_rejects_invalid_workflow` — This test likely passes an invalid workflow and checks for rejection. After the change, the error message may be richer (diagnostic format instead of plain schema error). Update assertion to match the new format.
+- Other tests that create valid workflows should continue passing (they already create workflows that pass schema validation; most should also pass full validation).
+
+**4c. `tests/test_mcp_server/test_workflow_save.py`**
+
+- Update any tests that check return type or call signature of `_save_and_format_result` (if directly tested)
+- Tests that go through `ExecutionService.save_workflow` should largely pass since the behavior is the same — just the internal flow changed
+
+**4d. `tests/test_integration/test_workflow_bundling.py`** (found by code review — missed in initial plan)
+
+This file calls `save_workflow_with_options` directly in 6 places across 3 test classes.
+
+- **Return type fix (4 sites)**: Update lines 347, 382, 562, 644 from `path, bundled = save_workflow_with_options(...)` to `path, bundled, ir = ...`
+- **Error source change (1 test)**: `test_raw_content_with_sub_workflow_ref_rejected` expects `WorkflowValidationError` matching `"file references"`. After the change, validation runs FIRST — the sub-workflow validator (step 8) will fail with `"Cannot resolve relative sub-workflow"` before `_reject_unbundleable_file_refs` runs. Update the assertion to match the new error. The behavior is actually better (more specific error, caught earlier).
+- **Verify prompt-ref test**: `test_raw_content_with_prompt_file_ref_rejected` should be unaffected (prompt path is a string param, not a sub-workflow reference), but verify during implementation.
+
+**Run bundling tests immediately after Phase 1** to catch any ordering interactions between the new validation and the existing file-ref guards.
+
+**4e. New regression test** (acceptance criteria from #236)
+
+Add to `tests/test_cli/test_workflow_save_cli.py`:
+
+```python
+def test_workflow_save_rejects_unknown_parameter_with_rich_diagnostic(self, ...):
+    """Regression test for GH #236: save must reject broken workflows
+    with the same rich diagnostic format as --validate-only."""
+    # Create workflow with unknown parameter (typo: file_pat instead of file_path)
+    broken_md = textwrap.dedent("""\
+        # Broken Workflow
+
+        ## Steps
+
+        ### writer
+        Writes content.
+
+        - type: write-file
+        - file_pat: output.txt
+        - content: hello
+    """)
+    draft = tmp_path / "broken.pflow.md"
+    draft.write_text(broken_md)
+
+    result = runner.invoke(workflow_cmd, ["save", str(draft), "--name", "test-broken"])
+    assert result.exit_code != 0
+    # Rich diagnostic format — same as --validate-only
+    # CliRunner mixes stderr into result.output by default
+    assert "Unknown parameter" in result.output
+    assert "file_pat" in result.output
+```
+
+Also add a positive test confirming valid workflows still save successfully (if not already covered).
+
+### Phase 5: Update documentation
+
+- `src/pflow/core/workflow/CLAUDE.md` — Update `save_service.py` section: document that `save_workflow_with_options` now owns parse + validate. Remove "pre-validated by caller" language. Note the return type change.
+- `src/pflow/cli/commands/CLAUDE.md` — Update workflow save section: remove mentions of `_load_and_parse_workflow` and `_save_with_overwrite_check`. Document the simplified flow.
+
+## Edge Cases Addressed
+
+| Edge case | How it's handled |
+|-----------|-----------------|
+| Unknown params (the #236 repro) | Full 9-step validation catches it, `WorkflowValidationError` with rich diagnostics |
+| `MarkdownParseError` from malformed content | Propagates from `save_workflow_with_options`; CLI catches and displays, MCP wraps as ValueError |
+| `WorkflowValidationError` from validation vs from I/O | CLI checks `e.validation_errors`: populated → rich display, empty → string message |
+| JSON file rejection | Stays in CLI command (before `save_workflow_with_options` call) — CLI-specific migration message |
+| `FileExistsError` without `--force` | Unchanged — still raised by save mechanics inside `save_workflow_with_options` |
+| Dependency bundling (sub-workflows, file refs) | Unchanged — runs after validation inside `save_workflow_with_options` |
+| File refs without source_path (MCP raw content) | `_reject_unbundleable_file_refs` still runs inside `save_workflow_with_options` |
+| #247 false positive (`${input.field}` in outputs) | Pre-existing — already affects MCP save and `--validate-only`. CLI save now gains the same exposure (previously skipped the validator entirely). This is correct: the validator is applied consistently. #247 should be fixed separately. Note in PR. |
+| Tests passing minimal fixtures | Update to use `ir_to_markdown()` with valid workflow content |
+
+## What's NOT Changing
+
+- `WorkflowValidator.validate()` — the underlying 9-step validator, untouched
+- `_validate_and_normalize_ir()` — the shared validation core, untouched (now called from one more place)
+- `load_and_validate_workflow()` — public API for load+validate, untouched. Note: loses its last production caller (MCP save) after this change; remains useful as public API and is exercised by tests
+- `WorkflowRunner._validate()` / `.validate()` — execution and validate-only paths, separate and correct
+- `_delete_draft_if_requested()` — post-save action, stays as-is
+- `_discover_and_bundle_deps()` / `_reject_unbundleable_file_refs()` — dependency handling, untouched
+
+## Verification
+
+1. **Reproduce the bug, confirm the fix:**
+   ```bash
+   # Create broken workflow (unknown param)
+   cat > /tmp/broken.pflow.md <<'PFLOW'
+   # Broken Workflow
+
+   ## Steps
+
+   ### writer
+   Writes content using a typoed parameter.
+
+   - type: write-file
+   - file_pat: output.txt
+   - content: hello
+   PFLOW
+
+   # Should now FAIL with rich diagnostic (was: silent success)
+   uv run pflow workflow save /tmp/broken.pflow.md --name test-broken
+
+   # Compare with --validate-only (should show same diagnostic format)
+   uv run pflow /tmp/broken.pflow.md --validate-only
+
+   # Valid workflow should still save
+   cat > /tmp/valid.pflow.md <<'PFLOW'
+   # Valid Workflow
+
+   ## Steps
+
+   ### echo
+   Echoes hello.
+
+   - type: shell
+   - command: echo hello
+   PFLOW
+
+   uv run pflow workflow save /tmp/valid.pflow.md --name test-valid --force
+   ```
+
+2. **Run tests:**
+   ```bash
+   # Targeted tests first (includes bundling tests — run early to catch ordering interactions)
+   pytest tests/test_core/test_workflow_save_service.py tests/test_cli/test_workflow_save_cli.py tests/test_mcp_server/test_workflow_save.py tests/test_integration/test_workflow_bundling.py tests/test_cli/test_validate_only.py -v
+
+   # Full suite
+   make test
+
+   # Quality checks
+   make check
+   ```
+
+3. **Verify CLI/MCP parity**: Both paths reject the same broken workflow with structured diagnostics.

--- a/.taskmaster/tasks/task_150/task-150.md
+++ b/.taskmaster/tasks/task_150/task-150.md
@@ -1,0 +1,87 @@
+# Task 150: Wire WorkflowValidator into Save Path
+
+## Description
+
+`pflow workflow save` bypasses `WorkflowValidator.validate()` entirely — broken workflows silently enter the library and only fail at run time. Fix by making `save_workflow_with_options` own parse + validate + save as one atomic operation, eliminating the bypass class.
+
+## Status
+
+not started
+
+## Priority
+
+high
+
+## Problem
+
+`save_workflow_with_options` trusts callers to pre-validate. Two callers (CLI, MCP) each implemented their own "prepare for save" logic. The MCP path correctly calls `load_and_validate_workflow` (full 9-step validator). The CLI path's `_load_and_parse_workflow` only calls `validate_ir` (schema-only). Result: unknown params, non-existent node refs, template errors, and broken sub-workflows are all accepted by `pflow workflow save` without complaint.
+
+Same bug class as GH #66 (pre-execution validation weaker than `--validate-only`), which was fixed for the run path but never addressed for save.
+
+Additionally, Task 147's error filter at `save_service.py:139` (the `Severity.ERROR` filter on validator diagnostics) is effectively dead code from the CLI surface — only reachable from the MCP path.
+
+## Solution
+
+Apply the Task 144 pattern: "delete the bypass, bring behavior into the unified pipeline."
+
+Move parse + validate into `save_workflow_with_options` itself. Callers pass raw markdown content; the function parses, validates via `_validate_and_normalize_ir` (which already exists in the same file), and saves. Return type expands to include the validated IR (callers need it for the success formatter).
+
+This deletes 2 CLI helper functions (`_load_and_parse_workflow`, `_save_with_overwrite_check`), simplifies the MCP save method, and makes it structurally impossible to save without validating.
+
+## Design Decisions
+
+- **Validation inside save, not patched in callers**: Options A/B/C (adding validation to the CLI caller) would fix this instance but leave the precondition unenforced. A third caller next month could make the same mistake. Option D (save owns validation) eliminates the bug class.
+- **Return type expands to 3-tuple, not a dataclass**: `tuple[Path, list[str], dict[str, Any]]` adds the validated IR. A `SaveResult` dataclass was considered but adds a new type for 3 fields — marginal benefit. Can be introduced later if the tuple grows further.
+- **`MarkdownParseError` propagates unchanged**: Both CLI and MCP already handle it. No wrapping needed.
+- **Rich diagnostic display for CLI save errors**: Uses `format_validation_failure()` — the same renderer as `--validate-only` — matching the acceptance criteria from GH #236.
+- **JSON rejection stays in CLI command**: It's a CLI-specific migration message, not a validation concern.
+
+## Dependencies
+
+None. All prerequisite infrastructure exists:
+- `_validate_and_normalize_ir` (save_service.py:83) — the shared validation core
+- `WorkflowValidator.validate()` returning `list[Diagnostic]` (Task 147)
+- `format_validation_failure()` (Task 144) — the rich error renderer
+
+## Requirements
+
+### Validation Parity
+- `pflow workflow save` rejects the same broken workflows that `--validate-only` and `pflow run` reject
+- Error output uses the same `format_validation_failure` renderer as `--validate-only` (numbered format with suggestions)
+- Valid workflows continue to save successfully
+
+### API Contract
+- `save_workflow_with_options` returns `tuple[Path, list[str], dict[str, Any]]` (path, bundled_files, validated_ir)
+- `save_workflow_with_options` can now raise `MarkdownParseError` (new) and `WorkflowValidationError` with `validation_errors` populated (new), in addition to existing exceptions
+- `WorkflowValidationError` from validation (has `validation_errors`) vs from save mechanics (summary-only) must be distinguishable by callers via `e.validation_errors`
+
+### Cleanup
+- `_load_and_parse_workflow` deleted from `workflow.py`
+- `_save_with_overwrite_check` deleted from `workflow.py`
+- MCP's manual `parse_markdown` + `load_and_validate_workflow` block deleted from `execution_service.py`
+
+## Implementation Notes
+
+**Validation ordering interaction**: Validation now runs BEFORE `_reject_unbundleable_file_refs` and `_discover_and_bundle_deps`. One bundling test (`test_raw_content_with_sub_workflow_ref_rejected`) relies on hitting the file-ref guard before validation. After the change, the sub-workflow validator (step 8) catches it first with a different error message. The test assertion needs updating — the behavior is actually better (more specific error, caught earlier).
+
+**#247 exposure change**: CLI save previously didn't run the validator, so it couldn't hit #247 (false positive on `${input.field}` in output sources). After this fix, CLI save gains the same #247 exposure that MCP save and `--validate-only` already have. Correct behavior — #247 should be fixed separately.
+
+**`load_and_validate_workflow` becomes test-only**: Loses its last production caller (MCP save) after this change. Still useful as public API and exercised by tests.
+
+**Double parse**: `save_workflow_with_options` will parse markdown (new), then `_discover_and_bundle_deps` parses it again internally. Pre-existing pattern (the old code also double-parsed). Not worth fixing in this PR.
+
+## Verification
+
+1. **Reproduce GH #236**: `pflow workflow save /tmp/broken.pflow.md --name test-broken` with unknown param `file_pat` — must fail with rich diagnostic showing "Unknown parameter" and "file_pat"
+2. **Parity check**: Compare save error output with `pflow /tmp/broken.pflow.md --validate-only` — same diagnostic format
+3. **Valid save**: `pflow workflow save /tmp/valid.pflow.md --name test-valid` — still succeeds
+4. **Targeted test suite**: `test_workflow_save_service.py`, `test_workflow_save_cli.py`, `test_workflow_save.py` (MCP), `test_workflow_bundling.py`, `test_validate_only.py` (regression)
+5. **Full suite**: `make test` + `make check`
+
+## References
+
+- **GH Issue**: spinje/pflow#236
+- **Implementation plan**: `.taskmaster/tasks/task_150/implementation/implementation-plan.md`
+- **Prior art (same pattern)**: Task 144 review — "delete the bypass, bring behavior into the unified pipeline"
+- **Task 147 review**: `.taskmaster/tasks/task_147/task-review.md` line 217 — filed #236 as incurred debt
+- **Key files**: `src/pflow/core/workflow/save_service.py`, `src/pflow/cli/commands/workflow.py`, `src/pflow/mcp_server/services/execution_service.py`

--- a/.taskmaster/tasks/task_150/task-review.md
+++ b/.taskmaster/tasks/task_150/task-review.md
@@ -1,0 +1,150 @@
+# Task 150 Review: Wire WorkflowValidator into Save Path
+
+## Metadata
+
+- Implementation Date: 2026-04-10
+- GitHub Issue: spinje/pflow#236
+- Branch: `fix/fix-pflow-workflow-save-validator`
+- Related: Task 147 (validator produces Diagnostics — filed #236 as incurred debt), Task 144 ("delete the bypass" pattern)
+
+## Executive Summary
+
+Made `save_workflow_with_options` own parse + validate + save as one atomic operation. CLI and MCP save paths now run the full 9-step `WorkflowValidator` — the same validation as `--validate-only` and `pflow run`. Deleted 2 CLI helper functions (`_load_and_parse_workflow`, `_save_with_overwrite_check`), simplified MCP `ExecutionService.save_workflow`, and added 3 tests (CLI rich diagnostics, MCP rich diagnostics, force-save ordering invariant). 12 files changed, net ~100 lines deleted from production code.
+
+## Implementation Overview
+
+### What Was Built
+
+`save_workflow_with_options()` in `save_service.py` gained two lines of actual logic at the top — `parse_markdown(markdown_content)` and `_validate_and_normalize_ir(result.ir, ...)` — plus a return-type expansion from `tuple[Path, list[str]]` to `tuple[Path, list[str], dict[str, Any]]`. Everything else was deletion and simplification of callers.
+
+### Deviations from Plan
+
+| Deviation | Why |
+|-----------|-----|
+| Added `except (WorkflowValidationError, MarkdownParseError): raise` to `_save_and_format_result` | Bug found during code review: the generic `except Exception` would swallow validation errors before `save_workflow` could render them with rich diagnostics. The plan's simplified `_save_and_format_result` didn't account for this. |
+| Added MCP regression test (`TestWorkflowSaveRichDiagnostics`) | Code review suggestion — without it, the exception-swallowing bug above had no test coverage. Existing MCP tests use loose `ValueError` pattern matching that passes regardless. |
+| Added ordering invariant test (`test_force_save_invalid_content_preserves_existing`) | Not in the plan. Identified during "high value test" analysis: if validation is moved after the existence check, `--force` with invalid content deletes the existing workflow before failing. |
+
+### Spec Assumptions That Were Wrong
+
+- **The plan assumed `_save_and_format_result` could be simplified to no error handling.** In reality, the existing `except Exception` catch was load-bearing for non-validation errors (I/O failures from `format_save_success`, `manager.save()` exceptions). Removing the `WorkflowValidationError` catch was correct; removing ALL catches would have let unexpected errors propagate as raw exceptions to the MCP tool layer.
+
+## Files Modified/Created
+
+### Core Changes (4 production files)
+
+- `src/pflow/core/workflow/save_service.py` — 2 lines of logic added: `parse_markdown` + `_validate_and_normalize_ir` at top of `save_workflow_with_options`. Return type expanded. Docstring updated. Both `parse_markdown` and `_validate_and_normalize_ir` were already available in the same file (imported/defined).
+- `src/pflow/cli/commands/workflow.py` — Deleted `_load_and_parse_workflow` (49 lines) and `_save_with_overwrite_check` (48 lines). Rewrote `save_workflow` Click command as a single try/except flow. Rich diagnostic display via `format_validation_failure()` when `e.validation_errors` is populated, matching `--validate-only` output.
+- `src/pflow/mcp_server/services/execution_service.py` — Deleted manual `parse_markdown` + `load_and_validate_workflow` block from `save_workflow`. Removed `workflow_ir` parameter from `_save_and_format_result`. Added `except (WorkflowValidationError, MarkdownParseError): raise` before the generic catch.
+- 3 CLAUDE.md files updated to reflect the new ownership model.
+
+### Test Files (4 files, 3 new tests)
+
+| Test | What it guards |
+|------|---------------|
+| `test_workflow_save_cli.py::test_workflow_save_renders_rich_validation_diagnostics` | Core #236 regression — CLI save rejects unknown params with numbered diagnostic format |
+| `test_workflow_save_cli.py::test_force_save_invalid_content_preserves_existing` | Ordering invariant — validation before deletion prevents data loss on force-save of broken content |
+| `test_workflow_save.py::test_unknown_param_produces_rich_diagnostic` | MCP parity — structured diagnostics survive the three-layer exception chain |
+| All `test_workflow_save_service.py::TestSaveWorkflowWithOptions` (7 tests) | Return type unpacking + validated IR assertions |
+| All `test_workflow_bundling.py` (4 unpack sites + 1 assertion update) | Bundling still works after return type change; sub-workflow validation fires before file-ref guard |
+
+## Architectural Decisions & Tradeoffs
+
+### Key Decisions
+
+**"Validation inside save" over "validation in caller"** — The GH issue proposed patching the CLI caller. We chose to move validation into `save_workflow_with_options` itself so the precondition is enforced by the API, not trusted from callers. This is the Task 144 pattern: "delete the bypass, bring behavior into the unified pipeline." Two callers (CLI, MCP) each had their own "prepare for save" logic; one forgot to validate.
+
+**3-tuple return instead of `SaveResult` dataclass** — A dataclass was considered but adds a new type for 3 fields. The tuple expansion touches 10+ unpack sites, but each change is mechanical. If the return grows further, a dataclass should be introduced.
+
+**`WorkflowValidationError` dual semantics preserved** — `save_workflow_with_options` raises `WorkflowValidationError` for two different reasons: validation failures (has `validation_errors` list) and save-mechanic failures (summary string only). CLI distinguishes them via `e.validation_errors` check. This is pre-existing and works, but is a design smell — a future cleanup could use distinct exception types.
+
+### Technical Debt
+
+| Item | Notes |
+|------|-------|
+| `load_and_validate_workflow` has zero production callers | MCP save was its last caller. Still useful as public API and exercised by tests. |
+| Triple `parse_markdown` on save-with-bundling | `save_workflow_with_options` parses, then `_discover_and_bundle_deps` parses again, then `_reject_unbundleable_file_refs` may parse a third time. Pre-existing double-parse; now triple. Not a correctness issue. |
+| #247 exposure expanded | CLI save now gets the same false positive on `${input.field}` in output sources that MCP save and `--validate-only` already have. Correct behavior — the validator is applied consistently. #247 should be fixed separately. |
+
+## Unexpected Discoveries
+
+### The Exception Swallowing Bug
+
+The plan's simplified `_save_and_format_result` (remove `workflow_ir` param, remove error handling) would have introduced a regression: the remaining generic `except Exception` catches `WorkflowValidationError` before `save_workflow` can render it with `format_validation_failure`. The MCP agent would get `"Failed to save workflow: Invalid workflow 'X' - Validation errors:..."` instead of the numbered diagnostic format. Existing MCP tests didn't catch this because they assert on `match=r"Invalid|Unknown"` which matches both.
+
+**Lesson**: When simplifying a function's error handling, verify that every exception type in the inner function's contract either (a) is caught explicitly or (b) propagates correctly through all intermediate layers. Three-layer exception chains are especially prone to this.
+
+### Validation Ordering Changes Bundling Test Behavior
+
+`test_raw_content_with_sub_workflow_ref_rejected` relied on `_reject_unbundleable_file_refs` catching sub-workflow file references before validation. After the change, the validator's step 8 (sub-workflow validation) fires first with `"Cannot resolve relative sub-workflow"` — a more specific error caught earlier. The behavior is strictly better, but the test assertion had to change.
+
+### The Review Process Caught Real Issues
+
+All 3 review agents independently found the missing `test_workflow_bundling.py` — a file with 6 `save_workflow_with_options` calls that would have broken on the return-type change. This was a genuine miss in the plan, not a theoretical concern. The convergent signal across independent agents was strong evidence.
+
+## Patterns Established
+
+### "The save function owns its validation"
+
+When a function persists data, validation belongs inside the function, not in the caller. This eliminates the "precondition not enforced by API" bug class. The pattern:
+
+```python
+def save_something(content: str, ...) -> SaveResult:
+    parsed = parse(content)          # Parse
+    validated = validate(parsed)      # Validate (raises on failure)
+    result = persist(content, ...)    # Save original content
+    return SaveResult(..., validated) # Return validated data for display
+```
+
+Callers never pre-validate. The function is the trust boundary.
+
+### Exception propagation in layered MCP services
+
+When an MCP service method delegates to a helper that has a generic `except Exception`, validation/parse errors must be explicitly re-raised before the generic catch:
+
+```python
+# In the helper (_save_and_format_result)
+except (WorkflowValidationError, MarkdownParseError):
+    raise  # Let caller handle with rich rendering
+except Exception as e:
+    raise ValueError(f"Failed: {e}") from e  # Wrap unexpected errors
+```
+
+### Ordering invariant test for data-safety
+
+When a function does "validate then delete then save", test that validation failure prevents deletion:
+
+```python
+def test_force_save_invalid_content_preserves_existing(...):
+    # Save valid workflow
+    # Try to force-save invalid content
+    assert exit_code != 0
+    assert existing.exists(), "Valid workflow was deleted before validation caught the error"
+    assert existing.read_text() == original_content
+```
+
+## AI Agent Guidance
+
+### Quick Start for Related Tasks
+
+1. Read `src/pflow/core/workflow/save_service.py:353-430` — `save_workflow_with_options` is the save-time trust boundary
+2. Read `src/pflow/mcp_server/services/execution_service.py:304-415` — the three-layer exception chain: `save_workflow` → `_save_and_format_result` → `save_workflow_with_options`
+3. Read `src/pflow/cli/commands/workflow.py:255-330` — the CLI save command's error handler, especially the `e.validation_errors` check
+
+### Common Pitfalls
+
+- **Don't add pre-validation in callers of `save_workflow_with_options`** — the function validates internally. Caller pre-validation is redundant and risks drift.
+- **Don't reorder `_save_and_format_result`'s exception handlers** — `(WorkflowValidationError, MarkdownParseError)` must come before `Exception`, or rich diagnostics are lost.
+- **Don't move validation after the existence check in `save_workflow_with_options`** — force-save of invalid content would delete the existing workflow before failing. The `test_force_save_invalid_content_preserves_existing` test guards this.
+- **`WorkflowValidationError` with `validation_errors` vs without** — validation failures populate `validation_errors` (list of Diagnostics). Save-mechanic failures (delete error, I/O error) only have a summary string. CLI/MCP error handlers must check `e.validation_errors` before calling `format_validation_failure`.
+
+### Test-First Recommendations
+
+When modifying save path code, run these first:
+```bash
+pytest tests/test_core/test_workflow_save_service.py tests/test_cli/test_workflow_save_cli.py tests/test_mcp_server/test_workflow_save.py tests/test_integration/test_workflow_bundling.py -v
+```
+
+---
+
+*Generated from implementation context of Task 150*

--- a/src/pflow/cli/commands/CLAUDE.md
+++ b/src/pflow/cli/commands/CLAUDE.md
@@ -76,6 +76,8 @@ Subcommands: `list` (with optional filter), `describe`, `history`, `discover` (L
 **Workflow save**:
 - Name validation: lowercase, numbers, hyphens only, max 30 chars (shell/URL/git-safe)
 - Description extracted from markdown H1 prose (`--description` flag removed)
+- The CLI save command reads raw markdown and delegates parse + full validation + save to `save_workflow_with_options()`
+- Validation failures with structured diagnostics are rendered through `format_validation_failure()` for parity with `--validate-only`
 - `--delete-draft` safety check: only works in `.pflow/workflows/`, resolves symlinks, refuses to delete symlinked files
 
 **Workflow history** (`pflow workflow history <name>`): Shows execution history and last used inputs — useful for finding previously used parameter values.
@@ -137,7 +139,7 @@ LLM model resolution chain (genuinely hard to discover):
 | `registry_run.py` | `test_registry_run.py` | `pflow.cli.commands.registry_run.Registry`, `.import_node_class`, `.inject_special_parameters` |
 | `registry.py` (normalization) | `test_registry_normalization.py` | None (direct function import) |
 | `read_fields.py` | `test_read_fields.py` | None |
-| `workflow.py` | `test_workflow_resolution.py` (partial) | None |
+| `workflow.py` | `test_workflow_save_cli.py`, `test_workflow_resolution.py` (partial) | None |
 | `skills.py` | `test_skills.py` | `pflow.cli.commands.skills.WorkflowManager`, `.create_skill_symlink`, `.enrich_workflow`, `.find_skill_for_workflow`, `.find_pflow_skills`, `.remove_skill_service` |
 | `visualize.py` | `test_visualize.py` | None |
 | `settings.py` | (tested via integration) | None |

--- a/src/pflow/cli/commands/workflow.py
+++ b/src/pflow/cli/commands/workflow.py
@@ -3,7 +3,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import Any
 
 import click
 
@@ -222,107 +221,6 @@ def _validate_discovery_query(query: str, command_name: str) -> str:
     return query
 
 
-def _load_and_parse_workflow(file_path: str) -> tuple[dict[str, Any], str, str | None]:
-    """Load workflow from .pflow.md file, parse, and validate.
-
-    Args:
-        file_path: Path to workflow .pflow.md file
-
-    Returns:
-        Tuple of (validated_ir, markdown_content, description)
-
-    Raises:
-        SystemExit: If file can't be loaded or validation fails
-    """
-    from pathlib import Path
-
-    from pflow.core import normalize_ir
-    from pflow.core.markdown_parser import parse_markdown
-
-    path = Path(file_path)
-
-    # Reject .json files with a clear migration message
-    if path.suffix == ".json":
-        click.echo(
-            "Error: JSON workflow format is no longer supported. Use .pflow.md format instead.",
-            err=True,
-        )
-        sys.exit(1)
-
-    try:
-        content = path.read_text(encoding="utf-8")
-        result = parse_markdown(content)
-
-        # Normalize IR (adds ir_version, etc.)
-        normalize_ir(result.ir)
-
-        # Validate IR structure (raises WorkflowValidationError on failure)
-        from pflow.core.ir_schema import validate_ir
-
-        validate_ir(result.ir)
-
-        return result.ir, content, result.description
-    except MarkdownParseError as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
-    except FileNotFoundError:
-        click.echo(f"Error: File not found: {file_path}", err=True)
-        sys.exit(1)
-    except Exception as e:
-        click.echo(f"Error loading workflow: {e}", err=True)
-        sys.exit(1)
-
-
-def _save_with_overwrite_check(
-    name: str,
-    markdown_content: str,
-    metadata: dict[str, Any] | None,
-    force: bool,
-    source_path: Path | None = None,
-) -> tuple[str, list[str]]:
-    """Save workflow to library with overwrite handling.
-
-    Args:
-        name: Workflow name
-        markdown_content: Original markdown content to save
-        metadata: Optional metadata
-        force: Whether to overwrite existing workflow
-        source_path: Optional source file path for dependency discovery
-
-    Returns:
-        Tuple of (saved_path, bundled_files_list)
-
-    Raises:
-        SystemExit: If workflow exists and force=False, or save fails
-    """
-    from pflow.core.workflow.save_service import save_workflow_with_options
-
-    try:
-        saved_path, bundled_files = save_workflow_with_options(
-            name=name,
-            markdown_content=markdown_content,
-            force=force,
-            metadata=metadata,
-            source_path=source_path,
-        )
-
-        if force:
-            click.echo(f"✓ Overwritten existing workflow '{name}'")
-
-        return str(saved_path), bundled_files
-
-    except FileExistsError as e:
-        click.echo(f"Error: {e}", err=True)
-        click.echo("  Use --force to overwrite.", err=True)
-        sys.exit(1)
-    except WorkflowValidationError as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
-    except Exception as e:
-        click.echo(f"Error saving workflow: {e}", err=True)
-        sys.exit(1)
-
-
 def _delete_draft_if_requested(file_path: str, delete_draft: bool) -> None:
     """Delete draft file if requested and safe to do so.
 
@@ -363,7 +261,7 @@ def save_workflow(file_path: str, name: str, delete_draft: bool, force: bool) ->
     Example:
         pflow workflow save ./my-workflow.pflow.md --name my-analyzer
     """
-    from pflow.core.workflow.save_service import validate_workflow_name
+    from pflow.core.workflow.save_service import save_workflow_with_options, validate_workflow_name
 
     # Validate workflow name
     is_valid, error = validate_workflow_name(name)
@@ -371,15 +269,50 @@ def save_workflow(file_path: str, name: str, delete_draft: bool, force: bool) ->
         click.echo(f"Error: {error}", err=True)
         sys.exit(1)
 
-    # Load, parse, and validate workflow
-    validated_ir, markdown_content, _description = _load_and_parse_workflow(file_path)
+    path = Path(file_path)
+
+    if path.suffix == ".json":
+        click.echo(
+            "Error: JSON workflow format is no longer supported. Use .pflow.md format instead.",
+            err=True,
+        )
+        sys.exit(1)
 
     metadata = None
 
-    # Save workflow (passes markdown content, not IR)
-    saved_path, bundled_files = _save_with_overwrite_check(
-        name, markdown_content, metadata, force, source_path=Path(file_path)
-    )
+    try:
+        markdown_content = path.read_text(encoding="utf-8")
+        saved_path, bundled_files, workflow_ir = save_workflow_with_options(
+            name=name,
+            markdown_content=markdown_content,
+            force=force,
+            metadata=metadata,
+            source_path=path,
+        )
+    except FileExistsError as e:
+        click.echo(f"Error: {e}", err=True)
+        click.echo("  Use --force to overwrite.", err=True)
+        sys.exit(1)
+    except WorkflowValidationError as e:
+        if e.validation_errors:
+            from pflow.execution.formatters.validation_formatter import format_validation_failure
+
+            click.echo(format_validation_failure(e.validation_errors), err=True)
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except MarkdownParseError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except FileNotFoundError:
+        click.echo(f"Error: File not found: {file_path}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Error saving workflow: {e}", err=True)
+        sys.exit(1)
+
+    if force:
+        click.echo(f"✓ Overwritten existing workflow '{name}'")
 
     # Delete draft if requested
     _delete_draft_if_requested(file_path, delete_draft)
@@ -389,8 +322,8 @@ def save_workflow(file_path: str, name: str, delete_draft: bool, force: bool) ->
 
     success_message = format_save_success(
         name=name,
-        saved_path=saved_path,
-        workflow_ir=validated_ir,
+        saved_path=str(saved_path),
+        workflow_ir=workflow_ir,
         metadata=metadata,
         bundled_files=bundled_files,
     )

--- a/src/pflow/core/workflow/CLAUDE.md
+++ b/src/pflow/core/workflow/CLAUDE.md
@@ -139,6 +139,8 @@ Uses Kahn's algorithm for topological sort. Catches: forward references, circula
 
 **Reserved workflow names**: `null`, `undefined`, `none`, `test`, `settings`, `registry`, `workflow`, `mcp`, `skill`.
 
+**`save_workflow_with_options()`** is now the save-time trust boundary: it parses markdown, normalizes IR, runs the full `WorkflowValidator`, then performs dependency bundling and persistence. Callers must pass raw markdown, not pre-validated IR. The return value is `(saved_path, bundled_files, validated_ir)`.
+
 **`generate_workflow_metadata()`**: Stub — returns None unconditionally (planning module removed).
 
 ### skill_service.py

--- a/src/pflow/core/workflow/save_service.py
+++ b/src/pflow/core/workflow/save_service.py
@@ -263,13 +263,13 @@ def load_and_validate_workflow(
 
 
 def _discover_and_bundle_deps(
-    name: str, markdown_content: str, source_path: Path
+    name: str, workflow_ir: dict[str, Any], source_path: Path
 ) -> tuple[Optional[list[tuple[str, Path]]], list[str]]:
     """Discover file dependencies and compute bundle-relative paths.
 
     Args:
         name: Workflow name (for error messages)
-        markdown_content: Workflow markdown content to parse
+        workflow_ir: Parsed and validated workflow IR
         source_path: Path to the source workflow file
 
     Returns:
@@ -281,9 +281,8 @@ def _discover_and_bundle_deps(
     from pflow.core.workflow.dependency_discovery import discover_dependencies
 
     try:
-        result = parse_markdown(markdown_content)
         parent_base = source_path.parent.resolve()
-        deps = discover_dependencies(result.ir, parent_base)
+        deps = discover_dependencies(workflow_ir, parent_base)
         if not deps:
             return None, []
 
@@ -310,7 +309,7 @@ def _discover_and_bundle_deps(
 
     except WorkflowValidationError:
         raise
-    except (FileNotFoundError, MarkdownParseError, ValueError) as e:
+    except (FileNotFoundError, ValueError) as e:
         raise WorkflowValidationError(f"Dependency discovery failed for '{name}': {e}") from e
     except Exception as e:
         raise WorkflowValidationError(
@@ -320,7 +319,7 @@ def _discover_and_bundle_deps(
         ) from e
 
 
-def _reject_unbundleable_file_refs(name: str, markdown_content: str) -> None:
+def _reject_unbundleable_file_refs(name: str, workflow_ir: dict[str, Any]) -> None:
     """Reject saves of workflows with file references when no source path is available.
 
     Without a source path, file references can't be bundled, producing a broken
@@ -329,10 +328,9 @@ def _reject_unbundleable_file_refs(name: str, markdown_content: str) -> None:
     from pflow.core.file_resolver import has_file_references, is_workflow_file_reference
 
     try:
-        result = parse_markdown(markdown_content)
-        file_refs = has_file_references(result.ir)
+        file_refs = has_file_references(workflow_ir)
         # Also check for sub-workflow file refs (not in FILE_RESOLVABLE_PARAMS)
-        for node in result.ir.get("nodes", []):
+        for node in workflow_ir.get("nodes", []):
             wf_ref = node.get("params", {}).get("workflow", "")
             if isinstance(wf_ref, str) and is_workflow_file_reference(wf_ref):
                 file_refs.append(wf_ref)
@@ -363,8 +361,11 @@ def save_workflow_with_options(
     When source_path is provided, discovers file dependencies (sub-workflows,
     prompts, scripts) and bundles them into the saved workflow folder.
 
+    Content validation (parse + full WorkflowValidator) is handled internally.
+    Name validation is the caller's responsibility (use validate_workflow_name).
+
     Args:
-        name: Workflow name (must be validated first using validate_workflow_name)
+        name: Workflow name (caller must validate via validate_workflow_name first)
         markdown_content: Original .pflow.md content string
         force: If True, overwrite existing workflow by deleting it first
         metadata: Optional metadata dict (keywords, capabilities, use cases)
@@ -408,9 +409,9 @@ def save_workflow_with_options(
     bundled_files: list[str] = []
 
     if source_path is not None:
-        dependencies, bundled_files = _discover_and_bundle_deps(name, markdown_content, source_path)
+        dependencies, bundled_files = _discover_and_bundle_deps(name, validated_ir, source_path)
     else:
-        _reject_unbundleable_file_refs(name, markdown_content)
+        _reject_unbundleable_file_refs(name, validated_ir)
 
     # Save workflow
     try:

--- a/src/pflow/core/workflow/save_service.py
+++ b/src/pflow/core/workflow/save_service.py
@@ -357,27 +357,36 @@ def save_workflow_with_options(
     force: bool = False,
     metadata: Optional[dict[str, Any]] = None,
     source_path: Optional[Path] = None,
-) -> tuple[Path, list[str]]:
-    """Save workflow to library with existence checks, dependency bundling, and overwrite handling.
+) -> tuple[Path, list[str], dict[str, Any]]:
+    """Parse, validate, and save a workflow with dependency bundling and overwrite handling.
 
     When source_path is provided, discovers file dependencies (sub-workflows,
     prompts, scripts) and bundles them into the saved workflow folder.
 
     Args:
         name: Workflow name (must be validated first using validate_workflow_name)
-        markdown_content: Original .pflow.md content string (pre-validated by caller)
+        markdown_content: Original .pflow.md content string
         force: If True, overwrite existing workflow by deleting it first
         metadata: Optional metadata dict (keywords, capabilities, use cases)
         source_path: Optional path to the source workflow file. When provided,
             dependency discovery runs and files are bundled into the saved folder.
 
     Returns:
-        Tuple of (path_to_saved_entry_point, list_of_bundled_relative_paths)
+        Tuple of (path_to_saved_entry_point, list_of_bundled_relative_paths, validated_ir)
 
     Raises:
+        MarkdownParseError: If markdown_content cannot be parsed
         FileExistsError: If workflow exists and force=False
-        WorkflowValidationError: If save fails
+        WorkflowValidationError: If validation or save fails
     """
+    result = parse_markdown(markdown_content)
+    validated_ir = _validate_and_normalize_ir(
+        result.ir,
+        auto_normalize=True,
+        source_desc=f"Invalid workflow '{name}'",
+        source_path=source_path,
+    )
+
     manager = WorkflowManager()
 
     # Check existence
@@ -418,7 +427,7 @@ def save_workflow_with_options(
     except Exception:
         logger.warning(f"Failed to re-enrich skill for '{name}'", exc_info=True)
 
-    return Path(saved_path), bundled_files
+    return Path(saved_path), bundled_files, validated_ir
 
 
 def generate_workflow_metadata(

--- a/src/pflow/mcp_server/services/CLAUDE.md
+++ b/src/pflow/mcp_server/services/CLAUDE.md
@@ -89,7 +89,7 @@ errors = [d for d in diagnostics if d.severity == Severity.ERROR]
 
 Every shared formatter has two call sites: CLI (`cli/main.py`) and MCP (`execution_service.py`). Adding a new parameter to a formatter WITHOUT updating both sides causes silent output divergence — the CLI gets the new field, MCP doesn't, and the error surfaces as "MCP output is missing X". Grep both files for the formatter name when modifying its signature.
 
-Same rule for rendering exceptions: the MCP `save_workflow` path catches `WorkflowValidationError` and renders it via `format_validation_failure(e.validation_errors)` — parity with the CLI validate path. `WorkflowValidationError.validation_warnings` is a constructor kwarg (not a dynamic attribute), so warnings survive the exception boundary without special plumbing.
+Same rule for rendering exceptions: the MCP `save_workflow` path relies on `save_workflow_with_options()` for parse + validation + save, then catches `WorkflowValidationError` and renders it via `format_validation_failure(e.validation_errors)` — parity with the CLI save/validate paths. `WorkflowValidationError.validation_warnings` is a constructor kwarg (not a dynamic attribute), so warnings survive the exception boundary without special plumbing.
 
 ## Testing
 

--- a/src/pflow/mcp_server/services/execution_service.py
+++ b/src/pflow/mcp_server/services/execution_service.py
@@ -322,9 +322,7 @@ class ExecutionService(BaseService):
             ValueError: If workflow name is invalid, content is invalid, or validation fails
             FileExistsError: If workflow exists and force=False
         """
-        from pflow.core.markdown_parser import parse_markdown
         from pflow.core.workflow.save_service import (
-            load_and_validate_workflow,
             validate_workflow_name,
         )
 
@@ -334,6 +332,7 @@ class ExecutionService(BaseService):
             raise ValueError(f"Invalid workflow name: {error}")
 
         # Determine markdown content from input
+        source_path: Optional[Path] = None
         if "\n" in workflow:
             # Raw markdown content
             markdown_content = workflow
@@ -343,20 +342,14 @@ class ExecutionService(BaseService):
             if not file_path.exists():
                 raise ValueError(f"Workflow file not found: {workflow}")
             markdown_content = file_path.read_text(encoding="utf-8")
+            source_path = file_path
         else:
             raise ValueError(f"Cannot save '{workflow}'. Pass raw .pflow.md content or a file path.")
 
-        # Parse and validate — parse once, use IR for display, content for save
         try:
-            result = parse_markdown(markdown_content)
-        except MarkdownParseError as e:
-            raise ValueError(f"Invalid workflow: {e}") from e
-
-        # Validate the parsed IR. WorkflowValidationError carries structured
-        # diagnostics (post task 147) — render them through format_validation_failure
-        # so the agent receives the same rich text the validate_workflow path produces.
-        try:
-            load_and_validate_workflow(result.ir, auto_normalize=True)
+            return cls._save_and_format_result(name, markdown_content, force, source_path)
+        except FileExistsError:
+            raise
         except WorkflowValidationError as e:
             from pflow.execution.formatters.validation_formatter import format_validation_failure
 
@@ -364,25 +357,14 @@ class ExecutionService(BaseService):
                 format_validation_failure(e.validation_errors) if e.validation_errors else f"Invalid workflow: {e}"
             )
             raise ValueError(rendered) from e
-        except ValueError as e:
+        except MarkdownParseError as e:
             raise ValueError(f"Invalid workflow: {e}") from e
-
-        # Determine source path for dependency discovery (file-based saves only)
-        source_path: Optional[Path] = None
-        if "\n" not in workflow:
-            candidate = Path(workflow).expanduser()
-            if candidate.exists():
-                source_path = candidate
-
-        # Save and format result
-        return cls._save_and_format_result(name, markdown_content, result.ir, force, source_path)
 
     @classmethod
     def _save_and_format_result(
         cls,
         name: str,
         markdown_content: str,
-        workflow_ir: dict[str, Any],
         force: bool,
         source_path: Optional[Path] = None,
     ) -> str:
@@ -391,7 +373,6 @@ class ExecutionService(BaseService):
         Args:
             name: Workflow name
             markdown_content: Original markdown content (preserved for save)
-            workflow_ir: Parsed workflow IR (used for display formatting)
             force: Whether to overwrite existing workflow
             source_path: Optional source file path for dependency discovery
 
@@ -406,7 +387,7 @@ class ExecutionService(BaseService):
         from pflow.execution.formatters.workflow_save_formatter import format_save_success
 
         try:
-            saved_path, bundled_files = save_workflow_with_options(
+            saved_path, bundled_files, workflow_ir = save_workflow_with_options(
                 name=name,
                 markdown_content=markdown_content,
                 force=force,
@@ -427,9 +408,8 @@ class ExecutionService(BaseService):
             raise FileExistsError(
                 f"Workflow '{name}' already exists. Use force=true to overwrite or choose a different name."
             ) from e
-        except WorkflowValidationError as e:
-            logger.error(f"Failed to save workflow: {e}", exc_info=True)
-            raise ValueError(f"Failed to save workflow: {e}") from e
+        except (WorkflowValidationError, MarkdownParseError):
+            raise
         except Exception as e:
             logger.error(f"Failed to save workflow: {e}", exc_info=True)
             raise ValueError(f"Failed to save workflow: {e}") from e

--- a/tests/test_cli/test_workflow_save_cli.py
+++ b/tests/test_cli/test_workflow_save_cli.py
@@ -100,10 +100,40 @@ class TestWorkflowSaveCLI:
 
         # Should fail
         assert result.exit_code != 0, "Should reject invalid workflow"
+        assert "Error:" in result.output or "Validation failed" in result.output
 
         # Should NOT create file
         saved_file = home_pflow / "bad-workflow" / "bad-workflow.pflow.md"
         assert not saved_file.exists(), "Invalid workflow should not be saved"
+
+    def test_workflow_save_renders_rich_validation_diagnostics(
+        self, runner: click.testing.CliRunner, tmp_path: Any
+    ) -> None:
+        """Unknown params should render the unified validator output, not a flat exception string."""
+        home_pflow = tmp_path / ".pflow" / "workflows"
+        home_pflow.mkdir(parents=True)
+
+        draft = tmp_path / "broken.pflow.md"
+        broken_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "reader", "type": "read-file", "params": {"file_pat": "README.md"}}],
+            "edges": [],
+        }
+        write_workflow_file(broken_ir, draft)
+
+        result = runner.invoke(
+            workflow_cmd,
+            ["save", str(draft), "--name", "broken-workflow"],
+            env={"HOME": str(tmp_path)},
+        )
+
+        assert result.exit_code != 0
+        assert "Validation failed (1 error)" in result.output
+        assert "Unknown parameter" in result.output
+        assert "file_pat" in result.output
+
+        saved_file = home_pflow / "broken-workflow" / "broken-workflow.pflow.md"
+        assert not saved_file.exists()
 
     def test_workflow_save_validates_name_format(
         self, runner: click.testing.CliRunner, tmp_path: Any, sample_workflow_ir: dict[str, Any]
@@ -256,6 +286,49 @@ class TestWorkflowSaveCLI:
         existing = home_pflow / "my-workflow" / "my-workflow.pflow.md"
         content = existing.read_text()
         assert "### new" in content
+
+    def test_force_save_invalid_content_preserves_existing(
+        self, runner: click.testing.CliRunner, tmp_path: Any, sample_workflow_ir: dict[str, Any]
+    ) -> None:
+        """Force-saving invalid content must NOT delete the existing valid workflow.
+
+        Ordering invariant: validation runs before deletion in the force-save path.
+        If this order is reversed, --force with broken content would delete the
+        existing workflow and then fail, causing data loss.
+        """
+        home_pflow = tmp_path / ".pflow" / "workflows"
+        home_pflow.mkdir(parents=True)
+
+        # Save a valid workflow first
+        from pflow.core.workflow.manager import WorkflowManager
+
+        wm = WorkflowManager(home_pflow)
+        wm.save("my-workflow", ir_to_markdown(sample_workflow_ir, title="Good Workflow"))
+
+        existing = home_pflow / "my-workflow" / "my-workflow.pflow.md"
+        assert existing.exists()
+        original_content = existing.read_text()
+
+        # Try to force-save invalid content over it
+        broken_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "bad", "type": "read-file", "params": {"file_pat": "x.txt"}}],
+            "edges": [],
+        }
+        draft = tmp_path / "broken.pflow.md"
+        write_workflow_file(broken_ir, draft)
+
+        result = runner.invoke(
+            workflow_cmd,
+            ["save", str(draft), "--name", "my-workflow", "--force"],
+            env={"HOME": str(tmp_path)},
+        )
+
+        assert result.exit_code != 0, "Should reject invalid workflow"
+
+        # The existing valid workflow must survive
+        assert existing.exists(), "Valid workflow was deleted before validation caught the error"
+        assert existing.read_text() == original_content, "Valid workflow content was modified"
 
     def test_workflow_save_rejects_overwrite_without_force(
         self, runner: click.testing.CliRunner, tmp_path: Any, sample_workflow_ir: dict[str, Any]

--- a/tests/test_core/test_workflow_save_service.py
+++ b/tests/test_core/test_workflow_save_service.py
@@ -402,13 +402,18 @@ class TestSaveWorkflowWithOptions:
             mock_wm.save.return_value = str(tmp_path / "new-workflow.pflow.md")
             mock_wm_class.return_value = mock_wm
 
-            path, bundled = save_workflow_with_options("new-workflow", markdown_content, force=False)
+            path, bundled, saved_ir = save_workflow_with_options("new-workflow", markdown_content, force=False)
 
             mock_wm.exists.assert_called_once_with("new-workflow")
             mock_wm.save.assert_called_once_with("new-workflow", markdown_content, None, None)
             mock_wm.delete.assert_not_called()
             assert path == Path(str(tmp_path / "new-workflow.pflow.md"))
             assert bundled == []
+            assert saved_ir["ir_version"] == sample_ir["ir_version"]
+            assert saved_ir["edges"] == sample_ir["edges"]
+            assert saved_ir["nodes"][0]["id"] == sample_ir["nodes"][0]["id"]
+            assert saved_ir["nodes"][0]["type"] == sample_ir["nodes"][0]["type"]
+            assert saved_ir["nodes"][0]["params"]["command"] == sample_ir["nodes"][0]["params"]["command"]
 
     def test_save_existing_with_force_deletes_first(self, sample_ir: dict[str, Any], tmp_path: Path) -> None:
         """FORCE OVERWRITE: Must delete existing before saving.
@@ -425,13 +430,18 @@ class TestSaveWorkflowWithOptions:
             mock_wm.save.return_value = str(tmp_path / "existing.pflow.md")
             mock_wm_class.return_value = mock_wm
 
-            path, bundled = save_workflow_with_options("existing", markdown_content, force=True)
+            path, bundled, saved_ir = save_workflow_with_options("existing", markdown_content, force=True)
 
             # Verify delete was called before save
             mock_wm.delete.assert_called_once_with("existing")
             mock_wm.save.assert_called_once_with("existing", markdown_content, None, None)
             assert path == Path(str(tmp_path / "existing.pflow.md"))
             assert bundled == []
+            assert saved_ir["ir_version"] == sample_ir["ir_version"]
+            assert saved_ir["edges"] == sample_ir["edges"]
+            assert saved_ir["nodes"][0]["id"] == sample_ir["nodes"][0]["id"]
+            assert saved_ir["nodes"][0]["type"] == sample_ir["nodes"][0]["type"]
+            assert saved_ir["nodes"][0]["params"]["command"] == sample_ir["nodes"][0]["params"]["command"]
 
     def test_save_existing_without_force_raises(self, sample_ir: dict[str, Any], tmp_path: Path) -> None:
         """OVERWRITE PROTECTION: Reject overwrite without force flag.
@@ -472,12 +482,17 @@ class TestSaveWorkflowWithOptions:
             mock_wm.save.return_value = str(tmp_path / "with-metadata.pflow.md")
             mock_wm_class.return_value = mock_wm
 
-            path, bundled = save_workflow_with_options("with-metadata", markdown_content, metadata=metadata)
+            path, bundled, saved_ir = save_workflow_with_options("with-metadata", markdown_content, metadata=metadata)
 
             # Verify metadata was passed to save()
             mock_wm.save.assert_called_once_with("with-metadata", markdown_content, metadata, None)
             assert path == Path(str(tmp_path / "with-metadata.pflow.md"))
             assert bundled == []
+            assert saved_ir["ir_version"] == sample_ir["ir_version"]
+            assert saved_ir["edges"] == sample_ir["edges"]
+            assert saved_ir["nodes"][0]["id"] == sample_ir["nodes"][0]["id"]
+            assert saved_ir["nodes"][0]["type"] == sample_ir["nodes"][0]["type"]
+            assert saved_ir["nodes"][0]["params"]["command"] == sample_ir["nodes"][0]["params"]["command"]
 
     def test_delete_failure_raises_clear_error(self, sample_ir: dict[str, Any], tmp_path: Path) -> None:
         """DELETE ERROR: Clear error when delete fails during force overwrite.
@@ -539,10 +554,15 @@ class TestSaveWorkflowWithOptions:
             mock_re_enrich.side_effect = Exception("Enrichment failed")
 
             # Save should still succeed
-            path, bundled = save_workflow_with_options("my-workflow", markdown_content, force=False)
+            path, bundled, saved_ir = save_workflow_with_options("my-workflow", markdown_content, force=False)
 
             assert path == Path(str(tmp_path / "my-workflow.pflow.md"))
             assert bundled == []
+            assert saved_ir["ir_version"] == sample_ir["ir_version"]
+            assert saved_ir["edges"] == sample_ir["edges"]
+            assert saved_ir["nodes"][0]["id"] == sample_ir["nodes"][0]["id"]
+            assert saved_ir["nodes"][0]["type"] == sample_ir["nodes"][0]["type"]
+            assert saved_ir["nodes"][0]["params"]["command"] == sample_ir["nodes"][0]["params"]["command"]
 
 
 class TestGenerateWorkflowMetadata:

--- a/tests/test_integration/test_workflow_bundling.py
+++ b/tests/test_integration/test_workflow_bundling.py
@@ -600,6 +600,9 @@ class TestRawContentSaveGuard:
         }
         markdown = ir_to_markdown(ir, title="Sub-Workflow Only")
 
+        # Validation now runs before _reject_unbundleable_file_refs, so the
+        # validator's sub-workflow step (step 8) catches the unresolvable
+        # reference first — more specific error than the generic "file references" guard.
         with pytest.raises(WorkflowValidationError, match="Cannot resolve relative sub-workflow"):
             save_workflow_with_options(
                 name="sub-only-test",

--- a/tests/test_integration/test_workflow_bundling.py
+++ b/tests/test_integration/test_workflow_bundling.py
@@ -344,7 +344,7 @@ class TestSaveWorkflowWithOptionsBundles:
         # Act: use the service-layer function with an explicit WorkflowManager path
         # save_workflow_with_options uses WorkflowManager() with default path,
         # which is patched by isolate_pflow_config to use a temp dir.
-        saved_path, bundled_files = save_workflow_with_options(
+        saved_path, bundled_files, validated_ir = save_workflow_with_options(
             name="bundle-svc",
             markdown_content=markdown,
             source_path=workflow_path,
@@ -356,6 +356,7 @@ class TestSaveWorkflowWithOptionsBundles:
         # Assert: bundled_files list includes the discovered dependency
         assert len(bundled_files) >= 1
         assert any("prompts/agent.md" in f for f in bundled_files)
+        assert validated_ir["nodes"][0]["id"] == "ask"
 
         # Assert: the actual bundled file exists on disk alongside the entry point
         bundle_dir = saved_path.parent
@@ -379,13 +380,14 @@ class TestSaveWorkflowWithOptionsBundles:
         }
         markdown = ir_to_markdown(ir, title="No Source Workflow")
 
-        saved_path, bundled_files = save_workflow_with_options(
+        saved_path, bundled_files, validated_ir = save_workflow_with_options(
             name="no-source",
             markdown_content=markdown,
         )
 
         assert saved_path.exists()
         assert bundled_files == []
+        assert validated_ir["nodes"][0]["id"] == "greet"
 
 
 class TestFileReferencesResolveFromBundle:
@@ -559,7 +561,7 @@ class TestFileReferencesResolveFromBundle:
         workflow_path.write_text(markdown)
 
         # Act: save via service layer (uses isolate_pflow_config temp dir)
-        _saved_path, _bundled_files = save_workflow_with_options(
+        _saved_path, _bundled_files, _workflow_ir = save_workflow_with_options(
             name="script-resolve",
             markdown_content=markdown,
             source_path=workflow_path,
@@ -598,7 +600,7 @@ class TestRawContentSaveGuard:
         }
         markdown = ir_to_markdown(ir, title="Sub-Workflow Only")
 
-        with pytest.raises(WorkflowValidationError, match="file references"):
+        with pytest.raises(WorkflowValidationError, match="Cannot resolve relative sub-workflow"):
             save_workflow_with_options(
                 name="sub-only-test",
                 markdown_content=markdown,
@@ -641,12 +643,13 @@ class TestRawContentSaveGuard:
         }
         markdown = ir_to_markdown(ir, title="No Refs")
 
-        saved_path, bundled = save_workflow_with_options(
+        saved_path, bundled, workflow_ir = save_workflow_with_options(
             name="no-refs-test",
             markdown_content=markdown,
         )
         assert saved_path.exists()
         assert bundled == []
+        assert workflow_ir["nodes"][0]["id"] == "greet"
 
 
 class TestSubWorkflowParseErrorPropagation:

--- a/tests/test_mcp_server/test_workflow_save.py
+++ b/tests/test_mcp_server/test_workflow_save.py
@@ -258,6 +258,40 @@ ${malformed
             ExecutionService.save_workflow(workflow=markdown_content, name="test-unused-input", force=True)
 
 
+class TestWorkflowSaveRichDiagnostics:
+    """MCP save must render validation errors through format_validation_failure.
+
+    Regression guard for GH #236: without the explicit re-raise in
+    _save_and_format_result, WorkflowValidationError is swallowed by
+    the generic except-Exception handler and the MCP agent gets a flat
+    'Failed to save workflow: ...' string instead of the rich numbered
+    diagnostic format.
+    """
+
+    def test_unknown_param_produces_rich_diagnostic(self) -> None:
+        """Unknown parameter error must include 'Validation failed' header and suggestions."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "reader",
+                    "type": "read-file",
+                    "params": {"file_pat": "README.md"},
+                }
+            ],
+            "edges": [],
+        }
+
+        markdown_content = ir_to_markdown(workflow)
+        with pytest.raises(ValueError, match=r"Validation failed \(1 error\)") as exc_info:
+            ExecutionService.save_workflow(workflow=markdown_content, name="test-rich-diag", force=True)
+
+        error_text = str(exc_info.value)
+        assert "Unknown parameter" in error_text
+        assert "file_pat" in error_text
+        assert "file_path" in error_text  # "Did you mean" suggestion
+
+
 class TestWorkflowSaveNameValidation:
     """Test workflow name validation during save."""
 


### PR DESCRIPTION
## Summary

`pflow workflow save` only ran schema validation (`validate_ir`), never the full 9-step `WorkflowValidator`. Broken workflows (unknown params, non-existent node refs, template errors) were silently accepted into the library and only failed at run time. The MCP save path correctly validated; the CLI save path didn't.

Moved parse + validate into `save_workflow_with_options` itself so callers can't skip validation. Applies the Task 144 pattern: "delete the bypass, bring behavior into the unified pipeline."

## Task

150

## Changes

- `save_workflow_with_options` now parses markdown and runs `_validate_and_normalize_ir` internally before saving — the save-time trust boundary
- Return type expanded to `tuple[Path, list[str], dict[str, Any]]` (adds validated IR for display formatting)
- **Deleted** `_load_and_parse_workflow` and `_save_with_overwrite_check` from CLI `workflow.py` — the bypasses that caused #236
- **Simplified** MCP `ExecutionService.save_workflow` — removed manual `parse_markdown` + `load_and_validate_workflow` block
- CLI save errors now use `format_validation_failure()` — same rich diagnostic format as `--validate-only`
- Added `except (WorkflowValidationError, MarkdownParseError): raise` in `_save_and_format_result` to prevent exception swallowing

**Net -78 lines of production code** across 3 files.

## Explanation

The root cause was a "precondition not enforced by API" design flaw — `save_workflow_with_options` trusted callers to pre-validate, and two callers (CLI, MCP) implemented validation independently. The CLI one only did schema validation, missing all 9 validator steps (data flow, templates, node types, output sources, unknown params, sub-workflows, cache lint).

Rather than patching the CLI caller (which would fix this instance but not the bug class), we moved validation inside the save function. A third caller added next month can't make the same mistake.

**Known**: CLI save now gains the same #247 false positive (`${input.field}` in output sources) that MCP save and `--validate-only` already have. This is correct — the validator is now applied consistently. #247 should be fixed separately.

## Created Docs

- `.taskmaster/tasks/task_150/task-150.md` — Task specification
- `.taskmaster/tasks/task_150/task-review.md` — Post-implementation review with patterns and pitfalls
- `.taskmaster/tasks/task_150/implementation/implementation-plan.md` — Implementation plan (reviewed by 3 specialist agents)

## Testing

3 new tests added:
- `test_workflow_save_renders_rich_validation_diagnostics` — CLI regression guard for #236
- `test_unknown_param_produces_rich_diagnostic` — MCP parity guard (catches exception swallowing in `_save_and_format_result`)
- `test_force_save_invalid_content_preserves_existing` — Ordering invariant: validation before deletion prevents data loss on `--force`

Plus 11 existing test updates (return type unpacking, assertion updates).

```
make test   → 4794 passed
make check  → ruff, mypy, deptry all clean
```

Manual verification: 16 end-to-end scenarios tested via `pflow workflow save` with broken/valid/edge-case workflows. Save and `--validate-only` produce byte-identical diagnostic output.