### PR TITLE
fix: register inputs keys for template validation + forward to sub-workflows (fixes #259, fixes #239)

### DIFF
--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -755,8 +755,15 @@ class WorkflowValidator:
         """Check that all required child inputs are provided by the parent node."""
         from pflow.runtime.workflow_executor import WorkflowExecutor
 
+        inputs_value = parent_params.get("inputs")
+        if inputs_value is not None and not isinstance(inputs_value, dict):
+            # Opaque template (e.g. inputs: '${item}') — can't check statically.
+            return []
+
         diagnostics: list[Diagnostic] = []
         parent_keys = {k for k in parent_params if k not in WorkflowExecutor.RESERVED_PARAMS and not k.startswith("__")}
+        if isinstance(inputs_value, dict):
+            parent_keys |= set(inputs_value.keys())
         for input_name, input_spec in child_inputs.items():
             is_required = input_spec.get("required", True)
             has_default = "default" in input_spec

--- a/src/pflow/runtime/template_validation/CLAUDE.md
+++ b/src/pflow/runtime/template_validation/CLAUDE.md
@@ -62,7 +62,7 @@ validator.py (orchestrator)
 
 ## `node_outputs` Dict Shape
 
-All passes consume the `node_outputs` dict built by `extract_node_outputs()` in `validator.py`. Three shapes exist — distinguished by flags:
+All passes consume the `node_outputs` dict built by `extract_node_outputs()` in `validator.py`. Four shapes exist — distinguished by flags:
 
 ```python
 # Standard node output (namespaced)
@@ -83,9 +83,15 @@ node_outputs["item"] = {
     "type": "any", "node_id": "process", "node_type": "llm",
     "is_batch_item": True,
 }
+
+# Inputs-as-context key (injected so ${key} and ${key.field} resolve during validation)
+node_outputs["concept_brief"] = {
+    "type": "any", "node_id": "consumer", "node_type": "llm",
+    "is_inputs_context": True,
+}
 ```
 
-Passes use `is_batch_output` and `is_batch_item` to branch behavior. Workflow nodes get special handling — `validator.py` tries to resolve child workflow outputs at validation time via `_resolve_child_workflow_outputs()`.
+Passes use `is_batch_output` to branch behavior (path_validation uses it to detect batch nodes). `is_batch_item` and `is_inputs_context` are metadata flags for provenance — not read by any pass currently. Workflow nodes get special handling — `validator.py` tries to resolve child workflow outputs at validation time via `_resolve_child_workflow_outputs()`.
 
 **Note:** `validator.py` has dual responsibility — it orchestrates validation passes AND builds the `node_outputs` dict (`extract_node_outputs`, also used by `compilation/compile_validation.py`). Agents looking for output-related code need to look here, not just in the passes.
 

--- a/src/pflow/runtime/template_validation/validator.py
+++ b/src/pflow/runtime/template_validation/validator.py
@@ -111,16 +111,6 @@ def validate_workflow_templates(
     # Get full output structure from nodes
     node_outputs = extract_node_outputs(workflow_ir, registry, available_params)
 
-    # Remove inputs keys from templates — these are resolved by the inputs-as-context
-    # mechanism at runtime, not from node_outputs. Per-node scoping is handled by
-    # data_flow.py validation (which gives better errors with node ID and param name).
-    inputs_keys: set[str] = set()
-    for node in workflow_ir.get("nodes", []):
-        inputs_param = node.get("params", {}).get("inputs")
-        if isinstance(inputs_param, dict):
-            inputs_keys.update(inputs_param.keys())
-    all_templates -= inputs_keys
-
     logger.debug(
         f"Extracted outputs from {len(node_outputs)} node variables", extra={"outputs": sorted(node_outputs.keys())}
     )
@@ -388,6 +378,13 @@ def extract_node_outputs(
         if not node_type or not node_id:
             continue
 
+        # Register inputs-as-context keys for all node types.
+        # Runs before type-specific branching so workflow, batch, and regular
+        # nodes all get their inputs keys registered.
+        inputs_param = node.get("params", {}).get("inputs")
+        if isinstance(inputs_param, dict):
+            _register_inputs_context_variables(node_outputs, node_id, node_type, inputs_param)
+
         # Workflow nodes: resolve child outputs for validation.
         if node_type in ("workflow", "pflow.runtime.workflow_executor"):
             _register_workflow_node_outputs(
@@ -501,6 +498,30 @@ def _register_batch_item_variables(
         "node_type": node_type,
         "is_batch_item": True,
     }
+
+
+def _register_inputs_context_variables(
+    node_outputs: dict[str, Any],
+    node_id: str,
+    node_type: str,
+    inputs_param: dict[str, Any],
+) -> None:
+    """Register inputs-as-context keys as available variables for template validation.
+
+    When a node declares ``- inputs: {key: ${source}}``, resolved keys become
+    template variables within that node (same mechanism as batch item aliases).
+    Registering them here lets path validation accept both bare (``${key}``) and
+    dotted (``${key.field}``) references.  Per-node scoping is handled by
+    ``data_flow.py`` validation.
+    """
+    for key in inputs_param:
+        node_outputs[key] = {
+            "type": "any",
+            "description": f"Template context variable from inputs mapping (node '{node_id}')",
+            "node_id": node_id,
+            "node_type": node_type,
+            "is_inputs_context": True,
+        }
 
 
 def _resolve_child_workflow_outputs(

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -58,7 +58,7 @@ class WorkflowExecutor(BaseNode):
         "max_depth",
         "error_action",
         "__registry__",
-        "inputs",  # Framework key consumed by engine's template resolution, not a child input
+        "inputs",  # Framework key consumed by engine's template resolution; resolved dict values forwarded via _extract_child_inputs
     })
 
     # Cross-cutting infrastructure keys propagated from parent to child storage.
@@ -407,12 +407,19 @@ class WorkflowExecutor(BaseNode):
         return f"Sub-workflow failed at {workflow_path} (returned error action)"
 
     def _extract_child_inputs(self) -> dict[str, Any]:
-        """Extract child workflow inputs from params (everything not reserved)."""
-        return {
-            key: value
-            for key, value in self.params.items()
-            if key not in self.RESERVED_PARAMS and not key.startswith("__")
-        }
+        """Extract child workflow inputs from params.
+
+        Includes non-reserved top-level params AND resolved ``inputs`` dict
+        values.  Top-level params take precedence over ``inputs`` values.
+        """
+        result: dict[str, Any] = {}
+        inputs = self.params.get("inputs")
+        if isinstance(inputs, dict):
+            result.update(inputs)
+        for key, value in self.params.items():
+            if key not in self.RESERVED_PARAMS and not key.startswith("__"):
+                result[key] = value
+        return result
 
     def _load_workflow(
         self, shared: dict[str, Any], execution_stack: list[str]

--- a/tests/test_core/test_sub_workflow_validation.py
+++ b/tests/test_core/test_sub_workflow_validation.py
@@ -1021,3 +1021,168 @@ Invokes the middle workflow.
         # guard against the overwrite bug.
         assert context.get("sub_workflow_step") == "invoke-grandchild"
         assert "grandchild.pflow.md" in str(context.get("sub_workflow_path", ""))
+
+
+# ---------------------------------------------------------------------------
+# 12. inputs mapping skips required-input check (fixes #239)
+# ---------------------------------------------------------------------------
+
+
+class TestInputsMappingRequiredCheck:
+    """When a parent uses ``inputs`` to forward values to a child workflow,
+    the validator should check key coverage for dict mappings and skip the
+    check entirely for opaque string templates."""
+
+    def test_inputs_dict_mapping_satisfies_required_check(self, tmp_path: Path) -> None:
+        """Parent with inputs: {name: ..., value: ...} should satisfy child requirements."""
+        child = tmp_path / "child.pflow.md"
+        write_pflow_md(
+            child,
+            """\
+# Child With Required Inputs
+
+A child workflow requiring name and value.
+
+## Inputs
+
+### name
+
+The name field for the child.
+
+- type: string
+- required: true
+
+### value
+
+The value field for the child.
+
+- type: integer
+- required: true
+
+## Steps
+
+### echo-it
+
+Echo the provided input values.
+
+- type: shell
+- command: echo "${name}=${value}"
+""",
+        )
+
+        parent_ir = _parent_ir(
+            str(child),
+            provided_params={"inputs": {"name": "${upstream.name}", "value": "${upstream.value}"}},
+        )
+        errors, _warnings = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            registry=None,
+            skip_node_types=True,
+        )
+        missing_input_errors = [e for e in errors if "requires input" in e.message]
+        assert missing_input_errors == [], f"False-positive missing-input errors: {missing_input_errors}"
+
+    def test_inputs_dict_partial_coverage_detected(self, tmp_path: Path) -> None:
+        """Parent with inputs: {name: ...} but child needs name AND value should error."""
+        child = tmp_path / "child.pflow.md"
+        write_pflow_md(
+            child,
+            """\
+# Child With Required Inputs
+
+A child workflow requiring name and value.
+
+## Inputs
+
+### name
+
+The name field for the child.
+
+- type: string
+- required: true
+
+### value
+
+The value field for the child.
+
+- type: integer
+- required: true
+
+## Steps
+
+### echo-it
+
+Echo the provided input values.
+
+- type: shell
+- command: echo "${name}=${value}"
+""",
+        )
+
+        # Only provide 'name' via inputs, not 'value'
+        parent_ir = _parent_ir(
+            str(child),
+            provided_params={"inputs": {"name": "${upstream.name}"}},
+        )
+        errors, _warnings = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            registry=None,
+            skip_node_types=True,
+        )
+        missing_value_errors = [e for e in errors if "requires input 'value'" in e.message]
+        assert len(missing_value_errors) == 1, f"Expected error for missing 'value', got: {errors}"
+        # 'name' should NOT be flagged
+        missing_name_errors = [e for e in errors if "requires input 'name'" in e.message]
+        assert missing_name_errors == [], f"Unexpected error for 'name': {missing_name_errors}"
+
+    def test_inputs_template_mapping_skips_required_check(self, tmp_path: Path) -> None:
+        """Parent with inputs: '${item}' (opaque template) should skip required-input check."""
+        child = tmp_path / "child.pflow.md"
+        write_pflow_md(
+            child,
+            """\
+# Child With Required Inputs
+
+A child workflow requiring name and value.
+
+## Inputs
+
+### name
+
+The name field for the child.
+
+- type: string
+- required: true
+
+### value
+
+The value field for the child.
+
+- type: integer
+- required: true
+
+## Steps
+
+### echo-it
+
+Echo the provided input values.
+
+- type: shell
+- command: echo "${name}=${value}"
+""",
+        )
+
+        parent_ir = _parent_ir(str(child), provided_params={"inputs": "${item}"})
+        errors, _warnings = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            registry=None,
+            skip_node_types=True,
+        )
+        missing_input_errors = [e for e in errors if "requires input" in e.message]
+        assert missing_input_errors == [], f"False-positive missing-input errors: {missing_input_errors}"

--- a/tests/test_integration/test_inputs_forwarding_e2e.py
+++ b/tests/test_integration/test_inputs_forwarding_e2e.py
@@ -1,0 +1,108 @@
+"""End-to-end test for inputs forwarding to sub-workflows.
+
+Guards the contract between the validator and runtime: when a parent workflow
+node uses ``inputs`` to forward values to a child with required inputs, both
+validation AND execution must succeed.  If either side regresses (validator
+rejects, or runtime stops forwarding), this test catches it.
+
+Crosses: parser → compiler → template resolution → WorkflowExecutor →
+child compilation → child execution → output resolution.
+"""
+
+from pflow.execution.result import RunnerConfig
+from pflow.execution.runner import WorkflowRunner
+
+
+class TestInputsForwardingEndToEnd:
+    """Full pipeline: parent with inputs forwarding → child executes correctly."""
+
+    def test_inputs_dict_forwarding_to_child(self, tmp_path):
+        """Parent forwards inputs via dict mapping to a child with required inputs."""
+        child_file = tmp_path / "child.pflow.md"
+        child_file.write_text(
+            """\
+# Child
+
+Child workflow with required inputs.
+
+## Inputs
+
+### name
+
+The name to echo.
+
+- type: string
+- required: true
+
+### value
+
+The value to echo.
+
+- type: string
+- required: true
+
+## Steps
+
+### echo-it
+
+Echo the provided values.
+
+- type: shell
+- command: echo "${name}=${value}"
+
+## Outputs
+
+### result
+
+The echoed output.
+
+- source: ${echo-it.stdout}
+""",
+            encoding="utf-8",
+        )
+
+        parent_file = tmp_path / "parent.pflow.md"
+        parent_file.write_text(
+            f"""\
+# Parent
+
+Parent forwards inputs to child via dict mapping.
+
+## Steps
+
+### build
+
+Build an object with name and value fields.
+
+- type: code
+
+```python code
+result: dict = {{"name": "alice", "value": "100"}}
+```
+
+### invoke-child
+
+Forward the built object's fields to the child workflow.
+
+- type: workflow
+- workflow: {child_file}
+- inputs:
+    name: ${{build.result.name}}
+    value: ${{build.result.value}}
+
+## Outputs
+
+### result
+
+The child's output.
+
+- source: ${{invoke-child.result}}
+""",
+            encoding="utf-8",
+        )
+
+        runner = WorkflowRunner()
+        result = runner.run(str(parent_file), {}, RunnerConfig())
+
+        assert result.success, f"Workflow failed: {result.diagnostics}"
+        assert result.shared_after.get("result").strip() == "alice=100"

--- a/tests/test_runtime/test_template_validation/test_validator.py
+++ b/tests/test_runtime/test_template_validation/test_validator.py
@@ -1306,3 +1306,113 @@ class TestBatchWorkflowNodeValidation:
         assert diagnostic.context is not None
         assert diagnostic.context.get("template") == "echo ${unclosed"
         assert diagnostic.context.get("path") == "nodes[id=n1].params.prompt"
+
+
+# ---------------------------------------------------------------------------
+# Inputs-as-context template validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputsContextTemplateValidation:
+    """Tests for inputs-as-context template validation.
+
+    When a node declares ``- inputs: {key: ${source}}``, the key becomes a valid
+    template root within that node.  Both bare (``${key}``) and dotted
+    (``${key.field}``) references must pass validation.
+    """
+
+    def test_inputs_key_bare_recognized(self):
+        """${key} should be valid when node has inputs: {key: ...}."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "upstream",
+                    "type": "llm",
+                    "params": {"prompt": "Hello"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {
+                        "inputs": {"concept_brief": "${upstream.response}"},
+                        "prompt": "Write about ${concept_brief}",
+                    },
+                },
+            ],
+            "edges": [{"from": "upstream", "to": "consumer"}],
+        }
+        registry = create_mock_registry()
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_inputs_key_dotted_path_recognized(self):
+        """${key.field} should be valid when key is in the node's inputs mapping."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "build-item",
+                    "type": "code",
+                    "params": {"code": "result = {'concept_md': 'test'}"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {
+                        "inputs": {"item": "${build-item.result}"},
+                        "prompt": "Repeat: ${item.concept_md}",
+                    },
+                },
+            ],
+            "edges": [{"from": "build-item", "to": "consumer"}],
+        }
+        registry = create_mock_registry()
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_inputs_key_deeply_nested_path_recognized(self):
+        """${key.a.b.c} should be valid when key is in the node's inputs mapping."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "upstream",
+                    "type": "code",
+                    "params": {"code": "result = {'a': {'b': {'c': 1}}}"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {
+                        "inputs": {"data": "${upstream.result}"},
+                        "prompt": "Value: ${data.a.b.c}",
+                    },
+                },
+            ],
+            "edges": [{"from": "upstream", "to": "consumer"}],
+        }
+        registry = create_mock_registry()
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_inputs_key_on_non_code_node(self):
+        """inputs-as-context works on any node type, not just code nodes."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "upstream",
+                    "type": "shell",
+                    "params": {"command": "echo hello"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "shell",
+                    "params": {
+                        "inputs": {"output": "${upstream.stdout}"},
+                        "command": "echo ${output}",
+                    },
+                },
+            ],
+            "edges": [{"from": "upstream", "to": "consumer"}],
+        }
+        registry = create_mock_registry()
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
@@ -957,26 +957,48 @@ class TestWorkflowExecutorComprehensive:
         assert is_workflow_file_reference("my-workflow") is False
         assert is_workflow_file_reference("simple") is False
 
-    # --- Test 33: 'inputs' key excluded from child inputs ---
+    # --- Test 33: 'inputs' dict values forwarded as child inputs ---
 
-    def test_inputs_not_passed_as_child_input(self):
-        """Verify 'inputs' framework key is excluded from child inputs.
+    def test_inputs_dict_values_forwarded_as_child_inputs(self):
+        """Resolved ``inputs`` dict values are forwarded as child inputs.
 
-        The 'inputs' param is consumed by the engine's template resolution to inject
-        additional template context. It must NOT leak through to child workflow
-        inputs — it is a framework-level concern, not a user param.
+        The ``inputs`` key itself stays reserved (consumed by template resolution),
+        but its resolved dict values are included in child inputs so that
+        ``inputs: ${item}`` forwarding works for sub-workflows.
         """
         executor = WorkflowExecutor()
         executor.params = {
             "workflow": "./child.pflow.md",
-            "inputs": {"api_key": "xxx"},  # Framework key, not a child input
+            "inputs": {"api_key": "xxx", "name": "alice"},
             "text": "hello",
             "count": 5,
         }
         child_inputs = executor._extract_child_inputs()
-        assert "inputs" not in child_inputs
+        assert "inputs" not in child_inputs  # The key itself is not forwarded
         assert "workflow" not in child_inputs  # Also reserved
-        assert child_inputs == {"text": "hello", "count": 5}
+        assert child_inputs == {"api_key": "xxx", "name": "alice", "text": "hello", "count": 5}
+
+    def test_inputs_toplevel_params_override_inputs_values(self):
+        """Top-level params take precedence over ``inputs`` dict values."""
+        executor = WorkflowExecutor()
+        executor.params = {
+            "workflow": "./child.pflow.md",
+            "inputs": {"name": "from-inputs"},
+            "name": "from-toplevel",
+        }
+        child_inputs = executor._extract_child_inputs()
+        assert child_inputs["name"] == "from-toplevel"
+
+    def test_inputs_non_dict_not_forwarded(self):
+        """When ``inputs`` resolves to a non-dict (e.g. a string), nothing is forwarded."""
+        executor = WorkflowExecutor()
+        executor.params = {
+            "workflow": "./child.pflow.md",
+            "inputs": "not-a-dict",
+            "text": "hello",
+        }
+        child_inputs = executor._extract_child_inputs()
+        assert child_inputs == {"text": "hello"}
 
     # --- Test 34: required: false with no default is not rejected ---
 


### PR DESCRIPTION
## Summary

- `- inputs:` keys are now recognized as valid template variable sources for dotted path access (`${item.concept_md}`)
- Sub-workflow nodes forward resolved `inputs` dict values as child inputs
- Validator checks dict-inputs key coverage statically, skips for opaque string templates

## Changes

- **`src/pflow/runtime/template_validation/validator.py`**: Add `_register_inputs_context_variables()` (same pattern as `_register_batch_item_variables()`), call from `extract_node_outputs()` for all node types, delete the incomplete pre-filter
- **`src/pflow/core/workflow/validator.py`**: Refine `_check_required_inputs()` — check dict `inputs` keys against required child inputs, skip only for opaque string templates
- **`src/pflow/runtime/workflow_executor.py`**: `_extract_child_inputs()` forwards resolved `inputs` dict values as child inputs (top-level params take precedence)
- **`src/pflow/runtime/template_validation/CLAUDE.md`**: Document `is_inputs_context` entry shape

## Explanation

Issue #161 established `- inputs:` as a framework-level template context mechanism for any node type. The implementation specified three validation changes — two were done (`data_flow.py` per-node refs, `validator.py` exemption), but the third ("add inputs keys to valid template sources for path validation") was implemented with a pre-filter that only handled bare keys, not dotted paths.

The fix registers inputs keys in `node_outputs` using the same pattern batch item aliases already use (`type: "any"`, globally registered, per-node scoping by `data_flow.py`). This lets path validation handle both bare and dotted references naturally — no pre-filter needed.

For sub-workflows (#239), `_extract_child_inputs()` now merges resolved `inputs` dict values into child inputs, and the validator checks dict key coverage statically instead of blindly skipping the required-inputs check.

## Testing

- 4 template validation unit tests (bare key, dotted path, deeply nested, non-code node)
- 3 sub-workflow validation tests (full dict coverage, partial dict detected, opaque template skipped)
- 3 `_extract_child_inputs` unit tests (forwarding, override precedence, non-dict guard)
- 1 end-to-end integration test through `WorkflowRunner.run()` (parent → child with required inputs)
- 9 manual verification workflows exercising edge cases (node ID shadowing, workflow input shadowing, multiple nodes with same key, batch + sub-workflow forwarding)

Run `make test` to verify all 4805 tests pass.