### PR TITLE
fix: validate output sources against nodes and declared inputs (fixes #247)

### DIFF
--- a/src/pflow/core/workflow/CLAUDE.md
+++ b/src/pflow/core/workflow/CLAUDE.md
@@ -127,8 +127,6 @@ Unified pre-execution orchestrator — returns `list[Diagnostic]` directly. Ever
 
 **Dual-propagation-path dedup invariant** — child workflow warnings flow through BOTH this validator path (`_add_child_provenance`) AND the runtime path (`WorkflowExecutor._propagate_child_parser_warnings`). Both MUST use `format_child_provenance()` for the message, `node_id=d.node_id or step_id` for differentiating siblings, and `setdefault` for context keys. Divergence on any of these breaks `Diagnostic.__hash__` equality and dedup silently duplicates warnings.
 
-**Known false positive in step 6**: `_validate_template_in_source` only treats bare `${name}` references as potential workflow inputs (the "skip if no dot or bracket" check). Any `${input_name.field}` or `${input_name[0]}` form falls through to the "node not in nodes_map" check and errors, even when `input_name` is declared in the workflow's `inputs:` section. Blocks `pflow workflow save` for workflows that access fields on declared inputs in output sources. Tracked as spinje/pflow#247.
-
 ### data_flow.py
 
 Uses Kahn's algorithm for topological sort. Catches: forward references, circular dependencies, references to non-existent nodes, undefined input parameters.
@@ -157,7 +155,6 @@ Tri-state: `SUCCESS` (all nodes clean), `DEGRADED` (completed with warnings, e.g
 
 ## Known Issues
 
-- **Validator rejects `${input.field}` in output sources** — see `validator.py` section. Workflows using workflow input field access in outputs cannot be saved.
 - **Claude Code requires `description` in frontmatter** for skill discovery (workaround in `skill_service.py`).
 
 ## Key Lessons

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -339,14 +339,11 @@ class WorkflowValidator:
 
     @staticmethod
     def _validate_output_sources(workflow_ir: dict[str, Any], registry: Optional[Registry] = None) -> list[Diagnostic]:
-        """Validate that workflow outputs reference valid nodes and output keys.
+        """Validate that workflow output sources reference valid roots.
 
-        This validation ensures that output source fields (when specified) point to
-        existing nodes in the workflow. The source field can use two formats:
-        - "node_id" - References entire node output
-        - "node_id.output_key" - References specific output key
-
-        Template variables (${...}) are skipped as they cannot be validated statically.
+        Ensures output source fields reference existing node IDs or declared
+        workflow input names. Supports plain references (node.key), template
+        references (${node.key}), and bracket access (${data[0]}).
 
         Args:
             workflow_ir: Workflow to validate
@@ -362,8 +359,9 @@ class WorkflowValidator:
         if not outputs:
             return diagnostics
 
-        # Build nodes map for O(1) lookup
-        nodes_map = {node["id"]: node for node in workflow_ir.get("nodes", [])}
+        # Build valid source roots: node IDs + declared input names
+        node_ids = {node["id"] for node in workflow_ir.get("nodes", [])}
+        valid_sources = node_ids | set((workflow_ir.get("inputs") or {}).keys())
 
         # Validate each output's source field
         for output_name, output_def in outputs.items():
@@ -395,20 +393,17 @@ class WorkflowValidator:
 
             # Validate templates instead of skipping
             if "${" in source:
-                diagnostics.extend(WorkflowValidator._validate_template_in_source(output_name, source, nodes_map))
+                diagnostics.extend(WorkflowValidator._validate_template_in_source(output_name, source, valid_sources))
                 continue
 
-            # Parse source format: "node_id.output_key" or "node_id"
-            if "." in source:
-                # Split on first dot only (supports nested keys like "node.a.b.c")
-                node_id, _output_key = source.split(".", 1)
-            else:
-                # Reference to entire node output
-                node_id = source
+            # Extract root identifier (handles both dot and bracket syntax)
+            node_id = TemplateResolver.extract_root_node_id(source)
 
-            # Validate node exists
-            if node_id not in nodes_map:
-                diagnostics.append(WorkflowValidator._build_node_not_found_diagnostic(output_name, node_id, nodes_map))
+            # Validate source root exists (node or declared input)
+            if node_id not in valid_sources:
+                diagnostics.append(
+                    WorkflowValidator._build_node_not_found_diagnostic(output_name, node_id, valid_sources)
+                )
                 continue
 
             # Note: Output key validation skipped in v1
@@ -418,16 +413,17 @@ class WorkflowValidator:
         return diagnostics
 
     @staticmethod
-    def _validate_template_in_source(output_name: str, source: str, nodes_map: dict[str, Any]) -> list[Diagnostic]:
+    def _validate_template_in_source(output_name: str, source: str, valid_sources: set[str]) -> list[Diagnostic]:
         """Validate template variable references in output source.
 
-        Validates that ${node.key} templates reference existing nodes.
+        Validates that ${root.key} templates reference valid source roots
+        (node IDs or declared workflow input names).
         Provides "Did you mean?" suggestions for typos.
 
         Args:
             output_name: Name of output being validated
             source: Source value with template (e.g., "${node.key}")
-            nodes_map: Map of node IDs to definitions
+            valid_sources: Set of valid root identifiers (node IDs + input names)
 
         Returns:
             Validation diagnostics (empty if valid)
@@ -460,22 +456,18 @@ class WorkflowValidator:
             # Split coalesce operands and validate each one
             operands = TemplateResolver.split_coalesce_operands(template_var)
             for operand in operands:
-                # Skip if not a node reference (no dot or bracket)
-                if "." not in operand and "[" not in operand:
-                    continue  # Could be workflow input
-
-                # Parse node.key via the canonical extractor so operands like
-                # `${data[0].x}` yield node_id="data" (not "data[0]").
+                # Parse root identifier via the canonical extractor so operands
+                # like `${data[0].x}` yield node_id="data" (not "data[0]").
                 # Strip a leading dot only so bracket forms like `[0].x` are
                 # preserved in the rendered output_key for error messages.
                 node_id = TemplateResolver.extract_root_node_id(operand)
                 output_key = operand[len(node_id) :].lstrip(".")
 
-                # Validate node exists
-                if node_id not in nodes_map:
+                # Validate source root exists (node ID or declared input)
+                if node_id not in valid_sources:
                     diagnostics.append(
                         WorkflowValidator._build_template_node_diagnostic(
-                            output_name, source, node_id, output_key, nodes_map
+                            output_name, source, node_id, output_key, valid_sources
                         )
                     )
 
@@ -485,26 +477,26 @@ class WorkflowValidator:
     def _build_node_not_found_diagnostic(
         output_name: str,
         missing_node_id: str,
-        nodes_map: dict[str, Any],
+        valid_sources: set[str],
     ) -> Diagnostic:
-        """Build diagnostic for plain reference to non-existent node."""
+        """Build diagnostic for plain reference to non-existent source."""
         from pflow.core.suggestion_utils import find_similar_items
 
-        available = sorted(nodes_map.keys())
+        available = sorted(valid_sources)
         similar = find_similar_items(missing_node_id, available, max_results=3, method="fuzzy") if available else []
 
         return Diagnostic(
             severity=Severity.ERROR,
             source="validator",
             title="Validation Error",
-            message=f"Output '{output_name}' references non-existent node '{missing_node_id}'.",
+            message=f"Output '{output_name}' references non-existent source '{missing_node_id}'.",
             suggestions=[f"Did you mean '{similar[0]}'?"] if similar else None,
             context={
                 "category": "validation",
                 "path": f"outputs.{output_name}.source",
                 "available_fields": available,
                 "available_fields_total": len(available),
-                "available_fields_label": "nodes",
+                "available_fields_label": "sources",
                 "similar_names": similar or None,
             },
         )
@@ -515,28 +507,29 @@ class WorkflowValidator:
         source: str,
         missing_node_id: str,
         output_key: str | None,
-        nodes_map: dict[str, Any],
+        valid_sources: set[str],
     ) -> Diagnostic:
-        """Build structured diagnostic for template reference to missing node."""
+        """Build structured diagnostic for template reference to missing source."""
         from pflow.core.suggestion_utils import find_similar_items
 
-        available = sorted(nodes_map.keys())
+        available = sorted(valid_sources)
         similar = find_similar_items(missing_node_id, available, max_results=3, method="fuzzy") if available else []
 
         suggestions: list[str] = []
         if similar:
             best = similar[0]
-            corrected = f"${{{best}.{output_key}}}" if output_key else f"${{{best}}}"
+            sep = "" if output_key and output_key.startswith("[") else "."
+            corrected = f"${{{best}{sep}{output_key}}}" if output_key else f"${{{best}}}"
             suggestions.append(f'Change "{source}" to "{corrected}"')
             for suggestion in similar[1:]:
-                alternative = f"${{{suggestion}.{output_key}}}" if output_key else f"${{{suggestion}}}"
+                alternative = f"${{{suggestion}{sep}{output_key}}}" if output_key else f"${{{suggestion}}}"
                 suggestions.append(f"Or use {alternative}")
 
         return Diagnostic(
             severity=Severity.ERROR,
             source="validator",
             title="Template Error",
-            message=f"Output '{output_name}' source references non-existent node '{missing_node_id}'.",
+            message=f"Output '{output_name}' source references non-existent source '{missing_node_id}'.",
             suggestions=suggestions or None,
             context={
                 "category": "template_error",
@@ -544,7 +537,7 @@ class WorkflowValidator:
                 "template": source,
                 "available_fields": available,
                 "available_fields_total": len(available),
-                "available_fields_label": "nodes",
+                "available_fields_label": "sources",
                 "similar_names": similar or None,
             },
         )

--- a/tests/test_core/test_output_source_validation.py
+++ b/tests/test_core/test_output_source_validation.py
@@ -56,7 +56,7 @@ class TestOutputSourceValidation:
         assert len(errors) == 1
         assert "nonexistent" in errors[0].message.lower()
         assert "result" in errors[0].message
-        assert "non-existent node" in errors[0].message.lower()
+        assert "non-existent source" in errors[0].message.lower()
 
     def test_invalid_output_source_shows_available_nodes(self):
         """❌ Invalid: Error message includes available nodes for debugging."""
@@ -74,7 +74,7 @@ class TestOutputSourceValidation:
         assert len(errors) == 1
         assert "missing" in errors[0].message
         assert errors[0].context is not None
-        assert errors[0].context.get("available_fields_label") == "nodes"
+        assert errors[0].context.get("available_fields_label") == "sources"
         assert "fetch" in errors[0].context.get("available_fields", [])
         assert "process" in errors[0].context.get("available_fields", [])
 
@@ -90,17 +90,38 @@ class TestOutputSourceValidation:
         errors, _ = split_validator_diagnostics(workflow, {}, Registry(), skip_node_types=True)
         assert len(errors) == 0
 
-    def test_valid_output_with_template_variable_in_source(self):
-        """✅ Valid: Template variables in source cannot be validated statically."""
+    def test_valid_output_with_template_input_field_access(self):
+        """✅ Valid: Template referencing declared input field passes.
+
+        Bug prevented: Validator rejects ${input.field} as non-existent node (GH #247).
+        Without this test: Can't use ${data.field} in outputs when data is a declared input.
+        """
         workflow = {
             "ir_version": "0.1.0",
             "nodes": [{"id": "node1", "type": "shell", "params": {}}],
             "edges": [],
-            "outputs": {"result": {"source": "${dynamic_node}.output"}},  # Template variable
+            "inputs": {"data": {"type": "dict", "description": "A dict with a field"}},
+            "outputs": {"result": {"source": "${data.field}"}},
         }
 
-        errors, _ = split_validator_diagnostics(workflow, {}, Registry(), skip_node_types=True)
-        # Should NOT error - template variables are skipped
+        errors, _ = split_validator_diagnostics(workflow, None, Registry(), skip_node_types=True)
+        assert len(errors) == 0
+
+    def test_valid_plain_source_references_declared_input(self):
+        """✅ Valid: Plain source referencing declared input passes.
+
+        Bug prevented: Plain data.field rejected when data is a declared input.
+        Without this test: Only template ${data.field} works, plain data.field doesn't.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "node1", "type": "shell", "params": {}}],
+            "edges": [],
+            "inputs": {"data": {"type": "dict", "description": "A dict"}},
+            "outputs": {"result": {"source": "data.field"}},
+        }
+
+        errors, _ = split_validator_diagnostics(workflow, None, Registry(), skip_node_types=True)
         assert len(errors) == 0
 
     def test_multiple_outputs_mixed_validity(self):

--- a/tests/test_core/test_workflow_validator.py
+++ b/tests/test_core/test_workflow_validator.py
@@ -571,7 +571,7 @@ class TestValidatorProducerStructure:
         assert diagnostic.context is not None
         assert diagnostic.context.get("path") == "outputs.result.source"
         assert "producer" in diagnostic.context.get("available_fields", [])
-        assert diagnostic.context.get("available_fields_label") == "nodes"
+        assert diagnostic.context.get("available_fields_label") == "sources"
         assert diagnostic.context.get("similar_names")
         assert any("producer" in name for name in diagnostic.context["similar_names"])
 

--- a/tests/test_core/test_workflow_validator_outputs.py
+++ b/tests/test_core/test_workflow_validator_outputs.py
@@ -77,21 +77,20 @@ class TestOutputTemplateValidation:
         assert "malformed" in "\n".join(d.message for d in errors).lower()
 
     def test_template_workflow_input_passes(self):
-        """CRITICAL: Template without dot (workflow input variable) passes.
+        """CRITICAL: Template referencing declared workflow input passes.
 
-        Bug prevented: Line 300-302 check removed (if "." not in template_var).
+        Bug prevented: Validator rejects valid input references in outputs.
         Without this test: Can't use ${api_key}, ${user_name} in outputs.
-
-        This is a DIFFERENT CODE PATH than node references.
         """
         workflow = {
             "ir_version": "0.1.0",
             "nodes": [{"id": "n1", "type": "llm", "params": {}}],
-            "outputs": {"result": {"source": "${user_input}"}},  # No dot - workflow input
+            "inputs": {"user_input": {"type": "string", "description": "User input"}},
+            "outputs": {"result": {"source": "${user_input}"}},
         }
 
         registry = Registry()
-        errors, _ = split_validator_diagnostics(workflow, {}, registry, skip_node_types=True)
+        errors, _ = split_validator_diagnostics(workflow, None, registry, skip_node_types=True)
 
         assert len(errors) == 0
 
@@ -113,7 +112,7 @@ class TestOutputTemplateValidation:
         errors, _ = split_validator_diagnostics(workflow, {}, registry, skip_node_types=True)
 
         assert len(errors) > 0
-        assert "non-existent node 'missing'" in "\n".join(d.message for d in errors)
+        assert "non-existent source 'missing'" in "\n".join(d.message for d in errors)
 
     def test_multiple_errors_reported(self):
         """CRITICAL: All errors collected, not just first one.
@@ -141,3 +140,101 @@ class TestOutputTemplateValidation:
         error_msg = "\n".join(d.message for d in errors)
         assert "missing1" in error_msg
         assert "missing2" in error_msg
+
+    def test_template_input_field_access_passes(self):
+        """CRITICAL: Template with dot-access on declared input passes.
+
+        Bug prevented: GH #247 — ${input.field} rejected as non-existent node.
+        Without this test: Can't use ${data.field} in output sources when
+        data is a declared workflow input.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "echo_it", "type": "shell", "params": {}}],
+            "inputs": {"data": {"type": "dict", "description": "A dict with a field"}},
+            "outputs": {"x": {"source": "${data.field}"}},
+        }
+
+        registry = Registry()
+        errors, _ = split_validator_diagnostics(workflow, None, registry, skip_node_types=True)
+
+        assert len(errors) == 0
+
+    def test_template_input_bracket_access_passes(self):
+        """CRITICAL: Template with bracket-access on declared input passes.
+
+        Bug prevented: Same root cause as GH #247 for bracket syntax.
+        Without this test: Can't use ${items[0]} in output sources.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "shell", "params": {}}],
+            "inputs": {"items": {"type": "list", "description": "A list"}},
+            "outputs": {"first": {"source": "${items[0]}"}},
+        }
+
+        registry = Registry()
+        errors, _ = split_validator_diagnostics(workflow, None, registry, skip_node_types=True)
+
+        assert len(errors) == 0
+
+    def test_template_nonexistent_shows_inputs_in_available(self):
+        """CRITICAL: Error for missing source includes both nodes and inputs.
+
+        Bug prevented: Available list only shows nodes, hiding valid inputs.
+        Without this test: Users with a typo don't see declared inputs as
+        alternatives in the fuzzy suggestions.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "fetch", "type": "shell", "params": {}}],
+            "inputs": {"api_key": {"type": "string", "description": "API key"}},
+            "outputs": {"result": {"source": "${typo.field}"}},
+        }
+
+        registry = Registry()
+        errors, _ = split_validator_diagnostics(workflow, None, registry, skip_node_types=True)
+
+        assert len(errors) == 1
+        available = errors[0].context.get("available_fields", [])
+        assert "fetch" in available
+        assert "api_key" in available
+
+    def test_bare_template_nonexistent_caught(self):
+        """CRITICAL: Bare template referencing undeclared name is caught.
+
+        Bug prevented: ${typo} (no dot) silently passes validation.
+        Without this test: Typos in bare output source templates only
+        fail at runtime with a cryptic error.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "shell", "params": {}}],
+            "outputs": {"result": {"source": "${typo}"}},
+        }
+
+        registry = Registry()
+        errors, _ = split_validator_diagnostics(workflow, {}, registry, skip_node_types=True)
+
+        assert len(errors) == 1
+        assert "typo" in errors[0].message
+
+    def test_bracket_typo_suggestion_format(self):
+        """CRITICAL: Bracket-access typo suggestion doesn't insert spurious dot.
+
+        Bug prevented: ${itmes[0]} suggests ${items.[0]} instead of ${items[0]}.
+        Without this test: Bracket-access suggestions have malformed syntax.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "items", "type": "shell", "params": {}}],
+            "outputs": {"first": {"source": "${itmes[0]}"}},
+        }
+
+        registry = Registry()
+        errors, _ = split_validator_diagnostics(workflow, {}, registry, skip_node_types=True)
+
+        assert len(errors) == 1
+        assert errors[0].suggestions
+        assert "${items[0]}" in errors[0].suggestions[0]
+        assert ".[0]" not in errors[0].suggestions[0]


### PR DESCRIPTION
## Summary

Output source validation rejected valid `${input.field}` references because it only checked node IDs, not declared workflow inputs. Blocked `pflow workflow save` for any workflow accessing fields on declared inputs in output sources.

## Changes

- **Root cause fix**: Replace `nodes_map: dict[str, Any]` with `valid_sources: set[str]` (node IDs + declared input names) across all four output source validation methods — the dict values were never used, and the type excluded inputs
- **Remove bare-reference skip**: The `if "." not in operand and "[" not in operand: continue` heuristic was a workaround for the same root cause — it let `${typo}` pass silently. With the correct valid set, bare typos are now caught
- **Fix bracket suggestion format**: `${itmes[0]}` now suggests `${items[0]}` instead of the malformed `${items.[0]}`
- **Consistent error messaging**: "non-existent source" + "Available sources" (was "non-existent node" + "Available nodes")
- **7 new tests**: dotted input access, bracket input access, plain input reference, bare typo detection, inputs in available list, bracket suggestion format
- **3 tests updated**: aligned to new message wording and label
- **Docs**: Removed known-issue entry from `src/pflow/core/workflow/CLAUDE.md`

## Explanation

The output source validator passed `nodes_map: dict[str, Any]` through four methods but only ever used the keys — for `in` membership tests and `sorted(keys())` available-name lists. The parameter type was carrying unused node definitions while excluding workflow inputs entirely.

The fix names the concept correctly: `valid_sources: set[str]` = "root identifiers that will exist in the shared store at resolution time." Both validation paths (plain `data.field` and template `${data.field}`) now check against this unified set. The bare-reference skip heuristic (which existed because the code lacked input information) becomes unnecessary and is removed — enabling detection of bare typos like `${typo}` that previously passed silently.

## Related issues

- Discovered during verification: filed #262 (template validator bracket-access root extraction) and #263 (Mermaid disconnected outputs for input-root sources)

## Testing

```bash
make test   # 4819 tests pass
make check  # lint, types, deps all clean
```

Manual verification: created `.pflow.md` workflows with `${input.field}` in output sources, validated, saved, and ran them through the real CLI. Tested error messages for typos, bare references, and coalesce expressions.