### PR TITLE
fix: batch results exclude failed items — downstream gets clean data (fixes #159)

### DIFF
--- a/docs/how-it-works/batch-processing.mdx
+++ b/docs/how-it-works/batch-processing.mdx
@@ -220,14 +220,14 @@ Batch nodes write a special output structure to the shared store:
       {"item": "input1", "response": "..."},
       {"item": "input2", "response": "..."}
     ],
+    "count": 3,
+    "success_count": 2,
+    "error_count": 1,
     "batch_metadata": {
       "parallel": true,
-      "total_items": 8,
-      "successful_items": 7,
-      "failed_items": 1,
       "timing": {
-        "total_duration_ms": 24900,
-        "avg_item_duration_ms": 3112
+        "total_items_ms": 24900,
+        "avg_item_ms": 3112
       }
     },
     "errors": [
@@ -237,9 +237,9 @@ Batch nodes write a special output structure to the shared store:
 }
 ```
 
-Each result pairs `item` (the original input) with the inner node's outputs — so downstream nodes always know which output came from which input. When passing `${node.results}` to an LLM, it sees both inputs and outputs together.
+`results` contains only **successful** items — each pairs `item` (the original input) with the inner node's outputs. With `error_handling: continue`, failed items are excluded from `results` and appear only in `errors`. `count` is the total items attempted, `success_count` equals `len(results)`, and `error_count` equals `len(errors)`.
 
-Inside a batch node, `${__index__}` gives the 0-based position of the current item. This is useful for position-aware processing like numbering outputs or selecting behavior based on position.
+Inside a batch node, `${__index__}` gives the 0-based position of the current item. Index-based access to results (like `${node.results[0].field}`) requires `fail_fast` mode (the default). With `error_handling: continue`, use iteration (`items: ${node.results}`) instead — the validator blocks index access because filtered results don't preserve original positions.
 
 Subsequent nodes can access results:
 

--- a/src/pflow/cli/resources/cli-agent-instructions.md
+++ b/src/pflow/cli/resources/cli-agent-instructions.md
@@ -1692,9 +1692,9 @@ your-command | jq -R -s 'split("\n") | map(select(. != ""))'
 ```
 
 **All outputs**: `${node.results}`, `.count`, `.success_count`, `.error_count`, `.errors`
-Results are always in input order. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs).
+Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`.
 
-**⚠️ Batch replaces the normal output structure.** `${node.response}`, `${node.llm_usage}`, `${node.stdout}`, etc. do NOT exist at the top level. Access them inside results: `${node.results[0].response}`, `${node.results[0].llm_usage}`.
+**⚠️ Batch replaces the normal output structure.** `${node.response}`, `${node.llm_usage}`, `${node.stdout}`, etc. do NOT exist at the top level. Access them inside results: `${node.results[0].response}`, `${node.results[0].llm_usage}`. Note: index-based access (`results[N]`) requires `fail_fast` mode (the default). With `error_handling: continue`, use iteration (`items: ${node.results}`) instead.
 
 **Inline array pattern** (parallel independent operations):
 Batch is the way to run operations concurrently (conditional branching picks ONE path, not multiple).
@@ -1764,10 +1764,10 @@ parallel: true
 ````
 Any `${item.field}` template works in any param — not just prompt/command.
 
-**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate:
+**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate (requires `fail_fast` — not supported with `error_handling: continue`):
 ```
-${previous.results[${__index__}]}     # Access by position
-${previous.results[${item.idx}]}      # Access by item field
+${previous.results[${__index__}]}     # Access by position (fail_fast only)
+${previous.results[${item.idx}]}      # Access by item field (fail_fast only)
 ```
 
 **Using results**:
@@ -1775,7 +1775,7 @@ ${previous.results[${item.idx}]}      # Access by item field
 ### report
 
 - type: llm
-- prompt: "Summary of ${process-each.count} items:\n${process-each.results}"
+- prompt: "Summary of ${process-each.success_count} items:\n${process-each.results}"
 ```
 
 ### Pattern: Conditional Branching

--- a/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
@@ -1678,7 +1678,7 @@ your-command | jq -R -s 'split("\n") | map(select(. != ""))'
 ```
 
 **All outputs**: `${node.results}`, `.count`, `.success_count`, `.error_count`, `.errors`
-Results are always in input order. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs).
+Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`.
 
 **Inline array pattern** (parallel independent operations):
 Batch is the way to run operations concurrently (conditional branching picks ONE path, not multiple).
@@ -1720,10 +1720,10 @@ parallel: true
 ````
 Each runs independently: `${parallel-tasks.results[0].response}`, `${parallel-tasks.results[0].item}` (original input)
 
-**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate:
+**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate (requires `fail_fast` — not supported with `error_handling: continue`):
 ```
-${previous.results[${__index__}]}     # Access by position
-${previous.results[${item.idx}]}      # Access by item field
+${previous.results[${__index__}]}     # Access by position (fail_fast only)
+${previous.results[${item.idx}]}      # Access by item field (fail_fast only)
 ```
 
 **Using results**:
@@ -1731,7 +1731,7 @@ ${previous.results[${item.idx}]}      # Access by item field
 ### report
 
 - type: llm
-- prompt: "Summary of ${process-each.count} items:\n${process-each.results}"
+- prompt: "Summary of ${process-each.success_count} items:\n${process-each.results}"
 ```
 
 ### Pattern: Conditional Branching

--- a/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
@@ -1668,7 +1668,7 @@ your-command | jq -R -s 'split("\n") | map(select(. != ""))'
 ```
 
 **All outputs**: `${node.results}`, `.count`, `.success_count`, `.error_count`, `.errors`
-Results are always in input order. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs).
+Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`.
 
 **Inline array pattern** (parallel independent operations):
 Batch is the way to run operations concurrently (conditional branching picks ONE path, not multiple).
@@ -1710,10 +1710,10 @@ parallel: true
 ````
 Each runs independently: `${parallel-tasks.results[0].response}`, `${parallel-tasks.results[0].item}` (original input)
 
-**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate:
+**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate (requires `fail_fast` — not supported with `error_handling: continue`):
 ```
-${previous.results[${__index__}]}     # Access by position
-${previous.results[${item.idx}]}      # Access by item field
+${previous.results[${__index__}]}     # Access by position (fail_fast only)
+${previous.results[${item.idx}]}      # Access by item field (fail_fast only)
 ```
 
 **Using results**:
@@ -1721,7 +1721,7 @@ ${previous.results[${item.idx}]}      # Access by item field
 ### report
 
 - type: llm
-- prompt: "Summary of ${process-each.count} items:\n${process-each.results}"
+- prompt: "Summary of ${process-each.success_count} items:\n${process-each.results}"
 ```
 
 ### Pattern: Conditional Branching

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -180,7 +180,7 @@ Peak memory is `O(events_per_item x max_concurrent)`. No hard cap today.
 
 ### Output shape
 
-`{results, count, success_count, error_count, errors, batch_metadata}` — identical to old `PflowBatchNode.post()`. Verified by `BATCH_OUTPUTS` contract in `template_validation/validator.py`.
+`{results, count, success_count, error_count, errors, batch_metadata}`. `results` contains only successful items (failed items filtered out via `error_indices`). `errors` is the authoritative failure record with index, item, and error message per failure. `count` = total items attempted. `success_count` = `len(results)`. `error_count` = `len(errors)`. Verified by `BATCH_OUTPUTS` contract in `template_validation/validator.py`.
 
 ## Instrumentation (`instrumentation.py`)
 

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -26,7 +26,7 @@ from .types import BatchConfig, NodeConfig
 logger = logging.getLogger(__name__)
 
 # Keys injected by the batch framework, not by the inner node.
-_BATCH_META_KEYS = frozenset({"item", "error", "exception"})
+_BATCH_META_KEYS = frozenset({"item", "original_index", "error", "exception"})
 
 
 def resolve_batch_items(items_template: Any, shared: dict[str, Any]) -> Any:
@@ -286,6 +286,7 @@ def _execute_batch_item(
                     extra={"node_id": config.node_id, "existing_item": result["item"]},
                 )
             result["item"] = item
+            result["original_index"] = idx
 
             # Check for error in result dict
             error_msg = _extract_error(result)
@@ -682,8 +683,12 @@ def _aggregate_batch_results(
     Without this, ``build_execution_steps`` could not surface batch error
     details for the failing batch node (spec acceptance criterion).
     """
-    # Count successes
-    success_count = sum(1 for r in exec_res if r is not None and not _extract_error(r))
+    # Filter results to successes only — errors list is the authoritative failure record.
+    # Using error_indices (not _extract_error) fixes the error-via-action edge case where
+    # the result dict has no "error" key but IS in the errors list.
+    error_indices = {e["index"] for e in errors}
+    successful_results = [r for idx, r in enumerate(exec_res) if idx not in error_indices]
+    success_count = len(successful_results)
 
     # Timing stats — computed once, used by both the normal and error path
     timing_stats: dict[str, float] | None = None
@@ -695,10 +700,11 @@ def _aggregate_batch_results(
             "max_item_ms": round(max(item_timings), 2),
         }
 
-    # Write to shared store — MUST match PflowBatchNode.post() output shape.
+    # Write to shared store — results contains only successful items.
+    # errors list is the authoritative record of failures (with index, item, error).
     # Happens BEFORE any abort-raise so the failure archive captures the data.
     shared[node_id] = {
-        "results": exec_res,
+        "results": successful_results,
         "count": len(exec_res),
         "success_count": success_count,
         "error_count": len(errors),

--- a/src/pflow/runtime/template_validation/CLAUDE.md
+++ b/src/pflow/runtime/template_validation/CLAUDE.md
@@ -72,9 +72,11 @@ node_outputs["fetch.stdout"] = {
 }
 
 # Batch node output (has is_batch_output flag + items with inner structure)
+# error_handling is stored on the results entry so path_validation can block
+# index access when continue mode filters out failed items from results.
 node_outputs["process.results"] = {
     "type": "array", "node_id": "process", "node_type": "llm",
-    "is_batch_output": True,
+    "is_batch_output": True, "error_handling": "fail_fast",
     "items": {"type": "dict", "structure": {"response": {"type": "any"}, "item": {"type": "any"}}},
 }
 
@@ -91,7 +93,7 @@ node_outputs["concept_brief"] = {
 }
 ```
 
-Passes use `is_batch_output` to branch behavior (path_validation uses it to detect batch nodes). `is_batch_item` and `is_inputs_context` are metadata flags for provenance — not read by any pass currently. Workflow nodes get special handling — `validator.py` tries to resolve child workflow outputs at validation time via `_resolve_child_workflow_outputs()`.
+Passes use `is_batch_output` to branch behavior (path_validation uses it to detect batch nodes and to block index access on results when `error_handling` is `"continue"` — results contains only successful items, so positional indices would be wrong). `is_batch_item` and `is_inputs_context` are metadata flags for provenance — not read by any pass currently. Workflow nodes get special handling — `validator.py` tries to resolve child workflow outputs at validation time via `_resolve_child_workflow_outputs()`.
 
 **Note:** `validator.py` has dual responsibility — it orchestrates validation passes AND builds the `node_outputs` dict (`extract_node_outputs`, also used by `compilation/compile_validation.py`). Agents looking for output-related code need to look here, not just in the passes.
 

--- a/src/pflow/runtime/template_validation/path_validation.py
+++ b/src/pflow/runtime/template_validation/path_validation.py
@@ -126,7 +126,9 @@ def validate_template_path(
     return (False, None)
 
 
-def _batch_results_index_error(output_info: dict[str, Any], base_var: str, template: str) -> tuple[bool, Diagnostic]:
+def _batch_results_index_error(
+    output_info: dict[str, Any], base_var: str, template: str
+) -> tuple[bool, Optional[Diagnostic]]:
     """Build ERROR diagnostic for index access on continue-mode batch results."""
     node_id = output_info.get("node_id", base_var)
     return (
@@ -931,8 +933,8 @@ def _build_batch_inner_field_diagnostic(node_id: str, attempted_key: str, node_e
 
     # With error_handling: continue, results only contains successes — index access
     # is blocked by the validation gate, so don't suggest it.
-    results_entry = node_entries.get("results", {})
-    is_continue = results_entry.get("error_handling") == "continue"
+    results_entry = node_entries.get("results")
+    is_continue = results_entry is not None and results_entry.get("error_handling") == "continue"
 
     suggestions = []
     if not is_continue:

--- a/src/pflow/runtime/template_validation/path_validation.py
+++ b/src/pflow/runtime/template_validation/path_validation.py
@@ -126,6 +126,81 @@ def validate_template_path(
     return (False, None)
 
 
+def _batch_results_index_error(output_info: dict[str, Any], base_var: str, template: str) -> tuple[bool, Diagnostic]:
+    """Build ERROR diagnostic for index access on continue-mode batch results."""
+    node_id = output_info.get("node_id", base_var)
+    return (
+        True,
+        Diagnostic(
+            severity=Severity.ERROR,
+            source="validator",
+            node_id=node_id,
+            message=(
+                f"Index-based access on batch results is not supported with "
+                f"error_handling: continue — results contains only successful "
+                f"items, so positional indices do not correspond to original "
+                f"input positions. Use iteration "
+                f"(items: ${{{base_var}.results}}) or switch to "
+                f"error_handling: fail_fast."
+            ),
+            context={
+                "template": template if template.startswith("${") else f"${{{template}}}",
+                "category": "validation",
+            },
+        ),
+    )
+
+
+def _validate_array_access(
+    parts: list[str],
+    base_var: str,
+    base_output: str,
+    output_info: dict[str, Any],
+    template: str,
+) -> tuple[bool, Optional[Diagnostic]]:
+    """Validate array index access on a node output (e.g., results[0].field)."""
+    # Block index access on results when upstream uses error_handling: continue.
+    # Results only contains successful items — positional indices don't correspond
+    # to original input positions, so index-based access would silently return
+    # wrong data.
+    if (
+        base_output == "results"
+        and output_info.get("is_batch_output")
+        and output_info.get("error_handling") == "continue"
+    ):
+        return _batch_results_index_error(output_info, base_var, template)
+
+    items_info = output_info.get("items", {})
+    if items_info:
+        # Use items structure for nested validation
+        if len(parts) == 2:
+            return (True, None)
+        return validate_nested_path(parts[2:], items_info, full_template=template, output_key=base_output)
+
+    # No items info but array access requested
+    output_type = output_info.get("type", "any")
+    # Allow if type is array (native array access)
+    if output_type == "array":
+        return (True, None)
+    # Also allow str types - they may contain JSON that gets auto-parsed at runtime
+    # This matches the behavior of check_type_allows_traversal for field access
+    if output_type in ["str", "string"]:
+        # Generate warning about JSON auto-parsing requirement
+        warning = Diagnostic(
+            severity=Severity.WARNING,
+            source="validator",
+            node_id=output_info.get("node_id", "unknown"),
+            message=(
+                f"Array access on '{output_type}' requires valid JSON array at runtime. "
+                f"Non-JSON strings cause 'Unresolved variables' error."
+            ),
+            suggestions=["Ensure the value is a valid JSON array at runtime."],
+            context={"template": template if template.startswith("${") else f"${{{template}}}"},
+        )
+        return (True, warning)
+    return (False, None)
+
+
 def validate_namespaced_output(
     parts: list[str],
     base_var: str,
@@ -161,36 +236,9 @@ def validate_namespaced_output(
 
     output_info = node_outputs[node_output_key]
 
-    # If array access, check if output has items structure
+    # If array access, validate array-specific rules
     if array_index is not None:
-        items_info = output_info.get("items", {})
-        if items_info:
-            # Use items structure for nested validation
-            if len(parts) == 2:
-                return (True, None)
-            return validate_nested_path(parts[2:], items_info, full_template=template, output_key=base_output)
-        # No items info but array access requested
-        output_type = output_info.get("type", "any")
-        # Allow if type is array (native array access)
-        if output_type == "array":
-            return (True, None)
-        # Also allow str types - they may contain JSON that gets auto-parsed at runtime
-        # This matches the behavior of check_type_allows_traversal for field access
-        if output_type in ["str", "string"]:
-            # Generate warning about JSON auto-parsing requirement
-            warning = Diagnostic(
-                severity=Severity.WARNING,
-                source="validator",
-                node_id=output_info.get("node_id", "unknown"),
-                message=(
-                    f"Array access on '{output_type}' requires valid JSON array at runtime. "
-                    f"Non-JSON strings cause 'Unresolved variables' error."
-                ),
-                suggestions=["Ensure the value is a valid JSON array at runtime."],
-                context={"template": template if template.startswith("${") else f"${{{template}}}"},
-            )
-            return (True, warning)
-        return (False, None)
+        return _validate_array_access(parts, base_var, base_output, output_info, template)
 
     if len(parts) == 2:
         return (True, None)
@@ -874,13 +922,24 @@ def _build_batch_inner_field_diagnostic(node_id: str, attempted_key: str, node_e
         Template diagnostic with corrected-path guidance
     """
     results_path = f"${{{node_id}.results}}"
-    item_path = f"${{{node_id}.results[0].{attempted_key}}}"
 
     available_fields: list[str] = []
     for key, info in node_entries.items():
         safe_key = sanitize_for_display(key)
         safe_type = sanitize_for_display(info.get("type", "any"))
         available_fields.append(f"${{{node_id}.{safe_key}}} ({safe_type})")
+
+    # With error_handling: continue, results only contains successes — index access
+    # is blocked by the validation gate, so don't suggest it.
+    results_entry = node_entries.get("results", {})
+    is_continue = results_entry.get("error_handling") == "continue"
+
+    suggestions = []
+    if not is_continue:
+        item_path = f"${{{node_id}.results[0].{attempted_key}}}"
+        suggestions.append(f"Use {item_path} for a single item.")
+    suggestions.append(f"Use {results_path} for the full results array.")
+    suggestions.append(f"To aggregate across items, pass {results_path} to a code node and iterate.")
 
     return Diagnostic(
         severity=Severity.ERROR,
@@ -891,11 +950,7 @@ def _build_batch_inner_field_diagnostic(node_id: str, attempted_key: str, node_e
             f"Node '{node_id}' uses batch processing. '{attempted_key}' is not available at the top level — "
             "batch wraps outputs in a 'results' array."
         ),
-        suggestions=[
-            f"Use {item_path} for a single item.",
-            f"Use {results_path} for the full results array.",
-            f"To aggregate across items, pass {results_path} to a code node and iterate.",
-        ],
+        suggestions=suggestions,
         context={
             "category": "template_error",
             "available_fields": available_fields,

--- a/src/pflow/runtime/template_validation/validator.py
+++ b/src/pflow/runtime/template_validation/validator.py
@@ -44,7 +44,7 @@ _PERMISSIVE_PATTERN = re.compile(rf"\$\{{({_PERM_VAR}(?:\s*\?\?\s*{_PERM_VAR})*)
 
 # Batch output definitions matching PflowBatchNode.post() structure
 BATCH_OUTPUTS: list[dict[str, str]] = [
-    {"key": "results", "type": "array", "description": "Array of results in input order"},
+    {"key": "results", "type": "array", "description": "Array of successful results (failed items filtered out)"},
     {"key": "count", "type": "number", "description": "Total items processed"},
     {"key": "success_count", "type": "number", "description": "Items that succeeded"},
     {"key": "error_count", "type": "number", "description": "Items that failed"},
@@ -403,7 +403,14 @@ def extract_node_outputs(
 
         if batch_config:
             # Batch node: register batch outputs instead of normal outputs
-            _register_batch_outputs(node_outputs, node_id, node_type, enable_namespacing, registry)
+            _register_batch_outputs(
+                node_outputs,
+                node_id,
+                node_type,
+                enable_namespacing,
+                registry,
+                error_handling=batch_config.get("error_handling", "fail_fast"),
+            )
             _register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
         else:
             # Non-batch node: extract outputs from registry interface
@@ -444,6 +451,7 @@ def _register_workflow_node_outputs(
                 enable_namespacing,
                 registry,
                 inner_outputs_override=inner_outputs,
+                error_handling=batch_config.get("error_handling", "fail_fast"),
             )
         else:
             # Child unresolvable: register batch outputs without inner structure.
@@ -456,6 +464,7 @@ def _register_workflow_node_outputs(
                 enable_namespacing,
                 registry,
                 skip_results_structure=True,
+                error_handling=batch_config.get("error_handling", "fail_fast"),
             )
         _register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
     elif child_outputs is not None:
@@ -623,12 +632,13 @@ def _register_batch_outputs(
     registry: Registry,
     inner_outputs_override: Optional[dict[str, Any]] = None,
     skip_results_structure: bool = False,
+    error_handling: str = "fail_fast",
 ) -> None:
     """Register batch-specific outputs for a node with batch configuration.
 
     Batch nodes wrap their inner node's outputs in a structured result with:
-    - results: Array of per-item results (with inner node's output structure)
-    - count: Total items processed
+    - results: Array of successful results (failed items filtered out at runtime)
+    - count: Total items attempted
     - success_count/error_count: Success/failure counts
     - errors: Error details if any
     - batch_metadata: Execution statistics
@@ -639,6 +649,9 @@ def _register_batch_outputs(
         skip_results_structure: When True, don't attach items structure to results.
             Used when inner outputs are unknown (e.g., dynamic workflow child ref)
             so the validator accepts any results[N].* path at validation time.
+        error_handling: The batch error handling mode ("fail_fast" or "continue").
+            Stored on the results entry so path validation can block index access
+            when continue mode filters out failed items.
     """
     if skip_results_structure:
         inner_outputs_structure: dict[str, Any] = {}
@@ -656,6 +669,11 @@ def _register_batch_outputs(
             "node_type": node_type,
             "is_batch_output": True,
         }
+
+        # Store error_handling on results entry so path validation can block
+        # index access when continue mode filters out failed items.
+        if key == "results":
+            output_info["error_handling"] = error_handling
 
         # For 'results' array, add inner node's output structure plus 'item'.
         # When skip_results_structure is True, omit items so the validator

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -266,23 +266,24 @@ class TestItemInResult:
     """Tests for the `item` field being included in each batch result."""
 
     def test_item_included_when_result_has_error_key(self):
-        """Original item is included even when result contains error key."""
+        """Error items are filtered from results; error details in errors list."""
         inner = MockInnerNode("test_node", behavior="error_in_result")
         inner.error_index = 1
 
         shared: dict = {"data": ["success", "will_fail", "success"]}
         _run_batch(inner, shared, error_handling="continue")
 
+        # results contains only successful items
         results = shared["test_node"]["results"]
+        assert len(results) == 2
         assert results[0]["response"] == "success"
         assert results[0]["item"] == "success"
+        assert results[1]["response"] == "success"
+        assert results[1]["item"] == "success"
 
-        # Error result still has item field for debugging
-        assert "error" in results[1]
-        assert results[1]["item"] == "will_fail"
-
-        assert results[2]["response"] == "success"
-        assert results[2]["item"] == "success"
+        # Error details are in the errors list with original item
+        assert shared["test_node"]["error_count"] == 1
+        assert shared["test_node"]["errors"][0]["item"] == "will_fail"
 
     def test_item_overwrite_warning_logged(self, caplog):
         """Warning is logged when node output already has 'item' key."""
@@ -477,12 +478,13 @@ class TestErrorHandling:
         assert shared["test_node"]["success_count"] == 2
         assert shared["test_node"]["error_count"] == 1
 
+        # results contains only successful items (failed items filtered out)
         results = shared["test_node"]["results"]
+        assert len(results) == 2
         assert results[0]["response"] == "a"
         assert results[0]["item"] == "a"
-        assert results[1] is None
-        assert results[2]["response"] == "c"
-        assert results[2]["item"] == "c"
+        assert results[1]["response"] == "c"
+        assert results[1]["item"] == "c"
 
         assert len(shared["test_node"]["errors"]) == 1
         assert shared["test_node"]["errors"][0]["index"] == 1
@@ -507,13 +509,16 @@ class TestErrorHandling:
         shared: dict = {"data": ["a", "b", "c"]}
         _run_batch(inner, shared, error_handling="continue")
 
+        # results contains only successful items — error item filtered out
         results = shared["test_node"]["results"]
-        assert results[1]["error"] == "Error: Processing failed for item b"
-        assert results[1]["item"] == "b"
+        assert len(results) == 2
+        assert results[0]["response"] == "a"
+        assert results[1]["response"] == "c"
 
         assert shared["test_node"]["success_count"] == 2
         assert shared["test_node"]["error_count"] == 1
         assert shared["test_node"]["errors"][0]["index"] == 1
+        assert shared["test_node"]["errors"][0]["error"] == "Error: Processing failed for item b"
 
 
 class TestResultStructure:
@@ -556,6 +561,88 @@ class TestResultStructure:
         assert results[1]["item"] == "b"
         assert shared["test_node"]["success_count"] == 2
         assert shared["test_node"]["error_count"] == 0
+
+
+class TestFilteredResultsContract:
+    """Tests for the filtered results contract: results = successes only."""
+
+    def test_results_only_contains_successes(self):
+        """With continue mode and partial failure, results excludes failed items."""
+        inner = MockInnerNode("test_node", behavior="error_on_index")
+        inner.error_index = 1
+
+        shared: dict = {"data": ["a", "b", "c"]}
+        _run_batch(inner, shared, error_handling="continue")
+
+        output = shared["test_node"]
+        assert len(output["results"]) == output["success_count"]
+        assert output["success_count"] + output["error_count"] == output["count"]
+        assert all(r is not None for r in output["results"])
+        assert all(r.get("error") is None for r in output["results"])
+
+        # Each result carries its original batch index for provenance
+        assert output["results"][0]["original_index"] == 0
+        assert output["results"][1]["original_index"] == 2
+
+    def test_results_unaffected_when_all_succeed(self):
+        """When no errors, results equals all items (filtering is a no-op)."""
+        inner = MockInnerNode("test_node")
+        shared: dict = {"data": ["a", "b", "c"]}
+        _run_batch(inner, shared)
+
+        output = shared["test_node"]
+        assert len(output["results"]) == 3
+        assert output["count"] == 3
+        assert output["success_count"] == 3
+        assert output["error_count"] == 0
+
+    def test_parallel_filtered_results_contract(self):
+        """Parallel mode also filters results to successes only."""
+
+        class FailOnB:
+            def __init__(self, node_id: str):
+                self.node_id = node_id
+
+            def __getstate__(self):
+                return self.__dict__.copy()
+
+            def __setstate__(self, state):
+                self.__dict__.update(state)
+
+            def _run(self, shared: dict) -> str:
+                item = shared.get("item")
+                if item == "b":
+                    raise ValueError("Error on b")
+                shared[self.node_id] = {"response": item}
+                return "default"
+
+        inner = FailOnB("test_node")
+        shared: dict = {"data": ["a", "b", "c"]}
+        _run_batch(inner, shared, parallel=True, error_handling="continue")
+
+        output = shared["test_node"]
+        assert len(output["results"]) == 2
+        assert output["success_count"] == 2
+        assert output["error_count"] == 1
+        assert output["count"] == 3
+        assert output["results"][0]["response"] == "a"
+        assert output["results"][1]["response"] == "c"
+
+    def test_original_index_disambiguates_duplicate_items(self):
+        """original_index distinguishes results when input items are duplicates."""
+        inner = MockInnerNode("test_node", behavior="error_on_index")
+        inner.error_index = 1
+
+        shared: dict = {"data": ["x", "x", "x"]}
+        _run_batch(inner, shared, error_handling="continue")
+
+        output = shared["test_node"]
+        assert len(output["results"]) == 2
+        # Both results have item="x" — only original_index tells them apart
+        assert output["results"][0]["item"] == "x"
+        assert output["results"][1]["item"] == "x"
+        assert output["results"][0]["original_index"] == 0
+        assert output["results"][1]["original_index"] == 2
 
 
 class TestItemsResolution:
@@ -907,7 +994,7 @@ class TestInputOutputFormats:
         assert results[1]["item"] == "y"
 
     def test_empty_dict_output(self):
-        """When node writes empty dict to namespace, it's returned as-is."""
+        """When node writes empty dict to namespace, result has item + original_index."""
 
         class EmptyDictNode:
             def __init__(self, node_id: str):
@@ -923,12 +1010,12 @@ class TestInputOutputFormats:
         _run_batch(inner, shared)
 
         results = shared["test_node"]["results"]
-        assert results[0] == {"item": "a"}
-        assert results[1] == {"item": "b"}
+        assert results[0] == {"item": "a", "original_index": 0}
+        assert results[1] == {"item": "b", "original_index": 1}
         assert shared["test_node"]["success_count"] == 2
 
     def test_node_writes_nothing(self):
-        """When node doesn't write to namespace, result is empty dict."""
+        """When node doesn't write to namespace, result is empty dict + metadata."""
 
         class SilentNode:
             def __init__(self, node_id: str):
@@ -943,8 +1030,8 @@ class TestInputOutputFormats:
         _run_batch(inner, shared)
 
         results = shared["test_node"]["results"]
-        assert results[0] == {"item": "a"}
-        assert results[1] == {"item": "b"}
+        assert results[0] == {"item": "a", "original_index": 0}
+        assert results[1] == {"item": "b", "original_index": 1}
         assert shared["test_node"]["success_count"] == 2
 
 
@@ -1363,12 +1450,13 @@ class TestParallelErrorHandling:
 
         _run_batch(inner, shared, parallel=True, error_handling="continue")
 
+        # results contains only successful items (failed items filtered out)
         results = shared["test_node"]["results"]
+        assert len(results) == 2
         assert results[0]["response"] == "a"
         assert results[0]["item"] == "a"
-        assert results[1] is None
-        assert results[2]["response"] == "c"
-        assert results[2]["item"] == "c"
+        assert results[1]["response"] == "c"
+        assert results[1]["item"] == "c"
 
 
 class TestParallelRetry:
@@ -2173,22 +2261,18 @@ class TestBatchActionFallbackErrorDetection:
             self.__dict__.update(state)
 
     def test_exec_single_detects_error_via_action_string(self):
-        """When _run() returns 'error' but result dict has no error key, error is recorded."""
+        """When _run() returns 'error' but result dict has no error key, all-fail abort fires."""
         inner = self.ErrorActionNode("test_node")
         shared: dict = {"data": ["a", "b"]}
 
-        _run_batch(inner, shared, error_handling="continue")
+        # All items return error action → success_count = 0 → all-fail abort
+        with pytest.raises(RuntimeError, match="all 2 items failed"):
+            _run_batch(inner, shared, error_handling="continue")
 
+        # Batch output is written to shared store BEFORE the abort raise
         assert shared["test_node"]["error_count"] == 2
-        assert len(shared["test_node"]["errors"]) == 2
-
-        for error_info in shared["test_node"]["errors"]:
-            assert error_info["error"] == "Node returned error action"
-
-        results = shared["test_node"]["results"]
-        for result in results:
-            assert result is not None
-            assert result["response"] == "partial output"
+        assert shared["test_node"]["success_count"] == 0
+        assert shared["test_node"]["results"] == []
 
     def test_exec_single_prefers_extract_error_over_action(self):
         """When both _extract_error finds an error AND action is 'error', _extract_error message wins."""
@@ -2242,22 +2326,48 @@ class TestBatchActionFallbackErrorDetection:
         assert shared["test_node"]["errors"] is None
 
     def test_exec_single_with_node_detects_error_via_action(self):
-        """Parallel path: detects error via action string fallback."""
+        """Parallel path: all error-action items → all-fail abort."""
         inner = self.ErrorActionNode("test_node")
         shared: dict = {"data": ["a", "b", "c"]}
 
-        _run_batch(inner, shared, parallel=True, error_handling="continue")
+        # All items return error action → success_count = 0 → all-fail abort
+        with pytest.raises(RuntimeError, match="all 3 items failed"):
+            _run_batch(inner, shared, parallel=True, error_handling="continue")
 
+        # Batch output is written to shared store BEFORE the abort raise
         assert shared["test_node"]["error_count"] == 3
-        assert len(shared["test_node"]["errors"]) == 3
+        assert shared["test_node"]["success_count"] == 0
+        assert shared["test_node"]["results"] == []
 
-        for error_info in shared["test_node"]["errors"]:
-            assert error_info["error"] == "Node returned error action"
+    def test_mixed_error_via_action_filters_correctly(self):
+        """Some items succeed, some fail via action — success_count and results are correct."""
 
-        results = shared["test_node"]["results"]
-        for result in results:
-            assert result is not None
-            assert result["response"] == "partial output"
+        class MixedActionNode:
+            """Succeeds on even indices, returns error action on odd indices."""
+
+            def __init__(self, node_id: str):
+                self.node_id = node_id
+
+            def _run(self, shared: dict) -> str:
+                idx = shared.get("__index__", 0)
+                shared[self.node_id] = {"response": f"output-{idx}"}
+                return "error" if idx % 2 == 1 else "default"
+
+        inner = MixedActionNode("test_node")
+        shared: dict = {"data": ["a", "b", "c", "d"]}
+
+        _run_batch(inner, shared, error_handling="continue")
+
+        output = shared["test_node"]
+        # Items at indices 1 and 3 fail via action — filtered from results
+        assert output["count"] == 4
+        assert output["success_count"] == 2
+        assert output["error_count"] == 2
+        assert len(output["results"]) == 2
+        assert output["results"][0]["response"] == "output-0"
+        assert output["results"][1]["response"] == "output-2"
+        # Invariant holds
+        assert output["success_count"] + output["error_count"] == output["count"]
 
     def test_exec_single_fail_fast_raises_on_action_error(self):
         """fail_fast mode raises RuntimeError when action-string fallback detects error."""
@@ -2380,20 +2490,15 @@ class TestBatchSubWorkflowErrorPropagationIntegration:
         assert batch_output["errors"][0]["index"] == 1
         assert batch_output["errors"][0]["item"] == "fail-b"
 
+        # results contains only successful items — failed sub-workflow filtered out
         results = batch_output["results"]
-        assert len(results) == 3
+        assert len(results) == 2
 
-        assert results[0] is not None
         assert results[0]["item"] == "good-a"
         assert results[0].get("error") is None
 
-        assert results[2] is not None
-        assert results[2]["item"] == "good-c"
-        assert results[2].get("error") is None
-
-        assert results[1] is not None
-        assert results[1]["item"] == "fail-b"
-        assert results[1].get("error") is not None
+        assert results[1]["item"] == "good-c"
+        assert results[1].get("error") is None
 
     def test_batch_workflow_partial_failure_parallel(self):
         """Parallel variant of partial-fail: exercises the parallel code path."""
@@ -2452,16 +2557,15 @@ class TestBatchSubWorkflowErrorPropagationIntegration:
         assert len(batch_output["errors"]) == 1
         assert batch_output["errors"][0]["item"] == "fail-b"
 
+        # results contains only successful items — failed sub-workflow filtered out
         results = batch_output["results"]
-        assert len(results) == 3
+        assert len(results) == 2
 
-        for i, expected_item in enumerate(["good-a", "fail-b", "good-c"]):
-            assert results[i] is not None
-            assert results[i]["item"] == expected_item
-
+        assert results[0]["item"] == "good-a"
         assert results[0].get("error") is None
-        assert results[2].get("error") is None
-        assert results[1].get("error") is not None
+
+        assert results[1]["item"] == "good-c"
+        assert results[1].get("error") is None
 
     def test_batch_workflow_all_fail_with_continue(self):
         """All items fail with error_handling: continue -- aborts with RuntimeError."""
@@ -2507,6 +2611,70 @@ class TestBatchSubWorkflowErrorPropagationIntegration:
         with pytest.raises(RuntimeError, match="all 3 items failed"):
             engine = WorkflowEngine()
             engine.run(workflow, shared)
+
+    def test_downstream_batch_iterates_only_successes(self):
+        """Full pipeline: partial-failure batch → downstream batch iterates filtered results.
+
+        This is the core use case from GH #159. Tests the full integration:
+        _aggregate_batch_results filtering → shared store write → template resolution
+        of ${step1.results} → downstream batch receiving only successes.
+        """
+        from pflow.registry.registry import Registry
+        from pflow.runtime import compile_workflow
+        from pflow.runtime.engine import WorkflowEngine
+
+        registry = Registry()
+
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "step1",
+                    "type": "shell",
+                    "params": {
+                        "command": 'if [ "${item}" = "bad" ]; then exit 1; fi; echo "s1-${item}"',
+                    },
+                    "batch": {
+                        "items": ["ok-a", "bad", "ok-c"],
+                        "error_handling": "continue",
+                    },
+                    "purpose": "Batch with partial failure to produce filtered results",
+                },
+                {
+                    "id": "step2",
+                    "type": "shell",
+                    "params": {
+                        "command": 'echo "s2-${item.stdout}"',
+                    },
+                    "batch": {
+                        "items": "${step1.results}",
+                    },
+                    "purpose": "Downstream batch iterating only successful results from step1",
+                },
+            ],
+            "edges": [{"from": "step1", "to": "step2"}],
+        }
+
+        workflow = compile_workflow(ir, registry=registry)
+        shared: dict = dict(workflow.resolved_defaults)
+        engine = WorkflowEngine()
+        engine.run(workflow, shared)
+
+        # Step 1: 3 attempted, 2 succeeded, 1 failed
+        s1 = shared["step1"]
+        assert s1["count"] == 3
+        assert s1["success_count"] == 2
+        assert s1["error_count"] == 1
+
+        # Step 2: received only 2 items (the successes from step1)
+        s2 = shared["step2"]
+        assert s2["count"] == 2
+        assert s2["success_count"] == 2
+        assert s2["error_count"] == 0
+
+        # Verify the data flowed correctly through the chain
+        outputs = sorted([r["stdout"] for r in s2["results"]])
+        assert outputs == ["s2-s1-ok-a", "s2-s1-ok-c"]
 
 
 class TestDetectEmptyOutputItems:

--- a/tests/test_runtime/test_template_validation/test_array_notation.py
+++ b/tests/test_runtime/test_template_validation/test_array_notation.py
@@ -217,3 +217,208 @@ class TestTemplateArrayNotation:
         assert "node.data[0].users[1].profile.name" in templates
         assert "username" in templates
         assert len(templates) == 4
+
+
+class TestBatchResultsIndexAccessGate:
+    """Validation gate: block index access on results with error_handling: continue."""
+
+    def _make_registry(self):
+        registry = Registry()
+        with patch.object(registry, "get_nodes_metadata") as mock:
+
+            def get_metadata(node_types):
+                result = {}
+                for nt in node_types:
+                    if nt == "shell":
+                        result[nt] = {
+                            "interface": {
+                                "outputs": [{"key": "stdout", "type": "string"}],
+                            }
+                        }
+                    elif nt == "llm":
+                        result[nt] = {
+                            "interface": {
+                                "outputs": [{"key": "response", "type": "string"}],
+                            }
+                        }
+                return result
+
+            mock.side_effect = get_metadata
+            yield registry
+
+    def test_index_access_blocked_with_continue(self):
+        """${batch.results[0].stdout} emits ERROR when batch uses error_handling: continue."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"], "error_handling": "continue"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {"prompt": "First: ${batch.results[0].stdout}"},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            gate_errors = [e for e in errors if "Index-based access" in e.message]
+            assert len(gate_errors) == 1
+            assert "error_handling: continue" in gate_errors[0].message
+
+    def test_index_access_allowed_with_fail_fast(self):
+        """${batch.results[0].stdout} passes when batch uses fail_fast (default)."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"]},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {"prompt": "First: ${batch.results[0].stdout}"},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            gate_errors = [e for e in errors if "Index-based access" in e.message]
+            assert len(gate_errors) == 0
+
+    def test_whole_array_access_allowed_with_continue(self):
+        """${batch.results} (no index) passes even with error_handling: continue."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"], "error_handling": "continue"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {"prompt": "All: ${batch.results}"},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            gate_errors = [e for e in errors if "Index-based access" in e.message]
+            assert len(gate_errors) == 0
+
+    def test_nested_index_template_blocked_with_continue(self):
+        """${batch.results[${__index__}].stdout} blocked with continue mode."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"], "error_handling": "continue"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "shell",
+                    "params": {"command": "echo ${batch.results[${__index__}].stdout}"},
+                    "batch": {"items": ["x", "y"]},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            gate_errors = [e for e in errors if "Index-based access" in e.message]
+            assert len(gate_errors) == 1
+
+    def test_errors_array_index_access_allowed_with_continue(self):
+        """${batch.errors[0]} is fine with continue — errors array is unfiltered."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"], "error_handling": "continue"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {"prompt": "Error: ${batch.errors[0]}"},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            gate_errors = [e for e in errors if "Index-based access" in e.message]
+            assert len(gate_errors) == 0
+
+    def test_batch_field_suggestion_omits_index_for_continue(self):
+        """${batch.stdout} on continue-mode batch should NOT suggest results[0]."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"], "error_handling": "continue"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {"prompt": "Got: ${batch.stdout}"},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            batch_errors = [e for e in errors if "batch processing" in e.message]
+            assert len(batch_errors) == 1
+            # Should NOT suggest results[0] for continue mode
+            for suggestion in batch_errors[0].suggestions:
+                assert "results[0]" not in suggestion, f"Contradictory suggestion for continue mode: {suggestion}"
+            # Should still suggest the full results array
+            assert any("results}" in s for s in batch_errors[0].suggestions)
+
+    def test_batch_field_suggestion_includes_index_for_fail_fast(self):
+        """${batch.stdout} on fail_fast batch SHOULD suggest results[0]."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch",
+                    "type": "shell",
+                    "params": {"command": "echo ${item}"},
+                    "batch": {"items": ["a", "b"]},
+                },
+                {
+                    "id": "consumer",
+                    "type": "llm",
+                    "params": {"prompt": "Got: ${batch.stdout}"},
+                },
+            ],
+            "edges": [{"from": "batch", "to": "consumer"}],
+        }
+
+        for registry in self._make_registry():
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            batch_errors = [e for e in errors if "batch processing" in e.message]
+            assert len(batch_errors) == 1
+            # Should suggest results[0] for fail_fast
+            assert any("results[0]" in s for s in batch_errors[0].suggestions)

--- a/tests/test_runtime/test_template_validation/test_array_notation.py
+++ b/tests/test_runtime/test_template_validation/test_array_notation.py
@@ -6,6 +6,7 @@ This module tests that:
 - Workflows with array templates work end-to-end
 """
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from pflow.registry import Registry
@@ -222,6 +223,7 @@ class TestTemplateArrayNotation:
 class TestBatchResultsIndexAccessGate:
     """Validation gate: block index access on results with error_handling: continue."""
 
+    @contextmanager
     def _make_registry(self):
         registry = Registry()
         with patch.object(registry, "get_nodes_metadata") as mock:
@@ -265,7 +267,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, warnings = split_template_diagnostics(workflow_ir, {}, registry)
             gate_errors = [e for e in errors if "Index-based access" in e.message]
             assert len(gate_errors) == 1
@@ -290,7 +292,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             gate_errors = [e for e in errors if "Index-based access" in e.message]
             assert len(gate_errors) == 0
@@ -314,7 +316,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             gate_errors = [e for e in errors if "Index-based access" in e.message]
             assert len(gate_errors) == 0
@@ -339,7 +341,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             gate_errors = [e for e in errors if "Index-based access" in e.message]
             assert len(gate_errors) == 1
@@ -363,7 +365,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             gate_errors = [e for e in errors if "Index-based access" in e.message]
             assert len(gate_errors) == 0
@@ -387,7 +389,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             batch_errors = [e for e in errors if "batch processing" in e.message]
             assert len(batch_errors) == 1
@@ -416,7 +418,7 @@ class TestBatchResultsIndexAccessGate:
             "edges": [{"from": "batch", "to": "consumer"}],
         }
 
-        for registry in self._make_registry():
+        with self._make_registry() as registry:
             errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             batch_errors = [e for e in errors if "batch processing" in e.message]
             assert len(batch_errors) == 1


### PR DESCRIPTION
## Summary

When a batch node uses `error_handling: continue` and some items fail, downstream nodes previously received `None` entries and error dicts mixed in with actual data. This caused template resolution failures or silent garbage propagation.

**Root cause**: `error_handling: continue` was bolted onto the existing `results` structure without redesigning the output contract. Failed items were represented in two places — as garbage in `results` AND as structured records in `errors`.

**Fix**: Complete the separation. `results` = successes only. `errors` = failures (already existed). This follows the industry-standard two-collection pattern (Stripe, Google AIP-233, Rust's `partition_result`, etc.).

## Changes

### Core fix (`batch_executor.py`)
- Filter `results` to only contain successful items using `error_indices` from the authoritative `errors` list
- Fix `success_count` bug where error-via-action items were double-counted (`success_count + error_count` could exceed `count`)
- Add `original_index` to each successful result for provenance (enables join-back with `errors` even when input items are duplicates)

### Validation gate (`path_validation.py`, `validator.py`)
- Block `${upstream.results[N]}` and `${upstream.results[${__index__}]}` when upstream has `error_handling: continue` — filtered results don't preserve original positions, so index access would silently return wrong data
- Plumb `error_handling` metadata through `_register_batch_outputs()` into `node_outputs` entries
- Fix contradictory suggestion that recommended `results[0]` for continue-mode batches (which the gate itself rejects)

### Documentation
- Updated agent instructions (3 files), user-facing docs, and internal CLAUDE.md files

## Explanation

The previous design had `results` serving two incompatible purposes: a data stream for downstream iteration AND a positional record of what happened to each input. With partial failures, these conflict — iteration needs clean data while positional access needs all slots. Rather than adding a second array (`successful_results`), we made `results` itself correct for the common case (iteration) and added a validation gate to catch the rare case (index access + continue) at compile time with an actionable error message.

The `original_index` field on each result preserves provenance — downstream code can still correlate results back to original input positions or join with the `errors` list when needed.

## Testing

- Updated 10 existing tests to match new filtered-results contract
- Added `TestFilteredResultsContract` (4 tests): invariant checks, parallel path, duplicate-item disambiguation
- Added `TestBatchResultsIndexAccessGate` (7 tests): gate triggers/non-triggers, suggestion text correctness
- Added integration test: partial-failure batch → downstream batch iterates filtered results through full `compile_workflow` + `WorkflowEngine` pipeline
- Verified with 13 end-to-end pflow workflow runs covering all failure paths, chained batches, sub-workflows, validation-only mode, and JSON output
- `make test`: 4826 passed, `make check`: all clean

---