### PR TITLE
refactor: rename coercion functions for pipeline-stage clarity (fixes #268)

### DIFF
--- a/src/pflow/cli/commands/registry_run.py
+++ b/src/pflow/cli/commands/registry_run.py
@@ -10,7 +10,7 @@ import click
 from pflow.cli.param_parsing import parse_workflow_params
 from pflow.core.diagnostic import exception_to_diagnostics, format_diagnostic
 from pflow.core.execution_cache import ExecutionCache
-from pflow.core.param_coercion import coerce_to_declared_type
+from pflow.core.param_coercion import coerce_param_for_node
 from pflow.core.user_errors import MCPError
 from pflow.core.validation_utils import is_valid_parameter_name
 from pflow.registry import Registry
@@ -118,7 +118,7 @@ def _coerce_params_for_node(
     coerced = {}
     for key, value in params.items():
         expected_type = param_types.get(key)
-        coerced[key] = coerce_to_declared_type(value, expected_type)
+        coerced[key] = coerce_param_for_node(value, expected_type)
 
     return coerced
 

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -282,8 +282,8 @@ Detects file path references in node params and batch items, reads the files, an
 ### param_coercion.py
 
 **Two functions for different contexts** — easy to confuse:
-- `coerce_to_declared_type(value, expected_type)`: For MCP tools. Converts dict/list → JSON string when declared type is `"str"`.
-- `coerce_input_to_declared_type(value, declared_type)`: For CLI inputs. Dispatch table handles all type pairs (str↔int, str↔bool, str↔JSON). **Lenient**: warns on failure instead of erroring — lets downstream validation catch it with full context.
+- `coerce_param_for_node(value, expected_type)`: For node execution. Intentionally narrow — only converts dict/list → JSON string when declared type is `"str"`. All other values pass through unchanged.
+- `coerce_workflow_input(value, declared_type)`: For CLI/env inputs entering a workflow. Full bidirectional coercion via dispatch table (str↔int, str↔bool, str↔JSON). **Lenient**: warns on failure instead of erroring — lets downstream validation catch it with full context.
 
 ### security_utils.py
 

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -281,7 +281,7 @@ Detects file path references in node params and batch items, reads the files, an
 
 ### param_coercion.py
 
-**Two functions for different contexts** — easy to confuse:
+**Two functions for different pipeline stages** — easy to confuse:
 - `coerce_param_for_node(value, expected_type)`: For node execution. Intentionally narrow — only converts dict/list → JSON string when declared type is `"str"`. All other values pass through unchanged.
 - `coerce_workflow_input(value, declared_type)`: For CLI/env inputs entering a workflow. Full bidirectional coercion via dispatch table (str↔int, str↔bool, str↔JSON). **Lenient**: warns on failure instead of erroring — lets downstream validation catch it with full context.
 

--- a/src/pflow/core/__init__.py
+++ b/src/pflow/core/__init__.py
@@ -2,7 +2,7 @@
 
 Import from specific submodules for symbols not listed here:
     from pflow.core.shell_integration import detect_stdin
-    from pflow.core.param_coercion import coerce_to_declared_type
+    from pflow.core.param_coercion import coerce_param_for_node
     from pflow.core.llm_pricing import calculate_llm_cost
 """
 

--- a/src/pflow/core/param_coercion.py
+++ b/src/pflow/core/param_coercion.py
@@ -1,11 +1,8 @@
 """Parameter type coercion utilities.
 
-Provides coercion between Python types and declared parameter types.
-
-Two main use cases:
-1. Serializing dict/list to JSON strings when declared type is "str" (for MCP tools)
-2. Coercing CLI-provided values to match workflow input declarations
-   (e.g., int → str when input declares type: string)
+Two functions for two pipeline stages:
+- coerce_param_for_node: Serializes dict/list → JSON string for nodes expecting "str"
+- coerce_workflow_input: Full bidirectional coercion for CLI/env values entering a workflow
 """
 
 import json
@@ -36,31 +33,36 @@ def _normalize_type(type_name: str) -> str:
     return normalized if normalized else type_name  # Preserve case for unknowns
 
 
-def coerce_to_declared_type(
+def coerce_param_for_node(
     value: Any,
     expected_type: str | None,
 ) -> Any:
-    """Coerce a value to match its declared parameter type.
+    """Coerce a resolved parameter value for node execution.
 
-    When expected_type is "str" and value is dict/list, serialize to JSON string.
-    This enables MCP tools that declare `param: str` but expect JSON content
-    to receive properly serialized JSON strings instead of Python dicts.
+    Intentionally narrow: only serializes dict/list → JSON string when the
+    node declares the parameter as type "str". All other values pass through
+    unchanged. This handles the MCP tool case where a tool declares `param: str`
+    but the upstream produced a dict/list.
+
+    This function does NOT perform general type coercion (e.g., str→int).
+    At this pipeline stage, values are already in their intended form from
+    template resolution or the shared store.
 
     Args:
-        value: The value to potentially coerce
+        value: The resolved value to potentially coerce
         expected_type: Declared type from node interface ("str", "dict", etc.)
 
     Returns:
         Coerced value if conversion needed, otherwise original value
 
     Examples:
-        >>> coerce_to_declared_type({"key": "value"}, "str")
+        >>> coerce_param_for_node({"key": "value"}, "str")
         '{"key": "value"}'
-        >>> coerce_to_declared_type([1, 2, 3], "str")
+        >>> coerce_param_for_node([1, 2, 3], "str")
         '[1, 2, 3]'
-        >>> coerce_to_declared_type("hello", "str")
+        >>> coerce_param_for_node("hello", "str")
         'hello'
-        >>> coerce_to_declared_type({"key": "value"}, "dict")
+        >>> coerce_param_for_node({"key": "value"}, "dict")
         {'key': 'value'}
     """
     if expected_type is None:
@@ -99,7 +101,7 @@ def _coerce_to_string(value: Any, log_context: dict[str, Any]) -> Any:
     """Coerce non-string values to string.
 
     For dict/list, uses json.dumps() to produce valid JSON strings.
-    This is consistent with coerce_to_declared_type() and ensures
+    This is consistent with coerce_param_for_node() and ensures
     nodes expecting JSON strings receive proper JSON, not Python repr.
     """
     if isinstance(value, str):
@@ -231,12 +233,12 @@ _COERCION_DISPATCH = {
 }
 
 
-def coerce_input_to_declared_type(
+def coerce_workflow_input(
     value: Any,
     declared_type: str | None,
     input_name: str | None = None,
 ) -> Any:
-    """Coerce a CLI-provided value to match the workflow input's declared type.
+    """Coerce a CLI/env-provided value to match the workflow input's declared type.
 
     This function handles the case where CLI parameter parsing (via infer_type)
     converts numeric strings to int/float before the workflow's declared type
@@ -268,15 +270,15 @@ def coerce_input_to_declared_type(
         - No declared type: Return value unchanged
 
     Examples:
-        >>> coerce_input_to_declared_type(1458059302022549698, "string")
+        >>> coerce_workflow_input(1458059302022549698, "string")
         '1458059302022549698'
-        >>> coerce_input_to_declared_type("42", "integer")
+        >>> coerce_workflow_input("42", "integer")
         42
-        >>> coerce_input_to_declared_type("3.14", "number")
+        >>> coerce_workflow_input("3.14", "number")
         3.14
-        >>> coerce_input_to_declared_type("true", "boolean")
+        >>> coerce_workflow_input("true", "boolean")
         True
-        >>> coerce_input_to_declared_type('{"a": 1}', "object")
+        >>> coerce_workflow_input('{"a": 1}', "object")
         {'a': 1}
     """
     if declared_type is None:

--- a/src/pflow/runtime/compilation/CLAUDE.md
+++ b/src/pflow/runtime/compilation/CLAUDE.md
@@ -104,7 +104,7 @@ IR structure validation and input preparation.
 - `prepare_inputs()` — validates inputs, resolves from fallback sources, coerces types. Returns `(errors, defaults, env_param_names)`. **Does NOT mutate `provided_params`** — returns defaults to be applied by the caller.
   - **5-tier precedence**: CLI args → `os.environ` → `settings.env` → workflow default → error if required
   - Only one `stdin: true` input allowed
-  - Type coercion via `coerce_input_to_declared_type()` — lenient (warns on failure, doesn't error)
+  - Type coercion via `coerce_workflow_input()` — lenient (warns on failure, doesn't error)
 
 **WARNING**: A DIFFERENT `validator.py` exists at `core/workflow/validator.py` (pre-execution 9-step orchestrator, 7+ external consumers). Don't confuse them.
 

--- a/src/pflow/runtime/compilation/ir_preparation.py
+++ b/src/pflow/runtime/compilation/ir_preparation.py
@@ -14,7 +14,7 @@ import os
 from typing import Any
 
 from pflow.core.exceptions import CompilationError
-from pflow.core.param_coercion import coerce_input_to_declared_type
+from pflow.core.param_coercion import coerce_workflow_input
 from pflow.core.validation_utils import get_parameter_validation_error, is_valid_parameter_name
 
 logger = logging.getLogger(__name__)
@@ -152,7 +152,7 @@ def _coerce_provided_input(
         )
         return None, False
 
-    coerced_value = coerce_input_to_declared_type(provided_value, declared_type, input_name=input_name)
+    coerced_value = coerce_workflow_input(provided_value, declared_type, input_name=input_name)
 
     # Explicit coercion check - don't rely on identity which is fragile
     # (e.g., string normalization could create new objects even when type matches)

--- a/src/pflow/runtime/engine/template_resolution.py
+++ b/src/pflow/runtime/engine/template_resolution.py
@@ -13,7 +13,7 @@ import logging
 from typing import Any, Optional
 
 from pflow.core.json_utils import try_parse_json
-from pflow.core.param_coercion import coerce_to_declared_type
+from pflow.core.param_coercion import coerce_param_for_node
 from pflow.runtime.template_resolver import TemplateResolver
 
 from .template_errors import (
@@ -70,7 +70,7 @@ def split_params(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Separate params into template_params and static_params.
 
-    Static params get type coercion via coerce_to_declared_type.
+    Static params get type coercion via coerce_param_for_node.
     _source_line keys are kept in static_params (nodes read them for error
     reporting, e.g. python_code.py uses _code_source_line for line numbers).
     They are filtered out later by compute_node_config() for cache hashing.
@@ -90,7 +90,7 @@ def split_params(
             template_params[key] = value
         else:
             expected_type = expected_types.get(key)
-            coerced_value = coerce_to_declared_type(value, expected_type)
+            coerced_value = coerce_param_for_node(value, expected_type)
             static_params[key] = coerced_value
 
     return template_params, static_params
@@ -335,7 +335,7 @@ def resolve_templates(  # noqa: C901
         # Reverse: serialize dict/list -> str when expected type is str
         if isinstance(resolved_value, (dict, list)):
             expected_type = template_config.expected_types.get(key)
-            resolved_value = coerce_to_declared_type(resolved_value, expected_type)
+            resolved_value = coerce_param_for_node(resolved_value, expected_type)
 
         # Type validation for simple templates
         if is_simple_template:

--- a/tests/test_core/test_param_coercion.py
+++ b/tests/test_core/test_param_coercion.py
@@ -1,13 +1,13 @@
 """Tests for parameter type coercion utilities.
 
 Focus:
-1. Behavior that matters for MCP tools expecting JSON strings (coerce_to_declared_type)
-2. CLI input coercion to match workflow input declarations (coerce_input_to_declared_type)
+1. Behavior that matters for MCP tools expecting JSON strings (coerce_param_for_node)
+2. CLI input coercion to match workflow input declarations (coerce_workflow_input)
 """
 
 import json
 
-from pflow.core.param_coercion import coerce_input_to_declared_type, coerce_to_declared_type
+from pflow.core.param_coercion import coerce_param_for_node, coerce_workflow_input
 
 
 class TestDictToStringCoercion:
@@ -15,7 +15,7 @@ class TestDictToStringCoercion:
 
     def test_dict_becomes_json_string_when_type_is_str(self):
         """Main use case: MCP tool expects JSON string, we have dict."""
-        result = coerce_to_declared_type({"channel_id": "123"}, "str")
+        result = coerce_param_for_node({"channel_id": "123"}, "str")
 
         assert isinstance(result, str)
         # Should be valid JSON that parses back to original
@@ -24,7 +24,7 @@ class TestDictToStringCoercion:
     def test_nested_dict_serializes_correctly(self):
         """Nested structures should serialize to valid JSON."""
         value = {"outer": {"inner": {"deep": "value"}}}
-        result = coerce_to_declared_type(value, "str")
+        result = coerce_param_for_node(value, "str")
 
         assert isinstance(result, str)
         assert json.loads(result) == value
@@ -35,7 +35,7 @@ class TestListToStringCoercion:
 
     def test_list_becomes_json_string_when_type_is_str(self):
         """List should serialize to JSON array string."""
-        result = coerce_to_declared_type([1, 2, 3], "str")
+        result = coerce_param_for_node([1, 2, 3], "str")
 
         assert isinstance(result, str)
         assert json.loads(result) == [1, 2, 3]
@@ -43,7 +43,7 @@ class TestListToStringCoercion:
     def test_list_of_dicts_serializes_correctly(self):
         """Complex list structures should serialize properly."""
         value = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
-        result = coerce_to_declared_type(value, "str")
+        result = coerce_param_for_node(value, "str")
 
         assert isinstance(result, str)
         assert json.loads(result) == value
@@ -55,7 +55,7 @@ class TestNoCoercionWhenTypeMatches:
     def test_dict_unchanged_when_type_is_dict(self):
         """Dict stays dict when expected type is dict."""
         original = {"key": "value"}
-        result = coerce_to_declared_type(original, "dict")
+        result = coerce_param_for_node(original, "dict")
 
         assert result is original  # Same object, not serialized
         assert isinstance(result, dict)
@@ -63,7 +63,7 @@ class TestNoCoercionWhenTypeMatches:
     def test_dict_unchanged_when_type_is_object(self):
         """Dict stays dict when expected type is object (JSON Schema alias)."""
         original = {"key": "value"}
-        result = coerce_to_declared_type(original, "object")
+        result = coerce_param_for_node(original, "object")
 
         assert result is original
         assert isinstance(result, dict)
@@ -71,7 +71,7 @@ class TestNoCoercionWhenTypeMatches:
     def test_list_unchanged_when_type_is_list(self):
         """List stays list when expected type is list."""
         original = [1, 2, 3]
-        result = coerce_to_declared_type(original, "list")
+        result = coerce_param_for_node(original, "list")
 
         assert result is original
         assert isinstance(result, list)
@@ -79,7 +79,7 @@ class TestNoCoercionWhenTypeMatches:
     def test_list_unchanged_when_type_is_array(self):
         """List stays list when expected type is array (JSON Schema alias)."""
         original = [1, 2, 3]
-        result = coerce_to_declared_type(original, "array")
+        result = coerce_param_for_node(original, "array")
 
         assert result is original
         assert isinstance(result, list)
@@ -90,24 +90,24 @@ class TestPassthroughBehavior:
 
     def test_string_unchanged_when_type_is_str(self):
         """String passes through unchanged (no double-encoding)."""
-        result = coerce_to_declared_type("already a string", "str")
+        result = coerce_param_for_node("already a string", "str")
         assert result == "already a string"
 
     def test_json_string_not_double_encoded(self):
         """If user already passed JSON string, don't double-encode."""
         json_string = '{"already": "json"}'
-        result = coerce_to_declared_type(json_string, "str")
+        result = coerce_param_for_node(json_string, "str")
         assert result == json_string  # Same string, not '"{...}"'
 
     def test_none_passes_through(self):
         """None should pass through (let node handle it)."""
-        result = coerce_to_declared_type(None, "str")
+        result = coerce_param_for_node(None, "str")
         assert result is None
 
     def test_no_coercion_when_type_unknown(self):
         """No coercion when expected_type is None (unknown)."""
         original = {"key": "value"}
-        result = coerce_to_declared_type(original, None)
+        result = coerce_param_for_node(original, None)
         assert result is original
 
 
@@ -116,7 +116,7 @@ class TestUnicodeHandling:
 
     def test_unicode_in_dict_serializes_correctly(self):
         """Unicode characters should serialize and parse correctly."""
-        result = coerce_to_declared_type({"emoji": "🚀", "chinese": "你好"}, "str")
+        result = coerce_param_for_node({"emoji": "🚀", "chinese": "你好"}, "str")
 
         assert isinstance(result, str)
         parsed = json.loads(result)
@@ -125,7 +125,7 @@ class TestUnicodeHandling:
 
     def test_special_characters_in_values(self):
         """Special characters (newlines, quotes) should be escaped."""
-        result = coerce_to_declared_type({"text": 'line1\nline2\twith "quotes"'}, "str")
+        result = coerce_param_for_node({"text": 'line1\nline2\twith "quotes"'}, "str")
 
         assert isinstance(result, str)
         parsed = json.loads(result)
@@ -142,7 +142,7 @@ class TestNonSerializableHandling:
             pass
 
         original = {"obj": CustomClass()}
-        result = coerce_to_declared_type(original, "str")
+        result = coerce_param_for_node(original, "str")
 
         # Should return original dict (not crash)
         assert result is original
@@ -154,13 +154,13 @@ class TestNonSerializableHandling:
 
         # File handles are not JSON serializable
         original = {"file": io.StringIO("test")}
-        result = coerce_to_declared_type(original, "str")
+        result = coerce_param_for_node(original, "str")
 
         assert result is original
 
 
 # =============================================================================
-# Tests for coerce_input_to_declared_type (CLI input → declared type)
+# Tests for coerce_workflow_input (CLI input → declared type)
 # =============================================================================
 
 
@@ -175,21 +175,21 @@ class TestInputCoercionIntToString:
         """THE BUG FIX: Discord snowflake ID should remain string."""
         # CLI's infer_type() converts "1458059302022549698" to int
         # But workflow declares type: string
-        result = coerce_input_to_declared_type(1458059302022549698, "string")
+        result = coerce_workflow_input(1458059302022549698, "string")
 
         assert isinstance(result, str)
         assert result == "1458059302022549698"
 
     def test_float_coerced_to_string_when_declared_string(self):
         """Floats should also coerce to string."""
-        result = coerce_input_to_declared_type(3.14159, "string")
+        result = coerce_workflow_input(3.14159, "string")
 
         assert isinstance(result, str)
         assert result == "3.14159"
 
     def test_bool_coerced_to_string_when_declared_string(self):
         """Booleans should coerce to string."""
-        result = coerce_input_to_declared_type(True, "string")
+        result = coerce_workflow_input(True, "string")
 
         assert isinstance(result, str)
         assert result == "True"
@@ -197,13 +197,13 @@ class TestInputCoercionIntToString:
     def test_string_unchanged_when_declared_string(self):
         """String stays string (no change needed)."""
         original = "already a string"
-        result = coerce_input_to_declared_type(original, "string")
+        result = coerce_workflow_input(original, "string")
 
         assert result is original  # Same object
 
     def test_type_alias_str_works(self):
         """Type alias 'str' should work like 'string'."""
-        result = coerce_input_to_declared_type(42, "str")
+        result = coerce_workflow_input(42, "str")
 
         assert isinstance(result, str)
         assert result == "42"
@@ -214,14 +214,14 @@ class TestInputCoercionStringToInt:
 
     def test_numeric_string_coerced_to_int(self):
         """String "42" should become int 42 when declared integer."""
-        result = coerce_input_to_declared_type("42", "integer")
+        result = coerce_workflow_input("42", "integer")
 
         assert isinstance(result, int)
         assert result == 42
 
     def test_negative_string_coerced_to_int(self):
         """Negative number strings should work."""
-        result = coerce_input_to_declared_type("-123", "integer")
+        result = coerce_workflow_input("-123", "integer")
 
         assert isinstance(result, int)
         assert result == -123
@@ -229,19 +229,19 @@ class TestInputCoercionStringToInt:
     def test_int_unchanged_when_declared_integer(self):
         """Int stays int when already correct type."""
         original = 42
-        result = coerce_input_to_declared_type(original, "integer")
+        result = coerce_workflow_input(original, "integer")
 
         assert result is original
 
     def test_invalid_string_returns_original(self):
         """Non-numeric string can't coerce, returns original."""
-        result = coerce_input_to_declared_type("hello", "integer")
+        result = coerce_workflow_input("hello", "integer")
 
         assert result == "hello"  # Unchanged
 
     def test_type_alias_int_works(self):
         """Type alias 'int' should work like 'integer'."""
-        result = coerce_input_to_declared_type("99", "int")
+        result = coerce_workflow_input("99", "int")
 
         assert isinstance(result, int)
         assert result == 99
@@ -252,21 +252,21 @@ class TestInputCoercionStringToNumber:
 
     def test_decimal_string_coerced_to_float(self):
         """String "3.14" should become float."""
-        result = coerce_input_to_declared_type("3.14", "number")
+        result = coerce_workflow_input("3.14", "number")
 
         assert isinstance(result, float)
         assert result == 3.14
 
     def test_integer_string_coerced_to_float(self):
         """Integer string should also work for number type."""
-        result = coerce_input_to_declared_type("42", "number")
+        result = coerce_workflow_input("42", "number")
 
         assert isinstance(result, float)
         assert result == 42.0
 
     def test_type_alias_float_works(self):
         """Type alias 'float' should work like 'number'."""
-        result = coerce_input_to_declared_type("2.718", "float")
+        result = coerce_workflow_input("2.718", "float")
 
         assert isinstance(result, float)
         assert result == 2.718
@@ -278,29 +278,29 @@ class TestInputCoercionStringToBool:
     def test_true_strings_coerce_to_true(self):
         """Various 'true' strings should become True."""
         for value in ["true", "True", "TRUE", "1", "yes", "Yes"]:
-            result = coerce_input_to_declared_type(value, "boolean")
+            result = coerce_workflow_input(value, "boolean")
             assert result is True, f"Expected True for '{value}'"
 
     def test_false_strings_coerce_to_false(self):
         """Various 'false' strings should become False."""
         for value in ["false", "False", "FALSE", "0", "no", "No"]:
-            result = coerce_input_to_declared_type(value, "boolean")
+            result = coerce_workflow_input(value, "boolean")
             assert result is False, f"Expected False for '{value}'"
 
     def test_invalid_bool_string_returns_original(self):
         """Invalid boolean string returns original."""
-        result = coerce_input_to_declared_type("maybe", "boolean")
+        result = coerce_workflow_input("maybe", "boolean")
 
         assert result == "maybe"
 
     def test_bool_unchanged_when_declared_boolean(self):
         """Bool stays bool when already correct type."""
-        assert coerce_input_to_declared_type(True, "boolean") is True
-        assert coerce_input_to_declared_type(False, "boolean") is False
+        assert coerce_workflow_input(True, "boolean") is True
+        assert coerce_workflow_input(False, "boolean") is False
 
     def test_type_alias_bool_works(self):
         """Type alias 'bool' should work like 'boolean'."""
-        result = coerce_input_to_declared_type("yes", "bool")
+        result = coerce_workflow_input("yes", "bool")
 
         assert result is True
 
@@ -310,40 +310,40 @@ class TestInputCoercionStringToObject:
 
     def test_json_object_string_coerced_to_dict(self):
         """Valid JSON object string should become dict."""
-        result = coerce_input_to_declared_type('{"key": "value"}', "object")
+        result = coerce_workflow_input('{"key": "value"}', "object")
 
         assert isinstance(result, dict)
         assert result == {"key": "value"}
 
     def test_nested_json_object_works(self):
         """Nested JSON should parse correctly."""
-        result = coerce_input_to_declared_type('{"outer": {"inner": 42}}', "object")
+        result = coerce_workflow_input('{"outer": {"inner": 42}}', "object")
 
         assert isinstance(result, dict)
         assert result["outer"]["inner"] == 42
 
     def test_invalid_json_returns_original(self):
         """Invalid JSON string returns original."""
-        result = coerce_input_to_declared_type("not json", "object")
+        result = coerce_workflow_input("not json", "object")
 
         assert result == "not json"
 
     def test_json_array_returns_original_for_object(self):
         """JSON array should NOT coerce to object type."""
-        result = coerce_input_to_declared_type("[1, 2, 3]", "object")
+        result = coerce_workflow_input("[1, 2, 3]", "object")
 
         assert result == "[1, 2, 3]"  # Original string
 
     def test_dict_unchanged_when_declared_object(self):
         """Dict stays dict when already correct type."""
         original = {"key": "value"}
-        result = coerce_input_to_declared_type(original, "object")
+        result = coerce_workflow_input(original, "object")
 
         assert result is original
 
     def test_type_alias_dict_works(self):
         """Type alias 'dict' should work like 'object'."""
-        result = coerce_input_to_declared_type('{"a": 1}', "dict")
+        result = coerce_workflow_input('{"a": 1}', "dict")
 
         assert isinstance(result, dict)
 
@@ -353,14 +353,14 @@ class TestInputCoercionStringToArray:
 
     def test_json_array_string_coerced_to_list(self):
         """Valid JSON array string should become list."""
-        result = coerce_input_to_declared_type("[1, 2, 3]", "array")
+        result = coerce_workflow_input("[1, 2, 3]", "array")
 
         assert isinstance(result, list)
         assert result == [1, 2, 3]
 
     def test_array_of_objects_works(self):
         """Array of objects should parse correctly."""
-        result = coerce_input_to_declared_type('[{"id": 1}, {"id": 2}]', "array")
+        result = coerce_workflow_input('[{"id": 1}, {"id": 2}]', "array")
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -368,20 +368,20 @@ class TestInputCoercionStringToArray:
 
     def test_json_object_returns_original_for_array(self):
         """JSON object should NOT coerce to array type."""
-        result = coerce_input_to_declared_type('{"key": "value"}', "array")
+        result = coerce_workflow_input('{"key": "value"}', "array")
 
         assert result == '{"key": "value"}'  # Original string
 
     def test_list_unchanged_when_declared_array(self):
         """List stays list when already correct type."""
         original = [1, 2, 3]
-        result = coerce_input_to_declared_type(original, "array")
+        result = coerce_workflow_input(original, "array")
 
         assert result is original
 
     def test_type_alias_list_works(self):
         """Type alias 'list' should work like 'array'."""
-        result = coerce_input_to_declared_type("[4, 5]", "list")
+        result = coerce_workflow_input("[4, 5]", "list")
 
         assert isinstance(result, list)
 
@@ -391,21 +391,21 @@ class TestInputCoercionNoType:
 
     def test_no_type_returns_original_int(self):
         """Without declared type, int stays int."""
-        result = coerce_input_to_declared_type(42, None)
+        result = coerce_workflow_input(42, None)
 
         assert result == 42
         assert isinstance(result, int)
 
     def test_no_type_returns_original_string(self):
         """Without declared type, string stays string."""
-        result = coerce_input_to_declared_type("hello", None)
+        result = coerce_workflow_input("hello", None)
 
         assert result == "hello"
 
     def test_no_type_returns_original_dict(self):
         """Without declared type, dict stays dict."""
         original = {"key": "value"}
-        result = coerce_input_to_declared_type(original, None)
+        result = coerce_workflow_input(original, None)
 
         assert result is original
 
@@ -415,12 +415,12 @@ class TestInputCoercionUnknownType:
 
     def test_unknown_type_returns_original(self):
         """Unknown type names should return original value."""
-        result = coerce_input_to_declared_type("test", "custom_type")
+        result = coerce_workflow_input("test", "custom_type")
 
         assert result == "test"
 
     def test_empty_type_returns_original(self):
         """Empty string type should return original value."""
-        result = coerce_input_to_declared_type(42, "")
+        result = coerce_workflow_input(42, "")
 
         assert result == 42

--- a/tests/test_runtime/test_prepare_inputs_coercion.py
+++ b/tests/test_runtime/test_prepare_inputs_coercion.py
@@ -1,6 +1,6 @@
 """Tests for workflow input type coercion in prepare_inputs().
 
-This tests the integration of coerce_input_to_declared_type() into the
+This tests the integration of coerce_workflow_input() into the
 workflow validation pipeline, ensuring CLI-provided values are coerced
 to match declared input types.
 


### PR DESCRIPTION
## Summary

Rename the two confusing coercion functions in `param_coercion.py` to communicate their pipeline stage:

- `coerce_to_declared_type` → `coerce_param_for_node` (narrow: only dict/list→JSON when type is "str")
- `coerce_input_to_declared_type` → `coerce_workflow_input` (broad: full bidirectional coercion for CLI/env values)

## Changes

- Renamed both functions and updated all 4 call sites
- Updated module docstring to clarify the two-function design
- Improved `coerce_param_for_node` docstring to emphasize it's intentionally narrow
- Updated doctests, test file imports, section comments
- Updated CLAUDE.md documentation in `core/` and `runtime/compilation/`

## Explanation

The old names (`coerce_to_declared_type` vs `coerce_input_to_declared_type`) were near-identical, making it easy to call the wrong one. The shorter name sounded like the general function but was actually the narrow special case. An agent calling the wrong one would either serialize dicts when they should pass through, or coerce strings to ints when they should stay as strings.

The new names disambiguate by pipeline position — the caller's primary question is "which one do I use HERE?", not "what does it do internally?"

## Testing

All 4832 tests pass. `make check` clean (ruff + mypy + deptry).

```
make test   # 4832 passed
make check  # all clean
```