### PR TITLE
fix: workflow scan warnings leak into unrelated commands (fixes #279)

### DIFF
--- a/src/pflow/cli/commands/describe.py
+++ b/src/pflow/cli/commands/describe.py
@@ -30,8 +30,8 @@ def describe_cmd(name: str) -> None:
 
 
 def _handle_workflow_not_found(name: str, workflow_manager: WorkflowManager) -> None:
-    all_workflows = workflow_manager.list_all()
-    similar = [workflow["name"] for workflow in all_workflows if name.lower() in workflow["name"].lower()][:3]
+    all_names = workflow_manager.list_names()
+    similar = [n for n in all_names if name.lower() in n.lower()][:3]
     click.echo(f"Error: Workflow '{name}' not found.", err=True)
     if similar:
         click.echo(f"  Did you mean: {', '.join(similar)}", err=True)

--- a/src/pflow/cli/commands/find.py
+++ b/src/pflow/cli/commands/find.py
@@ -54,5 +54,5 @@ def find_cmd(query: str) -> None:
         click.echo(format_discovery_result(result_dict, result.workflow))
         return
 
-    all_workflows = workflow_manager.list_all()
-    click.echo(format_no_matches_with_suggestions(all_workflows, validated_query, reasoning=result.reasoning))
+    all_names = workflow_manager.list_names()
+    click.echo(format_no_matches_with_suggestions(all_names, validated_query, reasoning=result.reasoning))

--- a/src/pflow/cli/commands/history.py
+++ b/src/pflow/cli/commands/history.py
@@ -29,8 +29,8 @@ def history_cmd(workflow_name: str) -> None:
 
 
 def _handle_workflow_not_found(workflow_name: str, workflow_manager: WorkflowManager) -> None:
-    all_workflows = workflow_manager.list_all()
-    similar = [workflow["name"] for workflow in all_workflows if workflow_name.lower() in workflow["name"].lower()][:3]
+    all_names = workflow_manager.list_names()
+    similar = [n for n in all_names if workflow_name.lower() in n.lower()][:3]
     click.echo(f"Error: Workflow '{workflow_name}' not found.", err=True)
     if similar:
         click.echo(f"  Did you mean: {', '.join(similar)}", err=True)

--- a/src/pflow/core/workflow/manager.py
+++ b/src/pflow/core/workflow/manager.py
@@ -309,6 +309,8 @@ class WorkflowManager:
     def list_names(self) -> list[str]:
         """List workflow names (directory names with valid entry points, no parsing).
 
+        Skips hidden directories (starting with '.').
+
         Returns:
             Sorted list of workflow names
         """

--- a/src/pflow/core/workflow/manager.py
+++ b/src/pflow/core/workflow/manager.py
@@ -306,8 +306,24 @@ class WorkflowManager:
         """
         return str(self._entry_point(name).resolve())
 
+    def list_names(self) -> list[str]:
+        """List workflow names (directory names with valid entry points, no parsing).
+
+        Returns:
+            Sorted list of workflow names
+        """
+        if not self.workflows_dir.exists():
+            return []
+        return sorted(
+            d.name
+            for d in self.workflows_dir.iterdir()
+            if d.is_dir() and not d.name.startswith(".") and (d / f"{d.name}.pflow.md").exists()
+        )
+
     def list_all(self) -> list[dict[str, Any]]:
-        """List all workflows in the directory.
+        """List all workflows in the directory with full metadata.
+
+        Silently skips workflows that fail to parse. Use --verbose to see details.
 
         Returns:
             List of workflow metadata dicts (flat structure), sorted by name
@@ -324,7 +340,7 @@ class WorkflowManager:
             name = workflow_dir.name
             entry_point = workflow_dir / f"{name}.pflow.md"
             if not entry_point.exists():
-                logger.warning(f"Workflow dir '{name}' missing entry point {name}.pflow.md, skipping")
+                logger.info(f"Workflow dir '{name}' missing entry point {name}.pflow.md, skipping")
                 continue
 
             try:
@@ -333,7 +349,8 @@ class WorkflowManager:
                 fm = result.metadata or {}
                 workflows.append(self._build_metadata_dict(name, result, fm))
             except Exception as e:
-                logger.warning(f"Failed to load workflow from {entry_point}: {e}")
+                msg = getattr(e, "raw_message", None) or str(e).split("\n", 1)[0]
+                logger.info(f"Skipping workflow '{name}': {msg}")
                 continue
 
         return workflows

--- a/src/pflow/execution/formatters/discovery_formatter.py
+++ b/src/pflow/execution/formatters/discovery_formatter.py
@@ -218,7 +218,7 @@ def format_workflow_inputs_outputs(ir: dict[str, Any]) -> list[str]:
 
 
 def format_no_matches_with_suggestions(
-    workflows: list[dict[str, Any]],
+    workflow_names: list[str],
     query: str,
     reasoning: str | None = None,
     max_suggestions: int = 10,
@@ -230,22 +230,17 @@ def format_no_matches_with_suggestions(
     Optionally includes LLM reasoning to explain why no match was found.
 
     Args:
-        workflows: List of workflow metadata dicts with 'name' and 'description'
+        workflow_names: List of workflow names
         query: The user's original search query
         reasoning: Optional LLM reasoning explaining why no match was found
-        max_suggestions: Maximum number of suggestions to show (default: 5)
+        max_suggestions: Maximum number of suggestions to show (default: 10)
 
     Returns:
         Formatted string with suggestions and guidance
 
     Example:
-        >>> workflows = [
-        ...     {"name": "test-workflow", "description": "Test workflow"},
-        ...     {"name": "github-analyzer", "description": "Analyze GitHub PRs"}
-        ... ]
-        >>> result = format_no_matches_with_suggestions(workflows, "test something")
-        >>> "Possibly related workflows:" in result
-        True
+        >>> names = ["test-workflow", "github-analyzer"]
+        >>> result = format_no_matches_with_suggestions(names, "test something")
         >>> "test-workflow" in result
         True
     """
@@ -258,21 +253,15 @@ def format_no_matches_with_suggestions(
     if reasoning:
         lines.append(f"\nWhy: {reasoning}")
 
-    if workflows:
-        # TODO: Change label back to "Possibly related workflows:" after enhancing LLM
-        # to return top 3-5 matches with individual confidence scores instead of just
-        # returning all workflows via list_all(). Current implementation shows ALL
-        # workflows, not LLM-ranked suggestions.
+    if workflow_names:
         lines.append("\nAvailable workflows:")
 
-        # Limit to max_suggestions
-        for workflow in workflows[:max_suggestions]:
-            name = workflow.get("name", "unknown")
+        for name in workflow_names[:max_suggestions]:
             lines.append(f"  • {name}")
 
         # Show count if more workflows exist
-        if len(workflows) > max_suggestions:
-            remaining = len(workflows) - max_suggestions
+        if len(workflow_names) > max_suggestions:
+            remaining = len(workflow_names) - max_suggestions
             lines.append(f"\n... and {remaining} more workflow{'' if remaining == 1 else 's'}")
 
     lines.append("\n**→ No match.** Build a new workflow.")

--- a/src/pflow/execution/workflow_resolver.py
+++ b/src/pflow/execution/workflow_resolver.py
@@ -214,8 +214,7 @@ def _check_inline_file_references(workflow_ir: dict[str, Any], source: str) -> N
 
 def _find_suggestions(query: str, wm: WorkflowManager) -> list[str]:
     """Find similar workflow names for error suggestions."""
-    all_workflows = wm.list_all()
-    all_names = [w.get("name", "") for w in all_workflows if w.get("name")]
+    all_names = wm.list_names()
     if not all_names:
         return []
     return find_similar_items(query, all_names, max_results=5, method="substring", sort_by_length=True)

--- a/src/pflow/mcp_server/services/discovery_service.py
+++ b/src/pflow/mcp_server/services/discovery_service.py
@@ -51,8 +51,8 @@ class DiscoveryService(BaseService):
             from pflow.execution.formatters.discovery_formatter import format_no_matches_with_suggestions
 
             logger.info("Workflow discovery found no matches")
-            all_workflows = workflow_manager.list_all()
-            return format_no_matches_with_suggestions(all_workflows, query, reasoning=result.reasoning)
+            all_names = workflow_manager.list_names()
+            return format_no_matches_with_suggestions(all_names, query, reasoning=result.reasoning)
 
     @classmethod
     @ensure_stateless

--- a/src/pflow/mcp_server/services/workflow_service.py
+++ b/src/pflow/mcp_server/services/workflow_service.py
@@ -93,8 +93,7 @@ Found {total_count} total {plural}. Try:
         # Check if workflow exists
         if not manager.exists(name):
             # Get suggestions for similar workflows
-            all_workflows = manager.list_all()
-            all_names = [w["name"] for w in all_workflows]
+            all_names = manager.list_names()
 
             from pflow.core.suggestion_utils import format_did_you_mean
 

--- a/src/pflow/registry/context_builder.py
+++ b/src/pflow/registry/context_builder.py
@@ -398,10 +398,13 @@ def build_component_context(
     # Input validation
     _validate_component_context_inputs(selected_node_ids, selected_workflow_names, registry_metadata, saved_workflows)
 
-    # Load workflows if not provided
+    # Load workflows only if some are selected
     if saved_workflows is None:
-        manager = workflow_manager if workflow_manager else WorkflowManager()
-        saved_workflows = manager.list_all()
+        if selected_workflow_names:
+            manager = workflow_manager if workflow_manager else WorkflowManager()
+            saved_workflows = manager.list_all()
+        else:
+            saved_workflows = []
 
     # Check for missing components
     error_dict = _check_missing_components(

--- a/tests/test_cli/test_workflow_commands.py
+++ b/tests/test_cli/test_workflow_commands.py
@@ -473,62 +473,50 @@ class TestWorkflowDescribeCommand:
 
     def test_describe_nonexistent_workflow_with_suggestions(self) -> None:
         """Test describing a workflow that doesn't exist with similar suggestions."""
-        all_workflows = [
-            {"name": "process-data"},
-            {"name": "process-images"},
-            {"name": "process-text"},
-            {"name": "backup-files"},
-        ]
-
         with patch("pflow.cli.commands.describe.WorkflowManager") as MockWM:
             mock_wm = MockWM.return_value
             mock_wm.exists.return_value = False
-            mock_wm.list_all.return_value = all_workflows
+            mock_wm.list_names.return_value = [
+                "process-data",
+                "process-images",
+                "process-text",
+                "backup-files",
+            ]
 
             result = invoke_cli(["describe", "process"])
 
             assert result.exit_code == 1
-            # Error messages go to stderr
             assert "Error: Workflow 'process' not found." in result.stderr
             assert "Did you mean: process-data, process-images, process-text" in result.stderr
             assert "backup-files" not in result.stderr
 
     def test_describe_nonexistent_workflow_no_suggestions(self) -> None:
         """Test describing a workflow that doesn't exist with no similar names."""
-        all_workflows = [
-            {"name": "backup-photos"},
-            {"name": "daily-report"},
-        ]
-
         with patch("pflow.cli.commands.describe.WorkflowManager") as MockWM:
             mock_wm = MockWM.return_value
             mock_wm.exists.return_value = False
-            mock_wm.list_all.return_value = all_workflows
+            mock_wm.list_names.return_value = ["backup-photos", "daily-report"]
 
             result = invoke_cli(["describe", "xyz-task"])
 
             assert result.exit_code == 1
-            # Error messages go to stderr
             assert "Error: Workflow 'xyz-task' not found." in result.stderr
             assert "Did you mean:" not in result.stderr
 
     def test_describe_workflow_case_insensitive_suggestions(self) -> None:
         """Test that suggestions are case-insensitive."""
-        all_workflows = [
-            {"name": "Backup-Photos"},
-            {"name": "backup-videos"},
-            {"name": "BACKUP-DOCS"},
-        ]
-
         with patch("pflow.cli.commands.describe.WorkflowManager") as MockWM:
             mock_wm = MockWM.return_value
             mock_wm.exists.return_value = False
-            mock_wm.list_all.return_value = all_workflows
+            mock_wm.list_names.return_value = [
+                "Backup-Photos",
+                "backup-videos",
+                "BACKUP-DOCS",
+            ]
 
             result = invoke_cli(["describe", "backup"])
 
             assert result.exit_code == 1
-            # Error messages go to stderr
             assert "Did you mean: Backup-Photos, backup-videos, BACKUP-DOCS" in result.stderr
 
     def test_describe_workflow_mixed_required_optional_inputs(self) -> None:
@@ -695,7 +683,7 @@ class TestWorkflowHistoryCommand:
         with patch("pflow.cli.commands.history.WorkflowManager") as MockWM:
             mock_wm = MockWM.return_value
             mock_wm.exists.return_value = False
-            mock_wm.list_all.return_value = []
+            mock_wm.list_names.return_value = []
 
             result = invoke_cli(["history", "nonexistent"])
 

--- a/tests/test_cli/test_workflow_resolution.py
+++ b/tests/test_cli/test_workflow_resolution.py
@@ -195,10 +195,10 @@ class TestWorkflowResolutionCLI:
             with patch("pflow.cli.commands.run.WorkflowManager", MockWM):
                 mock_wm = MockWM.return_value
                 mock_wm.exists.return_value = False
-                mock_wm.list_all.return_value = [
-                    {"name": "text-analyzer"},
-                    {"name": "text-summary"},
-                    {"name": "analyze-data"},
+                mock_wm.list_names.return_value = [
+                    "text-analyzer",
+                    "text-summary",
+                    "analyze-data",
                 ]
 
                 result = runner.invoke(main, ["text-analyz"])
@@ -216,7 +216,7 @@ class TestWorkflowResolutionCLI:
             with patch("pflow.cli.commands.run.WorkflowManager", MockWM):
                 mock_wm = MockWM.return_value
                 mock_wm.exists.return_value = False
-                mock_wm.list_all.return_value = []
+                mock_wm.list_names.return_value = []
 
                 result = runner.invoke(main, ["unknown-workflow"])
 

--- a/tests/test_core/test_workflow_manager.py
+++ b/tests/test_core/test_workflow_manager.py
@@ -270,8 +270,44 @@ class TestWorkflowManager:
             assert "updated_at" in workflow
             assert "version" in workflow
 
-    def test_list_all_skip_invalid(self, workflow_manager, sample_ir):
-        """Test that invalid files are skipped with warning."""
+    def test_list_names_returns_sorted_names(self, workflow_manager, sample_ir):
+        """Test list_names returns only names without parsing."""
+        for name in ["zz-last", "aa-first", "mm-middle"]:
+            workflow_manager.save(name, ir_to_markdown(sample_ir))
+
+        names = workflow_manager.list_names()
+
+        assert names == ["aa-first", "mm-middle", "zz-last"]
+
+    def test_list_names_skips_dirs_without_entry_point(self, workflow_manager, sample_ir):
+        """Test list_names skips directories missing the entry point file."""
+        workflow_manager.save("valid", ir_to_markdown(sample_ir))
+
+        # Directory without entry point (like 'archived' or 'temp')
+        (workflow_manager.workflows_dir / "no-entry-point").mkdir()
+
+        # Directory with wrong filename
+        bad_dir = workflow_manager.workflows_dir / "wrong-name"
+        bad_dir.mkdir()
+        (bad_dir / "other.pflow.md").write_text("# Wrong")
+
+        names = workflow_manager.list_names()
+
+        assert names == ["valid"]
+
+    def test_list_names_includes_unparseable_workflows(self, workflow_manager):
+        """Test list_names includes workflows that have entry points but fail to parse."""
+        corrupt_dir = workflow_manager.workflows_dir / "corrupt"
+        corrupt_dir.mkdir()
+        (corrupt_dir / "corrupt.pflow.md").write_text("not valid")
+
+        names = workflow_manager.list_names()
+
+        # Entry point exists, so name is included (list_names doesn't parse)
+        assert names == ["corrupt"]
+
+    def test_list_all_skip_invalid(self, workflow_manager, sample_ir, caplog):
+        """Test that invalid files are skipped silently (logged at INFO)."""
         # Save a valid workflow
         markdown_content = ir_to_markdown(sample_ir)
         workflow_manager.save("valid", markdown_content)
@@ -284,12 +320,12 @@ class TestWorkflowManager:
             f.write("not valid markdown workflow")
 
         # List should skip invalid and return only valid
-        with patch("logging.Logger.warning") as mock_warning:
-            workflows = workflow_manager.list_all()
+        caplog.set_level("INFO", logger="pflow.core.workflow.manager")
+        workflows = workflow_manager.list_all()
 
         assert len(workflows) == 1
         assert workflows[0]["name"] == "valid"
-        mock_warning.assert_called_once()
+        assert any("Skipping workflow" in record.message for record in caplog.records)
 
     def test_exists(self, workflow_manager, sample_ir):
         """Test checking if workflow exists."""
@@ -434,11 +470,11 @@ class TestWorkflowManager:
         corrupted_file = corrupted_dir / "corrupted.pflow.md"
         corrupted_file.write_text("# Corrupted\n\n## Steps\n\n### node1\n\nthis is not valid markdown workflow")
 
-        # list_all should skip it with warning
-        with caplog.at_level(logging.WARNING):
+        # list_all should skip it silently (logged at INFO)
+        with caplog.at_level(logging.INFO, logger="pflow.core.workflow.manager"):
             workflows = workflow_manager.list_all()
 
-        assert any("corrupted.pflow.md" in record.message for record in caplog.records)
+        assert any("Skipping workflow 'corrupted'" in record.message for record in caplog.records)
         assert not any(w["name"] == "corrupted" for w in workflows)
 
         # load should fail with clear validation error

--- a/tests/test_core/test_workflow_manager.py
+++ b/tests/test_core/test_workflow_manager.py
@@ -270,6 +270,11 @@ class TestWorkflowManager:
             assert "updated_at" in workflow
             assert "version" in workflow
 
+    def test_list_names_empty_when_dir_missing(self, tmp_path):
+        """Test list_names returns empty list when workflows_dir doesn't exist."""
+        manager = WorkflowManager(workflows_dir=tmp_path / "nonexistent")
+        assert manager.list_names() == []
+
     def test_list_names_returns_sorted_names(self, workflow_manager, sample_ir):
         """Test list_names returns only names without parsing."""
         for name in ["zz-last", "aa-first", "mm-middle"]:

--- a/tests/test_execution/formatters/test_discovery_formatter.py
+++ b/tests/test_execution/formatters/test_discovery_formatter.py
@@ -58,197 +58,108 @@ class TestFormatNoMatchesWithSuggestions:
 
     def test_limits_workflows_and_shows_remaining_count(self):
         """NO MATCHES: Limits displayed workflows and shows count of remaining."""
-        workflows = [{"name": f"workflow-{i}"} for i in range(15)]
+        names = [f"workflow-{i}" for i in range(15)]
         query = "test"
 
-        # Use explicit limit to test the behavior
-        formatted = format_no_matches_with_suggestions(workflows, query, max_suggestions=3)
+        formatted = format_no_matches_with_suggestions(names, query, max_suggestions=3)
 
-        # Verify header
         assert 'No workflows found matching "test" (minimum 70% confidence).' in formatted
-
-        # First 3 shown
         assert "• workflow-0" in formatted
         assert "• workflow-1" in formatted
         assert "• workflow-2" in formatted
-
-        # 4th not shown
         assert "workflow-3" not in formatted
-
-        # Remaining count displayed
         assert "... and 12 more" in formatted
-
-        # Verify guidance section
         assert "No match" in formatted
         assert "pflow guide core" in formatted
 
     def test_formats_with_few_workflows(self):
         """NO MATCHES: Shows all workflows when less than max_suggestions."""
-        workflows = [
-            {"name": "workflow-a", "description": "First workflow"},
-            {"name": "workflow-b", "description": "Second workflow"},
-            {"name": "workflow-c", "description": "Third workflow"},
-        ]
+        names = ["workflow-a", "workflow-b", "workflow-c"]
         query = "find something"
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
+        formatted = format_no_matches_with_suggestions(names, query)
 
-        # All 3 workflows should be shown
         assert "• workflow-a" in formatted
         assert "• workflow-b" in formatted
         assert "• workflow-c" in formatted
-
-        # No "... and X more" message
         assert "... and" not in formatted
 
     def test_formats_with_empty_workflow_list(self):
-        """NO MATCHES: Empty list shows different message."""
-        workflows = []
-        query = "test query"
+        """NO MATCHES: Empty list shows guidance to build new."""
+        formatted = format_no_matches_with_suggestions([], "test query")
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Verify header
         assert 'No workflows found matching "test query"' in formatted
-
-        # No "Available workflows" section
         assert "Available workflows:" not in formatted
-
-        # Guidance to build new
         assert "No match" in formatted
         assert "pflow guide core" in formatted
 
-    def test_shows_names_only(self):
-        """NO MATCHES: Shows only workflow names without descriptions."""
-        workflows = [
-            {
-                "name": "my-workflow",
-                "description": "This description should not appear in output",
-            }
-        ]
-        query = "test"
-
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Name should appear
-        assert "• my-workflow" in formatted
-        # Description should not appear
-        assert "This description should not appear" not in formatted
-
-    def test_handles_missing_names(self):
-        """NO MATCHES: Missing names show default text."""
-        workflows = [
-            {"description": "Has description but no name"},  # Missing name
-        ]
-        query = "test"
-
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        assert "• unknown" in formatted
-
     def test_respects_max_suggestions_parameter(self):
         """NO MATCHES: Respects custom max_suggestions limit."""
-        workflows = [{"name": f"workflow-{i}", "description": f"Workflow {i}"} for i in range(10)]
-        query = "test"
+        names = [f"workflow-{i}" for i in range(10)]
 
-        # Custom limit of 3
-        formatted = format_no_matches_with_suggestions(workflows, query, max_suggestions=3)
+        formatted = format_no_matches_with_suggestions(names, "test", max_suggestions=3)
 
-        # First 3 workflows shown
         assert "• workflow-0" in formatted
         assert "• workflow-1" in formatted
         assert "• workflow-2" in formatted
-
-        # 4th workflow not shown
         assert "workflow-3" not in formatted
-
-        # Count of remaining
         assert "... and 7 more workflows" in formatted
 
     def test_formats_singular_remaining_count(self):
         """NO MATCHES: Uses singular 'workflow' when 1 remaining."""
-        workflows = [{"name": f"workflow-{i}"} for i in range(4)]
-        query = "test"
+        names = [f"workflow-{i}" for i in range(4)]
 
-        formatted = format_no_matches_with_suggestions(workflows, query, max_suggestions=3)
+        formatted = format_no_matches_with_suggestions(names, "test", max_suggestions=3)
 
-        # 4 workflows, showing 3, 1 remaining
-        assert "... and 1 more workflow" in formatted  # Singular
-        assert "... and 1 more workflows" not in formatted  # Not plural
+        assert "... and 1 more workflow" in formatted
+        assert "... and 1 more workflows" not in formatted
 
     def test_formats_plural_remaining_count(self):
         """NO MATCHES: Uses plural 'workflows' when multiple remaining."""
-        workflows = [{"name": f"w-{i}"} for i in range(6)]
-        query = "test"
+        names = [f"w-{i}" for i in range(6)]
 
-        formatted = format_no_matches_with_suggestions(workflows, query, max_suggestions=3)
+        formatted = format_no_matches_with_suggestions(names, "test", max_suggestions=3)
 
-        # 6 workflows, showing 3, 3 remaining
-        assert "... and 3 more workflows" in formatted  # Plural
+        assert "... and 3 more workflows" in formatted
 
     def test_handles_special_characters_in_query(self):
         """NO MATCHES: Query with special chars displayed correctly."""
-        workflows = [{"name": "test", "description": "Test workflow"}]
         query = 'test with "quotes" and $special chars'
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
+        formatted = format_no_matches_with_suggestions(["test"], query)
 
-        # Query should be preserved exactly in header
         assert 'No workflows found matching "test with "quotes" and $special chars"' in formatted
 
     def test_handles_special_characters_in_names(self):
         """NO MATCHES: Names with special chars displayed correctly."""
-        workflows = [
-            {
-                "name": "special-workflow-${var}",
-                "description": "Some description",
-            }
-        ]
-        query = "test"
+        formatted = format_no_matches_with_suggestions(["special-workflow-${var}"], "test")
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Special characters in name preserved
         assert "• special-workflow-${var}" in formatted
 
     def test_includes_reasoning_when_provided(self):
         """NO MATCHES: Shows LLM reasoning when available."""
-        workflows = [{"name": "test", "description": "Test workflow"}]
-        query = "something random"
         reasoning = "The query is too vague and doesn't match any specific workflow purpose."
 
-        formatted = format_no_matches_with_suggestions(workflows, query, reasoning=reasoning)
+        formatted = format_no_matches_with_suggestions(["test"], "something random", reasoning=reasoning)
 
-        # Reasoning should be displayed
         assert "Why: The query is too vague" in formatted
         assert "doesn't match any specific workflow purpose" in formatted
 
     def test_omits_reasoning_section_when_none(self):
         """NO MATCHES: No 'Why:' section when reasoning is None."""
-        workflows = [{"name": "test", "description": "Test"}]
-        query = "test"
+        formatted = format_no_matches_with_suggestions(["test"], "test", reasoning=None)
 
-        formatted = format_no_matches_with_suggestions(workflows, query, reasoning=None)
-
-        # No 'Why:' section
         assert "Why:" not in formatted
 
     def test_reasoning_appears_before_suggestions(self):
         """NO MATCHES: Reasoning appears after header but before suggestions."""
-        workflows = [{"name": "test", "description": "Test"}]
-        query = "test"
-        reasoning = "Query is too vague."
-
-        formatted = format_no_matches_with_suggestions(workflows, query, reasoning=reasoning)
+        formatted = format_no_matches_with_suggestions(["test"], "test", reasoning="Query is too vague.")
 
         lines = formatted.split("\n")
-
-        # Find line indices
-        header_idx = 0  # First line
+        header_idx = 0
         why_idx = next(i for i, line in enumerate(lines) if line.startswith("Why:"))
         suggestions_idx = next(i for i, line in enumerate(lines) if "Available workflows:" in line)
 
-        # Verify order: header < why < suggestions
         assert header_idx < why_idx < suggestions_idx
 
 
@@ -303,32 +214,9 @@ class TestEdgeCases:
 
     def test_empty_query_displays_correctly(self):
         """EDGE: Empty query string handled gracefully."""
-        workflows = [{"name": "test", "description": "Test"}]
-        query = ""
+        formatted = format_no_matches_with_suggestions(["test"], "")
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Empty query should be shown in quotes
         assert 'No workflows found matching ""' in formatted
-
-    def test_workflows_without_name_key(self):
-        """EDGE: Workflows missing 'name' key show 'unknown'."""
-        workflows = [{"description": "No name provided"}]
-        query = "test"
-
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        assert "• unknown" in formatted
-
-    def test_workflows_with_none_values(self):
-        """EDGE: None values handled as missing."""
-        workflows = [{"name": "test", "description": None}]
-        query = "test"
-
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Name should appear without description
-        assert "• test" in formatted
 
 
 class TestCLIParity:
@@ -336,37 +224,23 @@ class TestCLIParity:
 
     def test_bullet_character_matches_cli(self):
         """PARITY: Uses bullet character (•) like CLI."""
-        workflows = [{"name": "test", "description": "Test"}]
-        query = "test"
+        formatted = format_no_matches_with_suggestions(["test"], "test")
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Verify bullet character
         assert "  • test" in formatted
 
     def test_guidance_format_matches_cli(self):
         """PARITY: Guidance section format matches CLI."""
-        workflows = [{"name": "test", "description": "Test"}]
-        query = "test"
+        formatted = format_no_matches_with_suggestions(["test"], "test")
 
-        formatted = format_no_matches_with_suggestions(workflows, query)
-
-        # Verify actionable guidance
         assert "No match" in formatted
         assert "pflow guide core" in formatted
         assert "pflow find" in formatted
 
     def test_section_spacing_matches_cli(self):
         """PARITY: Blank lines between sections match CLI."""
-        workflows = [{"name": "test", "description": "Test"}]
-        query = "test"
-
-        formatted = format_no_matches_with_suggestions(workflows, query)
+        formatted = format_no_matches_with_suggestions(["test"], "test")
 
         lines = formatted.split("\n")
-
-        # Find key sections
         suggestions_idx = lines.index("Available workflows:")
 
-        # Verify blank lines before sections
         assert lines[suggestions_idx - 1] == ""  # Blank before suggestions


### PR DESCRIPTION
## Summary

Commands like `pflow mcp find`, `pflow describe <bad-name>`, and `pflow history <bad-name>` emitted noisy multi-line WARNING messages about broken workflows in `~/.pflow/workflows/` — even though they have nothing to do with workflow management.

## Changes

Three independent fixes, each correct on its own:

1. **`WorkflowManager.list_names()`** — new method for cheap directory enumeration (stat only, no parsing). Six "did you mean?" callers switched from `list_all()` to `list_names()`. These callers only used the `name` field anyway.

2. **`list_all()` logs at INFO, not WARNING** — its job is returning valid workflows, not diagnosing the library. Visible with `--verbose`. Error messages trimmed to one line via `raw_message`.

3. **`build_component_context()` guard** — skip `list_all()` when `selected_workflow_names` is empty. Prevents `pflow mcp find` and MCP `registry_discover` from scanning workflows at all.

Additionally, `format_no_matches_with_suggestions()` now accepts `list[str]` instead of `list[dict]` since it only ever used the name field.

## Explanation

`WorkflowManager.list_all()` was used for two fundamentally different purposes: full metadata listing (needs parsing) and name enumeration (just needs directory names). The single method always did the expensive thing — parse every `.pflow.md` — and warned loudly about every failure. A single broken workflow polluted the output of many unrelated commands.

The `build_component_context()` issue was a separate coupling bug: `pflow mcp find` called `find_components()` which unconditionally called `build_component_context()` which called `list_all()` — even though `selected_workflow_names` was always `[]` and the loaded workflow data was never used.

## Testing

- 4758 tests pass (`make test`)
- `make check` clean (ruff, mypy, deptry)
- Manual verification: `pflow describe nonexistent` and `pflow --verbose list` produce expected output