### PR TITLE
feat: stdout routing symmetric with stdin (fixes #281)

### DIFF
--- a/architecture/features/shell-pipes.md
+++ b/architecture/features/shell-pipes.md
@@ -132,6 +132,40 @@ pflow summarize --format=json | jq '.summary'
 
 This enables pflow to be a true citizen in Unix pipelines, composing naturally with grep, awk, jq, and other tools.
 
+### Stdout Output Routing
+
+Workflows with multiple declared outputs mark one with `stdout: true` to pick which output lands on process stdout in text mode. This mirrors the stdin input model: a single routing slot, declared at authoring time, enforced by the validator.
+
+```markdown
+## Outputs
+
+### message
+
+Primary result — streams to stdout in text mode.
+
+- source: ${emit.stdout}
+- stdout: true
+
+### length
+
+Secondary metadata. Available via `-o length` or `--output-format json`.
+
+- source: ${count.stdout}
+```
+
+**Precedence (text mode):**
+
+1. `-o <name>` on the command line — caller override always wins.
+2. The output marked `stdout: true` — one per workflow, validator-enforced.
+3. The single declared output — implicit when only one exists (no marker needed).
+4. First declared output, with a stderr warning naming the other outputs and the three ways to change the routing (`stdout: true`, `-o`, `--output-format json`) — when multiple outputs are declared and none are marked. The warning is suppressed under `-p`, matching the auto-detect-warning pattern.
+
+**Label rendering.** When stdout is a TTY, the CLI prefixes the value with a `Workflow output (<description>):` header on stderr so an interactive user sees what they're looking at. When stdout is redirected or piped, the label is suppressed — the `✓ Workflow completed` summary already confirms success and a naked label with the value elsewhere reads as "empty output" to both humans and agents.
+
+**JSON mode is unaffected.** `--output-format json` emits every declared output as a structured JSON object. The `stdout: true` marker is a text-mode-only routing hint.
+
+**Nested workflows.** `stdout: true` only applies when a workflow is the top-level CLI invocation. When a workflow is used as a sub-workflow, its outputs are consumed by the parent node, not stdout.
+
 ## Importance and Benefits to Users
 
 * **Reduced Cognitive Load:** Users intuitively use pflow in shell workflows without additional mental overhead.
@@ -146,4 +180,4 @@ Native integration with Unix shell pipes positions pflow as a highly intuitive, 
 
 - [Shared Store](../core-concepts/shared-store.md) - Node communication patterns
 - [Architecture](../architecture.md) - CLI interface overview
-- [IR Schema](../reference/ir-schema.md) - Workflow input declarations including `stdin: true`
+- [IR Schema](../reference/ir-schema.md) - Workflow input/output declarations including `stdin: true` and `stdout: true`

--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -137,6 +137,38 @@ For workflow chaining, use the `-p` flag to output results for the next workflow
 pflow -p step1 | pflow -p step2 | pflow step3
 ```
 
+## Stdout output
+
+Workflows that declare multiple outputs mark one with `stdout: true` to pick which output lands on process stdout in text mode:
+
+```markdown
+## Outputs
+
+### message
+
+Primary result — streams to stdout on redirect or pipe.
+
+- source: ${emit.stdout}
+- stdout: true
+
+### length
+
+Secondary metadata. Available via `-o length` or `--output-format json`.
+
+- source: ${count.stdout}
+```
+
+Redirecting or piping the CLI in text mode now writes only the marked output to stdout:
+
+```bash
+pflow stdout-result.pflow.md > result.txt       # file contains the message only
+pflow stdout-result.pflow.md | next-step        # message streams to the next command
+pflow stdout-result.pflow.md -o length          # override: emit length instead
+pflow stdout-result.pflow.md --output-format json   # emit all outputs as structured JSON
+```
+
+Single-output workflows don't need the marker — their one output is unambiguous. Workflows with multiple declared outputs and no `stdout: true` stream the first declared output and print a warning on stderr naming the other outputs and the three ways to change the routing: add the marker, pass `-o`, or switch to JSON mode. The validator enforces that at most one output per workflow is marked.
+
 ## Output modes
 
 ### Text mode (default)

--- a/examples/core/stdout-result.pflow.md
+++ b/examples/core/stdout-result.pflow.md
@@ -1,0 +1,56 @@
+# Stdout Result
+
+Demonstrates explicit stdout output routing. A workflow that produces multiple outputs marks one with `stdout: true` so redirecting or piping the CLI lands that specific output on stdout.
+
+Usage:
+
+```
+pflow stdout-result.pflow.md greeting="hi alice" > result.txt      # content → result.txt
+pflow stdout-result.pflow.md greeting="hi alice" --output-format json   # all outputs as JSON
+```
+
+## Inputs
+
+### greeting
+
+The greeting message to emit.
+
+- type: string
+- default: hello world
+
+## Steps
+
+### emit
+
+Echo the greeting.
+
+- type: shell
+
+```shell command
+echo "${greeting}"
+```
+
+### count
+
+Count the characters in the greeting.
+
+- type: shell
+
+```shell command
+printf %s "${greeting}" | wc -c | tr -d ' '
+```
+
+## Outputs
+
+### message
+
+The greeting, streamed to stdout in text mode.
+
+- source: ${emit.stdout}
+- stdout: true
+
+### length
+
+Character count of the greeting. Available in JSON mode or via `-o length`.
+
+- source: ${count.stdout}

--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -101,12 +101,13 @@ This split is critical: `pflow workflow.pflow.md | jq` works because progress no
 
 ### Output routing (`_output_with_header` in workflow_output.py)
 
-Single rule: data → stdout, diagnostics → stderr. Always — no TTY checks, no mode branching.
+Routing is TTY-agnostic: data always goes to stdout, diagnostics always go to stderr. The stderr header (`Workflow output (<desc>):`) is the only TTY-sensitive element — suppressed when stdout is non-TTY because a naked label with the value elsewhere reads as "empty output" to both humans and agents.
 
 | Mode | When | Header | Data | Summary |
 |------|------|--------|------|---------|
 | `--print` (`-p`) | Explicitly requested | None | stdout | None |
-| Default | Everything else (TTY, non-TTY, agents, CI/CD, pipes) | stderr | stdout | stderr |
+| TTY stdout | Interactive terminal | stderr | stdout | stderr |
+| Non-TTY stdout | Pipe / redirect / CI / agent subprocess | None | stdout | stderr |
 
 `--print` suppresses header, summary, and warnings on stderr. Data still goes to stdout.
 
@@ -232,7 +233,7 @@ See `core/CLAUDE.md` (shell_integration section) for FIFO detection, StdinData m
 
 - **Use lazy imports** in command files and `commands/run.py` to avoid circular dependencies
 - **Don't mix output streams** — errors→stderr, results→stdout. This makes piping work.
-- **Don't mix routing and rendering** — stdout/stderr routing is unified; only TTY-specific cursor rendering (`\r` batch updates) should inspect `isatty()`
+- **Don't mix routing and rendering** — stdout/stderr routing is TTY-agnostic; the stderr header in `_output_with_header` and the `\r` batch counter are the only TTY-sensitive writes
 - **`ignore_unknown_options=True` tradeoff** — typos like `--output-formt` silently pass through. `_validate_workflow_flags` in `commands/run.py` catches common misplaced flags.
 
 ## Test Mapping

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -63,17 +63,20 @@ def safe_output(value: Any) -> bool:
 def _stdout_is_tty() -> bool:
     """Return whether stdout is a TTY, preferring OutputController's captured state.
 
-    Falls back to ``True`` when no Click context / OutputController is available
-    (preserves the pre-fix "always show label" behavior for direct unit-test
-    callers that bypass the full CLI setup).
+    Falls back to ``sys.stdout.isatty()`` when no Click context / OutputController
+    is available — matches what ``OutputController.__init__`` does itself, so the
+    TTY decision stays consistent for any caller of ``_output_with_header``
+    (including non-CLI entry points that don't thread through ``_initialize_context``).
     """
+    import sys
+
     try:
         ctx = click.get_current_context(silent=True)
     except RuntimeError:
         ctx = None
     if ctx is not None and ctx.obj and "output_controller" in ctx.obj:
         return bool(ctx.obj["output_controller"].stdout_tty)
-    return True
+    return sys.stdout.isatty() if sys.stdout is not None else False
 
 
 def _output_with_header(value: Any, print_flag: bool, description: str | None = None) -> None:
@@ -208,39 +211,49 @@ def _emit_declared_output(
     return False
 
 
-def _select_stdout_target(declared_outputs: dict[str, Any], print_flag: bool = False) -> dict[str, Any]:
+def _select_stdout_target(declared_outputs: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     """Choose which declared outputs to stream to stdout in text mode.
 
+    Pure selector — returns ``(target, dropped)`` and never writes to stderr.
+    The caller decides whether to emit the multi-output warning (see
+    ``_warn_multi_output_ambiguity``).
+
     Precedence:
-    - Any output marked ``stdout: true`` → emit only that output.
-    - Exactly one declared output → emit it (implicit — the unambiguous case).
-    - Multiple declared outputs with no marker → emit the first declared output
-      and warn on stderr that other outputs are available (suppressed under
-      ``-p``, matching the auto-detect warning pattern from Task 134).
+    - Any output marked ``stdout: true`` → return only that output, no drops.
+      Validator guarantees at most one marker, so this always yields a
+      single-entry dict.
+    - Exactly one declared output → return it (implicit, unambiguous case).
+    - Multiple declared outputs with no marker → return the first, with the
+      remaining names as ``dropped``.
 
-    The validator guarantees at most one output is marked, so "marked"
-    always yields a single-entry dict here.
+    Schema (``additionalProperties: false`` on outputs) guarantees dict
+    values by the time we run, so no defensive type checks.
     """
-    marked = {
-        name: config
-        for name, config in declared_outputs.items()
-        if isinstance(config, dict) and config.get("stdout") is True
-    }
+    marked = {name: config for name, config in declared_outputs.items() if config.get("stdout") is True}
     if marked:
-        return marked
+        return marked, []
     if len(declared_outputs) <= 1:
-        return declared_outputs
+        return declared_outputs, []
 
-    first_name = next(iter(declared_outputs))
-    if not print_flag:
-        names = ", ".join(declared_outputs.keys())
-        click.echo(
-            f"cli: Workflow declares {len(declared_outputs)} outputs ({names}). "
-            f"Streaming '{first_name}' to stdout. Mark one output with `- stdout: true`, "
-            "pass `-o <name>`, or use `--output-format json` to emit all.",
-            err=True,
-        )
-    return {first_name: declared_outputs[first_name]}
+    names = list(declared_outputs.keys())
+    first_name = names[0]
+    return {first_name: declared_outputs[first_name]}, names[1:]
+
+
+def _warn_multi_output_ambiguity(chosen: str, dropped: list[str]) -> None:
+    """Emit the stderr warning when multiple declared outputs have no ``stdout: true``.
+
+    Sibling of ``_warn_missing_declared_outputs``. Named so the selector stays
+    pure; caller gates on ``print_flag``.
+    """
+    total = 1 + len(dropped)
+    names = ", ".join([chosen, *dropped])
+    click.echo(
+        f"cli: Workflow declares {total} outputs ({names}). "
+        f"Streaming '{chosen}' to stdout. Mark one output with `- stdout: true`, "
+        "pass `-o <name>`, or use `--output-format json` to emit all.",
+        err=True,
+    )
 
 
 def _try_declared_outputs(
@@ -263,7 +276,9 @@ def _try_declared_outputs(
         return False
 
     declared_outputs = workflow_ir["outputs"]
-    target = _select_stdout_target(declared_outputs, print_flag=print_flag)
+    target, dropped = _select_stdout_target(declared_outputs)
+    if dropped and not print_flag:
+        _warn_multi_output_ambiguity(next(iter(target)), dropped)
 
     # First attempt: use already-populated outputs (preferred path via compiler wrapper)
     if _emit_declared_output(shared_storage, target, print_flag):

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -60,15 +60,33 @@ def safe_output(value: Any) -> bool:
         raise
 
 
+def _stdout_is_tty() -> bool:
+    """Return whether stdout is a TTY, preferring OutputController's captured state.
+
+    Falls back to ``True`` when no Click context / OutputController is available
+    (preserves the pre-fix "always show label" behavior for direct unit-test
+    callers that bypass the full CLI setup).
+    """
+    try:
+        ctx = click.get_current_context(silent=True)
+    except RuntimeError:
+        ctx = None
+    if ctx is not None and ctx.obj and "output_controller" in ctx.obj:
+        return bool(ctx.obj["output_controller"].stdout_tty)
+    return True
+
+
 def _output_with_header(value: Any, print_flag: bool, description: str | None = None) -> None:
     """Output value with Unix-convention routing.
 
-    - `--print` mode: data to stdout, no header.
-    - Default mode: header to stderr, data to stdout.
-
-    This is intentionally identical for TTY and non-TTY consumers.
+    - ``--print`` mode: data to stdout, no header.
+    - Non-TTY stdout (pipe/redirect): data to stdout, no header — the naked
+      stderr label would otherwise look like empty output when the terminal
+      has nothing to render below it.
+    - TTY stdout: header to stderr, data to stdout — the description is
+      useful interactive context.
     """
-    if print_flag:
+    if print_flag or not _stdout_is_tty():
         safe_output(value)
         return
 
@@ -190,6 +208,41 @@ def _emit_declared_output(
     return False
 
 
+def _select_stdout_target(declared_outputs: dict[str, Any], print_flag: bool = False) -> dict[str, Any]:
+    """Choose which declared outputs to stream to stdout in text mode.
+
+    Precedence:
+    - Any output marked ``stdout: true`` → emit only that output.
+    - Exactly one declared output → emit it (implicit — the unambiguous case).
+    - Multiple declared outputs with no marker → emit the first declared output
+      and warn on stderr that other outputs are available (suppressed under
+      ``-p``, matching the auto-detect warning pattern from Task 134).
+
+    The validator guarantees at most one output is marked, so "marked"
+    always yields a single-entry dict here.
+    """
+    marked = {
+        name: config
+        for name, config in declared_outputs.items()
+        if isinstance(config, dict) and config.get("stdout") is True
+    }
+    if marked:
+        return marked
+    if len(declared_outputs) <= 1:
+        return declared_outputs
+
+    first_name = next(iter(declared_outputs))
+    if not print_flag:
+        names = ", ".join(declared_outputs.keys())
+        click.echo(
+            f"cli: Workflow declares {len(declared_outputs)} outputs ({names}). "
+            f"Streaming '{first_name}' to stdout. Mark one output with `- stdout: true`, "
+            "pass `-o <name>`, or use `--output-format json` to emit all.",
+            err=True,
+        )
+    return {first_name: declared_outputs[first_name]}
+
+
 def _try_declared_outputs(
     shared_storage: dict[str, Any],
     workflow_ir: dict[str, Any] | None,
@@ -210,19 +263,20 @@ def _try_declared_outputs(
         return False
 
     declared_outputs = workflow_ir["outputs"]
+    target = _select_stdout_target(declared_outputs, print_flag=print_flag)
 
     # First attempt: use already-populated outputs (preferred path via compiler wrapper)
-    if _emit_declared_output(shared_storage, declared_outputs, print_flag):
+    if _emit_declared_output(shared_storage, target, print_flag):
         return True
 
     # Populate on-demand if not present
     _populate_declared_outputs_best_effort(shared_storage, workflow_ir)
 
     # Second attempt after population
-    if _emit_declared_output(shared_storage, declared_outputs, print_flag):
+    if _emit_declared_output(shared_storage, target, print_flag):
         return True
 
-    _warn_missing_declared_outputs(declared_outputs, verbose)
+    _warn_missing_declared_outputs(target, verbose)
     return False
 
 

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -168,6 +168,8 @@ Memory limit configurable via `PFLOW_STDIN_MEMORY_LIMIT`.
 
 **Stdin routing**: Stdin routes to workflow input declared with `"stdin": true`. Routing happens in CLI (`_route_stdin_to_params()`) before input validation. CLI params override piped stdin. Only one input per workflow can have `stdin: true`.
 
+**Stdout routing** (symmetric, text mode only): One output may declare `"stdout": true` to pick which declared output streams to process stdout. Precedence: `-o` flag > `stdout: true` marker > single declared output (implicit) > first declared with a stderr warning. JSON mode is immune — it emits all declared outputs regardless of marker. See `cli/CLAUDE.md` for the full precedence table and the TTY-gated header behavior.
+
 ### workflow/
 
 See `workflow/CLAUDE.md` for per-file details (storage format, validation pipeline, data flow algorithm, skill publishing, known issues).

--- a/src/pflow/core/ir_schema.py
+++ b/src/pflow/core/ir_schema.py
@@ -292,6 +292,11 @@ FLOW_IR_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "description": "Template expression specifying where to get the output value from (e.g., '${node_id.output_key}')",
                     },
+                    "stdout": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Whether this output streams to process stdout in text mode (only one output per workflow may set this)",
+                    },
                     "_source_line": {
                         "type": "integer",
                         "description": "Markdown source line for the output source declaration (internal parser metadata)",
@@ -364,7 +369,7 @@ def _get_output_suggestion(error: JsonSchemaValidationError, path_str: str) -> s
                 unexpected_field = match.group(1)
 
         # Build helpful message
-        lines = ["Output definitions can only have: description, type, source (all optional)"]
+        lines = ["Output definitions can only have: description, type, source, stdout (all optional)"]
 
         # Suggest replacement for common mistakes
         if unexpected_field == "value":

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -1349,7 +1349,7 @@ def _build_output_dict(entity: _Entity) -> dict[str, Any]:
     """Build an output definition dict from an entity.
 
     Outputs get flat dicts (no params wrapper).
-    Valid fields: description, type, source.
+    Valid fields: description, type, source, stdout.
     """
     _validate_description(entity)
     _validate_code_blocks(entity)

--- a/src/pflow/core/workflow/CLAUDE.md
+++ b/src/pflow/core/workflow/CLAUDE.md
@@ -11,7 +11,7 @@ core/workflow/
 ├── save_service.py          # Shared save operations for CLI + MCP (with dependency bundling)
 ├── dependency_discovery.py  # Recursive file dependency scanner for bundling
 ├── sub_workflow_resolver.py # Shared sub-workflow resolution (inline IR, file, saved name)
-├── validator.py             # Unified 9-step validation orchestrator
+├── validator.py             # Unified 10-step validation orchestrator
 ├── data_flow.py             # Execution order (topological sort) and dependency validation
 ├── mermaid/                 # Mermaid flowchart generation from workflow IR
 │   ├── __init__.py          # Re-exports: generate_mermaid + test-visible helpers
@@ -63,7 +63,7 @@ No cycles. All heavy imports are lazy (inside functions).
 | `save_service.py` | `load_and_validate_workflow`, `save_workflow_with_options`, `validate_workflow_name`, `delete_draft_safely`, `generate_workflow_metadata` |
 | `dependency_discovery.py` | `Dependency`, `discover_dependencies` |
 | `sub_workflow_resolver.py` | `resolve_sub_workflow`, `SubWorkflowResult` |
-| `validator.py` | `WorkflowValidator` (static `.validate()` method — 9-step pipeline) |
+| `validator.py` | `WorkflowValidator` (static `.validate()` method — 10-step pipeline) |
 | `data_flow.py` | `validate_data_flow`, `build_execution_order`, `CycleError` |
 | `mermaid/` | `generate_mermaid` |
 | `status.py` | `WorkflowStatus` (enum: SUCCESS, DEGRADED, FAILED) |
@@ -110,18 +110,19 @@ The entry point has YAML frontmatter for system metadata (timestamps, execution 
 
 Unified pre-execution orchestrator — returns `list[Diagnostic]` directly. Every helper builds `Diagnostic` objects at the detection site with `context["path"]`, `similar_names`, `available_fields`, and `suggestions` populated by the producer. No string intermediates, no pattern-matching post-processing.
 
-**9-step validation pipeline**:
+**10-step validation pipeline**:
 1. Structural (IR schema) — always runs
 2. Stdin inputs — only one `stdin: true` allowed per workflow
-3. Data flow (execution order, dependencies) — always runs
-4. Templates (variable resolution) — if params provided
-5. Node types (registry verification) — unless `skip_node_types=True`
-6. Output sources — validates `${node.key}` refs in outputs via `_validate_template_in_source`. Uses `TemplateResolver.extract_root_node_id()` to support bracket syntax like `${data[0].x}`. Provides fuzzy "did you mean?" suggestions.
-7. Unknown param errors — hard errors for params not in node interface metadata, with fuzzy-matched valid keys
-8. Sub-workflow validation — recursive validation of referenced child workflows (file, saved name, inline IR)
-9. Cache lint — warns when shell nodes have no template inputs and no `cache: false` (stale cache risk)
+3. Stdout outputs — only one `stdout: true` allowed per workflow
+4. Data flow (execution order, dependencies) — always runs
+5. Templates (variable resolution) — if params provided
+6. Node types (registry verification) — unless `skip_node_types=True`
+7. Output sources — validates `${node.key}` refs in outputs via `_validate_template_in_source`. Uses `TemplateResolver.extract_root_node_id()` to support bracket syntax like `${data[0].x}`. Provides fuzzy "did you mean?" suggestions.
+8. Unknown param errors — hard errors for params not in node interface metadata, with fuzzy-matched valid keys
+9. Sub-workflow validation — recursive validation of referenced child workflows (file, saved name, inline IR)
+10. Cache lint — warns when shell nodes have no template inputs and no `cache: false` (stale cache risk)
 
-**Pipeline order is load-bearing**: step 4 (templates) runs BEFORE step 5 (node types). Template validation silently skips unknown node types via `_register_node_outputs_from_registry` — step 5 produces the rich "Unknown node type" diagnostic. Reversing the order or making step 4 raise on unknown types produces duplicate diagnostics (one generic wrapper + one rich V6).
+**Pipeline order is load-bearing**: step 5 (templates) runs BEFORE step 6 (node types). Template validation silently skips unknown node types via `_register_node_outputs_from_registry` — step 6 produces the rich "Unknown node type" diagnostic. Reversing the order or making step 5 raise on unknown types produces duplicate diagnostics (one generic wrapper + one rich V6).
 
 **`_add_child_provenance` first-write-wins semantics** — sub-workflow diagnostics flow recursively up through nested parents. `sub_workflow_step` and `sub_workflow_path` use `dict.setdefault()` so the innermost wrapping (closest to the error) wins as recursion unwinds. This keeps structured provenance aligned with `node_id` and `context["path"]` (both of which already point at the deepest level). Regressing to overwrite semantics silently breaks 3-level nested workflows.
 

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -79,13 +79,14 @@ class WorkflowValidator:
         Performs multiple validation checks:
         1. Structural validation - IR schema compliance
         2. Stdin input validation - Only one stdin: true allowed
-        3. Data flow validation - Execution order and dependencies
-        4. Template validation - Variable resolution
-        5. Node type validation - Registry verification
-        6. Output source validation - Output node references
-        7. Unknown param errors - Rejects params not in node interface
-        8. Sub-workflow validation - Recursive validation of child workflows
-        9. Cache lint - Warn about input-less shell nodes without cache: false
+        3. Stdout output validation - Only one stdout: true allowed
+        4. Data flow validation - Execution order and dependencies
+        5. Template validation - Variable resolution
+        6. Node type validation - Registry verification
+        7. Output source validation - Output node references
+        8. Unknown param errors - Rejects params not in node interface
+        9. Sub-workflow validation - Recursive validation of child workflows
+        10. Cache lint - Warn about input-less shell nodes without cache: false
 
         Args:
             workflow_ir: Workflow to validate
@@ -108,37 +109,40 @@ class WorkflowValidator:
         # 2. Stdin input validation (ALWAYS run - only one stdin: true allowed)
         diagnostics.extend(WorkflowValidator._validate_stdin_inputs(workflow_ir))
 
-        # 3. Data flow validation (ALWAYS run)
+        # 3. Stdout output validation (ALWAYS run - only one stdout: true allowed)
+        diagnostics.extend(WorkflowValidator._validate_stdout_outputs(workflow_ir))
+
+        # 4. Data flow validation (ALWAYS run)
         diagnostics.extend(WorkflowValidator._validate_data_flow(workflow_ir))
 
-        # 4. Template validation (if params provided)
+        # 5. Template validation (if params provided)
         if extracted_params is not None:
             if registry is None:
                 registry = Registry()
             diagnostics.extend(WorkflowValidator._validate_templates(workflow_ir, extracted_params, registry))
 
-        # 5. Node type validation (if not skipped)
+        # 6. Node type validation (if not skipped)
         if not skip_node_types:
             if registry is None:
                 registry = Registry()
             diagnostics.extend(WorkflowValidator._validate_node_types(workflow_ir, registry))
 
-        # 6. Output source validation (ALWAYS run - validate output references)
+        # 7. Output source validation (ALWAYS run - validate output references)
         diagnostics.extend(WorkflowValidator._validate_output_sources(workflow_ir, registry))
 
-        # 7. Unknown param errors
+        # 8. Unknown param errors
         # Only run if registry available (need interface metadata for param keys)
         if registry is not None:
             diagnostics.extend(WorkflowValidator._validate_unknown_params(workflow_ir, registry))
 
-        # 8. Sub-workflow validation (recursive)
+        # 9. Sub-workflow validation (recursive)
         diagnostics.extend(
             WorkflowValidator._validate_sub_workflows(
                 workflow_ir, extracted_params, registry, _seen, _ir_cache, skip_node_types, workflow_file
             )
         )
 
-        # 9. Cache lint — warn about input-less shell nodes
+        # 10. Cache lint — warn about input-less shell nodes
         diagnostics.extend(WorkflowValidator._warn_inputless_shell_nodes(workflow_ir))
 
         errors = [d for d in diagnostics if d.severity == Severity.ERROR]
@@ -209,6 +213,41 @@ class WorkflowValidator:
                     ),
                     suggestions=["Mark only one workflow input with stdin: true."],
                     context={"category": "validation", "path": "inputs"},
+                )
+            ]
+
+        return []
+
+    @staticmethod
+    def _validate_stdout_outputs(workflow_ir: dict[str, Any]) -> list[Diagnostic]:
+        """Validate that at most one output has stdout: true.
+
+        Args:
+            workflow_ir: Workflow to validate
+
+        Returns:
+            Stdout validation diagnostics
+        """
+        outputs = workflow_ir.get("outputs", {})
+        if not outputs:
+            return []
+
+        stdout_outputs = [
+            name for name, spec in outputs.items() if isinstance(spec, dict) and spec.get("stdout") is True
+        ]
+
+        if len(stdout_outputs) > 1:
+            return [
+                Diagnostic(
+                    severity=Severity.ERROR,
+                    source="validator",
+                    title="Validation Error",
+                    message=(
+                        f'Multiple outputs marked with "stdout": true: {", ".join(stdout_outputs)}. '
+                        "Only one output can stream to stdout."
+                    ),
+                    suggestions=["Mark only one workflow output with stdout: true."],
+                    context={"category": "validation", "path": "outputs"},
                 )
             ]
 

--- a/src/pflow/execution/formatters/workflow_describe_formatter.py
+++ b/src/pflow/execution/formatters/workflow_describe_formatter.py
@@ -118,8 +118,9 @@ def _format_inputs_section(ir: dict[str, Any]) -> str:
         req_text = "required" if required else "optional"
         desc = config.get("description", "")
         default = config.get("default")
+        stdin_marker = " [stdin]" if config.get("stdin") is True else ""
 
-        lines.append(f"  - {input_name} ({req_text}): {desc}")
+        lines.append(f"  - {input_name}{stdin_marker} ({req_text}): {desc}")
         if default is not None:
             lines.append(f"    Default: {default}")
 
@@ -142,7 +143,8 @@ def _format_outputs_section(ir: dict[str, Any]) -> str:
 
     for output_name, config in ir["outputs"].items():
         desc = config.get("description", "")
-        lines.append(f"  - {output_name}: {desc}")
+        stdout_marker = " [stdout]" if config.get("stdout") is True else ""
+        lines.append(f"  - {output_name}{stdout_marker}: {desc}")
 
     return "\n".join(lines)
 

--- a/src/pflow/guide/core.md
+++ b/src/pflow/guide/core.md
@@ -299,6 +299,8 @@ What this output contains.
 
 **Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false — only one input can have this), description as prose.
 
+**Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false — at most one output may set this; marks the output that streams to stdout in text mode), description as prose.
+
 **Node fields**: `type` (required), all other params as `- key: value`. Code/prompts/batch go in tagged code blocks.
 
 **Execution order**: Top to bottom in `## Steps`. No explicit edges.

--- a/src/pflow/mcp_server/CLAUDE.md
+++ b/src/pflow/mcp_server/CLAUDE.md
@@ -77,7 +77,7 @@ All tools use async/sync bridge: `await asyncio.to_thread(_sync_operation)` — 
 
 **execution_tools.py** (5 tools):
 - `workflow_execute(workflow, parameters)` — Execute with agent defaults (no repair, silent, traces saved)
-- `workflow_validate(workflow)` — Static validation without execution (9 checks including sub-workflow validation and cache lint)
+- `workflow_validate(workflow)` — Static validation without execution (10 checks including sub-workflow validation and cache lint)
 - `workflow_save(workflow, name, force)` — Save to library (accepts raw markdown or file path)
 - `registry_run(node_type, parameters)` — Test node to discover output structure + template paths
 - `read_fields(execution_id, field_paths)` — Read specific fields from cached `registry_run` execution
@@ -171,7 +171,7 @@ See `utils/CLAUDE.md` for the 5-step resolution order used by `resolve_workflow(
 
 ### Validation
 
-`WorkflowValidator.validate()` runs 9 checks: structural (IR schema), stdin inputs, data flow (order, cycles), template (`${variable}` resolution), node types (registry), output sources, unknown params, sub-workflow validation (recursive), and cache lint (warns about input-less shell nodes without `cache: false`). `generate_dummy_parameters()` creates `__validation_placeholder__` values so templates resolve during validation without real API keys.
+`WorkflowValidator.validate()` runs 10 checks: structural (IR schema), stdin inputs, stdout outputs, data flow (order, cycles), template (`${variable}` resolution), node types (registry), output sources, unknown params, sub-workflow validation (recursive), and cache lint (warns about input-less shell nodes without `cache: false`). `generate_dummy_parameters()` creates `__validation_placeholder__` values so templates resolve during validation without real API keys.
 
 ## Testing
 

--- a/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
@@ -1005,6 +1005,8 @@ What this output contains.
 
 **Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false -- only one input can have this), description as prose.
 
+**Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false -- at most one output may set this; marks the output that streams to stdout in text mode). Single-output workflows don't need a marker. Multi-output workflows without a marker stream the first declared output and emit a stderr warning.
+
 **Node fields**: `type` (required), all other params as `- key: value`. Code/prompts/batch go in tagged code blocks.
 
 **Execution order**: Top to bottom in `## Steps`. No explicit edges.

--- a/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
@@ -987,6 +987,8 @@ What this output contains.
 
 **Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false -- only one input can have this), description as prose.
 
+**Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false -- at most one output may set this; marks the output that streams to stdout in text mode). Single-output workflows don't need a marker. Multi-output workflows without a marker stream the first declared output and emit a stderr warning.
+
 **Node fields**: `type` (required), all other params as `- key: value`. Code/prompts/batch go in tagged code blocks.
 
 **Execution order**: Top to bottom in `## Steps`. No explicit edges.

--- a/src/pflow/runtime/compilation/CLAUDE.md
+++ b/src/pflow/runtime/compilation/CLAUDE.md
@@ -106,7 +106,7 @@ IR structure validation and input preparation.
   - Only one `stdin: true` input allowed
   - Type coercion via `coerce_workflow_input()` — lenient (warns on failure, doesn't error)
 
-**WARNING**: A DIFFERENT `validator.py` exists at `core/workflow/validator.py` (pre-execution 9-step orchestrator, 7+ external consumers). Don't confuse them.
+**WARNING**: A DIFFERENT `validator.py` exists at `core/workflow/validator.py` (pre-execution 10-step orchestrator, 7+ external consumers). Don't confuse them.
 
 ## Dependency Graph (no cycles at import time)
 

--- a/tests/test_cli/test_dual_mode_stdout.py
+++ b/tests/test_cli/test_dual_mode_stdout.py
@@ -228,6 +228,37 @@ class TestMultiOutputAmbiguity:
         assert "ALPHA_SELECTED" in result.stdout
         assert "BETA_IGNORED" not in result.stdout
 
+    def test_o_flag_overrides_stdout_marker(self, tmp_path, prepared_subprocess_env):
+        """``-o`` wins over ``stdout: true`` — regression guard for the top of the precedence chain.
+
+        The documented precedence is ``-o`` > marker > single-implicit > first
+        + warn. A future refactor that moved marker-selection ahead of the
+        ``-o`` check would silently demote caller override. This test locks
+        the ordering so that reordering breaks it loudly.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "Marked", "source": "${a.stdout}", "stdout": True},
+                "beta": {"description": "Unmarked", "source": "${b.stdout}"},
+            },
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo ALPHA_VAL"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo BETA_VAL"}},
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow(["-o", "beta", str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert "BETA_VAL" in result.stdout, (
+            "-o beta must win over stdout: true on alpha — caller override is the top of the precedence chain"
+        )
+        assert "ALPHA_VAL" not in result.stdout
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
 class TestStdoutValidator:

--- a/tests/test_cli/test_dual_mode_stdout.py
+++ b/tests/test_cli/test_dual_mode_stdout.py
@@ -1,0 +1,274 @@
+"""Integration tests for stdout output routing (`stdout: true` marker + TTY-gated label).
+
+Mirrors ``test_dual_mode_stdin.py``. Covers the redirect UX bug (naked
+``Workflow output (desc):`` label when stdout is redirected) and the
+multi-output silent-drop bug (declared outputs vanishing without warning).
+
+These tests use real subprocesses because:
+- ``CliRunner`` always reports ``isatty() = False``, which can't distinguish
+  "stdout is a pipe" from "stdout is a file" from "stdout is a terminal".
+- Subprocess pipes let us verify that the label is suppressed on redirect
+  while the payload is intact on stdout.
+- The ambiguity error path goes through the full CLI exit-code and stderr
+  rendering pipeline, which ``CliRunner`` handles but fragilely.
+
+See `tests/test_cli/test_workflow_output_handling.py` for in-process unit
+tests of the selection logic itself.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from tests.shared.markdown_utils import ir_to_markdown
+
+
+def _skip_uv_sandbox_panic(result: subprocess.CompletedProcess) -> None:
+    """Skip when the uv subprocess panics in a restricted sandbox."""
+    if result.returncode == 101 and "Attempted to create a NULL object" in (result.stderr or ""):
+        pytest.skip("uv subprocess panics in this sandbox before pflow starts")
+
+
+def _run_pflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess:
+    """Run pflow via the in-repo Python module, capturing both streams."""
+    # Don't inherit PYTEST_CURRENT_TEST — causes configure_logging to short-circuit
+    # and partial-line filters to skip install. See tests/CLAUDE.md #10.
+    clean_env = {k: v for k, v in env.items() if k != "PYTEST_CURRENT_TEST"}
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "pflow.cli", *args],
+        capture_output=True,
+        text=True,
+        env=clean_env,
+        timeout=60,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
+class TestStdoutRedirectLabel:
+    """When stdout is not a TTY, the ``Workflow output (desc):`` label is suppressed."""
+
+    def test_single_output_label_suppressed_when_stdout_redirected(self, tmp_path, prepared_subprocess_env):
+        """Single declared output + pipe/redirect → no label, value on stdout."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {"greeting": {"description": "The greeting", "source": "${hello.stdout}"}},
+            "nodes": [
+                {
+                    "id": "hello",
+                    "type": "shell",
+                    "params": {"command": "echo CANARY_REDIRECT_VALUE"},
+                }
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow([str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert "CANARY_REDIRECT_VALUE" in result.stdout
+        # The naked label must not appear on stderr when stdout is captured
+        assert "Workflow output" not in result.stderr, (
+            f"Label should be TTY-gated; stderr still has it:\n{result.stderr}"
+        )
+
+    def test_stdout_marker_routes_to_stdout_on_redirect(self, tmp_path, prepared_subprocess_env):
+        """Multi-output with ``stdout: true`` on one → only that one on stdout."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "primary": {
+                    "description": "Primary result",
+                    "source": "${primary_node.stdout}",
+                    "stdout": True,
+                },
+                "metadata": {
+                    "description": "Secondary metadata",
+                    "source": "${meta_node.stdout}",
+                },
+            },
+            "nodes": [
+                {
+                    "id": "primary_node",
+                    "type": "shell",
+                    "params": {"command": "echo PRIMARY_MARKED_VALUE"},
+                },
+                {
+                    "id": "meta_node",
+                    "type": "shell",
+                    "params": {"command": "echo METADATA_VALUE"},
+                },
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow([str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert "PRIMARY_MARKED_VALUE" in result.stdout
+        assert "METADATA_VALUE" not in result.stdout, "Only the marked output should stream to stdout; metadata leaked"
+        # And no label on stderr (redirected stdout)
+        assert "Workflow output" not in result.stderr
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
+class TestMultiOutputAmbiguity:
+    """Multi-declared outputs + no marker + no ``-o`` → warn and emit first."""
+
+    def test_multi_output_no_marker_text_mode_warns_and_emits_first(self, tmp_path, prepared_subprocess_env):
+        """Text mode + 2 outputs + no marker + no ``-o`` → exit 0, first on stdout, warning on stderr."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "Alpha", "source": "${a.stdout}"},
+                "beta": {"description": "Beta", "source": "${b.stdout}"},
+            },
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo ALPHA_VAL"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo BETA_VAL"}},
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow([str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        # First declared output reaches stdout; the other does NOT
+        assert "ALPHA_VAL" in result.stdout
+        assert "BETA_VAL" not in result.stdout
+        # Warning on stderr names both outputs and the three escape hatches
+        assert "Workflow declares 2 outputs" in result.stderr
+        assert "alpha" in result.stderr
+        assert "beta" in result.stderr
+        assert "stdout: true" in result.stderr
+        assert "-o" in result.stderr
+        assert "--output-format json" in result.stderr
+
+    def test_multi_output_no_marker_print_mode_suppresses_warning(self, tmp_path, prepared_subprocess_env):
+        """``-p`` suppresses the multi-output warning, matching Task 134's auto-detect behavior."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "Alpha", "source": "${a.stdout}"},
+                "beta": {"description": "Beta", "source": "${b.stdout}"},
+            },
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo ALPHA_VAL"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo BETA_VAL"}},
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow(["-p", str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0
+        assert "ALPHA_VAL" in result.stdout
+        assert "Workflow declares" not in result.stderr
+
+    def test_multi_output_no_marker_json_mode_succeeds(self, tmp_path, prepared_subprocess_env):
+        """Regression: ambiguity error is text-mode-only; JSON emits all outputs.
+
+        PR #257 made ``--output-format`` and ``-p`` orthogonal. The stdout
+        marker is a text-mode routing hint and must not gate JSON output.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "Alpha", "source": "${a.stdout}"},
+                "beta": {"description": "Beta", "source": "${b.stdout}"},
+            },
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo A_VAL"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo B_VAL"}},
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow(["--output-format", "json", str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        payload = json.loads(result.stdout)
+        assert payload["success"] is True
+        assert payload["result"]["alpha"] == "A_VAL"
+        assert payload["result"]["beta"] == "B_VAL"
+
+    def test_multi_output_o_flag_bypasses_ambiguity(self, tmp_path, prepared_subprocess_env):
+        """``-o <name>`` at the call site resolves ambiguity without error."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "Alpha", "source": "${a.stdout}"},
+                "beta": {"description": "Beta", "source": "${b.stdout}"},
+            },
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo ALPHA_SELECTED"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo BETA_IGNORED"}},
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow(["-o", "alpha", str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert "ALPHA_SELECTED" in result.stdout
+        assert "BETA_IGNORED" not in result.stdout
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
+class TestStdoutValidator:
+    """The validator enforces at-most-one ``stdout: true`` per workflow."""
+
+    def test_multiple_stdout_markers_rejected_at_validation(self, tmp_path, prepared_subprocess_env):
+        """Two outputs both marked → ``--validate-only`` fails with named outputs."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {
+                    "description": "Alpha",
+                    "source": "${a.stdout}",
+                    "stdout": True,
+                },
+                "beta": {
+                    "description": "Beta",
+                    "source": "${b.stdout}",
+                    "stdout": True,
+                },
+            },
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo A"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo B"}},
+            ],
+        }
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(ir_to_markdown(workflow))
+
+        result = _run_pflow(["--validate-only", str(workflow_file)], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode != 0, (
+            f"Validator should reject two stdout markers.\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+        combined = (result.stdout + result.stderr).lower()
+        assert "stdout" in combined
+        assert "alpha" in combined
+        assert "beta" in combined
+
+
+if __name__ == "__main__":
+    # Allow `python tests/test_cli/test_dual_mode_stdout.py` for quick iteration.
+    pytest.main([__file__, "-xvs"])

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -231,7 +231,11 @@ class TestWorkflowOutputHandling:
             )
             assert "HELLO_STDOUT_CANARY_GH194" in result.stdout
             assert "HELLO_STDOUT_CANARY_GH194" not in result.stderr
-            assert "Workflow output" in result.stderr
+            # The "Workflow output (desc):" label is TTY-gated. CliRunner reports
+            # stdout_tty=False, so the label must be suppressed — this is the
+            # redirect-UX fix. For the gh194 invariant (data stream correctness)
+            # the relevant assertions are the two above.
+            assert "Workflow output" not in result.stderr
         finally:
             Path(workflow_file).unlink()
 
@@ -289,21 +293,26 @@ class TestWorkflowOutputHandling:
     def test_missing_declared_outputs_warning_in_verbose_mode(
         self, mock_registry_instance, mock_compile, mock_validate_ir
     ):
-        """Test that verbose mode warns when declared outputs aren't in shared store."""
+        """Test that verbose mode warns when declared outputs aren't in shared store.
+
+        Uses a single declared output. Multi-declared workflows without a
+        ``stdout: true`` marker now raise an ambiguity error BEFORE missing-
+        output warnings can fire — tested separately in
+        ``test_multi_output_without_marker_raises_ambiguity_error``.
+        """
         runner = click.testing.CliRunner()
 
         workflow = {
             "ir_version": "0.1.0",
             "outputs": {
                 "expected_output": {"description": "This output is expected but missing", "type": "string"},
-                "another_output": {"description": "Also missing", "type": "string"},
             },
             "nodes": [
                 {
                     "id": "test",
                     "type": "test-node",
                     "params": {
-                        # Node doesn't produce the declared outputs
+                        # Node doesn't produce the declared output
                         "output_key": "different_key",
                         "output_value": "Some value",
                     },
@@ -319,23 +328,29 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, ["--verbose", workflow_file])
 
             assert result.exit_code == 0
-            # Should warn about missing declared outputs
-            assert "expected_output, another_output" in result.output
+            # Should warn about the missing declared output
+            assert "expected_output" in result.output
             assert "but none could be resolved" in result.output
             # Should show success message since no output was produced
             assert "Workflow executed successfully" in result.output
         finally:
             Path(workflow_file).unlink()
 
-    def test_multiple_declared_outputs_first_matching(self, mock_registry_instance, mock_compile, mock_validate_ir):
-        """Test that first matching declared output is printed when multiple are declared."""
+    def test_stdout_marked_output_wins_over_unmarked(self, mock_registry_instance, mock_compile, mock_validate_ir):
+        """Multiple declared outputs + one marked ``stdout: true`` → marked wins.
+
+        Replaces the old "first-wins" behavior, which silently dropped every
+        output after the first. The marker makes the author's intent explicit
+        and the routing deterministic.
+        """
         runner = click.testing.CliRunner()
 
         workflow = {
             "ir_version": "0.1.0",
             "outputs": {
                 "primary_output": {"description": "Primary output", "type": "string"},
-                "secondary_output": {"description": "Secondary output", "type": "string"},
+                "stdout_output": {"description": "Marked for stdout", "type": "string", "stdout": True},
+                "trailing_output": {"description": "Trailing output", "type": "string"},
             },
             "nodes": [
                 {
@@ -343,8 +358,9 @@ class TestWorkflowOutputHandling:
                     "type": "test-node",
                     "params": {
                         "add_keys": {
-                            # Only secondary is present
-                            "secondary_output": "Secondary value"
+                            "primary_output": "PRIMARY_VALUE_SHOULD_NOT_APPEAR",
+                            "stdout_output": "STDOUT_MARKED_VALUE",
+                            "trailing_output": "TRAILING_VALUE_SHOULD_NOT_APPEAR",
                         }
                     },
                 }
@@ -358,14 +374,227 @@ class TestWorkflowOutputHandling:
         try:
             result = runner.invoke(main, [workflow_file])
 
-            assert result.exit_code == 0
-            # Should print the first available declared output
-            assert "Secondary value" in result.output
+            assert result.exit_code == 0, f"stderr: {result.stderr!r}"
+            assert "STDOUT_MARKED_VALUE" in result.stdout
+            assert "PRIMARY_VALUE_SHOULD_NOT_APPEAR" not in result.stdout
+            assert "TRAILING_VALUE_SHOULD_NOT_APPEAR" not in result.stdout
         finally:
             Path(workflow_file).unlink()
 
-    def test_verbose_mode_shows_output_descriptions(self, mock_registry_instance, mock_compile, mock_validate_ir):
-        """Test that verbose mode shows descriptions for declared outputs."""
+    def test_multi_output_without_marker_warns_and_emits_first(
+        self, mock_registry_instance, mock_compile, mock_validate_ir
+    ):
+        """Multiple declared outputs + no ``stdout: true`` + no ``-o`` → warn + emit first.
+
+        The warning names both outputs and the three fixes (`stdout: true`,
+        `-o <name>`, `--output-format json`). The first declared output
+        streams to stdout so existing callers keep working.
+        """
+        runner = click.testing.CliRunner()
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "First", "type": "string"},
+                "beta": {"description": "Second", "type": "string"},
+            },
+            "nodes": [
+                {
+                    "id": "test",
+                    "type": "test-node",
+                    "params": {"add_keys": {"alpha": "ALPHA_VAL", "beta": "BETA_VAL"}},
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pflow.md", delete=False) as f:
+            f.write(ir_to_markdown(workflow))
+            workflow_file = f.name
+
+        try:
+            result = runner.invoke(main, [workflow_file])
+
+            assert result.exit_code == 0, f"stderr: {result.stderr!r}"
+            # First declared output reaches stdout
+            assert "ALPHA_VAL" in result.stdout
+            assert "BETA_VAL" not in result.stdout
+            # Warning on stderr names both outputs and the three escape hatches
+            assert "Workflow declares 2 outputs" in result.stderr
+            assert "alpha" in result.stderr and "beta" in result.stderr
+            assert "stdout: true" in result.stderr
+            assert "-o" in result.stderr
+            assert "--output-format json" in result.stderr
+        finally:
+            Path(workflow_file).unlink()
+
+    def test_multi_output_warning_suppressed_under_print_flag(
+        self, mock_registry_instance, mock_compile, mock_validate_ir
+    ):
+        """``-p`` suppresses the multi-output warning, matching Task 134's auto-detect behavior."""
+        runner = click.testing.CliRunner()
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "First", "type": "string"},
+                "beta": {"description": "Second", "type": "string"},
+            },
+            "nodes": [
+                {
+                    "id": "test",
+                    "type": "test-node",
+                    "params": {"add_keys": {"alpha": "ALPHA_VAL", "beta": "BETA_VAL"}},
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pflow.md", delete=False) as f:
+            f.write(ir_to_markdown(workflow))
+            workflow_file = f.name
+
+        try:
+            result = runner.invoke(main, ["-p", workflow_file])
+
+            assert result.exit_code == 0
+            assert "ALPHA_VAL" in result.stdout
+            assert "Workflow declares" not in result.stderr
+        finally:
+            Path(workflow_file).unlink()
+
+    def test_multi_output_without_marker_json_mode_succeeds(
+        self, mock_registry_instance, mock_compile, mock_validate_ir
+    ):
+        """Regression: ambiguity error is text-mode-only; JSON emits all outputs."""
+        runner = click.testing.CliRunner()
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "alpha": {"description": "First", "type": "string"},
+                "beta": {"description": "Second", "type": "string"},
+            },
+            "nodes": [
+                {
+                    "id": "test",
+                    "type": "test-node",
+                    "params": {"add_keys": {"alpha": "A_VAL", "beta": "B_VAL"}},
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pflow.md", delete=False) as f:
+            f.write(ir_to_markdown(workflow))
+            workflow_file = f.name
+
+        try:
+            result = runner.invoke(main, ["--output-format", "json", workflow_file])
+
+            assert result.exit_code == 0, f"stderr: {result.stderr!r}"
+            payload = json.loads(result.stdout)
+            assert payload["success"] is True
+            assert payload["result"]["alpha"] == "A_VAL"
+            assert payload["result"]["beta"] == "B_VAL"
+        finally:
+            Path(workflow_file).unlink()
+
+    def test_stdout_marker_does_not_filter_json_output(self, mock_registry_instance, mock_compile, mock_validate_ir):
+        """The ``stdout: true`` marker is text-mode routing ONLY — JSON mode must still emit all declared outputs.
+
+        This guards the load-bearing contract that the marker picks which
+        single output streams to process stdout in text mode; it does NOT
+        filter the structured-output surface. A future "consistency" refactor
+        that also applied the marker to JSON mode would silently drop
+        outputs for MCP clients, CI pipelines, and workflow chaining — the
+        exact silent-data-loss shape this feature exists to prevent.
+        """
+        runner = click.testing.CliRunner()
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {
+                "primary": {"description": "Marked", "type": "string", "stdout": True},
+                "secondary": {"description": "Unmarked", "type": "string"},
+            },
+            "nodes": [
+                {
+                    "id": "test",
+                    "type": "test-node",
+                    "params": {"add_keys": {"primary": "PRIMARY_VAL", "secondary": "SECONDARY_VAL"}},
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pflow.md", delete=False) as f:
+            f.write(ir_to_markdown(workflow))
+            workflow_file = f.name
+
+        try:
+            result = runner.invoke(main, ["--output-format", "json", workflow_file])
+
+            assert result.exit_code == 0, f"stderr: {result.stderr!r}"
+            payload = json.loads(result.stdout)
+            assert payload["success"] is True
+            # BOTH outputs must appear — the marker must not filter JSON
+            assert payload["result"]["primary"] == "PRIMARY_VAL"
+            assert payload["result"]["secondary"] == "SECONDARY_VAL", (
+                "stdout: true marker leaked into JSON output filtering — "
+                "secondary output was silently dropped. The marker is text-mode-only."
+            )
+        finally:
+            Path(workflow_file).unlink()
+
+    def test_tty_mode_shows_output_descriptions(self, mock_registry_instance, mock_compile, mock_validate_ir):
+        """When stdout is a TTY, the output description renders in the stderr header.
+
+        CliRunner reports isatty()=False by default, so this test patches the
+        OutputController at construction to simulate a real interactive terminal
+        where the description label is useful context.
+        """
+        runner = click.testing.CliRunner()
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {"final_result": {"description": "The final processed result", "type": "string"}},
+            "nodes": [
+                {
+                    "id": "test",
+                    "type": "test-node",
+                    "params": {"output_key": "final_result", "output_value": "Processing complete"},
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pflow.md", delete=False) as f:
+            f.write(ir_to_markdown(workflow))
+            workflow_file = f.name
+
+        from pflow.core.output_controller import OutputController
+
+        original_init = OutputController.__init__
+
+        def force_tty_init(self, *args, **kwargs):
+            kwargs.setdefault("stdout_tty", True)
+            original_init(self, *args, **kwargs)
+
+        try:
+            with patch.object(OutputController, "__init__", force_tty_init):
+                result = runner.invoke(main, ["--verbose", workflow_file])
+
+            assert result.exit_code == 0
+            # Header appears in TTY mode
+            assert "Workflow output (The final processed result):" in result.output
+            # And the actual output
+            assert "Processing complete" in result.output
+        finally:
+            Path(workflow_file).unlink()
+
+    def test_non_tty_mode_suppresses_output_header(self, mock_registry_instance, mock_compile, mock_validate_ir):
+        """When stdout is not a TTY (pipe/redirect), the label is suppressed.
+
+        A naked ``Workflow output (description):`` header on stderr with the
+        value elsewhere (in the file/pipe) reads as "empty output" to both
+        humans and agents. The fix: skip the label on non-TTY stdout.
+        """
         runner = click.testing.CliRunner()
 
         workflow = {
@@ -385,13 +614,12 @@ class TestWorkflowOutputHandling:
             workflow_file = f.name
 
         try:
-            result = runner.invoke(main, ["--verbose", workflow_file])
+            # CliRunner already reports isatty()=False — this is the redirect case.
+            result = runner.invoke(main, [workflow_file])
 
             assert result.exit_code == 0
-            # Should show the output description in the header
-            assert "Workflow output (The final processed result):" in result.output
-            # And the actual output
-            assert "Processing complete" in result.output
+            assert "Workflow output" not in result.stderr
+            assert "Processing complete" in result.stdout
         finally:
             Path(workflow_file).unlink()
 

--- a/tests/test_core/test_workflow_validator.py
+++ b/tests/test_core/test_workflow_validator.py
@@ -124,6 +124,66 @@ class TestWorkflowValidator:
         # Should not have stdin-related errors
         assert not any("stdin" in d.message.lower() for d in errors)
 
+    def test_multiple_stdout_outputs_validation_error(self):
+        """Multiple outputs marked stdout: true → validator error.
+
+        Mirrors the stdin at-most-one invariant. The error message must name
+        all offending outputs so the user knows which ones to fix.
+        """
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "params": {}}],
+            "edges": [],
+            "outputs": {
+                "a": {"source": "${n1.out}", "stdout": True},
+                "b": {"source": "${n1.out}", "stdout": True},
+            },
+        }
+
+        errors, _warnings = split_validator_diagnostics(workflow, skip_node_types=True)
+
+        assert any("stdout" in d.message.lower() for d in errors)
+        assert any("'a'" in d.message or ", a" in d.message or ": a," in d.message for d in errors) or any(
+            "a" in d.message and "b" in d.message for d in errors
+        )
+        # Both offending names present in a single diagnostic message
+        stdout_diag = next(d for d in errors if "stdout" in d.message.lower())
+        assert "a" in stdout_diag.message
+        assert "b" in stdout_diag.message
+
+    def test_single_stdout_output_valid(self):
+        """A single output marked stdout: true is valid."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "params": {}}],
+            "edges": [],
+            "outputs": {
+                "a": {"source": "${n1.out}", "stdout": True},
+                "b": {"source": "${n1.out}"},
+            },
+        }
+
+        errors, _warnings = split_validator_diagnostics(workflow, skip_node_types=True)
+
+        # Should not flag stdout when only one output carries the marker
+        assert not any("stdout" in d.message.lower() and "multiple" in d.message.lower() for d in errors)
+
+    def test_no_stdout_marker_is_valid(self):
+        """Omitting the stdout marker does not fail validation — runtime decides."""
+        workflow = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "params": {}}],
+            "edges": [],
+            "outputs": {
+                "a": {"source": "${n1.out}"},
+                "b": {"source": "${n1.out}"},
+            },
+        }
+
+        errors, _warnings = split_validator_diagnostics(workflow, skip_node_types=True)
+
+        assert not any("stdout" in d.message.lower() for d in errors)
+
     def test_template_validation_errors(self, registry_with_nodes):
         """Test that template errors are caught when params provided."""
         workflow = {

--- a/tests/test_core/test_workflow_validator.py
+++ b/tests/test_core/test_workflow_validator.py
@@ -142,14 +142,8 @@ class TestWorkflowValidator:
 
         errors, _warnings = split_validator_diagnostics(workflow, skip_node_types=True)
 
-        assert any("stdout" in d.message.lower() for d in errors)
-        assert any("'a'" in d.message or ", a" in d.message or ": a," in d.message for d in errors) or any(
-            "a" in d.message and "b" in d.message for d in errors
-        )
-        # Both offending names present in a single diagnostic message
         stdout_diag = next(d for d in errors if "stdout" in d.message.lower())
-        assert "a" in stdout_diag.message
-        assert "b" in stdout_diag.message
+        assert "a" in stdout_diag.message and "b" in stdout_diag.message
 
     def test_single_stdout_output_valid(self):
         """A single output marked stdout: true is valid."""

--- a/tests/test_execution/formatters/test_workflow_describe_formatter.py
+++ b/tests/test_execution/formatters/test_workflow_describe_formatter.py
@@ -230,6 +230,26 @@ class TestFormatInputsSection:
 
         assert "implicit_required (required):" in result
 
+    def test_stdin_input_gets_marker(self):
+        """INPUTS: Input with stdin: True renders the [stdin] badge.
+
+        The describe output surfaces routing slots so agents reading a
+        workflow's interface can see where piped data lands without parsing
+        the full IR.
+        """
+        ir = {
+            "inputs": {
+                "data": {"required": True, "description": "Piped input", "stdin": True},
+                "other": {"required": False, "description": "Regular input"},
+            }
+        }
+
+        result = _format_inputs_section(ir)
+
+        assert "  - data [stdin] (required): Piped input" in result
+        # Unmarked inputs keep their normal rendering — no marker leak
+        assert "other [stdin]" not in result
+
 
 class TestFormatOutputsSection:
     """Test output section formatting."""
@@ -279,6 +299,26 @@ class TestFormatOutputsSection:
         result = _format_outputs_section(ir)
 
         assert result == "\nOutputs: None"
+
+    def test_stdout_output_gets_marker(self):
+        """OUTPUTS: Output with stdout: True renders the [stdout] badge.
+
+        The describe output surfaces routing slots so agents reading a
+        workflow's interface can see which declared output streams to stdout
+        in text mode without parsing the full IR.
+        """
+        ir = {
+            "outputs": {
+                "primary": {"description": "Main result", "stdout": True},
+                "secondary": {"description": "Secondary metadata"},
+            }
+        }
+
+        result = _format_outputs_section(ir)
+
+        assert "  - primary [stdout]: Main result" in result
+        # Unmarked outputs keep their normal rendering — no marker leak
+        assert "secondary [stdout]" not in result
 
 
 class TestFormatExampleUsageSection:

--- a/tests/test_integration/test_workflow_outputs_namespaced.py
+++ b/tests/test_integration/test_workflow_outputs_namespaced.py
@@ -108,8 +108,10 @@ class TestWorkflowOutputsNamespaced:
             Path(workflow_file).unlink(missing_ok=True)
 
     def test_multiple_outputs(self):
-        """Test workflow with multiple outputs from different nodes."""
-        # Create workflow with multiple shell nodes
+        """Multiple outputs — text mode routes the ``stdout: true`` marker; JSON emits all."""
+        # Create workflow with multiple shell nodes. One output is marked as
+        # the stdout payload so text mode has deterministic routing; the
+        # others are still emitted in JSON mode (multi-output parity).
         workflow_ir = {
             "ir_version": "0.1.0",
             "nodes": [
@@ -123,7 +125,7 @@ class TestWorkflowOutputsNamespaced:
             ],
             "edges": [{"from": "first", "to": "second"}, {"from": "second", "to": "third"}],
             "outputs": {
-                "repeated": {"description": "First message repeated", "source": "first.stdout"},
+                "repeated": {"description": "First message repeated", "source": "first.stdout", "stdout": True},
                 "uppercase": {"description": "Second message in uppercase", "source": "second.stdout"},
                 "prefixed": {"description": "Third message with prefix", "source": "third.stdout"},
             },
@@ -136,13 +138,16 @@ class TestWorkflowOutputsNamespaced:
         try:
             write_workflow_file(workflow_ir, Path(workflow_file))
 
-            # Test 1: Text format returns first output
+            # Test 1: text format routes the stdout-marked output
             runner = CliRunner()
             result = runner.invoke(cli, [workflow_file])
 
             assert result.exit_code == 0, f"Failed with output: {result.output}"
-            # Should return the first output (repeated message)
-            assert "First message First message" in result.output
+            # Marked output reaches stdout
+            assert "First message First message" in result.stdout
+            # Unmarked outputs do NOT leak onto stdout
+            assert "SECOND MESSAGE" not in result.stdout
+            assert "[INFO] Third message" not in result.stdout
 
             # Test 2: JSON format returns all outputs
             result = runner.invoke(cli, ["--output-format", "json", workflow_file])


### PR DESCRIPTION
## Summary

Adds a `stdout: true` per-output attribute that mirrors `stdin: true` on inputs. Workflow authors mark which declared output streams to process stdout in text mode. Closes both issues from #281 — multi-output silent drop and redirected-stdout orphaned label.

## Changes

**Schema + validator**
- `stdout` boolean added to output IR schema (`src/pflow/core/ir_schema.py`)
- `WorkflowValidator._validate_stdout_outputs` enforces at-most-one marker per workflow (new step 3 in the pipeline)

**Routing (`src/pflow/cli/workflow_output.py`)**
- New precedence in text mode: `-o` > `stdout: true` marker > single declared output (implicit) > first declared + stderr warning naming other outputs and the three fixes
- Warning is suppressed under `-p` (matches Task 134's auto-detect warning pattern)
- `_output_with_header` TTY-gates the `Workflow output (<desc>):` label — non-TTY stdout suppresses it

**Describe formatter**
- `pflow describe` now surfaces `[stdin]` and `[stdout]` markers on routed inputs/outputs — parity fix (stdin marker was also missing previously)

**Docs**
- CLI reference adds a Stdout Output section
- Agent guide adds an Output Fields reference
- Architecture doc extends shell-pipes with stdout routing contract
- Both MCP instruction resources updated for parity with the guide
- 4 CLAUDE.md files updated (10-step validator pipeline, stdout-routing note in core, three-mode output routing table in cli, one-word bumps elsewhere)

**Tests**
- New subprocess integration file `test_dual_mode_stdout.py` — 7 tests covering redirect/pipe/TTY behavior, marker routing, ambiguity warning, JSON parity, validator catching double marker
- New in-process routing tests in `test_workflow_output_handling.py`
- High-value regression guard: `test_stdout_marker_does_not_filter_json_output` — asserts JSON mode still emits ALL declared outputs when a marker is present (contract boundary for MCP consumers)
- Formatter tests for `[stdin]` / `[stdout]` markers
- Validator tests for at-most-one stdout marker

**Example**
- New canonical fixture `examples/core/stdout-result.pflow.md` showing a 2-output workflow with the marker

## Explanation

### Why `stdout: true` instead of "warn + first by default"

We debated this. Without a declared routing slot, a workflow with 2+ outputs is genuinely ambiguous — the CLI has to guess. Silent first-wins (prior behavior) drops outputs invisibly. Erroring is too strict and breaks existing workflows. The landed design: warn + emit first when no marker is set, and give authors `stdout: true` to resolve the ambiguity permanently per-workflow. Callers can override at any call site with `-o` or `--output-format json`.

### Why the label is TTY-gated, not removed

Interactive terminal: the `Workflow output (<description>):` label prints the author's description alongside the value — useful context for humans and agents running interactively. Redirect/pipe: value goes elsewhere, label is orphaned and reads as empty output. The fix reads `OutputController.stdout_tty` (captured at construction) and skips the label when stdout is non-TTY. Routing stays TTY-agnostic (stream invariants intact); only rendering varies.

### Why JSON mode is untouched

JSON and MCP already emit all declared outputs. The marker is a text-mode concept — a "pick one of these to stream" selector. Filtering JSON by the marker would break MCP clients silently. An explicit regression guard test locks this in.

## Testing

- 4,776 tests pass (`make test`)
- `make check` clean
- Manual verification of 30+ edge cases including: YAML `yes`/`no` coercion to bool, schema rejection of non-boolean, nested workflows with markers, save → load → run round-trip, `-p` suppression, `--only` bypass, `-o` override, empty marked value, missing-source error path, dict outputs, batch workflows, pty-based real-TTY label rendering

## Related

- Fixes #281
- Mirrors the stdin routing pattern introduced in Task 115
- Extends Task 134's auto-detect warning precedent to multi-output ambiguity