### PR TITLE
feat: type vocabulary coherence refactor (fixes #291)

### DIFF
--- a/.taskmaster/tasks/task_120/starting-context/braindump-post-task154-landing.md
+++ b/.taskmaster/tasks/task_120/starting-context/braindump-post-task154-landing.md
@@ -1,0 +1,212 @@
+# Braindump: post-Task-154 landing, what Task 120 inherits
+
+**Timestamp**: 2026-04-17
+
+**Context**: I just shipped Task 154 (type vocabulary coherence) on branch `fix/type-vocab-incoherence`, currently at commit `5b5a8cbd`. Two consolidation passes: initial review fixes, then architecture-level simplification (round-2). This braindump captures what's in my head that Task 120 will need but isn't written in the task files.
+
+---
+
+## Where Task 120 stands right now
+
+Task 154 was designed as Task 120's prerequisite. The vocabulary is now canonical; `TypeSpec` is the single source of truth. The plumbing point for strict runtime enforcement is documented as `TypeSpec.accepts(value)`. But the way Task 154 ended — specifically the round-2 deletion of `_TYPE_ALIASES` and the template-ref bypass close — changed the design constraints for Task 120 in ways the task_120.md file likely doesn't reflect yet.
+
+**Read first**: `.taskmaster/tasks/task_154/task-review.md` — I added a "Round-2 Addendum" at the top that contradicts several load-bearing claims in the rest of the doc. The addendum is the canonical post-task-154 design state. Don't skip it.
+
+---
+
+## The round-2 story (why `_TYPE_ALIASES` is GONE, not just relocated)
+
+The original Task 154 plan kept `_TYPE_ALIASES` and `_normalize_type` in `param_coercion.py` as "defense-in-depth for template-referenced sub-workflows that bypass `validate_ir`." This was a real bypass — the resolver returns None for `${...}` refs, so the parent validator skips them.
+
+In round-2, we closed the bypass directly: added `normalize_ir` + `validate_ir` at `workflow_executor.py:_validate_and_compile_child` so every IR path through `compile_workflow` is validated. This made `_TYPE_ALIASES` structurally dead, and it was deleted along with `_normalize_type`, the drift-guard test, and the defense-in-depth pin.
+
+**Why this matters for Task 120**: a natural instinct when implementing strict coercion is to think "let me handle both canonical and Python alias names, just in case." **Don't.** The invariant is now: by the time a value reaches `coerce_workflow_input`, the `declared_type` is guaranteed canonical. If Task 120 finds an untested entry point, the fix is to ADD `validate_ir` to that path, not to restore alias tolerance in coercion.
+
+**Most dangerous place to read**: `task-review.md` line ~249 before I added the addendum said *"Do NOT remove `_TYPE_ALIASES` in `param_coercion.py`"*. The addendum explicitly overrides this. If a future agent reads that line out of context and restores the map, they reintroduce ~40 lines of dead code and undo the round-2 simplification.
+
+---
+
+## The composable-`CompilationError` pattern just established (NEW)
+
+In this session I also fixed a latent bug in `CompilationError.to_diagnostics()` that will affect Task 120 if it wraps exceptions. Before this fix, `wrapped_diagnostics` and `details["sub_workflow_path"]` short-circuited each other — you got one OR the other. After:
+
+```python
+# exceptions.py:305-320
+def to_diagnostics(self) -> list[Diagnostic]:
+    if self.wrapped_diagnostics:
+        sub_workflow_path = self.details.get("sub_workflow_path")
+        if sub_workflow_path is None:
+            return list(self.wrapped_diagnostics)
+        return [
+            replace(d, context={"sub_workflow_path": sub_workflow_path, **(d.context or {})})
+            for d in self.wrapped_diagnostics
+        ]
+    ...
+```
+
+This means Task 120 can raise `CompilationError(wrapped_diagnostics=e.to_diagnostics(), details={"sub_workflow_path": ...})` and BOTH the inner structure (similar_names/available_fields) AND the outer container context (sub_workflow_path) reach the renderer. The `setdefault` semantics (wrapped-diag wins on conflict) are important — don't accidentally reverse the merge order.
+
+---
+
+## The user's mental model (verbatim where possible)
+
+Key things the user said during this session, in their words:
+
+> **"prioritize simplicity of the final code, not how easy it is to get there"**
+
+This came up twice. First when reviewing the 3.14 failures (I was about to just skip the tests). Second when evaluating the W1 reviewer finding (I had proposed the reviewer's patch verbatim). Both times, when I stepped back to think about end-state complexity instead of minimum-diff, I found a better answer. For Task 120: when you're tempted to add a config flag or a compatibility shim, stop and ask what the final shape should be.
+
+> **"what's the right solution that the top 10% of codebases similar to this one would implement, have we considered it yet?"**
+
+The user routinely pushes for this framing. "Similar" here means CLI-first Python tools with heavy emphasis on agent UX — Typer, Click, Ruff, FastAPI, Pydantic patterns. Not enterprise frameworks.
+
+> **"are you sure we should fix any of 5-7 issues? (F1-F3?)"**
+
+The user caught me being over-credulous of review-agent findings. They pushed back hard — I'd flagged three "warnings" as potential follow-ups without scrutinizing whether they were real. On re-examination, all three were non-issues. **Lesson for Task 120**: review agents produce findings by design; your job is to challenge each one before filing. Review findings aren't bugs until you've verified them.
+
+> **"make sure to not overfit to your context window, only add the most relevant information"**
+
+Came up when I over-wrote a CLAUDE.md entry with 15 lines when surrounding entries were 2-3. The user values terseness. Task 120's documentation additions should match the density of surrounding prose, not add more.
+
+> **"carefully implement B"**
+
+Trust earned through Options A/B/C analysis. When I present tradeoffs clearly with a recommendation, the user gives fast approval. When I just start coding without presenting options, they push back.
+
+---
+
+## The cross-layer testing lesson (W1 case study)
+
+The single most instructive moment in this session was the W1 bug. The `test_template_ref_bypass_close_end_to_end_through_runner` test was passing, but it was only asserting:
+
+```python
+assert "Use 'string' instead of 'str'" in diagnostic_messages  # joined .message fields
+```
+
+This substring matched because the OLD broken code flattened `suggestion` into the exception's string representation. When I fixed W1 to preserve structured context (moving the fix into `Diagnostic.suggestions` where it belongs), the test FAILED because the message no longer contained the fix text — it was in `.suggestions` now, which was the correct place all along.
+
+**The assertion itself was WRONG — pinning a symptom of the bug.** A structure-preserving fix broke the test because the test was designed around the broken behavior.
+
+**For Task 120 tests**: when you add strict-validation tests, assert on structured fields:
+- `d.context["similar_names"]` — for fuzzy/typo diagnostics
+- `d.context["available_fields"]` — for enumerated-option errors
+- `d.suggestions` — for opinionated canonical fixes
+- `d.context["path"]` — for the error location
+
+Never assert `"Use 'X' instead" in d.message` unless you're specifically testing message rendering. The same pattern is now pinned in `test_template_ref_bypass_close_end_to_end_through_runner:498-519` as a template.
+
+---
+
+## What Task 120 actually has to do (my read)
+
+From the existing task_120.md (read it fresh — I haven't in this session), plus what I know:
+
+1. **Strict `coerce_workflow_input`** — currently lenient, warns on failure, returns original value. Needs to raise `WorkflowValidationError` or similar on coercion failure.
+
+2. **`type: object` dict-only enforcement at runtime** — `_coerce_to_object` in `param_coercion.py` currently JSON-parses strings silently if they look like JSON. Strict mode should reject non-dict values (unless... UNCLEAR: should it still accept a JSON string that PARSES to a dict? That's a UX question — task 120 should decide).
+
+3. **Use `TypeSpec.accepts(value)` as the check primitive.** The asymmetric semantics are baked in:
+   - `integer` rejects `bool` (`isinstance(True, int)` returns True in Python, but JSON Schema says integer≠bool — the `accepts` method MUST enforce JSON Schema semantics, not Python's)
+   - `object` is dict-only (not wildcard, despite the historical overload)
+   - `any` returns True for everything
+   - `number` accepts both `int` and `float`
+
+   `TypeSpec.accepts`'s existing docstring comments this asymmetry. Don't "simplify" it by using `isinstance(value, TypeSpec.python_type())`. `TypeSpec.python_type()` was DELETED in round-2 precisely because its loose isinstance semantics were wrong for strict enforcement.
+
+4. **Extend `_validate_child_params`** — Task 153 added this at `workflow_executor.py:~485`. It currently checks only PRESENCE of keys (missing-required / extras). Task 120's natural extension is to also check value types against declared types using `TypeSpec.accepts(value)`. Preserves the defense-in-depth pattern task 153 established.
+
+---
+
+## ASSUMPTIONS / UNCLEAR / NEEDS VERIFICATION
+
+**ASSUMPTION**: Task 120's scope is strict runtime enforcement at CLI/workflow-input boundaries (where external values enter). Not internal type checks between nodes (that's template validation, different subsystem).
+
+**UNCLEAR**: Where exactly should the strict check fire?
+- Option A: `coerce_workflow_input` itself — closest to "where types enter the system"
+- Option B: `_validate_child_params` for sub-workflows only — mirrors task 153's pattern
+- Option C: Earlier in the pipeline at `prepare_inputs` stage — catches at compile time
+
+The natural answer is probably A for the top-level + B for sub-workflows. But I didn't verify this — check whether there are other entry points that currently call `coerce_workflow_input` and would need to change.
+
+**UNCLEAR**: `_coerce_to_object`'s JSON-parsing lenience. Current behavior: string `'{"a": 1}'` → `json.loads` → dict `{"a": 1}`. Is this:
+- (a) convenience that should stay (CLI users pass JSON strings)
+- (b) silent coercion that masks bugs and should be removed
+- The user's instinct on similar questions this session was "top 10% does the hard thing" — so probably (b), with CLI taking responsibility for parsing.
+
+**NEEDS VERIFICATION**: Does strict mode break any existing tests? Task 154 migrated 16 test files to canonical vocab, but did it also flush out tests that depended on LENIENT coercion? I didn't grep for this. Task 120 should start with a "what tests rely on lenient behavior" audit.
+
+**NEEDS VERIFICATION**: Does strict coercion at `coerce_workflow_input` interact with the compile-once cache? When batch item 1 passes strict check and item 2 has a type error, does the cache short-circuit the check for item 2? `workflow_executor.py:265-270` has a KNOWN LIMITATION comment about per-item coercion bypass. Task 120 needs to verify strict checks aren't bypassed here.
+
+---
+
+## UNEXPLORED / CONSIDER / MIGHT MATTER
+
+**UNEXPLORED**: `error_action: continue` + strict-validation errors. GH #284 documents that error_action doesn't catch prep-time errors. Task 120 would add MORE prep-time errors. Consider: should Task 120 fix #284 as part of its scope, or leave it for a separate task? The user generally prefers NOT bundling scope, but this specific interaction might create a noticeable UX regression (users set error_action: continue expecting bad values to fail gracefully, now they abort the whole workflow).
+
+**CONSIDER**: How does Task 120 interact with Claude Code `output_schema`? That's S3 (deliberately Python-named), and values are produced by LLM generation. If Task 120 adds strict `type: object` enforcement, do LLM-generated outputs that accidentally return a string instead of a dict fail loudly? Probably the right behavior, but worth checking the output_schema validation path separately.
+
+**MIGHT MATTER**: `type: any` passthrough. Current `_coerce_to_any` is pure identity. Strict mode preserves this (any = wildcard). But if the child has a code node annotating `x: int` for an input typed `any`, the code node raises `TypeError` at exec time with a confusing blame (user sees "int expected, got str" and wonders why the `any` declaration didn't help). Task 120 isn't responsible for fixing this, but it might surface the complaint more often once strict mode catches the easier cases. Flag for the task-120 task doc.
+
+**UNEXPLORED**: MCP server entry points. `pflow_execute` via MCP submits a workflow IR + parameters. Does it go through the same `coerce_workflow_input` path? If MCP has its own coercion that bypasses strictness, Task 120 ships an inconsistency between CLI and MCP. Search `src/pflow/mcp_server/` for coercion paths.
+
+**UNEXPLORED**: Test for strict + `null` input. Task 154 dropped `null` from vocabulary (deferred until union syntax lands). In strict mode, `type: string` with a None value — does it raise, or is None handled specially? Probably should raise, but verify the behavior is tested.
+
+---
+
+## Hard-won knowledge from this session
+
+**The AST walker in `_check_annotation_vocabulary` taught me that import detection matters.** Originally I tried to reject all typing-module names in annotations (`Union`, `List`, etc.) — but that broke `from typing import Literal` users. The fix was `_extract_imported_names` — only reject when NOT imported. Task 120 might need similar import-awareness if it validates Python code paths. Pattern: collect imports first, then check usage against the import set.
+
+**PEP 649 (Python 3.14+) changes annotation evaluation semantics.** This hit us in CI — the existing `NameError`-based opinionated hints stopped firing on 3.14 because annotations are deferred. Task 120 isn't directly exposed to this (runtime coercion happens before code annotations run). But any Task 120 design that relies on Python's runtime to enforce type checks must test across Python versions.
+
+**The review agents produce findings by design — challenge each one before acting.** The user called me on this explicitly. I'd reflexively listed every agent finding as potential follow-up work. Most were theoretical concerns that didn't apply. For Task 120: when review agents flag "strict mode could miss X edge case," verify the edge case is reachable before scoping work around it.
+
+**`make check` cyclomatic complexity (C901) limit is 10.** Adding a third `except` branch to `_compile_sub_workflow` pushed it to 11, blocking the commit. Had to extract `_validate_and_compile_child` static method. Task 120 will likely add dispatch logic that bumps against C901 — plan for extraction rather than `# noqa`. User memory explicitly says don't suppress linter warnings.
+
+**Subprocess vs in-process tests for rendering pipeline.** I've defaulted to in-process tests (format_diagnostic in the same process). ~3ms vs 500ms subprocess. Same coverage for everything except CLI entry wiring (which is a stable contract, separately tested). Task 120 renderer tests should be in-process unless specifically testing stderr/stdout separation.
+
+---
+
+## Open threads I didn't pursue
+
+The user mentioned the `error_action: continue` / `validate_ir` interaction as a follow-up candidate but didn't want it filed as a GH issue. If Task 120 goes there, it'll hit this. Consider whether Task 120's scope naturally extends to cover prep-time errors uniformly.
+
+The review mentioned `docs/reference/nodes/claude-code.mdx:134-142` teaches `str/int/bool/list/dict` for output_schema without a "this is S3, intentionally different from S1" clarifying sentence. I flagged it as low-stakes and moved on. Task 120 might run into agent confusion about this and want to add the clarifying sentence.
+
+I ran the review-feature-interactions agent earlier and it produced findings F1-F3 which the user correctly dismissed. But one finding I didn't fully explore was the scenario where the compile-once cache serves a stale strict-check result to a later batch item. If Task 120 doesn't explicitly address this, add an explicit invariant test: "batch item 2 with invalid type still raises even if item 1 passed."
+
+---
+
+## Relevant files (in priority order)
+
+- `.taskmaster/tasks/task_154/task-review.md` — **READ THE ROUND-2 ADDENDUM FIRST**. Many sections below it are stale.
+- `.taskmaster/tasks/task_154/implementation/progress-log.md` — the "post-merge-review round 2" entry has the Option B → Option D pivot that's load-bearing for Task 120's "don't reintroduce `_TYPE_ALIASES`" invariant.
+- `src/pflow/core/types.py` — `TypeSpec`, `CANONICAL_TYPES`, `PYTHON_ALIASES_AT_S1`. `TypeSpec.accepts()` is Task 120's extension point.
+- `src/pflow/core/param_coercion.py` — the lenient coercer. Look at `_COERCION_DISPATCH` and `_coerce_to_object` specifically.
+- `src/pflow/runtime/workflow_executor.py:_validate_and_compile_child` — the new static helper where W1 landed. Study the exception chain if Task 120 needs to add its own wrapping.
+- `src/pflow/core/exceptions.py:CompilationError.to_diagnostics` — the just-fixed compose behavior. Reuse the pattern if Task 120 wraps exceptions.
+- `tests/test_runtime/test_workflow_executor/test_workflow_executor.py:TestTemplateRefSubWorkflowValidation` — template for cross-layer rendering tests. Specifically `test_template_ref_bypass_close_end_to_end_through_runner` shows the structured-assertion pattern.
+- `tests/test_runtime/test_prepare_inputs_coercion.py` — pre-existing tests for `coerce_workflow_input`. Task 120 will extend/replace these.
+
+---
+
+## What I'd tell myself starting over
+
+1. **Don't bundle scope**. Task 120 is "strict enforcement of the vocabulary Task 154 established." It is NOT the place to fix `error_action`, rename the `<inline>` sentinel, or consolidate the three vocabularies (S1/S2/S3). If the user asks whether you should bundle, the answer is probably no — reviewers consistently preferred scoped PRs.
+
+2. **Design the test contract before writing code**. What does `result.diagnostics` look like for a strict-validation error? Which fields matter? Write the assertion pattern FIRST, then make the code match. The W1 lesson is that tests encoding the wrong contract hide real bugs.
+
+3. **Dispatch table, not if/elif**. `_COERCION_DISPATCH` in `param_coercion.py` is the existing pattern. Task 120's strict check should follow the same shape — `_STRICT_CHECK_DISPATCH: dict[str, Callable]` keyed by canonical S1 names.
+
+4. **The user will push back on over-engineered strict modes**. If Task 120 has feature-flag config for strict/lenient, the user will likely reject it (like task 154 rejected deprecation warnings). Just make it strict, breaking-change atomic ship, migrate tests in the same PR. MVP state = no external users = no compat debt.
+
+---
+
+## For the next agent
+
+- **Start by reading `task_154/task-review.md` top-to-bottom, especially the Round-2 Addendum.** Then re-read this braindump. Then the Task 120 task doc.
+- **Don't bother reinstating `_TYPE_ALIASES` or `_normalize_type`.** They're structurally unnecessary after the round-2 bypass close.
+- **The user cares most about**: (a) final-code simplicity over minimal-diff, (b) structured diagnostics over flattened messages, (c) top-10% patterns from CLI-first tools. Their review style is challenging — present options with tradeoffs, and they'll approve fast.
+- **Test cross-layer rendering, not just unit structure.** `test_template_ref_bypass_close_end_to_end_through_runner` is the template to copy.
+- **The branch `fix/type-vocab-incoherence` is still open and waiting for merge**. Task 120 work should happen on a fresh branch off `main` AFTER this PR merges. Don't continue on this branch.
+
+> **Note to next agent**: Read this document fully before taking any action. When ready, confirm you've read and understood by summarizing the key points, then state you're ready to proceed.

--- a/.taskmaster/tasks/task_154/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_154/implementation/implementation-plan.md
@@ -1,0 +1,1466 @@
+# Plan — Type Vocabulary Coherence Refactor
+
+> **For the implementing agent:** this plan is self-contained. Read top to bottom. Every line number, file path, exact string, and decision is provided. You should not need to re-research anything. If you find a genuine discrepancy between this plan and the code, STOP and ask — don't guess.
+
+## TL;DR
+
+**Create**: `src/pflow/core/types.py` (new `TypeSpec` class), `tests/test_core/test_types.py`.
+
+**Edit (code)**: `src/pflow/core/ir_schema.py` (shrink enum, new input-side suggestion routing), `src/pflow/core/exceptions.py` (extend `SchemaValidationError` with structured context fields), `src/pflow/nodes/python/python_code.py` (inject `Any` into exec namespace, reject lowercase `any` with `NonRetriableError`, fix NameError suggestion), `src/pflow/core/param_coercion.py` (add `any` dispatch), `src/pflow/core/markdown_parser.py` (line 147 hint).
+
+**Edit (tests)**: 3 test-fixture files (Python-alias `str`/`int` → canonical), plus removal of 6 now-dead alias tests and addition of ~40 new tests across 4 files.
+
+**Edit (docs)**: 10 files across `src/pflow/guide/`, `src/pflow/mcp_server/resources/instructions/`, `docs/`, `architecture/`.
+
+**Do NOT edit**: `TYPE_COMPATIBILITY_MATRIX`, `_TYPE_ALIASES` dict, registry `Interface:` docstrings, scratchpad probes, runtime template validation hardcoded lists, MCP JSON→Python mapping.
+
+**Atomic**: one PR. Breaking changes on Python aliases and `object` ship together.
+
+---
+
+## 1. Context
+
+### The problem
+
+pflow today has a subtly incoherent type vocabulary across two authoring surfaces:
+
+- **Surface 1 (S1)** — `## Inputs` / `## Outputs` blocks in `.pflow.md` files use a `type:` field.
+- **Surface 2 (S2)** — Python code-block annotations (`x: str`, `result: int = ...`).
+
+Three concrete bugs follow from the incoherence (see `scratchpads/type-vocabulary-incoherence/bug-report.md` for full probes):
+
+1. **Dual vocabulary at S1.** The IR schema silently accepts both JSON Schema names (`string`, `number`, `boolean`, `array`, `object`) and Python aliases (`str`, `int`, `integer`, `float`, `bool`, `dict`, `list`). Only the JSON Schema names are documented. This is a 12-name enum doing the work of 6 concepts.
+2. **`type: object` is a hidden wildcard.** Probe E confirmed that `type: object` silently accepts strings, lists, ints, dicts — not just dict-shaped values. A type label that looks restrictive but behaves permissively is worse than no label.
+3. **`any` is rejected at S1 but `Any` works at S2 only with import ceremony.** The natural wildcard name is illegal at the declaration layer; the Python wildcard requires `from typing import Any` or produces a misleading error (`Add 'Any' to the inputs dict: {"Any": ...}`).
+
+### The intended outcome
+
+- **One S1 vocabulary** — JSON Schema names only, 7 values: `string | number | integer | boolean | array | object | any`.
+- **S2 unchanged** — Python annotations, with one addition: `Any` auto-injected into the code exec namespace.
+- **Explicit bridge** documented between S1 and S2.
+- **`object` means dict-only** (documented and enforced at the vocabulary level; strict runtime rejection of non-dict values is deferred to Task 120).
+- **Hard errors on old spellings** with actionable fix suggestions — shipped in one atomic PR.
+
+### Scope boundary (load-bearing)
+
+This PR **does not** touch:
+
+- **Node registry `Interface:` docstrings** — these use Python type names (`str`, `int`, `dict`) as documented Python annotations. They are conceptually closer to S2 than S1, and the convention is enforced only to be lowercase (`tests/test_registry/test_type_string_conventions.py`). This PR leaves them Python-named.
+- **Lenient `coerce_workflow_input` behavior** — the function today returns original values on coercion failure rather than raising. This PR only adds an `"any"` passthrough entry. Tightening to strict rejection is Task 120's scope.
+- **Complex / nested input schemas** (`properties:`, `required: [...]`) — separate follow-up task.
+- **Union syntax at S1** (`string | null`, `int | float`) — deferred. `null` is dropped from the S1 vocabulary for now.
+
+### Decisions previously made (confirmed by polls)
+
+| # | Decision | Source |
+|---|---|---|
+| 1 | Separate vocabularies: S1 = JSON Schema, S2 = Python | Design discussion + 2 independent reviewers + poll P3 |
+| 2 | `any` at S1, `Any` at S2 — semantic match, not character-for-character | Poll P1 unanimous (3/3) |
+| 3 | `x: Any` (capitalized) works via namespace injection. Lowercase `x: any` in code blocks is a hard error | Poll P1 unanimous |
+| 4 | Also accept `x: typing.Any` (dotted form) | Poll P1 agent 2 |
+| 5 | Ship `object` fix + Python alias removal atomically in one PR | Poll P3 unanimous (3/3) |
+| 6 | Hard errors with fix suggestions, no deprecation warnings | Poll P3 unanimous |
+| 7 | Error for `type: str` must say exactly `"use 'string'"`; for wildcard `dict`, must name `any` as the migration path | Poll P3 explicit ask |
+| 8 | `required:` + `default:` stay as separate explicit fields; `default:` present implies optional | Design discussion |
+| 9 | Parameterized generics (`dict[str, int]`) rejected at S1 parse time. S2 Python code keeps today's outer-type-only validation | Design discussion |
+| 10 | `null` dropped from S1 vocabulary until union syntax lands | Design discussion |
+| 11 | No migration helper; manual sed for migrations | Design discussion (O4) |
+| 12 | Lenient coercion stays — Task 120 will tighten | Design discussion (O3) |
+
+---
+
+## 2. Target vocabulary
+
+### S1 — `## Inputs` / `## Outputs` `type:` field
+
+Exactly 7 legal values:
+
+```
+string | number | integer | boolean | array | object | any
+```
+
+**Semantics:**
+
+| S1 type | Accepts |
+|---|---|
+| `string` | Python `str` |
+| `integer` | Python `int` (not `float`) |
+| `number` | Python `int` or `float` |
+| `boolean` | Python `bool` |
+| `array` | Python `list` |
+| `object` | Python `dict` only (NOT wildcard) |
+| `any` | Any value — the explicit wildcard |
+
+**Rejected (old accepted values):** `str`, `int`, `float`, `bool`, `dict`, `list`. Each produces a hard error naming the canonical replacement.
+
+**Rejected (other):** `null` (deferred), parameterized generics (`list[str]`, `dict[str, int]`, etc.), uppercase variants (`String`, `Int`).
+
+### S2 — Python code-block annotations
+
+Unchanged. Valid Python types. Plus:
+
+- `Any` is auto-injected into the code exec namespace. `from typing import Any` is unnecessary but still works.
+- `typing.Any` also works (injected `typing` module continues to exist).
+- Lowercase `any` in code blocks is a hard error with a fix suggestion.
+- Parameterized generics (e.g., `list[dict]`) continue to work — outer type is enforced, generic params are documentation.
+
+### The S1 ↔ S2 bridge (must be documented in one place)
+
+| S1 (`## Inputs` `type:`) | Python annotation | Notes |
+|---|---|---|
+| `string` | `str` | |
+| `integer` | `int` | Rejects `float` |
+| `number` | `int \| float` or `float` | `float` accepts `int` per Python convention |
+| `boolean` | `bool` | |
+| `array` | `list` | |
+| `object` | `dict` | dict only, NOT wildcard |
+| `any` | `Any` | auto-injected, no import needed |
+
+Copy-paste-equivalent in meaning; spelling differs because each surface uses its native dialect.
+
+---
+
+## 3. Internal type model — `TypeSpec`
+
+### Location
+
+New file: `src/pflow/core/types.py`
+
+### Motivation
+
+Today the 7 (or 12) strings flow through ~10 fragmented consumer sites, each with its own `if s == "str" or s == "string"` branching. One canonical class will consolidate these, making future changes (e.g., Task 120 strict coercion, union syntax) single-site edits.
+
+### Public API
+
+```python
+# src/pflow/core/types.py
+from __future__ import annotations
+from typing import Any, ClassVar, Final
+from dataclasses import dataclass
+
+
+# Canonical S1 vocabulary
+CANONICAL_TYPES: Final[tuple[str, ...]] = (
+    "string", "number", "integer", "boolean", "array", "object", "any",
+)
+
+# Python aliases that are NO LONGER legal at S1 — map to their canonical replacement
+# for producing "use X instead" error messages.
+PYTHON_ALIASES_AT_S1: Final[dict[str, str]] = {
+    "str": "string",
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+    "dict": "object",  # special: also mention `any` for wildcard intent
+    "list": "array",
+}
+
+
+@dataclass(frozen=True)
+class TypeSpec:
+    """Canonical representation of a pflow S1 type.
+
+    Construct via `TypeSpec.parse(s)`. Exposes a small interface that every
+    consumer should use instead of comparing strings.
+    """
+
+    name: str  # one of CANONICAL_TYPES
+
+    def __post_init__(self) -> None:
+        if self.name not in CANONICAL_TYPES:
+            raise ValueError(f"TypeSpec.name must be in {CANONICAL_TYPES}, got {self.name!r}")
+
+    # -- construction --
+
+    @classmethod
+    def parse(cls, raw: str) -> "TypeSpec":
+        """Parse an S1 type string into a TypeSpec.
+
+        Raises ValueError with a specific, actionable message for:
+        - Python aliases (`str`, `int`, `dict`, ...) — "use '{canonical}'"
+        - Parameterized generics (`list[str]`, `dict[str, int]`) — "parameterized generics not supported"
+        - Unknown types — "did you mean '{closest}'?" using suggestion_utils.find_similar_items
+        - Empty / non-string input — "type must be a non-empty string"
+        """
+        ...
+
+    # -- semantics --
+
+    def accepts(self, value: Any) -> bool:
+        """Whether a Python value satisfies this type.
+
+        object → dict only; array → list only; any → True.
+        integer → int and NOT bool (matches JSON Schema convention); number → int OR float.
+        """
+        ...
+
+    def is_wildcard(self) -> bool:
+        """True for TypeSpec('any'), False for everything else."""
+        ...
+
+    def python_type(self) -> type | tuple[type, ...] | None:
+        """Return the Python type(s) this maps to for isinstance-style checks.
+
+        Returns None for `any` (no check).
+        Returns a tuple for `number` (int, float).
+        Excludes bool from integer (despite Python's `bool issubclass int`).
+        """
+        ...
+
+    def to_json_schema(self) -> dict[str, str]:
+        """Produce a minimal JSON Schema dict: {'type': name} except `any` which returns {}."""
+        ...
+
+    def __str__(self) -> str:
+        return self.name
+```
+
+### Implementation notes
+
+1. **`accepts()` for `integer`**: return `isinstance(value, int) and not isinstance(value, bool)` — Python's `bool` is a subclass of `int`, but JSON Schema treats them as distinct. This matches the convention users expect from "integer."
+2. **`accepts()` for `number`**: accept both `int` and `float`, exclude `bool`.
+3. **`accepts()` for `object`**: `isinstance(value, dict)`. Deliberately stricter than today's lenient passthrough — but this method is only used by future callers (Task 120). Current lenient `coerce_workflow_input` is unaffected.
+4. **`parse()` error detail** — `TypeSpec.parse` raises a typed subclass `TypeVocabularyError(ValueError)` carrying structured fields (see §3.5 below). The message strings are the prose suggestion; the structured fields feed `Diagnostic.context` for JSON/agent consumption:
+   - **`raw in PYTHON_ALIASES_AT_S1`**: message `f"Use '{canonical}' instead of '{raw}'"`. For `raw == "dict"` specifically, populate `suggestions_list` with TWO pasteable options (not a single prose string): `["Use 'object' if the value is a dict: - type: object", "Use 'any' if the value can be any type: - type: any"]`. For other aliases, `suggestions_list` has one entry.
+   - **`"[" in raw`** (parameterized generic): outer-name mapping rule is load-bearing:
+     - If the base name (before `[`) is in `PYTHON_ALIASES_AT_S1`, suggest its canonical replacement (`list[str]` → `"Use 'array'"`, `dict[str, int]` → `"Use 'object'"`).
+     - Else if the base name is in `CANONICAL_TYPES`, suggest the base itself (`array[string]` → `"Use 'array'"`).
+     - Else: `"Use the base type"`.
+     - Full message template: `f"Parameterized generics not supported in `## Inputs` / `## Outputs`. Got: {raw!r}. {recommendation}."`
+   - **`raw == "null"`**: **Lead with the fix, not the deferred feature.** Message: `"Use 'any' if the value may be None — it accepts null alongside other values. (Nullable-only types require union syntax, which pflow does not yet support.)"`
+   - **Unknown type**: use `find_similar_items(raw, CANONICAL_TYPES, method="fuzzy", cutoff=0.6)`. **Cutoff is 0.6, NOT 0.4** — at a 7-item universe, 0.4 produces false positives (e.g., `pool` ≈ `bool`). 0.6 still catches single-char typos (`strin`→`string` ≈ 0.93). If a match: `similar_names=[closest]`, message `f"Unknown type '{raw}'. Did you mean '{closest}'? Valid types: {', '.join(CANONICAL_TYPES)}"`. Else: `similar_names=[]`, message `f"Unknown type '{raw}'. Valid types: {', '.join(CANONICAL_TYPES)}"`.
+   - **Whitespace**: strip leading/trailing silently (common copy-paste artifact). `"  object  "` → `TypeSpec("object")`. Reject INTERNAL whitespace: `"str ing"` raises "Whitespace not allowed inside type names."
+   - **Non-string / empty**: explicit `isinstance(raw, str)` check. `parse(None)`, `parse(5)`, `parse("")` raise `"Type must be a non-empty string"`. Do NOT rely on type annotations alone — Python won't enforce at runtime.
+5. **Immutability**: `@dataclass(frozen=True)` so `TypeSpec` instances are hashable and can be cached or used as dict keys.
+
+### 3.5 `TypeVocabularyError` — structured error class
+
+Define inside `src/pflow/core/types.py`:
+
+```python
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TypeVocabularyError(ValueError):
+    """Raised by `TypeSpec.parse` for invalid S1 type strings.
+
+    Carries both prose (for `__str__`) and structured fields (for Diagnostic.context).
+    Consumers in `ir_schema._suggest_for_invalid_type` read the structured fields and
+    thread them through `SchemaValidationError.__init__` kwargs so they surface in
+    `Diagnostic.context`.
+    """
+
+    message: str
+    offending: str               # the raw input that failed to parse
+    similar_names: list[str] = field(default_factory=list)   # fuzzy matches (≤1 for type vocab)
+    available_fields: list[str] = field(default_factory=lambda: list(CANONICAL_TYPES))
+    available_fields_label: str = "types"
+    suggestions_list: list[str] = field(default_factory=list)  # 1-2 pasteable options
+
+    def __str__(self) -> str:
+        return self.message
+```
+
+**Critical**: the `dict → object/any` case populates `suggestions_list` with TWO entries; the renderer's numbered-list path (`diagnostic_render.py:105-111`) emits them as:
+
+```
+To fix this:
+  1. Use 'object' if the value is a dict: - type: object
+  2. Use 'any' if the value can be any type: - type: any
+```
+
+All other cases have one entry in `suggestions_list`.
+
+### Where TypeSpec is used in this PR
+
+- `src/pflow/core/ir_schema.py` — replaces the enum check + `_get_output_suggestion` case 3. Called from `_get_suggestion` (new input-side branch) to extract structured error data and thread it into `SchemaValidationError`.
+- `src/pflow/core/exceptions.py` — `SchemaValidationError` gets three new keyword args (see §4.x below) to carry the structured context.
+- `tests/test_core/test_types.py` — comprehensive unit tests (see §6).
+
+### Where TypeSpec is NOT used in this PR (deferred)
+
+- `src/pflow/core/param_coercion.py` — **not migrated in this PR.** The `_TYPE_ALIASES` + `_COERCION_DISPATCH` continue to handle runtime coercion. We only add an `"any"` passthrough dispatch entry (see §4.4).
+- `src/pflow/runtime/template_validation/type_checker.py` — **not migrated.** The `TYPE_COMPATIBILITY_MATRIX` continues to handle BOTH vocabularies (because the registry Interface side stays Python-named). Future consolidation is a separate refactor.
+- `src/pflow/nodes/python/python_code.py` — `_TYPE_MAP` is S2 (Python-named), not affected.
+
+This keeps the PR scope focused on S1. `TypeSpec` is introduced now so Task 120 and future union-type work have a single canonical model to grow from.
+
+---
+
+## 4. Per-file changes
+
+### 4.1 `src/pflow/core/types.py` — NEW FILE
+
+Create the file with the `TypeSpec` class as specified in §3 plus `TypeVocabularyError` per §3.5. This is the single new module this PR adds.
+
+**Imports required:** `from pflow.core.suggestion_utils import find_similar_items` (already-existing utility at `src/pflow/core/suggestion_utils.py:14-74`). Must tolerate circular-import risk — if needed, do the import locally inside `parse()`.
+
+**Public exports:** `TypeSpec`, `TypeVocabularyError`, `CANONICAL_TYPES`, `PYTHON_ALIASES_AT_S1`.
+
+### 4.2 `src/pflow/core/ir_schema.py` — primary enforcement edits
+
+#### 4.2.1 Shrink the `inputs.*.type` enum
+
+**Current** (lines 233-252):
+
+```python
+"type": {
+    "type": "string",
+    "enum": [
+        # JSON Schema canonical types
+        "string",
+        "number",
+        "boolean",
+        "object",
+        "array",
+        # Python type aliases
+        "str",
+        "int",
+        "integer",
+        "float",
+        "bool",
+        "dict",
+        "list",
+    ],
+    "description": "Data type hint (accepts JSON Schema or Python type names)",
+},
+```
+
+**Replace with:**
+
+```python
+"type": {
+    "type": "string",
+    "enum": list(CANONICAL_TYPES),  # imported from pflow.core.types
+    "description": "Data type: one of string, number, integer, boolean, array, object, any",
+},
+```
+
+Add `from pflow.core.types import CANONICAL_TYPES` at the top of the file (near existing imports around line 10-15).
+
+#### 4.2.2 Shrink the `outputs.*.type` enum
+
+**Current** (lines 271-289): identical enum to inputs. Apply the same replacement at lines 271-289.
+
+#### 4.2.3 Rewrite `_get_output_suggestion` case 3
+
+**Current** (lines 402-404):
+
+```python
+# Case 3: Invalid type enum value
+if error.validator == "enum" and "type" in path_str:
+    valid_types = "string, number, boolean, object, array (or Python aliases: str, int, float, bool, dict, list)"
+    return f"Type must be one of: {valid_types}"
+```
+
+**Replace with:**
+
+```python
+# Case 3: Invalid type enum value
+if error.validator == "enum" and "type" in path_str:
+    return _suggest_for_invalid_type(error.instance)
+```
+
+And add a new helper function immediately above `_get_output_suggestion`:
+
+```python
+def _suggest_for_invalid_type(offending: Any) -> tuple[str, dict[str, Any]]:
+    """Produce an actionable suggestion + structured context for an invalid `type:` enum value.
+
+    Returns (suggestion_text, structured_context_kwargs) tuple. The structured kwargs
+    feed `SchemaValidationError`'s new context parameters so `Diagnostic.context`
+    carries `similar_names`, `available_fields`, `available_fields_label`, and any
+    multi-suggestion list — matching the producers-are-self-describing principle
+    documented in `src/pflow/core/CLAUDE.md`.
+
+    Handles three cases:
+      1. Python alias (str/int/float/bool/dict/list) → "use '{canonical}' instead of '{alias}'"
+         For `dict`, returns TWO suggestions (use 'object' for dict-shaped; use 'any' for wildcard).
+      2. Parameterized generic (`list[str]`, `dict[str,int]`, etc.) → maps outer name to canonical
+         replacement per §3 note 4.b (`list` → `array`, `dict` → `object`).
+      3. Other unknown value → "did you mean '{closest}'?" via fuzzy match (cutoff=0.6).
+    """
+    from pflow.core.types import TypeSpec, TypeVocabularyError, CANONICAL_TYPES
+
+    # Non-string offending values (unusual — the schema requires a string, but be defensive)
+    if not isinstance(offending, str):
+        text = f"Type must be one of: {', '.join(CANONICAL_TYPES)}"
+        return text, {"available_fields": list(CANONICAL_TYPES), "available_fields_label": "types"}
+
+    try:
+        TypeSpec.parse(offending)
+    except TypeVocabularyError as exc:
+        ctx: dict[str, Any] = {
+            "available_fields": exc.available_fields,
+            "available_fields_label": exc.available_fields_label,
+        }
+        if exc.similar_names:
+            ctx["similar_names"] = exc.similar_names
+        if exc.suggestions_list:
+            ctx["suggestions_list"] = exc.suggestions_list
+        return str(exc), ctx
+
+    # Should not reach here if jsonschema flagged this as an enum error.
+    return (
+        f"Type must be one of: {', '.join(CANONICAL_TYPES)}",
+        {"available_fields": list(CANONICAL_TYPES), "available_fields_label": "types"},
+    )
+```
+
+#### 4.2.4 Route input-side enum errors to the suggestion helper
+
+**Current** (lines 420-424 in `_get_suggestion`):
+
+```python
+# OUTPUT-SPECIFIC ERROR HANDLING
+if "outputs" in path_str:
+    return _get_output_suggestion(error, path_str)
+```
+
+**Problem:** the input side never reaches `_get_output_suggestion`, so `type: str` in `## Inputs` today returns an empty suggestion. After the enum shrink, this gap becomes user-visible (the "use 'string'" message would never fire for inputs).
+
+**Fix — the routing change has to thread structured context, not just a string**. `_get_suggestion` today returns a single string. After the refactor, the type-vocab branch returns TWO values (the prose suggestion + the structured-context kwargs). Change `_get_suggestion`'s return type to `tuple[str, dict[str, Any]]` and update the call in `validate_ir` to pass both. OR — simpler if the diff is large — have `_get_suggestion` set a module-level `_last_suggestion_context` variable that `validate_ir` reads. Prefer the tuple approach if it's clean.
+
+```python
+def _get_suggestion(error: JsonSchemaValidationError) -> tuple[str, dict[str, Any]]:
+    """Return (suggestion_string, structured_context_kwargs)."""
+    path_str = str(error.absolute_path)
+
+    # TYPE-VOCAB ERROR HANDLING (applies to both inputs and outputs)
+    if error.validator == "enum" and "type" in path_str:
+        return _suggest_for_invalid_type(error.instance)
+
+    # OUTPUT-SPECIFIC ERROR HANDLING (kept for additionalProperties / type-shape cases)
+    if "outputs" in path_str:
+        return _get_output_suggestion(error, path_str), {}
+
+    # ...existing branches... wrap each existing return into (msg, {})
+```
+
+Then in `validate_ir` at line 515-517:
+
+```python
+suggestion, ctx_kwargs = _get_suggestion(error)
+raise SchemaValidationError(
+    message=error.message,
+    path=path,
+    suggestion=suggestion,
+    **ctx_kwargs,  # NEW — passes similar_names/available_fields/etc.
+)
+```
+
+This ensures `type: str` in either `## Inputs` or `## Outputs` produces the `"Use 'string' instead of 'str'"` suggestion AND populates `Diagnostic.context` with structured data for JSON consumers.
+
+#### 4.2.5 `SchemaValidationError` — extend with structured context kwargs
+
+**Rationale**: The existing three-string signature (`message`, `path`, `suggestion`) flattens all error signal into prose. Per `src/pflow/core/CLAUDE.md` ("Producers are self-describing") and `src/pflow/runtime/template_validation/CLAUDE.md` ("Every producer builds a `Diagnostic` directly at the call site and populates `context['path']`, `available_fields`, `similar_names`, and `suggestions`"), validators MUST populate structured context keys. The unified renderer (`src/pflow/core/diagnostic_render.py`) consumes `context["similar_names"]` (→ "Did you mean" block), `context["available_fields"]` + `context["available_fields_label"]` (→ "Available types (showing N of M)" block), and `suggestions_list` via the numbered-list path at lines 105-111.
+
+**Edit** `src/pflow/core/exceptions.py` lines 147-183:
+
+```python
+class SchemaValidationError(PflowError):
+    """Validation error for IR schema with helpful messages and field paths.
+
+    Attributes:
+        message: The validation error message
+        path: Dotted path to the invalid field (e.g., "nodes[0].type")
+        suggestion: Optional suggestion for fixing the error (single-line prose fallback)
+        similar_names: Optional fuzzy-match suggestions (renders as "Did you mean")
+        available_fields: Optional full list of valid alternatives (renders as "Available X")
+        available_fields_label: Optional noun for the alternatives block ("types", "nodes", etc.)
+        suggestions_list: Optional multi-suggestion list (renders as numbered list)
+    """
+
+    def __init__(
+        self,
+        message: str,
+        path: str = "",
+        suggestion: str = "",
+        *,
+        similar_names: list[str] | None = None,
+        available_fields: list[str] | None = None,
+        available_fields_label: str | None = None,
+        suggestions_list: list[str] | None = None,
+    ):
+        self.message = message
+        self.path = path
+        self.suggestion = suggestion
+        self.similar_names = similar_names or []
+        self.available_fields = available_fields or []
+        self.available_fields_label = available_fields_label
+        self.suggestions_list = suggestions_list or []
+
+        full_message = "Validation error"
+        if path:
+            full_message += f" at {path}"
+        full_message += f": {message}"
+        if suggestion:
+            full_message += f"\n{suggestion}"
+
+        super().__init__(full_message)
+
+    def to_diagnostics(self) -> list[Diagnostic]:
+        ctx: dict[str, Any] = {"category": "validation"}
+        if self.path:
+            ctx["path"] = self.path
+        if self.similar_names:
+            ctx["similar_names"] = self.similar_names
+        if self.available_fields:
+            ctx["available_fields"] = self.available_fields
+        if self.available_fields_label:
+            ctx["available_fields_label"] = self.available_fields_label
+
+        # Multi-suggestion list overrides single suggestion string — renderer emits
+        # numbered list at diagnostic_render.py:105-111 when suggestions has >1 item.
+        if self.suggestions_list:
+            suggestions = self.suggestions_list
+        elif self.suggestion:
+            suggestions = [self.suggestion]
+        else:
+            suggestions = None
+
+        return [
+            Diagnostic(
+                severity=Severity.ERROR,
+                message=self.message,
+                title="Validation Error",
+                suggestions=suggestions,
+                source="validation",
+                context=ctx,
+            )
+        ]
+```
+
+**Backward compat**: all new kwargs are keyword-only with `None` defaults. Existing call sites that use only `(message, path, suggestion)` continue to work unchanged.
+
+### 4.3 `src/pflow/nodes/python/python_code.py` — `Any` auto-injection + error message fix
+
+#### 4.3.1 Inject `Any` into the exec namespace
+
+**Current** (lines 321-325 inside `PythonCodeNode.exec()`):
+
+```python
+namespace: dict[str, Any] = {"__builtins__": __builtins__}
+namespace["typing"] = _typing_module
+namespace["Optional"] = _typing_module.Optional
+namespace.update(inputs)
+```
+
+**Replace** (insert one line after the `Optional` injection):
+
+```python
+namespace: dict[str, Any] = {"__builtins__": __builtins__}
+namespace["typing"] = _typing_module
+namespace["Optional"] = _typing_module.Optional
+namespace["Any"] = _typing_module.Any  # auto-injected so `x: Any` works without import
+namespace.update(inputs)
+```
+
+One line addition. Mirrors the existing `Optional` precedent.
+
+#### 4.3.2 Reject lowercase `any` in code annotations with a specific message
+
+Add a new helper near `_get_outer_type` (after line 144):
+
+```python
+def _check_annotation_vocabulary(annotations: dict[str, str]) -> None:
+    """Reject code-block annotations that use lowercase `any` or known-bad forms.
+
+    Fires at prep time to produce a focused, actionable error instead of letting
+    Python's exec() raise `TypeError: isinstance() arg 2 must be a type` at runtime
+    or a confusing NameError.
+
+    Raises NonRetriableError (not vanilla ValueError) so the engine treats this
+    as a deterministic validation rejection rather than a retriable exec-time failure.
+    See `src/pflow/nodes/CLAUDE.md` "Use NonRetriableError for validation errors".
+
+    KNOWN LIMITATION: only the outer name after stripping one level of Optional[] is
+    checked. Lowercase `any` nested inside a generic (e.g., `list[any]`) is not
+    detected here — it will error at exec time via Python's normal NameError path.
+    Accepted trade-off: detecting generic params requires recursive parsing and
+    the exec-time error is still reached.
+    """
+    from pflow.nodes.file.exceptions import NonRetriableError  # local import to avoid cycles
+
+    for var_name, annotation in annotations.items():
+        # Strip optional wrapper and generic params — we want the base name
+        inner = _get_inner_optional_type(annotation) or annotation
+        base = inner.split("[")[0].strip()
+
+        if base == "any":
+            raise NonRetriableError(
+                f"Invalid type annotation for '{var_name}': 'any' (lowercase).\n\n"
+                f"Use 'Any' (capitalized) in Python code blocks. "
+                f"pflow auto-injects `typing.Any` — no import needed.\n"
+                f"  {var_name}: Any\n\n"
+                f"Note: lowercase 'any' is the legal spelling in `## Inputs` / `## Outputs` "
+                f"sections (e.g., `- type: any`), but Python annotations must use 'Any' (capitalized)."
+            )
+```
+
+Call this from `PythonCodeNode.prep()` immediately after the existing `_check_input_annotation_syntax` call (current line 274):
+
+```python
+self._check_input_annotation_syntax(inputs, annotations)
+_check_annotation_vocabulary(annotations)  # NEW — rejects lowercase 'any'
+```
+
+#### 4.3.3 Fix the misleading NameError suggestion
+
+**Current** (lines 620-631 in `_format_exec_error`):
+
+```python
+if isinstance(exc, NameError):
+    var_name = getattr(exc, "name", str(exc))
+    msg = f"Undefined variable '{var_name}'"
+    if location:
+        msg += f"\n{location}"
+    msg += (
+        f"\n\nSuggestions:\n"
+        f'  - Add \'{var_name}\' to the inputs dict: "inputs": {{"{var_name}": ...}}\n'
+        f"  - Or define '{var_name}' in the code before use\n"
+        f"  - Check for typos in variable names"
+    )
+    return msg
+```
+
+**Replace with** (adds a branch for known typing names, keeps existing behavior for everything else):
+
+```python
+if isinstance(exc, NameError):
+    var_name = getattr(exc, "name", str(exc))
+    msg = f"Undefined variable '{var_name}'"
+    if location:
+        msg += f"\n{location}"
+
+    # Known typing names that pflow doesn't auto-inject
+    _TYPING_NAMES = {
+        "Union", "List", "Dict", "Tuple", "Set", "Callable",
+        "Literal", "TypeVar", "Iterable", "Iterator", "Sequence",
+        "Mapping", "Type", "Final", "ClassVar",
+    }
+    if var_name in _TYPING_NAMES:
+        msg += (
+            f"\n\nSuggestions:\n"
+            f"  - '{var_name}' is from the typing module. Two options:\n"
+            f"      1. Import it: from typing import {var_name}\n"
+            f"      2. Use modern syntax (Python 3.10+): `int | None` instead of `Optional[int]`,\n"
+            f"         `int | str` instead of `Union[int, str]`.\n"
+            f"  - pflow auto-injects 'Any' and 'Optional' — other typing names require explicit import."
+        )
+    else:
+        msg += (
+            f"\n\nSuggestions:\n"
+            f'  - Add \'{var_name}\' to the inputs dict: "inputs": {{"{var_name}": ...}}\n'
+            f"  - Or define '{var_name}' in the code before use\n"
+            f"  - Check for typos in variable names"
+        )
+    return msg
+```
+
+Note: post-refactor `Any` is injected, so a `NameError` for `"Any"` won't fire at runtime. The branch is defensive for `Union`/`List`/`Dict`/etc., which pflow does NOT inject (user must import those explicitly). This keeps the PR's new-injection story minimal (`Any` only) while improving the error message for the analogous cases.
+
+#### 4.3.4 Minor: error-message suggestion text in `_check_input_types`
+
+**Current** (lines 593-598):
+
+```python
+raise TypeError(
+    f"Input '{var_name}' expects {type_str} but received {actual}\n\n"
+    f"Suggestions:\n"
+    f"  - Change the type annotation to: {var_name}: {actual}\n"
+    f"  - Or convert the input value to {type_str}"
+)
+```
+
+**Add a third suggestion line — INPUT error only** (inputs often arrive with upstream-shape surprises; `Any` is a legitimate escape):
+
+```python
+raise TypeError(
+    f"Input '{var_name}' expects {type_str} but received {actual}\n\n"
+    f"Suggestions:\n"
+    f"  - Change the type annotation to: {var_name}: {actual}\n"
+    f"  - Or convert the input value to {type_str}\n"
+    f"  - Or use `Any` to accept any type: {var_name}: Any"
+)
+```
+
+**Do NOT add the third line to the result-type mismatch error at lines 408-414.** A `result:` annotation is the author's own intent statement; suggesting `Any` there tells them to defeat their own contract rather than fix the actual mismatch. Keep the result-mismatch error with its original two suggestions.
+
+### 4.4 `src/pflow/core/param_coercion.py` — add `any` passthrough
+
+**Current** (lines 226-233):
+
+```python
+_COERCION_DISPATCH = {
+    "string": _coerce_to_string,
+    "integer": _coerce_to_integer,
+    "number": _coerce_to_number,
+    "boolean": _coerce_to_boolean,
+    "object": _coerce_to_object,
+    "array": _coerce_to_array,
+}
+```
+
+**Add** one entry. **CRITICAL: signature must match the other coercers.** Every other `_coerce_to_*` takes `(value, log_context)` and the dispatcher at line 293 calls `coercer(value, log_context)`. A `(value,)` single-arg signature will raise `TypeError: takes 1 positional argument but 2 were given` on the first `type: any` invocation.
+
+```python
+def _coerce_to_any(value: Any, log_context: dict[str, Any]) -> Any:
+    """Passthrough coercion for `type: any` — accepts any value unchanged.
+
+    Signature mirrors the other _coerce_to_* functions; log_context is unused
+    because `any` is a pure passthrough, but the parameter is REQUIRED by the
+    dispatcher's calling convention (param_coercion.py:293).
+    """
+    return value
+
+
+_COERCION_DISPATCH = {
+    "string": _coerce_to_string,
+    "integer": _coerce_to_integer,
+    "number": _coerce_to_number,
+    "boolean": _coerce_to_boolean,
+    "object": _coerce_to_object,
+    "array": _coerce_to_array,
+    "any": _coerce_to_any,
+}
+```
+
+Do **NOT** touch `_TYPE_ALIASES` (lines 15-22). **Rationale (corrected from prior draft)**: `_normalize_type()` has exactly one caller today (`coerce_workflow_input` at `param_coercion.py:287`), and post-refactor the IR schema rejects Python aliases so the alias path is mostly unreachable via that call. **Keep it as defense-in-depth** for IR paths that bypass schema validation (programmatically-constructed IR dicts in tests, cached IRs, future MCP entry points that skip the validator). Removing `_TYPE_ALIASES` + `_normalize_type` is a legitimate follow-up cleanup but out of scope here — the goal of THIS PR is breaking vocabulary changes, not dead-code removal. Flag as `# Note: kept for non-S1 entry points; see plan §4.4.` with a short comment in the code.
+
+### 4.5 `src/pflow/runtime/template_validation/type_checker.py` — no changes
+
+Leave `TYPE_COMPATIBILITY_MATRIX` (lines 37-65) as-is. It still has entries under BOTH Python and JSON Schema names, which is correct because:
+
+- S1 (canonical) values flow in from IR `inputs`/`outputs`
+- Registry Interface metadata flows in with Python-named types
+
+Both must match compatibly. A future refactor can consolidate when the registry Interface vocabulary is unified, but that's out of scope.
+
+### 4.6 `src/pflow/runtime/template_validation/path_validation.py` — no changes
+
+The hardcoded type-list lines (185, 289-290, 304-340, 326, 334) continue to work because they already handle both vocabularies. Leave as-is.
+
+### 4.7 `src/pflow/runtime/template_validation/type_validation.py` — no changes
+
+`_SHELL_SAFE_TYPES`, `SHELL_BLOCKED_TYPES`, and the scattered type-string checks (lines 31, 126, 157, 162, 219, 231, 233, 274-293) continue to work for the same reason. Leave as-is.
+
+### 4.8 `src/pflow/runtime/engine/template_resolution.py` — no changes
+
+`build_type_cache` and `validate_resolved_type` (lines 29-145) continue to work. Leave as-is.
+
+### 4.9 `src/pflow/mcp/discovery.py` — no changes
+
+`_json_type_to_python` at lines 325-354 stays. Registry continues to use Python names.
+
+### 4.10 `src/pflow/cli/param_parsing.py` — no changes
+
+`infer_type` at lines 9-46 is orthogonal (it infers Python values from CLI strings, not type strings).
+
+### 4.11 `src/pflow/core/markdown_parser.py` — error-hint update (REQUIRED)
+
+**Line 147** — `_SECTION_SYNTAX_HINTS`:
+
+```python
+"    - type: str\n"
+```
+
+**Change to:**
+
+```python
+"    - type: string\n"
+```
+
+**This is NOT optional.** `tests/test_core/test_markdown_parser.py:2355` asserts on the hint text (`assert "- type: str" in err.suggestion` today). §5.3 updates that assertion to expect the new hint string. If §4.11 is skipped but §5.3 is applied, the test breaks. Ordering coupling: do §4.11 BEFORE §5.3 test-fixture updates, OR make them atomic.
+
+**Also**: audit other user-facing strings in `markdown_parser.py` for Python-alias leakage. Run:
+
+```bash
+grep -nE "type: (str|int|float|bool|dict|list)\b" src/pflow/core/markdown_parser.py
+```
+
+Every hit outside of the `_SECTION_SYNTAX_HINTS` block at line 147 is a separate error/hint surface that needs the same canonical-name treatment. Fix each.
+
+---
+
+## 5. Example workflow migrations
+
+Research (Searcher 4) confirmed:
+
+- **All production `.pflow.md` files under `examples/`** already use canonical JSON Schema names at S1. **Zero mechanical migration needed.**
+- **The scratchpad probes** at `scratchpads/type-vocabulary-incoherence/repro-files/` deliberately use Python aliases and `object`-as-wildcard. **Do not migrate — they're reference fixtures for the bug being fixed.**
+- **One ambiguous file:** `examples/output_validation_demo.pflow.md:43` declares `dynamic_result: type: object` with no `source:` — unclear if it's wildcard or dict. **See migration action below.**
+
+### 5.1 Ambiguous file — `examples/output_validation_demo.pflow.md`
+
+**Action**: change `examples/output_validation_demo.pflow.md:43` from `- type: object` to `- type: any`.
+
+**Rationale**: the output is named `dynamic_result` and has no `source:` declaration. The word "dynamic" in the name + the absence of a concrete source implies the shape is unknown or varies. `any` communicates this intent correctly under the new vocabulary. The runtime behavior is unchanged (output resolver never tries to resolve a `source:`-less declaration).
+
+This is a cosmetic choice — the prior draft's "pick one of three options" instruction was removed to avoid implementer ambiguity.
+
+### 5.2 Scratchpad repro files — do not modify
+
+Files in `scratchpads/type-vocabulary-incoherence/repro-files/` stay as-is. They'll become negative/positive test fixtures after the refactor:
+
+- `A3-input-type-any.pflow.md` (currently rejected) will START PASSING after the refactor. This is deliberate — it's the positive test case.
+- `A1-input-type-dict.pflow.md`, `A2-input-type-str.pflow.md` will START FAILING with the new "use 'object'"/"use 'string'" errors. This is the intended behavior.
+- `E-object-wildcard.pflow.md` continues to parse with `type: object`, but will behave as "dict-only" semantically (the strict runtime enforcement is Task 120, so today it still accepts non-dict values leniently). The file documents the semantic shift.
+
+### 5.3 Test inline workflow strings — migration inventory
+
+Research surfaced Python-alias usage in 4 test files' inline `.pflow.md` strings (not `.pflow.md` files on disk):
+
+| File | Occurrences | Action |
+|---|---|---|
+| `tests/test_core/test_markdown_parser.py` lines 460, 468, 2168, 2245, 2275, 2282, 2336, 2355 | `- type: str` in inline markdown | UPDATE to `- type: string` |
+| `tests/test_runtime/test_compile_once_regression.py` lines 275, 506, 509 | `- type: str` | UPDATE to `- type: string` |
+| `tests/test_integration/test_branch_convergence.py` lines 204, 308 | `- type: int` | UPDATE to `- type: integer` |
+
+**Special case**: `test_markdown_parser.py:2355` currently asserts `assert "- type: str" in err.suggestion`. The suggestion text changes under the refactor — update this assertion accordingly (likely asserting the new canonical message).
+
+These are mechanical `sed`-scale edits. The test behavior (parsing / validation) stays the same; only the fixture type names change.
+
+---
+
+## 6. Tests
+
+### 6.1 New test file — `tests/test_core/test_types.py`
+
+Create this file. Must cover:
+
+**`TestTypeSpecParse`:**
+- `test_parse_legal_types` — all 7 canonical types parse and round-trip
+- `test_parse_rejects_python_aliases_str` — `TypeSpec.parse("str")` raises, message contains `"Use 'string' instead of 'str'"` (exact substring match)
+- Same for `int` → `integer`, `float` → `number`, `bool` → `boolean`, `list` → `array`
+- `test_parse_rejects_dict_with_wildcard_hint` — `TypeSpec.parse("dict")` raises, message contains `"Use 'object' instead of 'dict'"` AND `"use 'any'"` (both assertions)
+- `test_parse_rejects_parameterized_generics` — `TypeSpec.parse("list[str]")`, `TypeSpec.parse("dict[str, int]")` both raise with `"Parameterized generics not supported"`
+- `test_parse_rejects_null` — raises with `"Union types"` hint mentioning `any`
+- `test_parse_rejects_unknown_with_fuzzy_suggestion` — `TypeSpec.parse("strin")` raises, message contains `"Did you mean 'string'"`
+- `test_parse_rejects_unknown_no_fuzzy_match` — `TypeSpec.parse("zzz")` raises with `"Valid types: ..."` but no "Did you mean"
+- `test_parse_rejects_uppercase` — `TypeSpec.parse("String")` raises
+- `test_parse_strips_whitespace` — `TypeSpec.parse("  object  ")` succeeds OR raises (decide based on impl — recommend raises; whitespace is a typo signal)
+
+**`TestTypeSpecAccepts`:**
+- `test_string_accepts_str_only` — `accepts("x") is True`, `accepts(1) is False`, `accepts({}) is False`, `accepts(None) is False`
+- `test_integer_accepts_int_rejects_bool` — `accepts(5) is True`, `accepts(5.5) is False`, `accepts(True) is False`
+- `test_number_accepts_int_and_float_rejects_bool` — `accepts(5) is True`, `accepts(5.5) is True`, `accepts(True) is False`
+- `test_boolean_accepts_bool_only` — `accepts(True) is True`, `accepts(1) is False`
+- `test_object_accepts_dict_only` — `accepts({}) is True`, `accepts([]) is False`, `accepts("x") is False`, `accepts(1) is False`
+- `test_array_accepts_list_only` — symmetric
+- `test_any_accepts_everything` — dict, list, str, int, bool, float, None all True
+
+**`TestTypeSpecIsWildcard`:**
+- `test_any_is_wildcard` — `TypeSpec("any").is_wildcard() is True`
+- `test_others_are_not_wildcard` — all 6 others False
+
+**`TestTypeSpecPythonType`:**
+- `test_python_type_mapping` — returns `str/int/float/bool/list/dict`. For `any` returns `None`. For `number` returns `(int, float)`. Integer returns `int` (not a tuple).
+
+**`TestTypeSpecToJsonSchema`:**
+- `test_simple_types` — `TypeSpec("string").to_json_schema() == {"type": "string"}`
+- `test_any_returns_empty_dict` — `TypeSpec("any").to_json_schema() == {}` (matches JSON Schema convention for "any value")
+
+**`TestTypeSpecRoundtrip`:**
+- `test_str_roundtrip` — `str(TypeSpec.parse(t)) == t` for all canonical types
+- `test_equality_and_hash` — `TypeSpec.parse("object") == TypeSpec.parse("object")`, usable as dict key
+
+**`TestTypeVocabularyError`** — NEW test class for the structured error type:
+- `test_structured_fields_on_alias_error` — `TypeSpec.parse("str")` raises `TypeVocabularyError`; asserts `.offending == "str"`, `.available_fields == list(CANONICAL_TYPES)`, `.available_fields_label == "types"`, `.suggestions_list == ["Use 'string' instead of 'str'"]` (exact)
+- `test_structured_fields_on_dict_alias_includes_two_suggestions` — `TypeSpec.parse("dict")` raises with `.suggestions_list` exactly equal to:
+  ```python
+  ["Use 'object' if the value is a dict: - type: object",
+   "Use 'any' if the value can be any type: - type: any"]
+  ```
+- `test_structured_fields_on_fuzzy_match` — `TypeSpec.parse("strin")` raises with `.similar_names == ["string"]`
+- `test_structured_fields_on_unknown` — `TypeSpec.parse("foobar")` raises with `.similar_names == []` (no fuzzy match at cutoff=0.6)
+- `test_case_sensitive_use_capital_U` — alias-error message contains literal `"Use '"` (capital U) — regression guard for the case-preservation contract from poll P3
+
+**Deferred (do not add in this PR):** union parsing, union acceptance.
+
+### 6.2 `tests/test_core/test_ir_schema.py` changes
+
+**UPDATE** existing tests:
+
+- `TestInputTypeAliases.test_json_schema_types_accepted` (lines 372-380) — SPLIT. Keep the canonical-accepted assertion, extend to include `integer` and `any` as accepted. Add a corresponding `outputs` test.
+- `TestInputTypeAliases.test_python_type_aliases_accepted` (lines 382-390) — REMOVE. Replace with tests below.
+- `TestInputTypeAliases.test_invalid_type_rejected` (lines 392-401) — UPDATE. Assert the error suggestion contains the new 7-name list (not the old 12).
+
+**ADD** new tests in `TestInputTypeAliases` (or a new `TestInputTypeVocabulary` class):
+
+- `test_str_alias_rejected_with_fix_suggestion` — IR with `type: str` fails `validate_ir`; `SchemaValidationError.suggestion` contains exact `"Use 'string' instead of 'str'"` (case-sensitive assertion)
+- Same for `int`, `float`, `bool`, `list`
+- `test_dict_alias_rejected_with_wildcard_hint` — `type: dict` raises `SchemaValidationError`; assert `.suggestions_list == [<exact two-entry list>]` (not just substring search) — verify both pasteable options
+- `test_any_now_accepted` — IR with `type: any` validates successfully (positive test for the new vocabulary)
+- `test_integer_now_accepted_and_bridges_to_int` — IR with `type: integer` validates; and a workflow that passes `type: integer` input to a code node annotated `x: int` runs successfully. This closes the `integer` canonical-name coverage gap.
+- `test_null_still_rejected` — IR with `type: null` fails; assert message contains `"Use 'any'"` FIRST (lead with the fix, not the deferred feature)
+- `test_parameterized_generic_rejected_list` — IR with `type: list[str]` fails; message contains exact `"Use 'array'"` (not `"Use 'list'"` or `"Use 'the base type'"`)
+- `test_parameterized_generic_rejected_dict` — IR with `type: dict[str, int]` fails; message contains exact `"Use 'object'"`
+- `test_unknown_type_fuzzy_suggestion` — IR with `type: strin` fails; `.similar_names == ["string"]` via structured field (not just substring)
+- `test_unknown_type_no_false_positive_fuzzy` — IR with `type: pool` fails; `.similar_names == []` (0.6 cutoff prevents bool match)
+- `test_outputs_apply_same_rules` — all of the above mirrored for `outputs.*.type`
+- `test_json_output_contains_structured_context` — run `validate_ir` on `type: str`, call `.to_diagnostics()[0].to_dict()`, assert `context["similar_names"]` / `context["available_fields"] == list(CANONICAL_TYPES)` / `context["available_fields_label"] == "types"` are all populated (verifies the diagnostic pipeline carries structured data, not just prose)
+
+### 6.3 `tests/test_core/test_param_coercion.py` changes
+
+**REMOVE** tests that enshrine the old alias acceptance:
+- `test_type_alias_str_works` (line 204)
+- `test_type_alias_int_works` (line 242)
+- `test_type_alias_float_works` (line 267)
+- `test_type_alias_bool_works` (line 301)
+- `test_type_alias_dict_works` (line 344)
+- `test_type_alias_list_works` (line 382)
+
+**ADD** new tests in a new `TestAnyTypeCoercion` class:
+- `test_any_accepts_str_unchanged` — `coerce_workflow_input("hello", "any") == "hello"`
+- `test_any_accepts_int_unchanged`
+- `test_any_accepts_float_unchanged`
+- `test_any_accepts_bool_unchanged`
+- `test_any_accepts_dict_unchanged`
+- `test_any_accepts_list_unchanged`
+- `test_any_accepts_none_unchanged`
+- `test_any_accepts_nested_complex` — dict-of-lists-of-dicts passes through unchanged
+
+**KEEP** all other tests (dispatch behavior for canonical types is unchanged).
+
+**NOTE on `coerce_param_for_node`:** The 4 `TestDictToStringCoercion.test_*_when_type_is_str` tests (lines 16-49) and `TestPassthroughBehavior.test_*_when_type_is_str` (lines 91-132) and `TestNonSerializableHandling.*` (lines 138-159) use the string `"str"` — but this function operates at the **node-execution boundary**, not S1. Registry Interface docstrings still use Python names, so `coerce_param_for_node` continues to accept `"str"`. **KEEP these tests unchanged.**
+
+For `TestNoCoercionWhenTypeMatches.test_dict_unchanged_when_type_is_dict` (line 55) and `test_list_unchanged_when_type_is_list` (line 71): these also exercise `coerce_param_for_node`. KEEP unchanged — same rationale.
+
+### 6.4 `tests/test_nodes/test_python/test_python_code.py` changes
+
+**KEEP** all 73 existing tests. The Python-annotation surface is unchanged.
+
+**One possible UPDATE:** `test_unknown_type_annotation_skips_check` (lines 231-245) uses `data: object` precisely because `object` is not in `_TYPE_MAP`. Post-refactor, `object` is still not in `_TYPE_MAP` (which is S2/Python-side). Test behavior unchanged — **KEEP**.
+
+**ADD** new test class `TestAnyAutoInjection`:
+
+- `test_any_without_import_works` — code block `x: Any\nresult: int = len(x)` (with `x="hello"` input) runs successfully without `from typing import Any`
+- `test_any_in_result_annotation_works` — `result: Any = {"nested": [1, 2, 3]}` post-check accepts the dict
+- `test_typing_Any_dotted_form_works` — `x: typing.Any\nresult: int = 1` succeeds (typing module is already injected)
+- `test_any_accepts_all_input_types` — annotation `x: Any` accepts dict, list, str, int, bool, None as input values without raising
+- `test_any_union_none_works` — `x: Any | None\nresult: int = 1` runs (tests that `Any | None` in an annotation is parseable)
+- `test_explicit_typing_import_still_works` — code that DOES `from typing import Any` continues to work (no double-definition error)
+- `test_lowercase_any_rejected` — code block `x: any\nresult: int = 1` raises at prep time; error message contains `"Use 'Any'"` and mentions `## Inputs`
+- `test_lowercase_any_in_result_rejected` — `result: any = 1` raises similarly
+
+**ADD** one test to `TestSafetyAndErrors` — regression guard for the `_format_exec_error` fix:
+
+- `test_nameerror_for_typing_symbol_suggests_import` — code `x: Union[int, str]\nresult: int = x` (without `from typing import Union`) raises; error message contains `"from typing import Union"` (not `"Add 'Union' to the inputs dict"`)
+
+### 6.5 `tests/test_registry/test_type_string_conventions.py` — no changes
+
+This file (lines 47-109) enforces the lowercase convention on registry metadata. Registry stays Python-named in this PR. No changes.
+
+### 6.6 `tests/test_runtime/test_template_validation/*` — minimal changes
+
+The compatibility matrix (`test_type_checker.py`, 22 tests) and integration tests (`test_types.py`, 37 tests) continue to use the Python-named fixtures because the **registry** side is still Python-named. **KEEP all tests unchanged** except any that specifically exercise IR `inputs`/`outputs` `type:` values with Python aliases (which would fail schema validation post-refactor). Research found none in these files.
+
+### 6.7 `tests/test_mcp/test_mcp_discovery_critical.py` — no changes
+
+`_json_type_to_python` still maps JSON Schema to Python for the registry. **KEEP.**
+
+### 6.8 Integration test updates
+
+Per §5.3:
+- `tests/test_core/test_markdown_parser.py` — 8 fixture updates
+- `tests/test_runtime/test_compile_once_regression.py` — 3 fixture updates
+- `tests/test_integration/test_branch_convergence.py` — 2 fixture updates
+
+---
+
+## 7. Documentation updates
+
+All doc edits use the new canonical vocabulary. File by file:
+
+### 7.1 `src/pflow/guide/core.md` — CRITICAL
+
+**Line 300** — replace:
+```
+**Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false — only one input can have this), description as prose.
+```
+with:
+```
+**Input fields**: `type` (string|number|integer|boolean|array|object|any), `required` (true|false), `default` (only when required: false), `stdin` (true|false — only one input can have this), description as prose.
+```
+
+**Lines 614-665** ("Parameter Types - Complete Guide" section) — rewrite to include `integer` and `any`; clarify `object` is dict-only, `any` is the explicit wildcard. See plan §2 bridge table for the shape; write one entity per type as in the current format.
+
+**New section** (insert near line 614, before the per-type details): add the S1↔S2 bridge table as documented in §2 above. Header: `### Type Vocabulary — Two Surfaces`.
+
+### 7.2 `src/pflow/guide/nodes/code.md` — CRITICAL
+
+**Lines 59-66** — the rule `"Use `object` as type when you don't know the type (skips validation)"` is WRONG post-refactor. Replace with:
+```
+- Use `Any` as the type when you don't want type validation (`Any` is auto-injected — no `from typing import Any` needed)
+```
+
+### 7.3 `src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md` — CRITICAL
+
+**Line 1006** — same fix as `guide/core.md:300` above (these strings are mirrored across MCP instructions).
+
+**Line 1262+** — extend the "Parameter Types - Complete Guide" section mirroring the updated `guide/core.md`.
+
+### 7.4 `src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md` — CRITICAL
+
+**Line 988** — same fix as above.
+
+### 7.5 `docs/reference/nodes/code.mdx` — CRITICAL
+
+**Lines 41-43** — update the `<Tip>` to recommend `Any` (auto-injected) instead of `object`.
+
+**Lines 45-60** — "Supported types" accordion: replace the `object` row with `Any` row noting auto-injection.
+
+**After line 142** — add a new "Bridge to workflow inputs" section with the S1↔S2 bridge table from §2.
+
+### 7.6 `docs/reference/nodes/claude-code.mdx` — NO CHANGE
+
+Uses Python names (`str/int/bool/list/dict`) in the Claude Code `output_schema` — this is a separate schema surface that uses Python names as a prompt convention (the strings are embedded into LLM prompts via `_build_schema_prompt`). Out of scope.
+
+### 7.7 `docs/changelog.mdx` — ADD NEW ENTRY
+
+Add at the top:
+
+```mdx
+<Update label="<MONTH> 2026" description="v0.12.0" tags={["Breaking changes", "Improvements"]}>
+  ## Type vocabulary coherence
+
+  The `## Inputs` and `## Outputs` `type:` field now accepts exactly 7 values:
+  `string`, `number`, `integer`, `boolean`, `array`, `object`, `any`.
+
+  **Breaking changes:**
+  - Python type aliases (`str`, `int`, `float`, `bool`, `dict`, `list`) removed from workflow input/output declarations. Each produces a hard error suggesting the canonical replacement.
+  - `object` now documented as dict-only (no longer a hidden wildcard). Use `any` for wildcard.
+  - Parameterized generics (`list[str]`, `dict[str, int]`) rejected at parse time.
+  - Saved workflows in `~/.pflow/workflows/` containing Python aliases will fail validation on next load or re-save — migrate by editing the saved `.pflow.md` file to use canonical names.
+
+  **New:**
+  - `any` explicit wildcard type.
+  - `Any` auto-injected into code node exec namespace — no `from typing import Any` needed.
+  - Bridge table documenting `## Inputs` ↔ Python annotation mapping in the guide.
+</Update>
+```
+
+### 7.8 `architecture/reference/ir-schema.md` — UPDATE (EXTENSIVE)
+
+Plan's prior draft listed only lines 83, 322-340, 588-597. Actual scope is larger — **~20 Python-alias S1 examples at lines 63, 68, 98, 103, 135, 140, 148, 153, 228, 235, 241, 275, 281, 287, 293, 331, 332, 335, 354, 355, 358, 359**. Plus 83, 322-340, 588-597 from the prior list. Update every `"type": "str"` / `"type": "int"` / `"type": "dict"` / `"type": "list"` / `"type": "float"` / `"type": "bool"` example that appears under workflow IR `inputs.*.type` or `outputs.*.type` context.
+
+Also add a note distinguishing workflow IR `inputs`/`outputs` (canonical 7 names) from node metadata Interface docstrings (Python names).
+
+**Required audit**: run `grep -nE '"type":\s*"(str|int|float|bool|dict|list)"' architecture/reference/ir-schema.md` and fix every hit where the context is workflow IR (not registry Interface metadata).
+
+### 7.9 `architecture/reference/enhanced-interface-format.md` — UPDATE
+
+**Lines 31-39** — add a cross-reference clarifying: "These type names describe node `Interface:` docstrings and are Python-named. Workflow `## Inputs` / `## Outputs` use a separate canonical vocabulary — see [type vocabulary](../..)."
+
+### 7.10 `architecture/reference/template-variables.md` — UPDATE (was OPTIONAL, now REQUIRED)
+
+**Lines 511-512, 678-683, 986-988** contain `inputs` block examples using Python aliases. These shape agent mental models of the IR format. Update each hit to canonical vocabulary.
+
+**Lines 604-620** (`TYPE_COMPATIBILITY_MATRIX` docs) — add a note explaining the matrix bridges two vocabularies (S1 canonical for workflow inputs; Python for registry Interface metadata).
+
+### 7.11 MCP agent instructions — additional mandatory line edits
+
+Beyond the lines §7.3/§7.4 already list, **two more lines explicitly teach the REMOVED `object == wildcard` behavior**:
+
+- `src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md:836` — `"Use \`object\` as type when you don't know the type (skips validation)"`. **Change to**: `"Use \`Any\` as the type when you don't want type validation — auto-injected into Python code blocks, no import needed."`
+- `src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md:822` — same line, same fix.
+
+**Required audit**: run `grep -nE 'object.*wildcard|object.*skip.*validation' src/pflow/mcp_server/resources/instructions/*.md` — every hit must be rewritten.
+
+### 7.12 `docs/CLAUDE.md` — UPDATE
+
+The voice-style guidance section uses as an exemplar sentence: `"Use \`object\` when you don't know the type — it skips validation entirely"`. Post-refactor this advice is wrong. Replace with an exemplar that teaches `Any` in code blocks and `any` in `## Inputs`.
+
+### 7.13 Docs — full sweep
+
+After the targeted edits above, run a final audit across the entire `docs/` and `src/pflow/guide/` and `architecture/` trees:
+
+```bash
+grep -rnE "type: (str|int|float|bool|dict|list)\b" \
+    docs/ src/pflow/guide/ src/pflow/mcp_server/resources/instructions/ architecture/
+grep -rnE '(object.*wildcard|object.*skips? validation|type: null)' \
+    docs/ src/pflow/guide/ src/pflow/mcp_server/resources/instructions/ architecture/
+```
+
+Every hit in workflow-IR-context examples must be updated. Hits in Claude Code `output_schema` / LLM `output_schema` context are out of scope (§7.6) — verify each hit's context before editing.
+
+---
+
+## 8. Implementation order
+
+The implementer should follow this order to keep each step testable:
+
+1. **Create `src/pflow/core/types.py`** with `TypeSpec` + `TypeVocabularyError`.
+2. **Write `tests/test_core/test_types.py`** — make it pass.
+3. **Update `src/pflow/core/exceptions.py`** — extend `SchemaValidationError.__init__` with the four new keyword args + update `to_diagnostics()` to populate structured context.
+4. **Update `src/pflow/core/ir_schema.py`** — enum shrink + `_suggest_for_invalid_type` (returns tuple) + `_get_suggestion` routing fix + `validate_ir` threading of structured kwargs.
+5. **Add/update tests in `tests/test_core/test_ir_schema.py`** — make them pass (including the JSON-output structured-context test).
+6. **Update `src/pflow/nodes/python/python_code.py`** — `Any` injection + `_check_annotation_vocabulary` with `NonRetriableError` + NameError-branch fix with expanded `_TYPING_NAMES` + input-only third-line `Any` suggestion.
+7. **Add/update tests in `tests/test_nodes/test_python/test_python_code.py`** — make them pass.
+8. **Update `src/pflow/core/param_coercion.py`** — add `any` dispatch entry with correct `(value, log_context)` signature + add the code comment citing this plan §4.4.
+9. **Add tests in `tests/test_core/test_param_coercion.py`**; remove the 6 alias tests; add one test pinning `_normalize_type` behavior so it isn't accidentally removed in a future cleanup.
+10. **Update `src/pflow/core/markdown_parser.py:147`** + audit other hints — REQUIRED step (was optional).
+11. **Fix test fixtures** per §5.3 (3 test files).
+12. **Migrate AMBIGUOUS example** per §5.1 (1 file).
+13. **Run full test suite** — `make test`. Expect all to pass.
+14. **Run type checker** — `make check`.
+15. **Doc updates** per §7 (including the doc files that were missing from the prior draft: `architecture/reference/template-variables.md`, `docs/CLAUDE.md`, MCP instruction lines 836/822).
+16. **Final doc sweep grep** per §7.13 — catch stragglers.
+17. **Manual verification** per §10 below.
+18. **Bug-report post-fix appendix** — update `scratchpads/type-vocabulary-incoherence/bug-report.md` per §10.2.
+
+---
+
+## 9. Critical files to modify (summary)
+
+**Code:**
+- `src/pflow/core/types.py` — NEW FILE (`TypeSpec` + `TypeVocabularyError`)
+- `src/pflow/core/ir_schema.py` — enum + suggestion logic + `_get_suggestion` returns tuple
+- `src/pflow/core/exceptions.py` — `SchemaValidationError` new kwargs + `to_diagnostics` context population
+- `src/pflow/nodes/python/python_code.py` — Any injection + lowercase-any rejection with `NonRetriableError` + NameError fix + expanded `_TYPING_NAMES`
+- `src/pflow/core/param_coercion.py` — add `any` dispatch with correct `(value, log_context)` signature
+- `src/pflow/core/markdown_parser.py` — line 147 (required, not optional) + audit grep for other Python-alias hints
+
+**Tests:**
+- `tests/test_core/test_types.py` — NEW FILE
+- `tests/test_core/test_ir_schema.py` — update + add
+- `tests/test_nodes/test_python/test_python_code.py` — add `TestAnyAutoInjection`
+- `tests/test_core/test_param_coercion.py` — remove 6 alias tests, add `TestAnyTypeCoercion`
+- `tests/test_core/test_markdown_parser.py` — fixture `str` → `string` (8 locations)
+- `tests/test_runtime/test_compile_once_regression.py` — fixture `str` → `string` (3 locations)
+- `tests/test_integration/test_branch_convergence.py` — fixture `int` → `integer` (2 locations)
+
+**Examples:**
+- `examples/output_validation_demo.pflow.md` — line 43: classify and migrate the ambiguous `dynamic_result`
+
+**Docs:**
+- `src/pflow/guide/core.md` — vocabulary + bridge table
+- `src/pflow/guide/nodes/code.md` — `object` → `Any` recommendation
+- `src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md` — lines 836, 1006, 1262+
+- `src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md` — lines 822, 988, 1244+
+- `docs/reference/nodes/code.mdx` — Tip + Supported types + new Bridge section
+- `docs/changelog.mdx` — new entry (includes saved-workflow migration note)
+- `docs/CLAUDE.md` — voice-style exemplar sentence no longer teaches `object == wildcard`
+- `architecture/reference/ir-schema.md` — ~20 example updates across lines 63-359 plus 588-597
+- `architecture/reference/enhanced-interface-format.md` — cross-reference note distinguishing S1 / S2 / S3 (registry)
+- `architecture/reference/template-variables.md` — lines 511-512, 678-683, 986-988 (was OPTIONAL, now REQUIRED)
+- Final full-tree grep sweep per §7.13
+
+**NOT changed (explicit):**
+- `src/pflow/runtime/template_validation/type_checker.py` (compatibility matrix — already includes both vocabularies, including `integer` row at line 56)
+- `src/pflow/runtime/template_validation/path_validation.py` (hardcoded lists unchanged)
+- `src/pflow/runtime/template_validation/type_validation.py` (shell safety lists unchanged)
+- `src/pflow/runtime/engine/template_resolution.py` (runtime validator unchanged — Task 120 will tighten)
+- `src/pflow/mcp/discovery.py` (registry conversion unchanged)
+- `src/pflow/cli/param_parsing.py` (CLI inference unchanged)
+- `src/pflow/nodes/claude/claude_code.py` (`output_schema` keeps Python names — intentional third dialect, see §11.8)
+- `src/pflow/nodes/llm/llm.py` (`output_schema` passes through as opaque dict — JSON Schema native)
+- `tests/test_registry/test_type_string_conventions.py` (registry vocabulary unchanged)
+- `scratchpads/type-vocabulary-incoherence/repro-files/*` (bug reproducers preserved; `bug-report.md` gets a post-fix appendix per §10.2)
+
+---
+
+## 10. Verification
+
+### 10.1 Automated gates
+
+1. `make test` — full test suite passes.
+2. `make check` — type checker and linter pass.
+3. Specifically confirm these tests pass:
+   - `tests/test_core/test_types.py` — all new `TypeSpec` tests
+   - `tests/test_core/test_ir_schema.py::TestInputTypeVocabulary` — new vocabulary rejection tests
+   - `tests/test_nodes/test_python/test_python_code.py::TestAnyAutoInjection` — new `Any` injection tests
+
+### 10.2 Probe-based manual verification
+
+From `scratchpads/type-vocabulary-incoherence/repro-files/`, run each probe and confirm the expected post-refactor behavior:
+
+```bash
+cd scratchpads/type-vocabulary-incoherence/repro-files/
+
+# Should now SUCCEED (was failing before):
+uv run pflow ./A3-input-type-any.pflow.md x=hello --validate-only
+
+# Should now FAIL with "Use 'object' instead of 'dict'" AND numbered list containing 'any':
+uv run pflow ./A1-input-type-dict.pflow.md x='{"a":1}' --validate-only
+
+# Should now FAIL with "Use 'string' instead of 'str'":
+uv run pflow ./A2-input-type-str.pflow.md x=hello --validate-only
+
+# Should now SUCCEED without `from typing import Any` (B2 probe):
+uv run pflow ./B2-annot-Any.pflow.md x='{"a":1}'
+
+# Should still pass — lenient coercion unchanged (Task 120 will tighten):
+uv run pflow ./E-object-wildcard.pflow.md x=hello
+```
+
+**Positive probe for `integer`** (add a new file under `/tmp/` for this test — not a repro file):
+
+```bash
+cat >/tmp/int-bridge.pflow.md <<'EOF'
+# int-bridge
+## Inputs
+### count
+Count.
+- type: integer
+- required: true
+## Steps
+### c
+Count.
+- type: code
+- inputs:
+    n: ${count}
+
+```python code
+n: int
+result: int = n * 2
+```
+EOF
+uv run pflow /tmp/int-bridge.pflow.md count=5
+# Expected: exits 0, result=10. Tests the integer→int bridge through TYPE_COMPATIBILITY_MATRIX.
+```
+
+**Post-refactor bug-report update**: after verification passes, append a short "Post-fix behavior" section to `scratchpads/type-vocabulary-incoherence/bug-report.md` documenting the new expected outputs for each probe (so future readers see both the bug AND the fix captured in the same file).
+
+### 10.3 Error-message wording spot-checks
+
+Write these tiny probes and confirm the exact error substrings are present. **Use case-sensitive `grep` (no `-i` flag) to catch accidental case regressions in "Use" capitalization.**
+
+```bash
+# "Use 'string' instead of 'str'" — EXACT case
+cat >/tmp/p1.pflow.md <<'EOF'
+# p1
+## Inputs
+### x
+Input.
+- type: str
+- required: true
+## Steps
+### e
+Echo.
+- type: shell
+- cmd: echo
+EOF
+uv run pflow /tmp/p1.pflow.md --validate-only 2>&1 | grep "Use 'string'"
+
+# "Use 'object' if the value is a dict" AND "Use 'any' if the value can be any type"
+cat >/tmp/p2.pflow.md <<'EOF'
+# p2
+## Inputs
+### x
+Input.
+- type: dict
+- required: true
+## Steps
+### e
+Echo.
+- type: shell
+- cmd: echo
+EOF
+uv run pflow /tmp/p2.pflow.md --validate-only 2>&1 | grep "Use 'object' if the value is a dict"
+uv run pflow /tmp/p2.pflow.md --validate-only 2>&1 | grep "Use 'any' if the value can be any type"
+
+# "Did you mean 'string'" (fuzzy match on 'strin')
+cat >/tmp/p3.pflow.md <<'EOF'
+# p3
+## Inputs
+### x
+Input.
+- type: strin
+- required: true
+## Steps
+### e
+Echo.
+- type: shell
+- cmd: echo
+EOF
+uv run pflow /tmp/p3.pflow.md --validate-only 2>&1 | grep "Did you mean 'string'"
+
+# "Parameterized generics not supported" AND "Use 'array'" (canonical replacement, not 'list')
+cat >/tmp/p4.pflow.md <<'EOF'
+# p4
+## Inputs
+### x
+Input.
+- type: list[str]
+- required: true
+## Steps
+### e
+Echo.
+- type: shell
+- cmd: echo
+EOF
+uv run pflow /tmp/p4.pflow.md --validate-only 2>&1 | grep "Parameterized generics not supported"
+uv run pflow /tmp/p4.pflow.md --validate-only 2>&1 | grep "Use 'array'"
+
+# Outputs-side symmetry — same error pathway as inputs
+cat >/tmp/p5.pflow.md <<'EOF'
+# p5
+## Inputs
+### x
+Input.
+- type: string
+- required: true
+## Steps
+### e
+Echo.
+- type: shell
+- cmd: echo ${x}
+## Outputs
+### result
+Result.
+- type: str
+- source: ${e.stdout}
+EOF
+uv run pflow /tmp/p5.pflow.md --validate-only 2>&1 | grep "Use 'string'"
+
+# JSON output — structured context populated, not just prose
+uv run pflow /tmp/p1.pflow.md --validate-only --output-format json 2>&1 | \
+    python -c "import json,sys; d=json.loads(sys.stdin.read()); assert any('similar' in str(e).lower() or 'available_fields' in str(e).lower() for e in d.get('diagnostics', [])), 'structured context missing'"
+```
+
+All greps should return non-empty. If any are empty, the corresponding `_suggest_for_invalid_type` branch has wrong wording — fix it. The JSON check validates that `Diagnostic.context` carries structured fields (not just the prose suggestion).
+
+### 10.4 `Any` injection in code blocks
+
+```bash
+cat >/tmp/any-code.pflow.md <<'EOF'
+# any-code
+## Inputs
+### x
+Input.
+- type: any
+- required: true
+## Steps
+### process
+Process.
+- type: code
+- inputs:
+    x: ${x}
+
+```python code
+x: Any
+result: str = str(type(x).__name__)
+```
+
+## Outputs
+### result
+Result.
+- source: ${process.result}
+EOF
+uv run pflow /tmp/any-code.pflow.md x='{"nested":[1,2,3]}'
+# Expected: exits 0, output contains `dict`
+```
+
+### 10.5 Lowercase `any` in code block
+
+```bash
+cat >/tmp/lower-any.pflow.md <<'EOF'
+# lower-any
+## Inputs
+### x
+Input.
+- type: any
+- required: true
+## Steps
+### process
+Process.
+- type: code
+- inputs:
+    x: ${x}
+
+```python code
+x: any
+result: str = "ok"
+```
+
+## Outputs
+### result
+Result.
+- source: ${process.result}
+EOF
+uv run pflow /tmp/lower-any.pflow.md x=hello 2>&1 | grep -i "Use 'Any'"
+# Expected: grep returns a line
+```
+
+### 10.6 Regression spot check — old behavior still working
+
+```bash
+# Existing canonical workflow should still run:
+uv run pflow examples/test_llm_templates.pflow.md --validate-only
+# Expected: exits 0, no errors.
+# Note: this file uses `type: object` for its `llm_usage` output at line 58 —
+# runtime value is an actual dict, so `object` is semantically correct; no migration needed.
+
+# Probe that uses `type: object` with a dict (B1) should still succeed — lenient coercion untouched:
+uv run pflow scratchpads/type-vocabulary-incoherence/repro-files/B1-annot-dict.pflow.md x='{"a":1}'
+# Expected: exits 0.
+
+# Claude Code output_schema examples — separate surface (Python names in LLM prompts, not IR).
+# Plan §7.6 says NO CHANGE to claude-code.mdx because the output_schema vocabulary is intentionally
+# a third dialect (Python names embedded into LLM prompts via _build_schema_prompt). Verify the
+# example files parse and validate without schema errors:
+uv run pflow examples/nodes/claude-code/claude-code-schema.pflow.md --validate-only
+# Expected: exits 0. The `type: str`/`int`/`list` inside the fenced `yaml output_schema` block
+# is a node param value (opaque dict), NOT a workflow-level ## Outputs `type:` declaration —
+# the IR schema enum shrink does not affect it.
+```
+
+### 10.7 Documentation spot-check
+
+- Run `uv run pflow guide core | grep -iE "any|integer"` — should show the new types listed.
+- Run `uv run pflow guide code | grep -iE "Any|auto-inject"` — should mention auto-injection.
+
+---
+
+## 11. Known quirks and edge cases
+
+1. **`additionalProperties: false` on input/output schema** means unknown fields (`- wildcard: true`) produce a different error than unknown type values. Existing suggestion logic for `additionalProperties` (`_get_output_suggestion` case 1, lines 356-388) is unrelated and unchanged.
+2. **`_TYPE_ALIASES` in `param_coercion.py` stays as defense-in-depth** — kept for IR paths that bypass schema validation (programmatically-constructed IR dicts in tests, cached IRs, future MCP entry points). Post-refactor the alias path is mostly unreachable via normal S1 flow, but removing it is a separate cleanup.
+3. **`coerce_param_for_node` accepts `"str"`** — this is the node-execution boundary where registry Interface (Python-named) meets actual values. Leave unchanged. Registry Interface vocabulary is **NOT** in scope for this PR.
+4. **`test_type_string_conventions.test_type_convention_examples` (line 80-104)** lists Python names (`str`, `int`, `list[str]`, etc.) as valid registry types. **Don't change it** — it codifies the node Interface convention which stays Python-named.
+5. **Parameterized generics in Python code blocks** continue to work as today (outer-type-only validation). The "rejected at parse time" rule applies ONLY to S1 IR schema parsing, not to Python AST parsing of code blocks.
+6. **The `Any | None` annotation form** must still work in code blocks (it's valid Python 3.10+ syntax). The `_is_optional_type` / `_get_inner_optional_type` helpers handle this — no changes needed.
+7. **`Optional[Any]`** also must still work. Same helpers handle it.
+8. **Three type vocabularies coexist post-refactor** — this is intentional and documented:
+   - **S1** (workflow IR `inputs`/`outputs`): canonical 7 names — `string | number | integer | boolean | array | object | any`
+   - **S2** (Python code-block annotations): Python types, `Any` auto-injected
+   - **S3** (node registry `Interface:` docstrings and Claude Code `output_schema`): Python names (`str`, `int`, `dict`, ...) — intentionally unchanged because S3 feeds LLM prompt construction (`_build_schema_prompt`) and registry metadata whose authors are Python library writers. The S1↔S2 bridge table is documented; the S3 vocabulary is a third dialect that's kept stable because it has different consumers.
+9. **Lowercase `any` inside parameterized generics** (e.g., `list[any]`) is NOT caught by `_check_annotation_vocabulary` — the helper only inspects the outer name. It will surface as a `NameError` at exec time via the normal Python path. Accepted trade-off; documented in the helper's docstring.
+10. **Saved workflows containing Python aliases** (at `~/.pflow/workflows/*/`) will fail validation on next load or `--force` re-save. Migration is manual: edit the saved `.pflow.md` to use canonical names. Changelog entry captures this.
+11. **`TypeSpec.accepts()` uses strict JSON-Schema-style semantics** (e.g., `TypeSpec("integer").accepts(True) is False`, even though Python's `bool` is a subclass of `int`). This diverges from `python_code._TYPE_MAP`'s Python-permissive rules (`_TYPE_MAP["int"] == int` accepts `True`). No caller uses `accepts()` in this PR (it's for Task 120), but future callers should know the two semantics exist side by side. Document in `TypeSpec.accepts()`'s docstring.
+
+---
+
+## 12. Out of scope — things the implementer must NOT do
+
+- Do NOT modify `TYPE_COMPATIBILITY_MATRIX` in `type_checker.py`.
+- Do NOT modify `_TYPE_ALIASES` in `param_coercion.py`.
+- Do NOT change `coerce_workflow_input` to raise on non-matching types (that's Task 120).
+- Do NOT change registry Interface docstrings (stay Python-named).
+- Do NOT remove `_TYPE_MAP` entries in `python_code.py`.
+- Do NOT add complex/nested schema syntax (`properties:`, `required: [...]`) — separate task.
+- Do NOT add union type syntax (`string | null`) — separate task.
+- Do NOT migrate `scratchpads/type-vocabulary-incoherence/repro-files/*`.
+
+---
+
+## 13. Rationale notes for future readers
+
+**Why separate S1 and S2 vocabularies?** S1 is an external contract; external consumers (CLI users, MCP clients, non-Python tooling) shouldn't need Python context. S2 must be Python because the runtime is Python. They serve different purposes, so they use different dialects. An explicit bridge keeps both surfaces clean.
+
+**Why `object` → dict and `any` → wildcard instead of keeping `object` as wildcard?** A type label that looks restrictive but behaves permissively is worse than no label. Author predictability trumps implementation convenience.
+
+**Why ship both `object` fix and alias removal in one PR?** Two breaks in one release = one migration. Spread across releases = a confused intermediate state. No external users means no backward-compat debt.
+
+**Why hard errors not deprecation warnings?** Agents ignore warnings until they become errors. The confusing intermediate state ("works but will break") is a worse cost than the focused "here's the fix" error.
+
+**Why `Any` auto-injected and lowercase `any` rejected?** Python code should BE Python. Each surface speaks its native dialect. But `from typing import Any` ceremony is pure tax; injecting `Any` (like `Optional` is already injected) removes the tax without leaking `typing` knowledge into workflow authoring.
+
+**Why skip `null` for now?** Nullability is semantically distinct from absence — absence is `required: false` + no `default:`; nullability is a value-level concern. Handling null without union syntax collapses these. Add when union syntax lands.
+
+---
+
+_End of plan._

--- a/.taskmaster/tasks/task_154/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_154/implementation/progress-log.md
@@ -1,0 +1,787 @@
+# Task 154 Progress Log
+
+> **What this file is**: the epistemic trail for this task — decisions, rejected alternatives, reviewer findings that shifted the plan, and non-obvious traps. Complementary to (not redundant with) `task-154.md` (the what/why) and `implementation-plan.md` (the how).
+>
+> Read this before touching code. Append to it as you work.
+
+---
+
+## 1. Planning journey — what the design NEARLY was and why it isn't
+
+### 1.1 First attempt: "one Python vocabulary everywhere"
+
+Before reviewer input, the plan was going to unify S1 and S2 onto a single Python vocabulary. Rationale: *"Pydantic/FastAPI/Typer/Prefect/Dagster all use Python type hints as the single type language."*
+
+**Why this was wrong**: those are all Python libraries whose contract IS Python. pflow is a workflow format that happens to run Python. Shell nodes, HTTP nodes, LLM nodes, Claude Code nodes don't use Python annotations at all — forcing S1 to speak Python alienates non-Python consumers (CLI users piping values, MCP clients, docs readers) without any corresponding payoff.
+
+Two independent external reviewers caught this with a cleaner framing: *"S1 is a declarative contract; S2 is Python because runtime is Python."* They serve different purposes, so they use different dialects.
+
+**Implication for the implementer**: if you're ever tempted to "simplify" by collapsing the two vocabularies, know this was deliberately rejected. The bridge is documented once; each surface stays in its native dialect.
+
+### 1.2 Four-agent poll on authoring preference
+
+Before external reviewers, I polled four `pflow-codebase-searcher` agents on what vocabulary they'd naturally want as authoring agents. Result: 3 of 4 voted for the unified Python vocabulary. One dissenter (Agent 4) argued exactly what the external reviewers later argued: two vocabularies with an explicit bridge.
+
+**Lesson**: unanimous-ish preference among authoring agents is a weak signal when the alternative has architectural coherence on its side. Don't let "what feels natural" override "what's structurally right" — authoring agents optimize for their own cognitive load, not for system coherence.
+
+### 1.3 Poll P1 — how `any` should work at Surface 2
+
+Three agents polled with three designs:
+- **Design A**: `x: any` (lowercase) rewritten to `Any` behind the scenes
+- **Design B**: `x: Any` with auto-injection (selected)
+- **Design C**: omit annotation for `any` inputs
+
+Result: 3/3 chose B. Most important thing they agreed on: **Design A rejected forcefully** — *"Invisible source rewriting is never invisible when it breaks."* The plan calls for Design B; if a future PR proposes silently rewriting annotations, this decision's rationale explains why not.
+
+Design C rejected because *"missing annotation reads as 'I forgot'; explicit `Any` documents deliberate intent."*
+
+### 1.4 Poll P3 — breaking-change cost/value
+
+Three agents polled on three paths:
+- Path A: keep Python aliases silently, only fix `object`-as-wildcard
+- Path B: hard errors, ship both breaks atomically (selected)
+- Path C: deprecation warnings, two-release cutover
+
+Result: 3/3 chose B, all recommending atomic shipping. Key quote: *"Deprecation warnings are the worst of both worlds — ambiguous, ignored until they become errors anyway."*
+
+This matters because the plan's "hard errors with fix suggestions" posture is not merely stylistic — it's the polled judgment of three independent authoring-agent perspectives. Softening to warnings would walk back a validated decision.
+
+### 1.5 The unresolved split — `number` vs `float`
+
+Polls split 3/1 between:
+- *Keep `number` as first-class type* (maps to int-or-float)
+- *Use `float` since `int` satisfies `float` per Python convention*
+
+**Resolution**: kept `number`. Reasons: JSON Schema semantics (number = numeric, integer = integer); `integer` distinction gives authors a way to require int-only; bridges cleanly to `int | float` in code.
+
+**Implementer note**: the plan's bridge table shows `number → int | float (or float)` as the Python-side equivalent. Both work; `float` is simpler if the author doesn't care about int narrowing. This isn't a trap, just a documented flexibility.
+
+### 1.6 `?` suffix syntax for optional was considered and rejected
+
+One external reviewer proposed `- type: string?` as ergonomic shorthand for optional inputs. Rejected because it conflates two distinct axes:
+- **Absence** (input key may be missing) — expressed by `required: false` + optional `default:`
+- **Nullability** (value may be `None`) — expressed by `type: any` today, union syntax later
+
+Collapsing both into `?` is the mistake Pydantic v1 made and v2 untangled. We're keeping them orthogonal from day one.
+
+### 1.7 Strict runtime enforcement deferred to Task 120
+
+This is the single most important scope boundary to preserve.
+
+This PR ships the **vocabulary change**:
+- Enum accepts only canonical names
+- `object` is documented as dict-only
+- `any` is the explicit wildcard
+- Error messages teach the new rules
+
+This PR does NOT tighten runtime coercion:
+- `coerce_workflow_input` stays lenient
+- Existing workflows with `type: object` that actually pass non-dict values will continue to work (leniently) until Task 120 lands
+
+**Why this boundary**: the runtime-strictness change has its own test surface, its own migration complexity, and its own risk profile. Bundling them would make the PR harder to review and harder to revert. The polls specifically endorsed this split.
+
+**Implementer trap**: if you find `coerce_workflow_input` "seems wrong" because it accepts non-dict for `type: object`, that's by design *for this PR*. Don't fix it here — Task 120 is the home for that change.
+
+### 1.8 Three vocabularies intentionally coexist post-refactor
+
+Not two. Three. This is the single most confusing thing about the post-refactor state:
+
+| Surface | Vocabulary | Example | Why |
+|---|---|---|---|
+| **S1** — workflow IR `## Inputs`/`## Outputs` | 7 canonical JSON Schema names | `type: object` | External contract; readable by non-Python consumers |
+| **S2** — Python code-block annotations | Python types (`Any` auto-injected) | `x: dict` | Runtime is Python |
+| **S3** — node registry `Interface:` docstrings AND LLM `output_schema` / Claude Code `output_schema` | Python types (not changed) | `Writes: shared["x"]: dict` | Authored by Python library writers; feeds LLM prompt construction for Claude Code (`_build_schema_prompt` embeds names literally into prompts) |
+
+The S1↔S2 bridge is the primary doc artifact. S3 is acknowledged as a deliberate third dialect.
+
+**Implementer trap**: if a reviewer or later contributor says "why don't we unify S3 too?" — the answer is (a) LLM prompt construction embeds literal Python names, (b) node library authors write `Interface:` docstrings as Python annotations, (c) Registry Interface vocab has a different consumer population. The three-dialect coexistence is intentional, not technical debt.
+
+### 1.9 `null` dropped from vocabulary (for now)
+
+Considered adding `null` to the 7-name list. Dropped. Without union syntax (`string | null`, `int | null`), `type: null` on its own means "value must be None" — almost never useful. Value of `null` is in unions; add when unions land.
+
+**Guidance today**: "use `type: any` if the value may be None." This phrasing is deliberately in the `null` rejection error message (plan §3 note 4) — lead with the fix, not the deferred feature.
+
+### 1.10 Complex nested input schemas out of scope
+
+User asked if we could support complex schemas (e.g., `type: object` with `properties:`) — deferred to a later task.
+
+**Relevant context the implementer should know**: pflow already has `yaml output_schema` fenced blocks in Claude Code and LLM nodes for structured output. When complex input schemas are added, the natural implementation reuses that existing flat `{field: {type, description}}` YAML convention. Verified that both `llm` node and `claude-code` node accept the same outer YAML shape (they diverge on internal interpretation — see `src/pflow/nodes/llm/llm.py:285` vs `src/pflow/nodes/claude/claude_code.py:199-214`).
+
+---
+
+## 2. Reviewer findings that reshaped the plan
+
+Five specialized reviewers ran against the draft plan. Findings that changed the plan follow. These are documented NOT in the plan itself (plan shows the corrected end-state) — they live here as the "why this file looks the way it does" record.
+
+### 2.1 Critical — `_coerce_to_any` signature mismatch (`review-plan`)
+
+**Draft plan had**: `def _coerce_to_any(value: Any) -> Any: return value`
+
+**Verified against code**: `param_coercion.py:293` calls `coercer(value, log_context)`. Single-arg signature would `TypeError` on the first `type: any` workflow.
+
+**Plan corrected**: §4.4 now specifies `(value, log_context)` with a code comment referencing this log.
+
+**Trap for the implementer**: the `log_context` parameter is unused in the body but REQUIRED by the dispatcher convention. Don't "clean it up" by removing it.
+
+### 2.2 Critical — diagnostic context pipeline bypass (`review-agent-ux`)
+
+**Draft plan had**: error signal flattened into `SchemaValidationError.suggestion` as a prose string.
+
+**Verified against code**: `src/pflow/core/CLAUDE.md` explicitly documents *"Error handling philosophy — producers are self-describing. Never flatten structured data (paths, fuzzy matches, available fields, suggestions) into string messages for downstream code to reverse-engineer."* The unified renderer in `diagnostic_render.py` already consumes `context["similar_names"]` → "Did you mean" block, `context["available_fields"]` → numbered-list block, `suggestions_list` → multi-suggestion rendering.
+
+**Plan corrected**: extended `SchemaValidationError.__init__` with four structured kwargs (`similar_names`, `available_fields`, `available_fields_label`, `suggestions_list`); introduced `TypeVocabularyError` dataclass that carries both prose and structured fields; threaded them through `_suggest_for_invalid_type` → `_get_suggestion` → `validate_ir`.
+
+**Why this matters**: agents consuming JSON output (`--output-format json`) get programmatic access to the canonical replacement via `context.suggestions_list[0]`. Without this, they'd have to regex-parse prose. Respect the pattern.
+
+### 2.3 Critical — parameterized generic canonical mapping (`review-agent-ux`)
+
+**Draft plan had**: for `list[str]`, error message would produce `"Use 'list'"` or `"Use 'the base type'"`. But `list` is a Python alias, so the fix suggestion was itself illegal — agent would need two round-trips.
+
+**Plan corrected**: the rule is now "if the outer name is in `PYTHON_ALIASES_AT_S1`, suggest its canonical replacement." So `list[str]` → `"Use 'array'"`, `dict[str, int]` → `"Use 'object'"`. One-shot fix.
+
+### 2.4 Critical — `dict` wildcard hint must be multi-suggestion, not prose (`review-agent-ux`)
+
+**Draft plan had**: single prose string `"Use 'object' instead of 'dict' (for a wildcard that accepts any type, use 'any')"`.
+
+**Problem**: ambiguous about WHEN to pick which. Agent has to infer semantics from parenthetical.
+
+**Plan corrected**: populate `suggestions_list` as a two-entry list — renderer emits numbered list:
+```
+To fix this:
+  1. Use 'object' if the value is a dict: - type: object
+  2. Use 'any' if the value can be any type: - type: any
+```
+
+### 2.5 Rationale correction — `_TYPE_ALIASES` kept, but for the right reason
+
+**Draft plan claim**: `_TYPE_ALIASES` stays because "`_normalize_type()` has downstream consumers (template validation, registry interop)."
+
+**Verified against code**: `_normalize_type()` has exactly ONE caller: `coerce_workflow_input` itself. No downstream consumers.
+
+**Plan corrected**: rationale rewritten to "defense-in-depth for IR paths that bypass schema validation (programmatically-constructed IR dicts, cached IRs, future MCP entry points)." The code stays; the reason is honest.
+
+**Implementer guidance**: if you find this and think "this is dead code, let me remove it" — that's a legitimate follow-up cleanup, NOT this PR's scope. Flag as a follow-up issue.
+
+### 2.6 Documentation inventory undercounted
+
+**Draft plan listed**: ~3 files in `architecture/` and 2 sets of lines in MCP instruction files.
+
+**Reviewer found**:
+- `architecture/reference/ir-schema.md` has ~20 Python-alias examples, not 3
+- `architecture/reference/template-variables.md` has lines 511-512, 678-683, 986-988 (was marked OPTIONAL; now REQUIRED)
+- `mcp-agent-instructions.md:836` and `mcp-sandbox-agent-instructions.md:822` contain `"Use \`object\` as type when you don't know the type (skips validation)"` — directly teaches REMOVED semantics
+- `docs/CLAUDE.md` uses the old advice as a voice-style exemplar
+
+**Plan corrected**: §7.8–§7.13 now enumerate all of these explicitly, plus a final grep sweep across `docs/`, `architecture/`, `src/pflow/guide/`, `src/pflow/mcp_server/resources/instructions/`.
+
+### 2.7 `NonRetriableError` not `ValueError` (`review-agent-ux`)
+
+**Draft plan had**: `raise ValueError(...)` in `_check_annotation_vocabulary`.
+
+**Per `src/pflow/nodes/CLAUDE.md`**: node validation errors must use `NonRetriableError`. Vanilla `ValueError` triggers retries (wasteful for deterministic validation failures).
+
+**Plan corrected**: §4.3.2 now imports `NonRetriableError` and raises that subclass.
+
+### 2.8 Disputed — "`integer` missing from compatibility matrix" (false claim)
+
+One reviewer (review-validation-consistency) claimed `TYPE_COMPATIBILITY_MATRIX` lacks an `"integer"` key, saying post-refactor `type: integer` inputs would fail compatibility.
+
+**Verified against code**: `src/pflow/runtime/template_validation/type_checker.py:56` has `"integer": ["any", "int", "integer", "float", "number", "str", "string"]`. The claim is false.
+
+**Lesson**: reviewers are not infallible. When a claim names specific code, verify against that code before acting on it. Several of the "critical" findings above (signature mismatch, misleading NameError) WERE verified real; this one wasn't.
+
+**Kept in plan as §11.2**: the `integer` row is verified present, no action needed.
+
+### 2.9 Lower-priority but confirmed
+
+- **Fuzzy cutoff 0.6, not 0.4** — prevents false positives at 7-item universe (`pool` ≈ `bool` at 0.4).
+- **`Any` third-line suggestion** added to input-type-mismatch error ONLY, not result-mismatch — result annotations are author's own intent; suggesting `Any` there tells them to defeat their own contract.
+- **Markdown parser line 147 hint change** promoted from OPTIONAL to REQUIRED because `test_markdown_parser.py:2355` asserts on the hint string.
+- **Saved workflows** in `~/.pflow/workflows/*/` containing Python aliases will fail on next load/re-save. Changelog entry captures this; no automated migration tool provided (zero external users, manual `sed` is sufficient).
+- **Lowercase `any` inside parameterized generics** (`list[any]`) NOT caught by `_check_annotation_vocabulary` — helper only checks outer name. **Correction (post-review)**: earlier draft claimed `list[any]` "will surface as a NameError at exec time." That claim is **false**. Python's `any` is a valid built-in (the `any()` function); `list[any]` evaluates cleanly via PEP 585's `list.__class_getitem__` and no error fires. The annotation is stored; the outer `list` isinstance check passes; the agent never learns `any` is the wrong spelling at S2 inside a generic. Documented limitation; no runtime safety net. Recursive-scan of generic parameters would catch it but is deferred — not a blocker because agents hitting the outer case (`x: any`) will learn the two-surface rule before nesting it.
+
+---
+
+## 3. Non-obvious implementer traps
+
+A collection of "easy to get wrong" items surfaced during planning. None of these appear obvious from reading the plan alone.
+
+### 3.1 The `scratchpad/type-vocabulary-incoherence/repro-files/` probes change behavior post-fix
+
+This is intentional, not a regression:
+
+- `A3-input-type-any.pflow.md` — currently FAILS (pflow rejects `type: any`). Post-fix: **should succeed**. Positive smoke test for the new vocabulary.
+- `A1-input-type-dict.pflow.md` — currently succeeds. Post-fix: **should fail** with "Use 'object' if the value is a dict: - type: object" / "Use 'any' if the value can be any type: - type: any" numbered list.
+- `A2-input-type-str.pflow.md` — currently succeeds. Post-fix: **should fail** with "Use 'string' instead of 'str'".
+- `E-object-wildcard.pflow.md` — continues to parse (lenient coercion unchanged for this PR). Under future Task 120, strict runtime will reject non-dict values.
+
+Do NOT "fix" these files. They're the canonical behavioral probes.
+
+### 3.2 The markdown parser hint change and its test must be atomic
+
+`markdown_parser.py:147` is the hint text `"    - type: str\n"`. `test_markdown_parser.py:2355` asserts `"- type: str" in err.suggestion`. Change one without the other and the test breaks.
+
+Plan §5.3 + §4.11 both cover this — just do them in the same commit.
+
+### 3.3 `TypeSpec.accepts()` has different semantics than `python_code._TYPE_MAP`
+
+`TypeSpec("integer").accepts(True) is False` (JSON Schema strict — `bool` is not `int`).
+`_TYPE_MAP["int"] == int` and `isinstance(True, int) is True` (Python lax).
+
+Both coexist intentionally. `TypeSpec.accepts()` has no callers in this PR (it's for Task 120). But future readers will wonder; the `TypeSpec.accepts()` docstring must document this asymmetry so nobody "fixes" it.
+
+### 3.4 `_get_suggestion()` signature change is load-bearing
+
+Existing: returns `str`. Refactored: returns `tuple[str, dict[str, Any]]`.
+
+EVERY existing branch in `_get_suggestion` must be wrapped to return `(existing_return_value, {})` — if any branch still returns a bare string, `validate_ir` crashes with "too many values to unpack" when that branch fires.
+
+Plan §4.2.4 shows the pattern; the implementer needs to apply it to every `return` in the function.
+
+### 3.5 `coerce_param_for_node` still accepts `"str"` — do NOT change it
+
+Registry Interface docstrings use Python names. `coerce_param_for_node` is called at the node-execution boundary where registry metadata meets actual values. It must continue to accept `"str"`. Plan §4.4 is explicit; the test inventory at §6.3 keeps all `TestDictToStringCoercion.test_*_when_type_is_str` tests unchanged.
+
+If you find yourself removing `"str"` support from param_coercion — STOP. That breaks every node that accepts `str`-typed params from registry metadata.
+
+### 3.6 The six alias tests to REMOVE in `test_param_coercion.py` are specifically for `coerce_workflow_input`, not `coerce_param_for_node`
+
+Plan §6.3 lists the six by name. They're at lines 204, 242, 267, 301, 344, 382. Don't confuse them with the `TestDictToStringCoercion` tests (which stay) — those exercise the OTHER function.
+
+### 3.7 Test `test_type_string_conventions.test_type_convention_examples` lists Python names as valid — DO NOT modify
+
+This test codifies the registry `Interface:` convention. Registry stays Python-named. Modifying it would unify S3 into S1, which is out of scope (see §1.8 above).
+
+### 3.8 Claude Code `output_schema` example files parse with "wrong"-looking types
+
+`examples/nodes/claude-code/claude-code-schema.pflow.md` has `type: str`, `type: int`, `type: list`, `type: bool` INSIDE a fenced `\`\`\`yaml output_schema` block. These are NOT workflow-level `## Outputs` declarations — they're a node param value (opaque dict to the outer parser). The IR schema enum shrink does NOT affect them.
+
+Plan §10.6 includes a spot check that this file still validates post-refactor. If it fails, something leaked the schema-enum check into node params.
+
+---
+
+## 4. Implementation notes — what actually happened during coding
+
+This section records the delta between the plan and the real implementation/debugging journey.
+
+### 4.1 Additional workflow-facing test fixtures required migration
+
+The plan's fixture inventory in §5.3 was directionally correct but incomplete.
+
+During implementation, the first wave of failing tests revealed that the break on
+workflow-level `inputs.*.type` / `outputs.*.type` affected more **programmatically
+constructed IR dicts in tests** than the plan listed. These were not markdown
+fixtures; they were direct Python dicts passed into validation, compilation, or
+runner flows.
+
+Files updated beyond the original narrow inventory included:
+
+- `tests/test_core/test_output_source_validation.py`
+- `tests/test_core/test_workflow_validator_outputs.py`
+- `tests/test_execution/test_runner.py`
+- `tests/test_mcp_server/test_registry_template.py`
+- `tests/test_core/test_workflow_manager.py`
+- `tests/test_integration/test_workflow_manager_integration.py`
+- `tests/test_runtime/test_cache_integration.py`
+- `tests/test_runtime/test_memoization_integration.py`
+- `tests/test_runtime/test_initial_params_override_removal.py`
+- `tests/test_runtime/test_trace_integration.py`
+- `tests/test_cli/test_find.py`
+- `tests/test_runtime/test_template_validation/test_type_checker.py`
+- `tests/test_runtime/test_template_validation/test_validator.py`
+- `tests/test_runtime/test_template_validation/test_unused_inputs.py`
+- `tests/test_runtime/test_template_validation/test_batch_item_validation.py`
+
+**Why this matters**: future vocabulary-breaking tasks should search not only for
+`.pflow.md` examples and markdown fixture strings, but also for direct IR dicts in
+tests. Those bypass the authoring surface but still exercise the same schema
+validation path.
+
+### 4.2 `TypeSpec.parse()` had a real precedence bug
+
+The first implementation checked for internal whitespace before handling
+parameterized generics.
+
+That produced the wrong error for:
+
+- `dict[str, int]`
+
+Instead of:
+
+- `"Parameterized generics not supported ... Use 'object'."`
+
+it produced:
+
+- `"Whitespace not allowed inside type names."`
+
+This was incorrect because the generic-specific guidance is the actionable fix.
+
+**Final decision**: generic detection must run before the internal-whitespace
+check. This is now the actual behavior in `TypeSpec.parse()`.
+
+### 4.3 Alias errors now populate `similar_names`, not just `suggestions_list`
+
+The plan's structured-context work focused mainly on:
+
+- `available_fields`
+- `available_fields_label`
+- `suggestions_list`
+
+While debugging JSON/diagnostic expectations, it became clear that alias errors
+also benefit from carrying the canonical replacement in `similar_names`. Example:
+
+- `str` → `similar_names=["string"]`
+- `dict` → `similar_names=["object"]`
+
+**Why this was done**: downstream JSON/MCP consumers already understand the
+`similar_names` channel. Reusing it for alias replacement makes these errors more
+uniform with typo/fuzzy-match errors and keeps the diagnostic surface coherent.
+
+### 4.4 The `integer -> int` bridge test required both compile-time and runtime seeding
+
+The new test in `tests/test_core/test_ir_schema.py` went through three iterations:
+
+1. Compile without `edges` → failed on compiler structure validation.
+2. Compile with `edges`, but no `initial_params` → failed on required-input validation.
+3. Compile with `initial_params`, but no `shared["value"]` before engine run → failed template resolution for `${value}`.
+
+The subtle point is:
+
+- `compile_workflow(..., initial_params=...)` satisfies compile-time input validation.
+- `WorkflowEngine.run(workflow, shared)` still resolves templates from the **shared
+  store context at runtime**.
+
+So the correct end-to-end fixture for this test is:
+
+- pass `initial_params={"value": 5}` to compilation
+- seed `shared["value"] = 5` before execution
+
+This is not a bug in Task 154; it is the expected separation between compilation
+validation and runtime template resolution.
+
+### 4.5 `TypeSpec.parse()` needed a small structural refactor after behavior was correct
+
+After the implementation was functionally correct, static checks surfaced two
+follow-up issues:
+
+- Ruff: `parse()` exceeded the complexity threshold (`C901`)
+- mypy: helper calls that always raise were typed as returning `None`, so mypy
+  complained about a missing return path
+
+**Final decision**:
+
+- Extracted three helper functions:
+  - `_raise_parameterized_generic_error(...)`
+  - `_raise_alias_error(...)`
+  - `_raise_unknown_type_error(...)`
+- Typed them as `NoReturn`
+
+This is a pure maintenance refactor; behavior was intentionally preserved.
+
+### 4.6 Verification constraints in this agent environment were environmental, not code-related
+
+In this coding environment:
+
+- `uv run ...` failed due sandbox restrictions on `/Users/andfal/.cache/uv/...`
+- forcing `UV_CACHE_DIR=/tmp/uv-cache` triggered a separate `uv` panic during env creation
+- `.venv/bin/python` existed but did not have `pytest` installed
+
+Because of that, verification here relied on:
+
+- `python3 -m py_compile` over changed source and test files
+- targeted grep/audit passes
+- user-provided failing test output from a real project environment
+
+**Important**: this should not be interpreted as a repository issue. The `uv`
+failures observed during implementation were environment/sandbox-specific.
+
+### 4.7 Documentation sweep result: grep hits must be interpreted by surface, not blindly removed
+
+After the doc sweep, remaining grep hits for `type: str` / `type: list` / etc.
+were mostly in:
+
+- Claude Code `output_schema` examples
+- registry Interface metadata examples
+- architecture implementation docs describing registry/template-validation internals
+
+Those are legitimate S3 / registry-Python surfaces, not missed S1 migrations.
+
+**Operational lesson**: broad grep is necessary, but final judgment must be made by
+surface:
+
+- S1 workflow `inputs` / `outputs` examples → canonicalize
+- S2 code annotations / S3 registry Interface / Claude `output_schema` → preserve
+
+### 4.8 No production runtime strictness changes were made beyond the plan boundary
+
+While fixing the failing tests, multiple places still exposed the pre-existing
+semantic looseness around `object` and lenient coercion. None of those were
+tightened in this task.
+
+This boundary was consciously preserved:
+
+- vocabulary and messaging changed
+- coercion strictness did not
+- runtime `object` enforcement remains Task 120
+
+That boundary held during implementation despite several tempting adjacent fixes.
+
+---
+
+## 4. Verification strategy reasoning
+
+The plan's §10 verification is structured this way on purpose. Context:
+
+- **§10.1 automated gates** (`make test`, `make check`) — first line of defense
+- **§10.2 probe-based manual verification** — catches behavioral regressions the automated tests don't cover (because tests use mocks; probes exercise the full CLI)
+- **§10.3 error-message spot checks with CASE-SENSITIVE `grep`** — reviewers specifically asked for this because the initial draft used `grep -i` which would have hidden accidental case regressions. "Use 'string'" (capital U) is the contract; a refactor that lowercased it would silently pass `grep -i`.
+- **§10.3 JSON output check** — validates the diagnostic context pipeline (the critical finding from §2.2). If prose works but structured context isn't populated, this test catches it.
+- **§10.6 regression smoke tests** — specifically includes `claude-code-schema.pflow.md` to verify the "three vocabularies coexist" design (§1.8) didn't accidentally collapse.
+- **§10.2 "Post-fix behavior" appendix to bug-report.md** — future readers see both the bug AND the fix captured in the same file. Avoids a stale bug report.
+
+If you're tempted to skip any of these: they each catch a category of bug that the automated tests miss. Don't skip.
+
+---
+
+## 5. Methodology notes for future similar tasks
+
+### 5.1 Agent-opinion polling worked
+
+Two polls (P1: `any` semantics at S2, P3: breaking-change path) generated 3-4-agent unanimous consensus that validated non-obvious design calls. The methodology: describe the situation neutrally (no leading options), ask for unbiased preference, compare results.
+
+**When to use**: agent-facing UX decisions where the "natural" answer isn't obvious from architecture principles.
+
+**When NOT to use**: architectural decisions (§1.1 showed polls voted wrong relative to what external reviewers caught). Cross-check with reviewers or analogy to proven systems.
+
+### 5.2 Five-reviewer plan review caught real bugs
+
+`/code-review` with 5 specialized agents (`review-plan`, `review-impact-completeness`, `review-validation-consistency`, `review-feature-interactions`, `review-agent-ux`) ran in parallel. Caught:
+- 1 crash-level bug (`_coerce_to_any` signature)
+- 1 architectural mismatch (diagnostic context bypass)
+- 1 agent-UX regression (parameterized generics wrong canonical name)
+- 4 doc inventory omissions
+
+Cost: ~15 minutes of reviewer time. Saved: hours of implementation rework if these had surfaced at test time.
+
+**When to use this pattern again**: complex refactors that touch shared abstractions. Not for single-file bug fixes.
+
+### 5.3 Trust-but-verify reviewer claims
+
+Reviewer `review-validation-consistency` claimed `integer` was missing from `TYPE_COMPATIBILITY_MATRIX`. Reading the code showed it's at line 56. One false positive out of six critical findings — not bad, but always verify.
+
+---
+
+## 6. Implementation steps (reference)
+
+Full step-by-step plan is in `implementation-plan.md` §8. Not duplicated here.
+
+---
+
+## 7. Live log
+
+Append below as you work. Timestamp + what happened + what you learned. Keep entries append-only.
+
+### [2026-04-16 pre-implementation] — Plan approved; progress log created
+
+Plan reviewed by 5 specialized reviewers. 6 critical findings + 9 warnings + 6 suggestions applied. User approved plan via ExitPlanMode. Task 154 created. This progress log created to capture reasoning trail separately from the plan/spec.
+
+**Next step**: begin implementation at §8 step 1 (create `src/pflow/core/types.py`).
+
+---
+
+### [2026-04-16 post-fix code review] — 4-agent code review + ten review-prompted fixes landed
+
+What I'm doing: ran `/code-review` skill with 4 specialized agents on the staged PR (impact-completeness, agent-ux, feature-interactions, validation-consistency). Evaluated findings, classified confidence, implemented three rounds of fixes in priority order. Agents deployed in parallel; each reviewed from its specific blindspot category. This captures the delta from the pre-review staged state.
+
+**Review inventory:**
+- 1 critical finding (agent-ux + feature-interactions both flagged): parameterized-generic prose lost at rendered CLI/JSON layer — `suggestions_list` preempts `suggestion` in `SchemaValidationError.to_diagnostics()`, so the full "Parameterized generics not supported" message never reached users. Only the terse "Use 'array'" survived. Confirmed real.
+- 7 confirmed warnings across the agents
+- 6 suggestions, some out-of-scope
+- 2 disputed (TypeVocabularyError base class, asymmetric diagnostic shape for `_check_annotation_vocabulary`)
+
+**Pass 1 — minimum-viable merge set (items #1, #3, #6, #7, plus bonus)**:
+- `src/pflow/core/types.py` — `_raise_parameterized_generic_error` now emits self-contained `suggestions_list=[f"Use '{canonical}' — parameterized generics not supported at ... (got {raw!r})"]`. Full WHY surfaces at both CLI and JSON output layers.
+- `src/pflow/core/types.py` — `null` branch now carries `suggestions_list=["Use 'any' if the value may be None"]` for parity with alias errors.
+- `src/pflow/core/ir_schema.py` — enum description strings now `f"Data type: one of {', '.join(CANONICAL_TYPES)}"` (drift-proof).
+- `src/pflow/core/param_coercion.py` — `_TYPE_ALIASES` comment rewritten to cite the concrete production bypass path (template-referenced sub-workflows via `sub_workflow_resolver.py`) instead of generic "defense-in-depth."
+- **Bonus simplification (null-through-markdown)**: during verification I noticed `type: null` in markdown parses to Python `None`, hitting jsonschema's `type` validator (not `enum`), so my #3 fix for `TypeSpec.parse("null")` was unreachable via the real markdown authoring path. Fixed at the routing layer instead:
+  - `_get_suggestion` now uses a list-based path check (`len(path_list) >= 3 and path_list[0] in ("inputs", "outputs") and path_list[-1] == "type"`) — precise, catches both validator errors (`enum` AND `type`), and avoids the prior `"type" in path_str` substring fragility that accidentally matched `nodes[N].type`.
+  - `_suggest_for_invalid_type` maps `offending is None` → `"null"` so it reaches the `TypeSpec.parse("null")` branch and produces the right suggestion.
+  - `_get_output_suggestion` case 3 removed — dead code after the routing upstream refactor.
+  - Added regression test `test_null_as_python_none_rejected_with_same_suggestion` in `test_ir_schema.py`.
+- `progress-log.md` §2.9 corrected: the earlier claim that "lowercase `any` in `list[any]` will surface as a NameError at exec time" was **false**. Python's `any` is a valid built-in (the `any()` function); `list[any]` evaluates cleanly via PEP 585's `list.__class_getitem__`. Documented as a limitation without a runtime safety net; recursive-scan would catch it but deferred.
+
+Result:
+- ✅ All 4842 tests pass (+1 from baseline: the null-through-markdown regression guard)
+- ✅ `make check` clean
+- ✅ CLI/JSON output for `type: list[str]` now surfaces the full prose with canonical fix
+- ✅ CLI/JSON output for `type: null` in markdown now surfaces "Use 'any' if the value may be None" instead of the generic "Change type from 'NoneType' to 'string'"
+
+**Pass 2 — opinionated NameError hint + canonical syntax table (items #2, #5)**:
+- `src/pflow/nodes/python/python_code.py` — extracted `_suggest_for_nameerror()` helper. Three categories, ONE canonical fix per case (no menus):
+  - `_MODERN_GENERIC_NAMES = {"List", "Dict", "Tuple", "Set", "FrozenSet", "Type"}` → "Use '{lower}[...]' instead — Python 3.9+ supports lowercase built-in generics (PEP 585). Example: ..."
+  - `"Union"` → "Use pipe syntax instead: 'A | B' (PEP 604). Example: ..."
+  - `_REQUIRES_TYPING_IMPORT = {"Literal", "TypeVar", "Callable", "Final", "ClassVar", "Iterable", "Iterator", "Sequence", "Mapping"}` → "Add 'from typing import X'"
+  - Not a known typing name → original input-variable suggestions
+- `_format_exec_error` NameError branch simplified from ~40 lines of inline conditionals to 4 lines + delegation.
+- Tests: renamed `test_nameerror_for_typing_symbol_suggests_import` → `test_nameerror_for_union_suggests_pipe_syntax`; added `test_nameerror_for_list_suggests_lowercase_generic`; added `test_nameerror_for_literal_suggests_import`. Each asserts the opinionated hint AND that the other fix isn't mentioned (no menu).
+- `src/pflow/guide/nodes/code.md` — new "Type annotation syntax" section with the canonical table (Any, built-in scalars, list[T], dict[K,V], tuple[T,...], set[T], A | B, Optional[T] | T | None). Auto-inject list stated explicitly (`Any`, `Optional`, `typing`). Explicit "Not allowed" list for `List[T]`/`Dict`/`Union`/etc. Notes outer-type-only enforcement.
+- `src/pflow/guide/core.md` — one-line pointer at the S1↔S2 bridge table directing to `pflow guide code`.
+- `src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md` and `mcp-sandbox-agent-instructions.md` — the "Use `Any`..." bullet replaced with modern-syntax summary; pointer line added at the bridge table. Two mirror files kept in sync.
+
+Rationale (FastAPI/Pydantic/Typer pattern): opinionated tools give ONE canonical answer per case, not a menu of options. The NameError hint for `List[str]` was previously a two-option menu with Union/Optional examples that didn't match the variable the agent typed — leading to an agent pattern-match failure. The opinionated hint now teaches PEP 585/PEP 604 as a side effect of the error itself.
+
+Result:
+- ✅ All 4844 tests pass (+2 from the prior step: List opinionated hint, Literal import suggestion)
+- ✅ CLI output for `List[int]` now reads: "Use 'list[...]' instead — Python 3.9+ supports lowercase built-in generics (PEP 585). Example: 'x: list[str]' instead of 'x: List[str]'."
+- ✅ CLI output for `Union[int, str]` reads: "Use pipe syntax instead: 'A | B' (PEP 604). Example: ..."
+- ✅ CLI output for `Literal["a"]` reads: "Add 'from typing import Literal' at the top of your code block. (pflow auto-injects 'Any' and 'Optional' — other typing names need explicit import.)"
+
+**Pass 3 — renderer cleanup + drift guards (items A, B, C)**:
+- `src/pflow/core/diagnostic_render.py` — `_format_available_fields_block` truncation policy changed: show all entries when `len(available) <= 10`, truncate only beyond. Rationale: for a 7-item closed set (the canonical type vocabulary), hiding 2 types under "... and 2 more (in error details)" was actively hostile UX — the agent had to pivot to `--output-format json` to see them. Truncation was designed for 100-item registries, not small closed vocabularies. Change affects every error with `available_fields`, not just type errors.
+- `tests/test_core/test_param_coercion.py` — new `TestTypeAliasesSyncWithCanonicalSource` class with `test_alias_maps_stay_in_sync`: asserts `param_coercion._TYPE_ALIASES == types.PYTHON_ALIASES_AT_S1`. Prevents silent drift between the runtime-lenience map and the validator error-suggestion source. Cheap regression guard against a real drift risk (both maps define the same 6 Python→canonical mappings; edit one without the other and template-referenced sub-workflows silently diverge from what `validate_ir` teaches).
+- `tests/test_runtime/test_prepare_inputs_coercion.py` — `test_type_aliases_work` renamed to `test_type_aliases_work_as_defense_in_depth` with an expanded docstring warning future agents NOT to misread the test as "Python aliases are supported S1 vocabulary." They're rejected at the validator per Task 154; the test pins the DEFENSE-IN-DEPTH behavior for IR paths that legitimately skip validation (template-referenced sub-workflows). Without this clarification, a future cleanup agent could remove both the test AND `_normalize_type` together, breaking the bypass path.
+
+Result:
+- ✅ All 4845 tests pass (+1 from the prior step: alias-map sync guard)
+- ✅ `make check` clean
+- ✅ Rendered output for `type: str` now shows `Available types (showing 7 of 7):` with all types listed. No more "... and 2 more (in error details)" noise.
+
+**Deliberately NOT done (reviewer findings deferred or disputed):**
+- `TypeVocabularyError` continues to subclass `ValueError` not `PflowError`. Agent-UX review (S8) flagged this as a `core/CLAUDE.md` convention violation, but `TypeVocabularyError` is always caught internally by `_suggest_for_invalid_type` and converted to `SchemaValidationError` (which IS `PflowError`-derived). Switching the base would likely require a circular-import refactor. Flagged as a Task 120 concern if/when future callers raise without wrapping.
+- `_check_annotation_vocabulary` keeps prose-based `NonRetriableError` without structured context. Agent-UX review (S9) flagged asymmetric diagnostic shape vs IR-schema-layer errors, but the audiences are genuinely different (authoring agent reading CLI vs external JSON/MCP consumers).
+- `pflow describe` / `pflow list` spot check on old-vocab saved workflows (feature-interactions W1) — not run. Any issue here is a separate saved-workflow-display bug, not Task 154's vocabulary scope.
+- `TypeSpec.parse` whitespace silent-accept kept (impact-completeness W2). Plan explicitly left this to implementer discretion; silent-accept is copy-paste-tolerant.
+- Pre-existing `value:` hint in `markdown_parser.py:163` (impact-completeness W1 + agent-ux S10) — pre-existing bug from before Task 154. Scope-disciplined skip.
+- Cascading spurious template-validation errors for typo/generic type rejections (validation-consistency W2) — cosmetic, not wrong. The authoritative schema error is first in the list. Follow-up candidate if it bites.
+
+**Lessons worth keeping for future similar refactors:**
+- **Reviewer cross-confirmation is the strongest confidence signal.** The parameterized-generic prose loss was flagged independently by both review-agent-ux and review-feature-interactions. That's what promoted it from "noted" to "critical fix."
+- **"Prioritize simplicity of final code, not ease of getting there" (user principle) applied twice**: once pushing the NameError hint from category-with-menu to one-canonical-fix-per-case, once pushing the null-through-markdown fix from a special-case branch to a broadened list-based path check that deleted a dead code path. Both cases: the simpler final shape required more upfront thought than the patch-the-symptom fix.
+- **The rendered-output probe that surfaced the null-through-markdown gap** (running the probe on the actual CLI, not just the unit test) caught the gap that unit tests missed. The unit test was passing because it called `TypeSpec.parse("null")` directly; the markdown authoring path never reaches that code. Integration probes > unit tests for user-facing error UX.
+
+**Cumulative PR totals:**
+- 4845 tests pass (+4 new regression guards: null-through-markdown, opinionated List hint, opinionated Literal import hint, alias-map drift guard)
+- `make check` clean (ruff, ruff-format, mypy, deptry)
+- 9 review findings closed as code changes, 1 closed as progress-log correction
+- 6 findings deliberately deferred with documented rationale
+
+Next: task ready for user review. PR branch `fix/type-vocab-incoherence` carries the complete refactor + review-prompted polish. Per user preference, no commits or pushes without explicit instruction.
+
+**Pass 4 — one high-value cross-layer regression guard**:
+- `tests/test_core/test_ir_schema.py::TestInputTypeAliases::test_full_render_pipeline_for_type_vocabulary_error` — single in-process test exercising the full pipeline: `validate_ir` → `SchemaValidationError.to_diagnostics()` → `format_diagnostic()` → rendered string.
+- Asserts: (a) exact case-sensitive `"Use 'string' instead of 'str'"` (poll P3 contract), (b) `"Available types (showing 7 of 7)"` (Pass 3 A truncation policy), (c) all 7 canonical types listed, (d) `"Did you mean"` block present (similar_names threading).
+- Decided in-process over subprocess: same coverage, ~160x faster (3ms vs 500ms). Subprocess only adds "does the CLI entry actually wire format_diagnostic" verification, which is a stable contract with no current risk. Per `core/CLAUDE.md`: "CLI, JSON, and MCP all flow through the same `format_diagnostic()` pipeline — the only place rendering happens" — testing it directly covers every consumer.
+- Why this test is the single high-value addition: every existing test covers one layer in isolation (TypeSpec parse, TypeVocabularyError fields, Diagnostic context, format_diagnostic behavior). No existing test pins the full chain's output contract. Would have caught the critical review finding (parameterized-generic prose loss from Pass 1) before it shipped — the prose was in `SchemaValidationError.suggestion` but preempted by `suggestions_list` in `to_diagnostics`; any per-layer test passed. Only an end-to-end rendering test would have caught it.
+- Failure modes it guards against: renderer refactor drops suggestions_list preemption, suggestion wording lowercase regression, available_fields truncation revert, similar_names threading breakage.
+
+**Final cumulative totals:**
+- 4846 tests pass (+5 new regression guards: null-through-markdown, opinionated List hint, opinionated Literal import hint, alias-map drift guard, full-render-pipeline cross-layer guard)
+- `make check` clean
+- 10 review findings closed as code changes, 1 closed as progress-log correction
+- 6 findings deliberately deferred with documented rationale
+- 1 high-value test added targeting the single gap unit tests can't cover (full rendering chain)
+
+---
+
+### [2026-04-16 post-implementation verification] — Full §10 verification run
+
+What I'm doing: executing the plan's §10 verification checklist against the staged implementation in the user's real environment (previously blocked by sandbox `uv` failures per §4.6).
+
+Result:
+
+**Automated gates (§10.1):**
+- ✅ `make check` → all pre-commit hooks pass (ruff, ruff-format, mypy, deptry). `Success: no issues found in 177 source files.`
+- ✅ `make test` → **4841 passed in 13.44s**. Zero failures across the full suite including the 16 fixture-migrated test files from §4.1.
+
+**Probe-based verification (§10.2):**
+- ✅ `A3-input-type-any.pflow.md --validate-only` → `✓ Workflow is valid` (was failing pre-fix).
+- ✅ `A1-input-type-dict.pflow.md` → rejected; rendered output shows the two-entry numbered list exactly as planned (`Use 'object' if the value is a dict` / `Use 'any' if the value can be any type`).
+- ✅ `A2-input-type-str.pflow.md` → rejected with `→ Use 'string' instead of 'str'`.
+- ✅ `B2-annot-Any.pflow.md` → runs successfully without `from typing import Any`; outputs `dict` as expected.
+- ✅ `E-object-wildcard.pflow.md` → still parses (lenient coercion unchanged per scope boundary §1.7); produces `type=str value='hello'` — Task 120 will tighten.
+- ✅ `integer→int` bridge probe (custom `/tmp/int-bridge.pflow.md`) → exits 0, result=10. The `integer` canonical name bridges cleanly to Python `int` via `TYPE_COMPATIBILITY_MATRIX`.
+
+**Error-message wording spot-checks (§10.3):**
+- ✅ `Use 'string'` (exact case, capital U) — case-sensitive grep match.
+- ✅ `Use 'object' if the value is a dict` + `Use 'any' if the value can be any type` — both numbered-list entries present.
+- ✅ `Did you mean 'string'` — fuzzy match fires for `strin` typo.
+- ✅ `→ Use 'array'` — canonical replacement for `list[str]` generic (not `Use 'list'`, not `Use 'the base type'`).
+- ✅ Outputs-side symmetry — `## Outputs` `type: str` produces same `Use 'string'` suggestion as inputs.
+
+**JSON structured-context check (§10.3):**
+- ✅ `--output-format json` diagnostics carry `context.similar_names=['string']`, `context.available_fields=['string','number','integer','boolean','array','object','any']`, `context.available_fields_label='types'`, `suggestions=["Use 'string' instead of 'str'"]`. Producers-are-self-describing pipeline intact.
+
+**Any injection / lowercase-any rejection (§10.4–§10.5):**
+- ✅ `x: Any` in code block works without import.
+- ✅ Lowercase `x: any` rejected with `Use 'Any' (capitalized) in Python code blocks. pflow auto-injects typing.Any — no import needed.` — teaches the two-surface model.
+
+**Regression spot checks (§10.6):**
+- ✅ `examples/nodes/claude-code/claude-code-schema.pflow.md` does NOT regress from the IR enum shrink. The `type: str`/`int`/`list` inside the fenced `yaml output_schema` block is a node param value (opaque to the IR enum check). The file has pre-existing template-reference errors unrelated to this PR (`${input.code_content}` wiring); those are not Task 154's concern.
+- ✅ `B1-annot-dict.pflow.md` — `type: object` with a dict value runs cleanly; lenient coercion path unchanged.
+
+**Documentation spot-checks (§10.7):**
+- ✅ `pflow guide core` renders `type (string|number|integer|boolean|array|object|any)` — seven canonical names including `integer` and `any`.
+- ✅ `pflow guide code` renders `Use Any as the type when you don't want type validation (Any is auto-injected — no from typing import Any needed)`.
+
+**bug-report.md appendix (§10.2):**
+- ✅ Present at `scratchpads/type-vocabulary-incoherence/bug-report.md` lines 450–504. My earlier evaluation missed this because the scratchpads directory is untracked (not in `git diff --staged`); the file is on disk and the content matches the plan's requirement.
+
+**Minor finding — documented here, not a blocker:**
+- 💡 The `TypeVocabularyError` message for parameterized generics (`"Parameterized generics not supported in `## Inputs` / `## Outputs`. Got: 'list[str]'. Use 'array'."`) is preserved in the error's `.message` / `str(exc)` but the renderer surfaces only `suggestions_list=["Use 'array'"]` because `suggestions_list` preempts the `suggestion` string in `SchemaValidationError.to_diagnostics()` (`exceptions.py:199-204`). Plan §10.3 expected a grep for `"Parameterized generics not supported"` to return a line — at the rendered-CLI layer it doesn't, only at the unit-test layer (where `test_parse_rejects_parameterized_generics` in `test_types.py` asserts against the full message). The user-facing rendered output is still actionable — the jsonschema's own message (`'list[str]' is not one of [...]`) plus the `Use 'array'` fix together give the author enough to correct the type. If future work wants the full prose surfaced at the CLI too, populate `suggestions_list` with a single richer entry like `["Parameterized generics not supported — use 'array' (generic parameters aren't enforced at S1)"]`. Flagging as a **follow-up candidate, not a blocker** for this PR.
+
+- 🔀 Decision: do not widen scope. The rendered output meets the "actionable fix" bar even without the full prose. The single-phrase suggestion (`Use 'array'`) is the canonical form used across all vocabulary errors — changing only the generic case would create inconsistency.
+
+**Scope boundary held:**
+- Lenient coercion on `coerce_workflow_input` untouched — `type: object` with non-dict values still passes through with a warning (Task 120's scope per §1.7).
+- `_TYPE_ALIASES` + `_normalize_type` kept in `param_coercion.py` per §2.5 (defense-in-depth).
+- Registry `Interface:` docstrings unchanged (S3 stays Python-named per §1.8).
+- Claude Code `output_schema` Python names preserved (intentional third dialect).
+
+Next: all verification gates green. PR is ready for user review. Recommended next step: user runs `git diff --staged` and decides on commit/push cadence (per their standing preference, I am NOT to commit or push without explicit instruction).
+
+---
+
+### [2026-04-16 post-merge-review round 2] — Second review pass + architecture-level simplification
+
+What I'm doing: second code review came in (scratchpad `code-review-task-154.md` + PR comment #4263057796). Evaluated via 4 parallel `pflow-codebase-searcher` subagents with explicit framing "simplicity of final code, not ease of getting there — what would top-10% codebases do?"
+
+**Findings inventory:**
+- Critical #1 (scratchpad): runtime sub-workflow compilation accepts banned S1 aliases via `coerce_workflow_input`'s `_TYPE_ALIASES`. Template-ref children (`workflow: ${var}`) bypass `validate_ir`. Confirmed reachable via `examples/nested/deep-research/deep-research.pflow.md:72`.
+- Warning #2 (both reviewers): `_check_annotation_vocabulary` only rejects outermost `any` — misses `list[any]`, `dict[str, any]`, `int | any`.
+- Warning #3 (scratchpad): `TypeSpec.python_type()` encodes looser isinstance-compatible semantics than `accepts()` — zero production callers, reintroduces bool-coercion trap if ever used.
+- Warning #1 (PR comment): Claude Code `output_schema` is a fourth surface still using Python aliases — undocumented in `types.py`.
+- Warning #3 (PR comment): Redundant `similar_names` + `suggestions_list` for `dict` alias — agent sees `object` three times.
+
+**The pivot — Option B → Option D for the critical finding:**
+
+Initial plan: reject aliases inside `coerce_workflow_input` (Option B, local/safe). After searcher evidence I switched to Option D — add `validate_ir` at the one unvalidated entry point (`workflow_executor.py:202`) and delete the entire dual-map machinery. Agent 1 proved the mechanics:
+
+- `coerce_workflow_input` has exactly ONE direct caller (`ir_preparation.py:155`).
+- `coerce_param_for_node` does NOT use `_TYPE_ALIASES` — structurally independent (registry metadata consumers still read `"str"` literally).
+- Every IR entry point hits `validate_ir` except `workflow_executor.py:202` (template-ref bypass).
+- Adding one `validate_ir` call there makes `_TYPE_ALIASES` + `_normalize_type` + drift-guard test + defense-in-depth test provably dead.
+
+Agent 4 confirmed `compilation/CLAUDE.md` documents a "dual-layer" convention, but the specific template-ref bypass is an *asymmetry* (not a deliberate layering choice — file/name/inline children DO validate recursively; only template-ref skips). Closing the asymmetry aligns with the codebase intent.
+
+**Top-10% framing**: single validation invariant at `compile_workflow` entry > defense-in-depth tolerance on one path. Option D removes ~40 lines + 2 tests, adds 1 line + 1 test. Strictly simpler final state.
+
+**Regex vs AST for `_check_annotation_vocabulary`:**
+
+Agent 2 found that `ast` is already imported in `python_code.py` (used by `_extract_annotations`). AST walk is ~5 lines, handles `Literal['any']` correctly without the regex approach's quote-strip workaround. "Second paradigm" concern is weak when `ast` is already the file's parsing tool. Picked AST.
+
+**Dropping `similar_names` for alias errors:**
+
+Agent 3 found that 14 of 15 `similar_names` producers populate it for fuzzy-guessing (the rendered header literally says "Did you mean one of these?" — uncertainty framing). `_raise_alias_error` was the lone outlier using it in known-canonical sense. The `null` branch already followed the "suggestions_list only" pattern. Dropping aligns aliases with existing convention.
+
+**Execution — changes landed:**
+
+- `src/pflow/runtime/workflow_executor.py:~207` — added `normalize_ir(workflow_ir); validate_ir(workflow_ir)` before `compile_workflow(...)`. Import updated to `from pflow.core.ir_schema import normalize_ir, validate_ir`.
+- `src/pflow/core/param_coercion.py:15-38` — DELETED `_TYPE_ALIASES` + `_normalize_type`. Call site at line 298 now uses `declared_type` directly.
+- `src/pflow/nodes/python/python_code.py:197-223` — rewrote `_check_annotation_vocabulary` as `ast.parse(mode="eval")` + `ast.walk` looking for `ast.Name(id="any")`. Hoisted `from pflow.nodes.file.exceptions import NonRetriableError` to module top.
+- `src/pflow/core/types.py:177-198` — removed `similar_names=[canonical]` from both branches of `_raise_alias_error` (dict two-suggestion case AND single-canonical case). Added docstring explaining the channel split.
+- `src/pflow/core/types.py:127-143` — DELETED `TypeSpec.python_type()`. Zero production callers; Task 120's documented extension point is `accepts()`.
+- `src/pflow/core/types.py` module docstring — added paragraph acknowledging Claude Code `output_schema` as deliberate fourth Python-aliased surface (embedded literally into LLM prompts by `_build_schema_prompt`).
+- `tests/test_core/test_param_coercion.py` — DELETED `TestNormalizeType` + `TestTypeAliasesSyncWithCanonicalSource` (drift-guard vacuous without duplication). Removed `_normalize_type` from imports.
+- `tests/test_runtime/test_prepare_inputs_coercion.py:184-210` — DELETED `test_type_aliases_work_as_defense_in_depth`. Its reason for existing (pinning the bypass behavior) is gone.
+- `tests/test_core/test_types.py:136-144` — DELETED `TestTypeSpecPythonType.test_python_type_mapping`.
+- `tests/test_core/test_types.py:174` — updated `similar_names` assertion from `["string"]` to `[]` on alias error.
+- `tests/test_core/test_ir_schema.py:560` — updated JSON context test: `similar_names` now `[]` for alias errors.
+- `tests/test_core/test_ir_schema.py:603` — updated `test_full_render_pipeline_for_type_vocabulary_error`: assertion inverted from `"Did you mean" in rendered` to `"Did you mean" not in rendered`. Updated docstring to reflect the new contract.
+- `tests/test_nodes/test_python/test_python_code.py` — added 5 tests: `test_lowercase_any_in_list_generic_rejected`, `test_lowercase_any_in_dict_value_rejected`, `test_lowercase_any_in_pipe_union_rejected`, `test_lowercase_any_in_optional_rejected`, `test_literal_string_any_not_rejected` (pins the carve-out — `Literal['any']` passes as `ast.Constant`, not `ast.Name`).
+- `tests/test_runtime/test_workflow_executor/test_workflow_executor.py` — added `TestTemplateRefSubWorkflowValidation` with two tests: `test_compile_rejects_python_alias_in_child_ir` (pin the bypass close) and `test_compile_accepts_canonical_type_in_child_ir` (pin canonical still works).
+- `tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py:477-502` — `test_compilation_error` fixture IR updated from `{"invalid": "ir"}` to `simple_workflow_ir` so validate_ir passes and the mocked `compile_workflow` is what raises (the path this test actually pins).
+
+**Stumbles encountered + resolved:**
+
+- First test run: 31 failures. Root cause — `validate_ir` requires `ir_version`, but many runtime/test paths construct IRs without it. Fix: added `normalize_ir(workflow_ir)` before `validate_ir` (mirrors `validator.py:731` — `normalize_ir` is the canonical pre-validation step). Failures dropped to 3.
+- `test_compile_rejects_python_alias_in_child_ir` expected `SchemaValidationError` but `_compile_sub_workflow` wraps all exceptions in `CompilationError`. Updated test to assert on `CompilationError` with `"Use 'string' instead of 'str'"` in the message — exception path pins both the rejection AND the structured suggestion survives the wrapping.
+- `test_python_aliases_no_longer_coerce` (my own test) asserted wrong behavior — deleted it. The behavior is now pinned at the workflow_executor level where it actually matters.
+- `ruff-format` / `end-of-file-fixer` auto-fixed trailing whitespace and formatting on two test files. Re-ran `make check` — clean.
+
+**Final cumulative totals after round 2:**
+- ✅ **4849 tests pass** (was 4846 before this round; +5 nested `any` tests + 2 template-ref regression tests – 2 deleted drift-guards – 1 deleted defense-in-depth pin – 1 deleted python_type pin – 1 redundant new-test deletion = net +3)
+- ✅ `make check` clean (ruff, ruff-format, mypy, deptry)
+- ✅ **Net code delta: deletions > additions.** ~40 lines removed (`_TYPE_ALIASES`, `_normalize_type`, `python_type`, 3 obsolete tests); 1 line + ~5 lines + ~5 tests + 1 docstring paragraph added.
+- ✅ CLI rendered output verified via in-process probe: `type: str` → directive `→ Use 'string' instead of 'str'` (no "Did you mean"); `type: dict` → numbered list "1. Use 'object'... 2. Use 'any'..."; `type: strin` (typo) → keeps "Did you mean 'string'" (typo channel intact).
+- ✅ Nested `any` probe verified: `list[any]`, `dict[str, any]`, `int | any`, `Optional[any]` all rejected; `Literal['any']` passes through; `Any` (capitalized) unaffected.
+
+**Invariants established:**
+- **Single validation boundary at `compile_workflow` entry**: every IR path now runs through `validate_ir` before reaching coercion. No production path tolerates Python aliases; `_TYPE_ALIASES` is gone, not "deprecated."
+- **Uniform alias-error convention**: `similar_names` is strictly the typo / "Did you mean" channel; `suggestions_list` is the directive / known-fix channel. Dropping the blur between them matches 14 of 15 existing producers.
+- **AST-based annotation vocabulary check**: `list[any]` and all generic-nested variants are caught at the same layer as `x: any`. No runtime-only escape hatch.
+- **Claude Code `output_schema` is documented as the deliberate fourth surface**: future agents won't mistake its Python aliases for leaked S1 vocabulary.
+
+**Patterns worth keeping for future similar refactors:**
+- **"Simplest final code > smallest local change"** — the Option B→D pivot came from asking the searchers to frame options by end-state simplicity. Option B would have worked; Option D deleted more code and restored a cleaner invariant.
+- **Check if the language primitive is already imported before adding a new paradigm.** `ast` was already in `python_code.py` for `_extract_annotations`; adding AST-walk for `_check_annotation_vocabulary` added zero imports. The "second paradigm" objection was weak when checked against the file.
+- **"Did you mean" framing is the semantic test for similar_names usage.** The rendered template says it literally; any known-canonical case that populates it fights the renderer's intent.
+
+Next: task complete. PR branch `fix/type-vocab-incoherence` carries two consolidation passes (post-merge review round 1 from previous entry + this round 2 architecture pass). Per user preference, no commits or pushes without explicit instruction.
+
+---
+
+### [2026-04-16 round-2 verification + follow-ups]
+
+What I'm doing: end-to-end verification of round-2 changes ("try to break it, don't confirm it works"), then addressing one doc gap that became obvious during verification.
+
+**Verification — all 14 authoritative probes pass the post-fix contract (`bug-report.md:450-504`):**
+- A1/A2/A3 via real CLI: `type: dict` → numbered list; `type: str` → directive `→ Use 'string'`; `type: any` → accepted. No "Did you mean" on alias errors; preserved on typos (`strin`).
+- B1/B2/B3: all three run cleanly, confirmed with `--no-cache` to bust memoization (first run showed `↻ cached` which could have been pre-refactor results).
+- C/C4/D1-D3/E/F/G: runtime behavior matches scope-boundary expectations. `E-object-wildcard` leniency preserved (Task 120 territory).
+
+**Custom probes that matter:**
+- Template-ref bypass close — ran parent with `workflow: ${child_path}` → legacy child with `type: str`. At runtime: `Failed to compile sub-workflow... Use 'string' instead of 'str'`. The bypass is closed on the exact path the reviewer identified.
+- Saved legacy workflow planted at `~/.pflow/workflows/` — rejected at load AND run with canonical suggestion.
+- Happy-path nested workflow via template ref — runs end-to-end. New `validate_ir` does NOT false-positive on valid children.
+- 16 AST edge cases for nested `any` rejection — all correct. Notably, `Literal['any']`, `Annotated[int, 'any']`, `typing.any` (attribute), `T_any`/`any_var` (substring identifiers) are correctly NOT rejected. `Callable[..., any]`, `dict[str, Callable[..., list[any]]]`, `tuple[int, any, str]`, `set[any]` all correctly rejected. This closes the `list[any]` "no runtime safety net" limitation documented in §2.9.
+- Examples regression sweep — 39 pass / 10 fail. Stashed changes → identical 10 fail. Zero Task 154 regressions.
+
+**Observed adjacent issues — filed separately, not bundled into PR:**
+- **GH #292** — `pflow describe` raises uncaught `MarkdownParseError` Python traceback when saved workflow has parse errors. Pre-existing; likely related to #224 (CLI handlers bypassing diagnostic pipeline).
+- **GH #293** — 8 example workflows fail `pflow --validate-only` but pass CI because `tests/test_docs/test_example_validation.py` only runs `validate_ir()` (schema-only), not the full `WorkflowValidator.validate()` 10-step pipeline. Root cause: test coverage gap lets examples rot. Three categories documented (undeclared inputs, stale `llm_usage` refs, stale `${input.x}` convention).
+
+**Doc fix — `features/sub-workflows.md` template-ref form:**
+
+During verification I noticed the guide documents only two `workflow:` forms (literal path, saved name) but the code supports a third (template reference via `${var}`). The production example `examples/nested/deep-research/deep-research.pflow.md:72` uses it; the guide doesn't mention it; my round-2 `validate_ir` call specifically protects it.
+
+Fixed in same PR (not filed as separate issue) because:
+1. The round-2 code change exists specifically to serve this pattern — shipping the fix while leaving the pattern undocumented is incoherent.
+2. ~25 line doc addition, no scope creep risk.
+
+Changes:
+- `src/pflow/guide/features/sub-workflows.md` — updated opening capability bullet; added `### Dynamic Child Selection (Template References)` section with the deep-research fan-out pattern and the runtime-vs-validate-time trade-off.
+- Verified via `pflow guide sub-workflows` renders cleanly.
+- `make check` clean. `tests/test_docs/` 4/4 pass.
+
+**Why the trade-off note matters for future agents:** the section explicitly calls out that invalid children surface as runtime errors, not validate-time errors. Without this note, an agent would assume `--validate-only` catches everything and be confused when a template-ref child fails only during actual execution.
+
+**Final state for the PR:**
+- 4849 tests pass, `make check` clean
+- 13 files modified: 5 source, 1 guide, 7 tests (plus 1 progress-log)
+- 2 follow-up issues filed (#292, #293) — pre-existing, not regressions
+- 1 doc gap closed (sub-workflows template-ref) — adjacent scope, justified inclusion
+- The formal post-fix contract in `bug-report.md` appendix holds for all 14 probes
+
+---
+
+### Template for future entries
+
+```markdown
+### [YYYY-MM-DD HH:MM] — [Short description]
+
+What I'm doing: ...
+Result:
+- ✅ Worked: ...
+- ❌ Failed: ...
+- 💡 Insight: ...
+- 🔀 Decision: ... (if any non-trivial call made)
+
+Code that worked:
+\`\`\`python
+# snippet
+\`\`\`
+
+Next: ...
+```

--- a/.taskmaster/tasks/task_154/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_154/implementation/progress-log.md
@@ -766,6 +766,130 @@ Changes:
 
 ---
 
+### [2026-04-16 squash + rebase onto post-task-153 main]
+
+What I'm doing: task 153 landed on main (PR #286, commit d3982fdf) while this branch was in progress. Squashed 5 review-pass commits into 1 (`feat: type vocabulary coherence refactor (task 154)`) and rebased onto origin/main.
+
+Two text conflicts, both expected:
+
+1. `src/pflow/guide/features/sub-workflows.md` — 153 added a "Heterogeneous Batch over Sub-Workflows" section, 154 round-2 had added "Dynamic Child Selection (Template References)". Resolution: kept both — 154's conceptual intro first, then 153's advanced pattern. Rewrote 154's example to use post-153 `inputs:` dict form (old form used top-level free-form params, which `ALLOWED_PARAMS` now rejects).
+
+2. `tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py:491` — 153 renamed `workflow_ir` → `child_ir` in `prep_res`; 154 had changed `{"invalid": "ir"}` → `simple_workflow_ir` (so `validate_ir` passes and the mocked `compile_workflow` is what raises). Synthesized: `"child_ir": simple_workflow_ir` — key from 153, value from 154.
+
+Semantic fix without textual conflict:
+- `tests/test_runtime/test_workflow_executor/test_workflow_executor.py::TestTemplateRefSubWorkflowValidation::test_template_ref_bypass_close_end_to_end_through_runner` — my round-2 regression test used pre-153 parent IR (`"params": {"workflow": ..., "message": "hello"}`). Post-153 rejects top-level `message` via `ALLOWED_PARAMS`. Rewrote to `"params": {"workflow": ..., "inputs": {"message": "hello"}}`.
+- `test_workflow_executor_comprehensive.py::test_template_resolution_dict_and_list_inputs` — added by 153 with pre-154 vocab (`{"type": "dict"}`, `{"type": "list"}`). Now fails at 154's new `validate_ir` in `_compile_sub_workflow`. Migrated to canonical (`object`, `array`).
+
+Verified validate_ir landed in the cache-miss branch of `_compile_sub_workflow` (post-rebase line 208-209, after cache early-return at line 192) — cache hits skip re-validation. 3-way merge placed it correctly; no manual fix needed.
+
+Safety branch `fix/type-vocab-incoherence-pre-rebase` kept at the pre-squash tip for rollback.
+
+Result: 4857 pass (+3 from post-rebase audit fixes, -2 from squash bookkeeping), `make check` clean. Force-pushed.
+
+**Lesson for future rebases**: when two tasks each change a shared API shape (task 153 = child-inputs API, task 154 = vocabulary), the text-conflict count understates work. Auto-merging files can still encode semantic drift (pre-153 test fixtures with post-154 vocab rejection). Grep for API-shape markers from both tasks in every auto-merged file, not just the conflict-marked ones.
+
+---
+
+### [2026-04-16 cross-task audit cycle]
+
+What I'm doing: user asked for a careful review of "potential issues the combination of task 153 and task 154 could cause." Ran 3 review agents in parallel (`review-feature-interactions`, `review-impact-completeness`, `review-silent-failures`). Synthesized findings and triaged.
+
+**Real findings (fixed):**
+- `architecture/architecture.md:497-499` — sub-workflow example taught pre-153 top-level free-form API. Updated to nested `inputs:`.
+- `examples/nested/README.md:28-36` — same pre-153 example + now-false prose ("all other params are passed as child inputs"). Rewrote.
+- `architecture/reference/template-variables.md` — 4 locations (~1052, ~1234, ~1349, ~1634) teaching pre-154 S1 vocab (`str`/`int`/`float`) in workflow-level `inputs:`. Migrated to canonical. Lines 680-685 stay Python-named (they're S3 node output metadata, not S1).
+- `.taskmaster/tasks/task_154/task-review.md` — structurally stale vs round-2. Added Round-2 Addendum prepended at the top, explicitly contradicting the line 249 "Do NOT remove `_TYPE_ALIASES`" pitfall (the code was deleted in round-2). Several sections below (Two duplicated alias maps, drift-guard tests, TypeSpec.python_type extension) are also stale; the addendum calls these out rather than rewriting the whole doc.
+
+**Review-agent findings I initially flagged as follow-ups, then retracted after user pushback**:
+- F1: `error_action: continue` doesn't catch `validate_ir` errors. Not a bug — compilation errors SHOULD fail loud; error_action is for child-ran-and-returned-error semantics.
+- F2: Top-level programmatic callers bypassing `validate_ir` silently skip coercion. Not reachable — all production entry points validate. Theoretical defense-in-depth for a path no caller takes.
+- F3: `_expose_child_outputs` name-collision with `ALLOWED_PARAMS`. Conceptual confusion in the review — shared store keys and node parameter names live in different namespaces.
+
+**User's framing** ("are you sure we should fix any of 5-7 issues?") caught me over-crediting review-agent findings. Lesson: review agents produce findings by design; the triage step is where engineering judgment happens. Don't pass through unchecked.
+
+**CLAUDE.md audit**:
+- `src/pflow/core/workflow/CLAUDE.md:13` — module listing said `sub_workflow_resolver.py # Shared sub-workflow resolution (inline IR, file, saved name)` but task 153 removed inline-IR support. Task 153's own diff updated this CLAUDE.md elsewhere (added `ALLOWED_PARAMS` coverage) but missed this line. Fixed to "file path or saved name".
+- `src/pflow/core/CLAUDE.md:297` — `coerce_workflow_input` description used Python-named shorthand for dispatch (`str↔int, str↔bool`). Ambiguous post-154 since the dispatch keys are now S1 canonical. Rewrote to name the 7 canonical types explicitly and note Python aliases are rejected upstream.
+- `src/pflow/core/CLAUDE.md` — task 154's new `types.py` wasn't in the module-structure listing or "Key Components" section. Added both. Initially over-wrote with 15 lines of S1/S2/S3 rationale; user corrected ("don't overfit to context window") — trimmed to match surrounding 2-3 line entries.
+
+Result: 4857 pass, `make check` clean. Force-pushed.
+
+---
+
+### [2026-04-16 Python 3.14 CI failure — PEP 649 interaction]
+
+What I'm doing: CI reported 3 failures on Python 3.14 only (3.10-3.13 passed):
+- `test_nameerror_for_union_suggests_pipe_syntax`
+- `test_nameerror_for_list_suggests_lowercase_generic`
+- `test_nameerror_for_literal_suggests_import`
+
+All 3 tests wrote code like `x: Union[int, str] = 1` and asserted `action == "error"` with opinionated hint text in `shared["error"]`. On 3.10-3.13 this worked because Python evaluated the annotation eagerly, raising NameError → `_format_exec_error` → `_suggest_for_nameerror` fired.
+
+**Root cause**: PEP 649 lands as default in Python 3.14. Annotations are evaluated lazily (via `__annotate__` function) rather than at statement execution. `x: Union[int, str] = 1` stores the annotation as a deferred expression, assigns 1 to x, and never triggers NameError. Code runs to completion → action="default" → tests fail.
+
+**Trade-off considered**:
+- Option A: Skip tests on 3.14+. Minimal change, ships CI today. But on 3.14 users writing `List[int]` silently succeed with no opinionated hint — UX regression.
+- Option B: Extend `_check_annotation_vocabulary` AST walker to catch typing names proactively at prep time. ~20-30 lines, works across Python versions.
+
+User approved Option B: "carefully implement B".
+
+**Key design refinement during implementation**: initial draft rejected ALL typing names (Union/List/Dict/Literal/etc.) unconditionally. But users who follow `_suggest_for_nameerror`'s own hint ("Add 'from typing import Literal'") would then get rejected by our AST walker — regressing legitimate imported usage. Added `_extract_imported_names(code)` helper; only reject names NOT in the import set. AST-based (`ast.ImportFrom` + `ast.Import` walk). Pattern: walk the whole code for imports, then check each annotation's Name nodes against the import set.
+
+**Why one change, not two (the user's "simplicity of final code" principle)**: initially I thought about duplicating the opinionated-hint suggestion logic in both `_check_annotation_vocabulary` (AST-walk rejection) and `_suggest_for_nameerror` (NameError fallback for value-usage like `x = Union[int, str]`). Ended up reusing `_suggest_for_nameerror` directly in both paths — same canonical fix, different trigger.
+
+Added constant `_REJECTED_ANNOTATION_NAMES = _MODERN_GENERIC_NAMES | {"Union"} | _REQUIRES_TYPING_IMPORT`. Helper `_extract_imported_names` uses AST to collect `ImportFrom` + `Import` bindings.
+
+Tests:
+- Renamed failing tests to `test_{union,list,literal}_in_annotation_rejected_with_*_hint` (accurate after mechanism change).
+- Updated from `assert action == "error"` to `pytest.raises(NonRetriableError, match=...)` (NonRetriableError from prep propagates, doesn't convert to action).
+- Added `test_typing_name_in_annotation_accepted_when_imported` — regression guard against future "simplification" of the import check.
+
+Result: 4858 pass (+1 regression guard), `make check` clean. Force-pushed with `[skip review]` tag on the commit subject (minor review-prompted fix).
+
+---
+
+### [2026-04-17 code-review evaluation — W1/W2/S2 fixes]
+
+What I'm doing: ran `/evaluate-review` on https://github.com/spinje/pflow/pull/290#issuecomment-4263676831. Reviewer produced 2 warnings (W1, W2), 3 suggestions, 2 nits. Triaged each against the code.
+
+**Initial W1 plan (reviewer's proposed fix)**: insert `except PflowError as e: raise CompilationError(..., wrapped_diagnostics=e.to_diagnostics())` between the existing `except CompilationError` and `except Exception` branches. Uses the `wrapped_diagnostics` API to forward `SchemaValidationError`'s structured context (similar_names, available_fields, suggestions_list) through the CompilationError wrap.
+
+**User pushback** ("we should prioritize simplicity of the final code, not how easy it is to get there... what's the right solution the top 10% would implement?"). Stepped back. Dispatched a searcher to map all callers and the CompilationError API surface.
+
+**Key discovery the searcher surfaced**: `CompilationError.to_diagnostics()` has asymmetric behavior — when `wrapped_diagnostics` is set, it returns them verbatim, DISCARDING `details["sub_workflow_path"]`. The reviewer's fix as-stated preserves vocab structure but loses the "Sub-workflow: <path>" rendering line. Would ship a subtle new regression while fixing the old one.
+
+**Revised plan — fix at two layers**:
+
+1. **`CompilationError.to_diagnostics()` composes `wrapped_diagnostics` with `details`**. When both are present, iterate `wrapped_diagnostics` and merge `sub_workflow_path` into each diagnostic's `context` via `dataclasses.replace(d, context={"sub_workflow_path": ..., **(d.context or {})})`. setdefault semantics — inner-diagnostic context wins on key conflict. ~6 lines in `exceptions.py`.
+
+2. **Add `except PflowError` branch in `_compile_sub_workflow`** as reviewer originally suggested. Uses `wrapped_diagnostics=e.to_diagnostics()`. With fix (1) in place, sub_workflow_path now composes correctly.
+
+3. **Extract `_validate_and_compile_child` static helper** — adding the 3rd except branch pushed `_compile_sub_workflow` from 10 → 11 cyclomatic complexity, triggering ruff's C901. Moved the validate+compile+wrap sequence into the helper. User memory: no `# noqa` — fix the structure.
+
+**W1 test update — critical lesson**. The existing `test_template_ref_bypass_close_end_to_end_through_runner` asserted `"Use 'string' instead of 'str'" in diagnostic_messages` (joined `.message` fields). This passed on the OLD flattened code because suggestion text was embedded in the exception's string representation. After fix, `"Use 'string' instead of 'str'"` lives in `.suggestions`, not `.message` — the structurally correct location. Test failed on my first run of the new code.
+
+**The assertion was pinning a symptom of the bug, not the contract**. Rewrote to assert on structured fields directly:
+- `vocab_diag.context["available_fields"]` == the 7 canonical types (rich rendering block preserved)
+- `vocab_diag.context["sub_workflow_path"] == str(child_path)` (container context merged by fix 1)
+- `vocab_diag.suggestions == ["Use 'string' instead of 'str'"]` (opinionated fix in structured field)
+
+This is now the template for future cross-layer rendering tests.
+
+**W2 fix — forward-reference annotation unwrap**. `_extract_annotations` runs `ast.unparse(node.annotation)` which preserves outer quotes, so `x: "list[any]"` becomes the string `"'list[any]'"`. `ast.parse(..., mode="eval")` on that sees `ast.Constant`, no `ast.Name(id="any")`, check silently passes. On 3.14+, PEP 649 means runtime doesn't catch it either. Fix: after initial parse, if `tree.body` is `ast.Constant` with string value, re-parse the inner string before walking. ~4 lines. Preserves existing behavior for inner `Literal['any']` Constants (those stay as-is, correctly ignored). Added regression test `test_lowercase_any_in_forward_reference_rejected`.
+
+**S2 — one-line clarifying comment on `coerce_param_for_node`** about the S3-vs-S1 surface distinction (why it still accepts Python-aliased `"str"`/`"dict"` while `coerce_workflow_input` dropped aliases).
+
+**Findings explicitly disputed/skipped**:
+- S1 (redundant validate_ir for static-path children): reviewer themselves said "leave unless a profile shows it" — the "every path through compile_workflow is validated" invariant is worth more than the micro-redundancy.
+- S3 (tighten message-based tests to assert on structured fields): the structured-field contract is already pinned by the dedicated `TestTypeVocabularyErrorFields` class; tightening the message tests too would test the same contract twice.
+- 2 nits: pure style.
+
+Result: 4859 pass (+1 forward-ref regression), `make check` clean. Force-pushed to `5b5a8cbd`.
+
+**The user's "simplicity of final code" principle applied here**: the reviewer's fix was ~5 lines; my revised fix was ~8 lines. But the revised fix corrects a latent API design bug (`wrapped_diagnostics + details` composition) that benefits every future caller, not just sub-workflow compilation. Net-simpler final state despite slightly more lines.
+
+---
+
 ### Template for future entries
 
 ```markdown

--- a/.taskmaster/tasks/task_154/task-154.md
+++ b/.taskmaster/tasks/task_154/task-154.md
@@ -1,0 +1,118 @@
+# Task 154: Type Vocabulary Coherence
+
+## Description
+
+Fix the incoherent type vocabulary at pflow's workflow authoring surface. Today `## Inputs` and `## Outputs` accept 12 type names as silent synonyms (JSON Schema canonical + undocumented Python aliases), `type: object` silently accepts any value (not just dicts), and `type: any` — the natural escape hatch — is rejected outright. Code-block annotations using bare `Any` fail with a misleading error that tells the agent to add `Any` to the inputs dict.
+
+This task shrinks the `## Inputs` / `## Outputs` `type:` vocabulary to seven canonical JSON Schema names, makes `object` mean dict-only, introduces `any` as the explicit wildcard, and auto-injects `typing.Any` into Python code-block exec namespaces. Breaking change, shipped as one atomic PR.
+
+The implementation plan lives at `implementation/implementation-plan.md` in this task folder — this file captures the **what** and **why**; the plan captures the **how**.
+
+## Status
+
+not started
+
+## Priority
+
+medium
+
+## Problem
+
+Authoring `.pflow.md` files today is dragged down by three compounding incoherences in the type system (reproduced as executable probes in `scratchpads/type-vocabulary-incoherence/repro-files/` and documented in full at `scratchpads/type-vocabulary-incoherence/bug-report.md`):
+
+1. **Two vocabularies for the same thing, one undocumented.** The IR schema accepts both `string` and `str`, `object` and `dict`, `array` and `list`, etc. — 12 names doing the job of 6 concepts. Only the JSON Schema names are documented. Agents pattern-match against whatever example they see first; the same repo ends up with `type: str` in one file and `type: string` in another, authored by the same agent on different days.
+
+2. **`type: object` is a hidden wildcard.** Probe E confirms pflow accepts any value (string, list, int, dict) through `type: object`. A type label that looks restrictive but behaves permissively creates false confidence — downstream bugs surface as schema bugs disguised as application bugs. The natural wildcard name `any` is rejected at the declaration layer; the unnatural one (`object`) does the wildcard's job silently.
+
+3. **`Any` in code blocks requires import ceremony — and the error message is misleading.** Writing bare `x: Any` in a code block produces `NameError: name 'Any' is not defined`, which pflow's error handler incorrectly formats as `"Add 'Any' to the inputs dict: {"Any": ...}"` — sending agents to fix a nonexistent missing-input problem. Users must write `from typing import Any` not because Python needs it but because pflow's exec path didn't pre-inject it.
+
+Compounding these, the user-facing documentation (`src/pflow/guide/core.md`, MCP agent instructions, mintlify reference) teaches only the 5-name JSON Schema vocabulary — silently under-stating what the parser accepts and never explaining what any of the words actually mean at runtime.
+
+## Solution
+
+Ship a single atomic PR that:
+
+1. **Collapses S1 vocabulary to 7 canonical names.** `## Inputs` and `## Outputs` `type:` accepts exactly `string | number | integer | boolean | array | object | any`. Python aliases (`str`, `int`, `float`, `bool`, `dict`, `list`) become hard errors with actionable fix suggestions ("Use 'string' instead of 'str'").
+
+2. **Makes `object` mean dict-only (semantically and in docs).** Documents the change; the `any` keyword becomes the explicit wildcard. Strict runtime rejection of non-dict values for `type: object` is deferred to Task 120 — this task is vocabulary, not enforcement strictness.
+
+3. **Auto-injects `typing.Any` into Python code-block exec namespaces.** `x: Any` works without `from typing import Any`. Lowercase `x: any` in code blocks becomes a hard error with a message that teaches the two-surface model. The misleading NameError handler is fixed for common typing names (`Union`, `List`, `Dict`, etc. — with modern `int | None` syntax suggested as an alternative).
+
+4. **Centralizes vocabulary knowledge in a new `TypeSpec` class** (`src/pflow/core/types.py`). Canonical parsing, acceptance semantics, JSON Schema export, and structured error types in one place — so Task 120 (strict coercion) and future union-type work have a single model to grow from.
+
+5. **Extends `SchemaValidationError` to carry structured context** (`similar_names`, `available_fields`, `suggestions_list`) — bringing type-vocabulary errors in line with the producers-are-self-describing diagnostic pipeline the rest of the codebase already uses.
+
+6. **Updates every doc surface that teaches the old vocabulary** — guides, MCP agent instructions, architecture specs, changelog. The new S1↔S2 bridge is documented in one place and cross-referenced from all type-teaching surfaces.
+
+## Rationale
+
+### Why separate S1 and S2 vocabularies (vs one shared vocabulary)
+
+S1 is an external contract; external consumers (CLI users, MCP clients, non-Python tooling) shouldn't need Python context to read an `## Inputs` declaration. S2 must be Python because the runtime is Python. They serve different purposes, so they use different dialects. Four independent AI agents polled on this question independently landed on the same framing: "authoring surface speaks its native dialect; the bridge is documented once." Forcing them to match character-for-character either drags Python into the contract or forces the code block to accept non-Python spellings that break syntax highlighting.
+
+### Why `object` → dict and `any` → wildcard instead of keeping `object` as the wildcard
+
+A type label that looks restrictive but behaves permissively is worse than no label. Author predictability trumps implementation convenience. Making `object` restrictive and introducing `any` as the explicit wildcard aligns the vocabulary with its own name.
+
+### Why ship both breaking changes in one PR
+
+Single-user repo — no backward-compat debt. Two breaks in one release = one migration. Spread across releases = a confused intermediate state where `object` is strict but `str` still works. Polls of five independent reviewers unanimously recommended atomic shipping.
+
+### Why hard errors, not deprecation warnings
+
+Agents ignore warnings until they become errors. The confusing intermediate state ("works but will break") is a worse cost than the focused "here's the fix" error. Error quality (copy-pasteable suggestions like `"Use 'string' instead of 'str'"`) is what makes hard errors acceptable.
+
+### Why `Any` auto-injected but lowercase `any` rejected in code blocks
+
+Python code should BE Python. Each surface speaks its native dialect. But `from typing import Any` ceremony is pure tax; injecting `Any` (like `Optional` is already injected) removes the tax without leaking `typing` knowledge into workflow authoring. Lowercase `any` is a clear signal of surface confusion — rejecting it with a fix suggestion teaches the two-surface model rather than silently mapping.
+
+## Scope
+
+### In scope
+
+- IR schema enum for `inputs.*.type` and `outputs.*.type` (shrink 12 → 7)
+- Python code-block `Any` auto-injection
+- Vocabulary-rejection error messages with actionable suggestions
+- Parameterized-generic rejection at S1 parse time (e.g., `list[str]` → "Use 'array'")
+- `TypeSpec` centralization class
+- `SchemaValidationError` structured-context extension
+- Full doc sweep (guides, MCP instructions, architecture specs, changelog)
+- Test fixture migration for the few tests authored with Python aliases
+- Example workflow cleanup (`examples/output_validation_demo.pflow.md:43`)
+
+### Out of scope — deferred
+
+- **Strict runtime enforcement** for non-dict values passed to `type: object` inputs (deferred to Task 120)
+- **Complex / nested input schemas** (`properties:`, `required: [...]`) — separate follow-up task
+- **Union syntax at S1** (`string | null`, `int | float`) — `null` is dropped from the vocabulary for now; unions land in a later task
+- **Registry `Interface:` docstring canonicalization** — node Interface metadata stays Python-named; it's a third dialect with different consumers and a different migration story
+- **Claude Code `output_schema` vocabulary** — intentionally Python-named because it's embedded into LLM prompt construction; documented as third dialect, not migrated
+
+## Dependencies
+
+None blocking. Task lands independently.
+
+## Sequencing with other work
+
+- **Unblocks Task 120** (strict input type validation) — that task adds validate-time enforcement against the `TypeSpec` model this task introduces, rather than adding another independent vocabulary surface.
+- **Unblocks future complex-schema work** — nested input schemas can reuse the flat `{field: {type, description}}` YAML convention that the Claude Code `output_schema` feature already uses, now against a consistent S1 vocabulary.
+- **Independent of Task 153** (reserved for another refactor).
+
+## Success Criteria
+
+1. Every probe in `scratchpads/type-vocabulary-incoherence/repro-files/` produces the expected post-refactor behavior (A3 passes; A1/A2 fail with exact fix suggestions; B2 passes without import).
+2. `make test` and `make check` both pass.
+3. `grep -rnE "type: (str|int|float|bool|dict|list)\b"` across `src/pflow/guide/`, `docs/`, `architecture/`, and `src/pflow/mcp_server/resources/instructions/` returns zero hits in workflow-IR contexts.
+4. JSON-formatted validation errors (`--output-format json`) carry structured `context.similar_names` / `context.available_fields` / `context.available_fields_label` — not just prose suggestions.
+5. The `scratchpads/type-vocabulary-incoherence/bug-report.md` file gets a "Post-fix behavior" appendix documenting the new expected outputs.
+6. No production `.pflow.md` workflow regresses (most already use canonical names; zero mechanical migration needed in `examples/`).
+
+## Research
+
+- Full problem analysis and reproducible probes: `scratchpads/type-vocabulary-incoherence/bug-report.md`
+- Fourteen minimal probe workflows demonstrating each bug: `scratchpads/type-vocabulary-incoherence/repro-files/`
+- Five-agent code review of the implementation plan (5 confirmed critical findings, 7 warnings, all addressed): captured in the implementation plan's revision history
+
+## Implementation
+
+See `implementation/implementation-plan.md` for the atomic, line-level implementation plan — including exact file paths, code changes, test additions, documentation edits, and a probe-based verification strategy. The plan is self-contained and executable by a single AI agent without further research.

--- a/.taskmaster/tasks/task_154/task-review.md
+++ b/.taskmaster/tasks/task_154/task-review.md
@@ -1,0 +1,290 @@
+# Task 154 Review: Type Vocabulary Coherence Refactor
+
+> **⚠️ Round-2 Addendum — read this first before acting on any guidance below.**
+>
+> This review was written after round-1 review-prompted fixes but **before round-2**. Round-2 deleted code that round-1 preserved as defense-in-depth, replacing the dual-map architecture with a single validation chokepoint. Several sections below are structurally stale as a result. Specifically:
+>
+> **Deleted in round-2 (any reference below is stale):**
+> - `_TYPE_ALIASES` dict in `src/pflow/core/param_coercion.py` — DELETED. The "Two intentionally-duplicated alias maps" section (lines ~100-105), the "Defense-in-depth comments cite concrete bypass paths" pattern example (~135-145), and the "Technical debt" bullet on `_TYPE_ALIASES` duplication (~123) all describe state that no longer exists.
+> - `_normalize_type` helper in `param_coercion.py` — DELETED. Its sole caller was `coerce_workflow_input`; now the raw `declared_type` is used directly.
+> - `test_alias_maps_stay_in_sync` / `TestTypeAliasesSyncWithCanonicalSource` — DELETED. The drift-guard test (line ~37 executive summary, ~67 tests section, ~150 pattern section) is no longer needed because the duplication is gone.
+> - `test_type_aliases_work_as_defense_in_depth` — DELETED (line ~73). Its reason for existing (pinning the bypass behavior) went away with the bypass close.
+> - `TypeSpec.python_type()` — DELETED (line ~207 extension points). Zero production callers; `TypeSpec.accepts()` is the documented extension point for Task 120.
+>
+> **Added in round-2:**
+> - `normalize_ir(workflow_ir)` + `validate_ir(workflow_ir)` at `src/pflow/runtime/workflow_executor.py:208-209` (inside the cache-miss branch of `_compile_sub_workflow`) — the single chokepoint that replaced the dual-map defense. Every IR path now goes through `validate_ir` before reaching `compile_workflow`.
+> - AST-walk in `_check_annotation_vocabulary` (`nodes/python/python_code.py`) — catches lowercase `any` nested in generics (`list[any]`, `dict[str, any]`, `int | any`, `Optional[any]`) at the same layer as `x: any`. `Literal['any']` correctly passes through (it's an `ast.Constant`, not `ast.Name`).
+> - Claude Code `output_schema` acknowledged as deliberate fourth Python-aliased surface in `src/pflow/core/types.py` module docstring.
+>
+> **Common pitfall correction (line ~249):** The pitfall "Do NOT remove `_TYPE_ALIASES` in `param_coercion.py`" is **contradicted by reality**. The code has been removed. The new invariant is: **single validation boundary at `compile_workflow` entry** — every IR entry point runs through `validate_ir` before reaching coercion. The `validate_ir` call at `workflow_executor.py:208-209` is the round-2 addition that made `_TYPE_ALIASES` removable.
+>
+> **For future agents working on Task 120** (strict runtime enforcement): start at `TypeSpec.accepts()` in `src/pflow/core/types.py`. The plumbing point is `param_coercion.coerce_workflow_input` (still lenient). Do NOT reintroduce `_TYPE_ALIASES` — it is intentionally gone. Do NOT add duplicate validation at `_compile_sub_workflow` — `validate_ir` is already there.
+>
+> **For the full reasoning trail of round-2**, see `implementation/progress-log.md` → "[2026-04-16 post-merge-review round 2]" entry (the "Option B → Option D pivot"). It documents why the dual-map defense was replaced with the single chokepoint.
+>
+> Sections below are preserved for their architectural context and round-1 reasoning. Read with this addendum in mind.
+
+## Metadata
+
+- **Branch**: `fix/type-vocab-incoherence`
+- **Date**: 2026-04-16
+- **Issue**: [#291](https://github.com/spinje/pflow/issues/291) (retrospective motivating issue)
+- **PR**: [#290](https://github.com/spinje/pflow/pull/290)
+- **Commit**: `a32eda47`
+- **Diff**: 45 files, +3,765 / -193 lines (round-1 figures; round-2 is net-deletion — see progress-log)
+- **Tests**: 4,846 pass at round-1 (+5 new regression guards); 4,849 at round-2 (net +3 after drift-guard/defense-in-depth test deletions)
+
+## Executive Summary
+
+Shrunk the Surface-1 (workflow IR `## Inputs` / `## Outputs`) `type:` enum from 12 silent synonyms to 7 canonical JSON Schema names (`string | number | integer | boolean | array | object | any`). Made `object` dict-only (documented; runtime enforcement deferred to Task 120), introduced `any` as the explicit wildcard, auto-injected `Any` / `Optional` / `typing` into code-block exec namespaces. Breaking change shipped atomically. Introduced `TypeSpec` as the single source of truth for future vocabulary work (unions, complex schemas, strict runtime validation).
+
+## Implementation Overview
+
+### What was built
+
+**Core vocabulary refactor (per plan):**
+- New `src/pflow/core/types.py` module: `TypeSpec` dataclass, `TypeVocabularyError`, `CANONICAL_TYPES`, `PYTHON_ALIASES_AT_S1`
+- IR schema enum shrink (12 → 7 values) in both `inputs.*.type` and `outputs.*.type`
+- `SchemaValidationError` extended with four keyword-only structured-context kwargs
+- `_suggest_for_invalid_type` helper routes all type-vocab errors through `TypeSpec.parse` and threads structured context into diagnostics
+- `Any` + `Optional` + `typing` auto-injected into code-block exec namespace
+- Lowercase `any` in code annotations rejected with `NonRetriableError` teaching the two-surface split
+- Parameterized generics (`list[str]`, `dict[str, int]`) rejected at S1 parse time
+
+**Added during review-prompted polish (10 review findings + 1 bonus):**
+- Opinionated one-fix-per-case NameError hints (PEP 585 for generics, PEP 604 for Union, import for others) — replaced prior menu-of-options
+- `_get_suggestion` rewritten to use list-based path check (catches both `enum` and `type` validator failures at `inputs.*.type` / `outputs.*.type`, drops brittle substring match)
+- `_suggest_for_invalid_type(None)` maps to `"null"` so YAML `- type: null` (parses to Python None) reaches the TypeSpec.parse("null") branch
+- `_get_output_suggestion` case 3 deleted (dead code after routing consolidation)
+- Renderer truncation policy: show-all when `len(available_fields) <= 10`, truncate only beyond
+- Parameterized-generic `suggestions_list` rewritten as self-contained (`"Use 'array' — parameterized generics not supported at '## Inputs' / '## Outputs' (got 'list[str]')"`) — full prose survives the `to_diagnostics` preemption
+- Drift-guard test: `_TYPE_ALIASES == PYTHON_ALIASES_AT_S1`
+- Canonical syntax table in `guide/nodes/code.md` + one-line pointers from 3 other surfaces
+- Cross-layer in-process regression test: `validate_ir → to_diagnostics → format_diagnostic` contract
+
+### Deviations from spec (load-bearing to know)
+
+- **Plan §5.3 listed 3 test fixture files; actual migration needed 16.** The extras were test files constructing IR dicts *programmatically* rather than via markdown — they bypass the parser but still hit `validate_ir`. Future vocabulary changes must grep for direct `"type": "<alias>"` dict literals across `tests/`, not just `.pflow.md` fixture strings.
+- **Plan §10.3 expected grep `"Parameterized generics not supported"` to match CLI output; it didn't.** The prose lived in `SchemaValidationError.message` but `suggestions_list` preempted it in `to_diagnostics`. Review finding #1 caught this. Fix: populate `suggestions_list` with a self-contained entry that includes the WHY.
+- **Plan §2.9 claimed `list[any]` would surface as NameError at exec time. False.** Python's `any` is a valid builtin (the `any()` function); `list[any]` evaluates cleanly via PEP 585 `__class_getitem__`. The limitation is genuine — no runtime safety net. Progress log corrected.
+- **Plan §2.5 described `_TYPE_ALIASES` as defense-in-depth for "programmatically-constructed IR dicts, cached IRs, future MCP entry points".** The validation-consistency review identified the *one concrete production path* that actually matters: template-referenced sub-workflows (`workflow: ${dynamic_var}`) bypass `validate_ir` at `sub_workflow_resolver.py:64`. Comment in `param_coercion.py` now cites this specifically to prevent "dead code" cleanup.
+
+## Files Modified / Created
+
+### Core changes (single-source-of-truth surfaces)
+
+- `src/pflow/core/types.py` (NEW, 214 lines) — `TypeSpec`, `TypeVocabularyError`, vocabulary constants. Every future vocabulary consumer should import from here.
+- `src/pflow/core/ir_schema.py` — enum shrink, `_suggest_for_invalid_type`, `_get_suggestion` rewritten to return `tuple[str, dict]` and route via list-based path check.
+- `src/pflow/core/exceptions.py::SchemaValidationError` — four keyword-only kwargs (`similar_names`, `available_fields`, `available_fields_label`, `suggestions_list`) thread through to `Diagnostic.context`.
+- `src/pflow/core/param_coercion.py` — added `"any"` dispatch entry with `(value, log_context)` signature matching convention; kept `_TYPE_ALIASES` as defense-in-depth with specific bypass-path comment.
+- `src/pflow/core/diagnostic_render.py::_format_available_fields_block` — truncation policy: show-all for ≤10 entries.
+- `src/pflow/core/markdown_parser.py:147` — hint text `str` → `string` (coupled with `test_markdown_parser.py:2355`).
+
+### Code annotation surface (S2)
+
+- `src/pflow/nodes/python/python_code.py` — `Any` injected at line 344, `_check_annotation_vocabulary` rejects lowercase `any`, `_suggest_for_nameerror` helper emits one canonical fix per case (`_MODERN_GENERIC_NAMES` → PEP 585 lowercase, `Union` → PEP 604 pipe, `_REQUIRES_TYPING_IMPORT` → import).
+
+### Tests
+
+**Critical regression guards (added, in priority order):**
+- `tests/test_core/test_ir_schema.py::TestInputTypeAliases::test_full_render_pipeline_for_type_vocabulary_error` — cross-layer end-to-end: `validate_ir → to_diagnostics → format_diagnostic`. **Single most load-bearing test** — would have caught the critical review finding.
+- `tests/test_core/test_param_coercion.py::TestTypeAliasesSyncWithCanonicalSource::test_alias_maps_stay_in_sync` — pins `_TYPE_ALIASES == PYTHON_ALIASES_AT_S1`. Prevents silent drift between runtime bypass path and validator error source.
+- `tests/test_core/test_ir_schema.py::test_null_as_python_none_rejected_with_same_suggestion` — pins that YAML `- type: null` (Python None) routes to the same "Use 'any'" suggestion as the string `"null"` case.
+- `tests/test_core/test_types.py::test_parse_rejects_parameterized_generics` — asserts the self-contained `suggestions_list[0]` content (`"Use 'array'" + "parameterized generics not supported"`). Regression guard for suggestions_list preemption.
+- `tests/test_nodes/test_python/test_python_code.py::test_nameerror_for_list_suggests_lowercase_generic` / `test_nameerror_for_union_suggests_pipe_syntax` / `test_nameerror_for_literal_suggests_import` — pin the opinionated one-fix-per-case hint; each asserts the correct suggestion AND that the alternative isn't mentioned (no menu regression).
+
+**Existing test renamed (defense-in-depth clarity):**
+- `tests/test_runtime/test_prepare_inputs_coercion.py::test_type_aliases_work_as_defense_in_depth` — renamed from `test_type_aliases_work` + expanded docstring explicitly warning future agents NOT to misread it as "Python aliases are supported vocabulary." They're rejected at the validator; this test pins the one legitimate bypass.
+
+**Fixture migrations**: 16 test files updated from Python aliases (`str`/`int`/`list`) to canonical names (`string`/`integer`/`array`) — listed in progress log §4.1.
+
+### Documentation
+
+- `src/pflow/guide/nodes/code.md` — new "Type annotation syntax" section with canonical table. **Single source of truth for allowed syntax.**
+- `src/pflow/guide/core.md` — S1↔S2 bridge table + pointer to `pflow guide code`.
+- `src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md` + `mcp-sandbox-agent-instructions.md` — modern-syntax summary + pointer.
+
+## Integration Points & Dependencies
+
+### Validation routing chain
+
+`TypeSpec.parse(raw)` → raises `TypeVocabularyError(message, offending, similar_names, available_fields, available_fields_label, suggestions_list)` → caught in `_suggest_for_invalid_type` → returns `(suggestion_str, context_kwargs)` → consumed by `_get_suggestion` → threaded as `**kwargs` into `SchemaValidationError.__init__` in `validate_ir` → stored on exception → `SchemaValidationError.to_diagnostics()` produces `Diagnostic` with structured `context` → `format_diagnostic` renders.
+
+**Every link in this chain must preserve structured context.** No prose flattening.
+
+### Cross-surface consumers of `CANONICAL_TYPES`
+
+- `ir_schema.py` — `enum: list(CANONICAL_TYPES)` for both inputs and outputs
+- `ir_schema.py` description strings — `f"Data type: one of {', '.join(CANONICAL_TYPES)}"`
+- `types.py` — `TypeSpec.__post_init__` validation
+- `types.py` — `find_similar_items(..., list(CANONICAL_TYPES), ...)` for fuzzy match
+
+Any new surface rendering the vocabulary must import from `pflow.core.types` — do not hardcode the 7-name list.
+
+### Two intentionally-duplicated alias maps
+
+- `pflow.core.types.PYTHON_ALIASES_AT_S1` — source of truth for validator error suggestions
+- `pflow.core.param_coercion._TYPE_ALIASES` — runtime defense-in-depth
+
+**They must stay equal.** Enforced by `test_alias_maps_stay_in_sync`. A future cleanup consolidating them into one import (e.g., `from pflow.core.types import PYTHON_ALIASES_AT_S1 as _TYPE_ALIASES`) is legitimate but out of scope for this task.
+
+## Architectural Decisions & Tradeoffs
+
+### Key decisions
+
+**Separate S1 and S2 vocabularies (not unified Python)** — S1 is an external contract; external consumers (CLI users, MCP clients, non-Python tooling) shouldn't need Python context. S2 must be Python because the runtime is Python. Four poll agents voted 3-of-4 for unified Python; two external reviewers caught the "contract vs implementation" framing that unanimously rerouted to separate-with-bridge. **Lesson**: authoring-agent preference polls optimize for cognitive load, not architectural coherence — cross-check with reviewers.
+
+**Three intentional vocabularies (S1 / S2 / S3)** — S1 = workflow IR (canonical 7), S2 = Python code annotations (modern PEP 585/604), S3 = node registry `Interface:` docstrings + Claude Code `output_schema` (Python-named, feeds LLM prompt construction). **The S1↔S2 bridge is documented; S3 is acknowledged as a deliberate third dialect.** Unifying S3 would break LLM prompt embedding (`_build_schema_prompt` uses the literal Python names).
+
+**Opinionated one-fix-per-case error messages (not menus)** — Pattern matches FastAPI / Pydantic / Typer. A menu (`"option 1: import; option 2: modern syntax"`) forces the agent to decide; the one canonical answer teaches the project's stance. For `List[str]` → `"Use 'list[str]' (PEP 585 lowercase built-in)"`, no import alternative offered. Regression-guarded: each opinionated test asserts the OTHER fix is NOT mentioned.
+
+**`suggestions_list` preempts `suggestion` in `to_diagnostics`** — load-bearing contract. Numbered-list rendering kicks in when `len(suggestions_list) > 1`; single-entry `suggestions_list` overrides `suggestion` prose. **This is why the parameterized-generic fix populates `suggestions_list` with a self-contained entry containing both the fix AND the WHY** — the prose in `suggestion`/`message` is invisible at the renderer layer when `suggestions_list` is non-empty.
+
+**Hard errors, no deprecation window** — No external users = no backward-compat debt. Deprecation warnings create a "works but will break later" intermediate state that agents ignore until it matters.
+
+### Technical debt incurred
+
+- `_TYPE_ALIASES` in `param_coercion.py` duplicates `PYTHON_ALIASES_AT_S1` in `types.py` — intentional defense-in-depth, drift-guarded by test. Consolidation is a legitimate follow-up.
+- `TYPE_COMPATIBILITY_MATRIX` in `runtime/template_validation/type_checker.py` carries both Python and JSON Schema names as first-class keys (bridges S1↔S3). Future S3 canonicalization could shrink it.
+- `TypeVocabularyError` subclasses `ValueError` not `PflowError` — a `core/CLAUDE.md` convention violation, but the exception is always caught internally and converted to `SchemaValidationError`. Switching the base class likely requires a circular-import refactor; deferred.
+
+## Patterns Established
+
+### Producers are self-describing
+
+`TypeVocabularyError` carries structured fields (`similar_names`, `available_fields`, `available_fields_label`, `suggestions_list`) that thread through `_suggest_for_invalid_type` → `SchemaValidationError` → `Diagnostic.context`. The renderer consumes the structure; agents reading JSON get programmatic access; CLI users get formatted text — all from one structured source.
+
+**Propagate this**: any new error-producing code should populate structured context at the detection site, never flatten to prose for downstream code to reverse-engineer. `src/pflow/core/CLAUDE.md` documents this as project-wide principle; Task 154 is the canonical implementation example.
+
+### Defense-in-depth comments cite concrete bypass paths
+
+```python
+# Kept as defense-in-depth for template-referenced sub-workflows that skip
+# `validate_ir`: `WorkflowValidator._validate_sub_workflows` returns None for
+# template refs (see `core/workflow/sub_workflow_resolver.py`), so the child IR
+# reaches `coerce_workflow_input` without the S1 enum check. Task 154 progress
+# log §2.5 documents this as defense-in-depth, not dead code.
+```
+
+**Not** `"# Kept for non-S1 entry points that may bypass validation."` Generic defense-in-depth comments invite "this looks dead, remove it" cleanups. Concrete-path comments preserve the rationale.
+
+### Drift-guard tests for duplicated-by-design state
+
+```python
+def test_alias_maps_stay_in_sync():
+    from pflow.core.param_coercion import _TYPE_ALIASES
+    from pflow.core.types import PYTHON_ALIASES_AT_S1
+    assert _TYPE_ALIASES == PYTHON_ALIASES_AT_S1
+```
+
+Cheap, specific, catches a real drift mode. Pattern: when two modules must share state by design (not by import), assert the sync in a test.
+
+### Cross-layer in-process rendering tests (not subprocess)
+
+Per `core/CLAUDE.md`: *"CLI, JSON, and MCP all flow through the same `format_diagnostic()` pipeline — the only place rendering happens."* This means testing the full chain (`validate_ir → to_diagnostics → format_diagnostic`) in-process covers every consumer. ~3ms vs ~500ms subprocess, identical coverage for everything except the CLI entry wiring (stable contract). **Subprocess tests remain correct for progress-streaming / logger-interleaving / pipe-routing scenarios** per the user memory on CliRunner — but rendering pipeline tests should be in-process.
+
+### List-based path checks > substring checks for jsonschema routing
+
+```python
+# GOOD — precise, covers both enum and type validator errors at the right path
+is_type_vocab_path = (
+    len(path_list) >= 3
+    and path_list[0] in ("inputs", "outputs")
+    and path_list[-1] == "type"
+)
+
+# BAD — substring check on deque repr. Matches nodes[N].type accidentally;
+# requires validator-name guard to compensate.
+if error.validator == "enum" and "type" in str(error.absolute_path):
+```
+
+## Anti-Patterns to Avoid
+
+**Menu-of-options error suggestions.** If you find yourself writing `"Two options: 1. Do X. 2. Do Y."` — stop. Pick the canonical answer and emit only that. Agents pattern-match one option and ignore the other; you've wasted the other option's bytes and introduced ambiguity.
+
+**Invisible source rewriting of user code.** Poll P1 rejected design A (lowercase `any` silently rewritten to `Any` in code blocks) forcefully. Once a tool starts transforming user source, every debugging session becomes harder because the code shown ≠ the code run. **Namespace injection is fine** (Jupyter-style pre-bound names); **text rewriting is not**.
+
+**Trusting Python runtime claims without verification.** The plan's `list[any]` NameError safety-net claim was false. Always verify Python edge-case claims against an actual interpreter before documenting them as invariants.
+
+**Substring path-checking for precise validation routing.** `"type" in path_str` matched `nodes[N].type` by accident; it was only correct because `error.validator == "enum"` guarded it. List-based checks (`path_list[-1] == "type"`) are both shorter and correct.
+
+## Breaking Changes
+
+**S1 vocabulary**: `type: str` / `int` / `float` / `bool` / `dict` / `list` are now hard errors at `validate_ir`. Migration is mechanical sed to canonical names.
+
+**`object` semantic shift**: documented as dict-only (though runtime enforcement is deferred to Task 120). Workflows using `type: object` as a wildcard should migrate to `type: any`.
+
+**Parameterized generics**: `type: list[str]` / `dict[str, int]` rejected at parse time. Use bare `array` / `object`.
+
+**`null` dropped**: use `type: any` for nullable inputs (union syntax not yet supported).
+
+**Code-block annotation**: lowercase `x: any` is a hard error; use `x: Any` (auto-injected).
+
+Saved workflows in `~/.pflow/workflows/` containing Python aliases will fail validation on next load or `--force` re-save. Manual migration; no tooling.
+
+## Future Considerations
+
+### Extension points for Task 120 (strict runtime enforcement)
+
+- `TypeSpec.accepts(value)` — currently unused in production; designed as the strict-check entry point. Semantics: `integer` rejects `bool` (JSON Schema convention), `object` is dict-only, `any` returns True. Asymmetry with Python-lax `_TYPE_MAP` is documented.
+- `TypeSpec.python_type()` — returns isinstance-compatible type(s). Tuples for `number` (int, float).
+- `_coerce_to_object` in `param_coercion.py` currently lenient; Task 120's tightening point.
+
+### Extension points for union syntax
+
+- `TypeSpec.parse` currently rejects `null` with a "use `any`" hint and `A | B` as an unknown type. Union syntax lands here.
+- `TYPE_COMPATIBILITY_MATRIX` already handles `"int|float"` via split-on-pipe in `is_type_compatible`.
+- `_suggest_for_invalid_type` would need to recognize union-shaped offending values.
+
+### Extension points for complex schemas
+
+- The flat `{field: {type, description}}` YAML convention used by Claude Code `output_schema` is the natural shape. Agent-ux review noted the `llm` node uses the same YAML parsing path.
+- Integration would recurse `TypeSpec.parse` into nested `properties` fields.
+
+### Scope boundary that must be preserved
+
+**Three vocabularies coexist intentionally.** A future agent tempted to unify S3 (registry Interface docstrings + Claude Code `output_schema`) must know:
+- `_build_schema_prompt` in `claude_code.py` embeds the literal Python names (`str`, `int`, `dict`) into LLM prompts
+- Registry Interface metadata is authored by node library writers as Python annotations
+- `TYPE_COMPATIBILITY_MATRIX` bridges S1↔S3 and would need rethinking
+
+## AI Agent Guidance
+
+### Quick start for related tasks
+
+**Task 120 (strict input type validation):**
+1. Start at `src/pflow/core/types.py::TypeSpec.accepts` — already designed for this.
+2. Plumbing point: `src/pflow/core/param_coercion.py::coerce_workflow_input` — currently lenient, needs a strict mode that calls `TypeSpec.accepts`.
+3. Error path: produce `WorkflowValidationError` with structured context matching Task 154's pattern — populate `similar_names` / `available_fields` / `suggestions_list`.
+4. Test template: cross-layer rendering test like `test_full_render_pipeline_for_type_vocabulary_error`.
+
+**Union syntax at S1 (`A | B`):**
+1. Extend `TypeSpec.parse` — currently raises on `|` via the unknown-type branch.
+2. Update `TYPE_COMPATIBILITY_MATRIX` — already has a `split("|")` path, extend for canonical names.
+3. Remove the "null deferred" branch; `string | null` becomes the canonical nullable spelling.
+
+**Complex nested schemas (properties):**
+1. Reuse the `yaml output_schema` convention from `nodes/claude/claude_code.py::_validate_schema`.
+2. Extend `TypeSpec.parse` to accept nested dicts.
+3. IR schema gains `properties` sibling field on input/output declarations.
+
+### Common pitfalls
+
+- **Do NOT remove `_TYPE_ALIASES` in `param_coercion.py`.** Reachable via template-referenced sub-workflows that skip `validate_ir`. Drift-guard test prevents accidental desync from `PYTHON_ALIASES_AT_S1` but doesn't prevent outright removal.
+- **Do NOT change `suggestions_list` to complement `suggestion` in `SchemaValidationError.to_diagnostics`.** The preemption is deliberate and catches multi-suggestion cases. Changing it reintroduces the parameterized-generic prose loss bug.
+- **Do NOT unify S1 / S2 / S3 vocabularies.** The three-dialect coexistence is architectural; `_build_schema_prompt` LLM prompt construction depends on the Python names.
+- **Do NOT tighten runtime coercion outside of Task 120.** Lenient `_coerce_to_object` accepting non-dict values is a deliberate scope boundary; Task 120 owns this.
+- **Do NOT claim `any`-in-generics (`list[any]`) produces a NameError safety net.** Python's `any` is a valid builtin; `list[any]` evaluates cleanly. This is a documented limitation, not a runtime catch.
+- **Do NOT use substring path-checking (`"X" in path_str`) for precise jsonschema error routing.** Use list-based checks via `list(error.absolute_path)`.
+- **Do NOT emit menu-of-options error suggestions.** One canonical fix per case.
+
+### Test-first recommendations for related work
+
+- **Write the cross-layer rendering test first.** Per-layer unit tests miss `suggestions_list` preemption bugs and context-threading regressions. See `test_full_render_pipeline_for_type_vocabulary_error` as the template.
+- **If you touch `SchemaValidationError`**: run `tests/test_core/test_ir_schema.py::TestInputTypeAliases` — that class pins every vocabulary contract.
+- **If you touch `param_coercion.py`**: run `tests/test_core/test_param_coercion.py::TestTypeAliasesSyncWithCanonicalSource` and `tests/test_runtime/test_prepare_inputs_coercion.py::test_type_aliases_work_as_defense_in_depth` — these protect the bypass path.
+- **If you touch `diagnostic_render.py::_format_available_fields_block`**: the truncation policy (show-all when ≤10) is poll-validated agent-UX. `test_full_render_pipeline_for_type_vocabulary_error` pins it.
+
+---
+
+*Generated from implementation context of Task 154. Progress log at `.taskmaster/tasks/task_154/implementation/progress-log.md` carries the full reasoning trail — 7 sections covering planning journey, reviewer findings that reshaped the plan, non-obvious implementer traps, implementation notes, verification strategy, methodology notes, and append-only live log across 4 implementation passes.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ MVP feature-complete. Published to PyPI (v0.8.0). See `.taskmaster/versions.md` 
 - ✅ Task 151: CLI Surface Restructure
 - ✅ Task 77: Pflow Guide — tailored agent instructions
 - ✅ Task 153: Reject Undeclared Sub-Workflow Inputs
+- ✅ Task 154: Type Vocabulary Coherence
 
 ### Planned Features (in order of priority)
 

--- a/architecture/architecture.md
+++ b/architecture/architecture.md
@@ -496,7 +496,8 @@ Run a sub-workflow for processing.
 
 - type: workflow
 - workflow: path/to/workflow.pflow.md
-- input_data: ${data}
+- inputs:
+    input_data: ${data}
 ```
 
 **What happens internally**:

--- a/architecture/reference/enhanced-interface-format.md
+++ b/architecture/reference/enhanced-interface-format.md
@@ -38,6 +38,8 @@ All components support type annotations using Python's built-in types:
 - `list` - List/array structures
 - `any` - Any type (default when not specified)
 
+These names describe node `Interface:` docstrings and stay Python-named. Workflow `## Inputs` / `## Outputs` use a separate canonical vocabulary: `string`, `number`, `integer`, `boolean`, `array`, `object`, `any`.
+
 #### Union Types
 
 Union types allow you to specify that a value can be one of multiple types using the pipe (`|`) operator:

--- a/architecture/reference/ir-schema.md
+++ b/architecture/reference/ir-schema.md
@@ -60,12 +60,12 @@ The optional `inputs` field defines the parameters a workflow expects to receive
   "ir_version": "0.1.0",
   "inputs": {
     "url": {
-      "type": "str",
+      "type": "string",
       "required": true,
       "description": "YouTube video URL to process"
     },
     "language": {
-      "type": "str",
+      "type": "string",
       "required": false,
       "default": "en",
       "description": "Language code for transcript extraction"
@@ -80,7 +80,7 @@ The optional `inputs` field defines the parameters a workflow expects to receive
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | string | Data type: `str`, `int`, `float`, `bool`, `dict`, `list`, `any` |
+| `type` | string | Data type: `string`, `number`, `integer`, `boolean`, `array`, `object`, `any` |
 | `required` | boolean | Whether the input must be provided |
 | `default` | any | Default value if not provided (only for optional inputs) |
 | `description` | string | Human-readable description for documentation |
@@ -95,12 +95,12 @@ The optional `outputs` field declares what the workflow produces:
   "ir_version": "0.1.0",
   "outputs": {
     "summary": {
-      "type": "str",
+      "type": "string",
       "description": "Generated summary of the video content",
       "source": "${create-summary.response}"
     },
     "metadata": {
-      "type": "dict",
+      "type": "object",
       "description": "Video metadata including title and duration",
       "source": "${fetch-metadata.video_info}"
     }
@@ -132,12 +132,12 @@ The optional `outputs` field declares what the workflow produces:
   },
   "inputs": {
     "url": {
-      "type": "str",
+      "type": "string",
       "required": true,
       "description": "YouTube video URL"
     },
     "summary_style": {
-      "type": "str",
+      "type": "string",
       "required": false,
       "default": "concise",
       "description": "Summary style: concise, detailed, or bullet-points"
@@ -145,12 +145,12 @@ The optional `outputs` field declares what the workflow produces:
   },
   "outputs": {
     "summary": {
-      "type": "str",
+      "type": "string",
       "description": "Video summary in requested style",
       "source": "${summarize.response}"
     },
     "word_count": {
-      "type": "int",
+      "type": "integer",
       "description": "Word count of original transcript",
       "source": "${analyze.stats.word_count}"
     }
@@ -205,6 +205,8 @@ The optional `outputs` field declares what the workflow produces:
 - **CLI**: The `pflow run` command validates inputs against workflow declarations
 
 > **Note**: While nodes declare their interfaces in docstrings (extracted to metadata), workflows declare their interfaces directly in the IR. This enables workflows to be first-class citizens in the pflow ecosystem, reusable and composable just like nodes.
+
+> **Vocabulary note**: Workflow `inputs` / `outputs` use the canonical workflow vocabulary (`string`, `number`, `integer`, `boolean`, `array`, `object`, `any`). Node metadata `Interface:` docstrings remain Python-named (`str`, `int`, `dict`, `list`, ...). They are separate surfaces with different consumers.
 
 ---
 

--- a/architecture/reference/template-variables.md
+++ b/architecture/reference/template-variables.md
@@ -508,8 +508,8 @@ Warns if declared inputs are never used:
 ```json
 {
   "inputs": {
-    "user_id": {"type": "str", "required": true},
-    "api_key": {"type": "str", "required": true}
+    "user_id": {"type": "string", "required": true},
+    "api_key": {"type": "string", "required": true}
   },
   "nodes": [
     {
@@ -599,6 +599,8 @@ if unresolved_templates:
 Located: `src/pflow/runtime/template_validation/type_checker.py`
 
 pflow validates that template types match parameter expectations using node interface schemas.
+
+This compatibility layer bridges two vocabularies: workflow-authored `## Inputs` / `## Outputs` use canonical names like `string` and `object`, while node Interface metadata uses Python names like `str` and `dict`.
 
 #### Type Compatibility Matrix
 
@@ -983,9 +985,9 @@ assert resolve_template("Status: ${enabled}", context) == "Status: True"
 ```json
 {
   "inputs": {
-    "source_dir": {"type": "str"},
-    "dest_dir": {"type": "str"},
-    "file_name": {"type": "str"}
+    "source_dir": {"type": "string"},
+    "dest_dir": {"type": "string"},
+    "file_name": {"type": "string"}
   },
   "nodes": [
     {
@@ -1047,10 +1049,10 @@ assert resolve_template("Status: ${enabled}", context) == "Status: True"
 ```json
 {
   "inputs": {
-    "task": {"type": "str"},
-    "model": {"type": "str", "default": "claude-3-5-sonnet-20241022"},
-    "max_tokens": {"type": "int", "default": 1000},
-    "temperature": {"type": "float", "default": 0.7}
+    "task": {"type": "string"},
+    "model": {"type": "string", "default": "claude-3-5-sonnet-20241022"},
+    "max_tokens": {"type": "integer", "default": 1000},
+    "temperature": {"type": "number", "default": 0.7}
   },
   "nodes": [
     {
@@ -1230,12 +1232,12 @@ There is no mechanism to execute code through templates.
   "template_resolution_mode": "strict",
   "inputs": {
     "user_id": {
-      "type": "str",
+      "type": "string",
       "required": true,
       "description": "User identifier"
     },
     "count": {
-      "type": "int",
+      "type": "integer",
       "default": 10,
       "description": "Number of items to process"
     }
@@ -1345,12 +1347,12 @@ export PFLOW_TEMPLATE_RESOLUTION_MODE=permissive
 {
   "inputs": {
     "api_token": {
-      "type": "str",
+      "type": "string",
       "required": true,
       "description": "API authentication token"
     },
     "max_retries": {
-      "type": "int",
+      "type": "integer",
       "default": 3,
       "description": "Maximum retry attempts"
     }
@@ -1629,7 +1631,7 @@ Template variable ${api_token} has no valid source
    ```json
    {
      "inputs": {
-       "api_token": {"type": "str", "required": true}
+       "api_token": {"type": "string", "required": true}
      }
    }
    ```

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -115,7 +115,7 @@ Write like a developer explaining what they built to another developer — at a 
 
 **The register:** Second-person, direct, technical. Confident because you've tested it, not because you're performing confidence. When you state a rule, explain why it exists — a rule with reasoning sticks, a rule without reasoning gets ignored.
 
-- "Use `object` when you don't know the type — it skips validation entirely" — not "You could consider using `object` if the type is uncertain"
+- "Use `Any` in code blocks when you don't want type validation, and `type: any` in workflow inputs when the value can be any shape" — not "You could consider using `object` if the type is uncertain"
 - "Templates go in `inputs`, never in the code block — because the code block is literal Python, and `${var}` isn't valid Python syntax" — not "It is important to note that template variables should be placed in the inputs parameter"
 - "Upstream JSON is auto-parsed before your code runs" — not "The system automatically handles JSON deserialization of upstream data"
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -5,6 +5,24 @@ icon: "clock"
 rss: true
 ---
 
+<Update label="April 2026" description="v0.12.0" tags={["Breaking changes", "Improvements"]}>
+  ## Type vocabulary coherence
+
+  The `## Inputs` and `## Outputs` `type:` field now accepts exactly 7 values:
+  `string`, `number`, `integer`, `boolean`, `array`, `object`, `any`.
+
+  **Breaking changes**
+  - Python type aliases (`str`, `int`, `float`, `bool`, `dict`, `list`) no longer work in workflow input/output declarations. Validation errors now suggest the canonical replacement.
+  - `object` is now documented as dict-only. Use `any` when the value can be any type.
+  - Parameterized generics such as `list[str]` and `dict[str, int]` are rejected in workflow input/output declarations.
+  - Saved workflows in `~/.pflow/workflows/` that still use Python aliases will fail validation until the file is updated to the canonical names.
+
+  **New**
+  - `any` is the explicit wildcard type for workflow inputs and outputs.
+  - `Any` is auto-injected into code node execution, so `from typing import Any` is optional.
+  - The guides now document the bridge between workflow `type:` declarations and Python code annotations.
+</Update>
+
 <Update label="April 2026" description="v0.11.0" tags={["New releases", "Improvements", "Breaking changes"]}>
   ## Execution core and iteration speed
 

--- a/docs/reference/nodes/code.mdx
+++ b/docs/reference/nodes/code.mdx
@@ -39,7 +39,7 @@ result: dict = {}     # required on result too
 ```
 
 <Tip>
-  Use `object` as the type when you don't know or care what the input type is — it skips validation entirely.
+  Use `Any` when you don't know or care what the input type is. pflow auto-injects `Any`, so you don't need `from typing import Any`.
 </Tip>
 
 <Accordion title="Supported types">
@@ -54,7 +54,7 @@ result: dict = {}     # required on result too
   | `set` | `set` | |
   | `tuple` | `tuple` | |
   | `bytes` | `bytes` | |
-  | `object` | — | Skips type validation entirely |
+  | `Any` | — | Auto-injected. Skips type validation entirely |
 
   Only the outer type is checked — `list[dict]` validates that the value is a `list`, but doesn't check whether the elements are dicts.
 </Accordion>
@@ -82,6 +82,20 @@ result: list = [u for u in data if u['active']]
 ````
 
 Templates in the `inputs` dict get resolved before your code runs. By the time Python sees `data`, it's already a native object — no parsing needed.
+
+## Bridge to workflow inputs
+
+Workflow `## Inputs` / `## Outputs` use canonical names. Code blocks use Python annotations.
+
+| Workflow `type:` | Code annotation |
+|---|---|
+| `string` | `str` |
+| `integer` | `int` |
+| `number` | `int \| float` or `float` |
+| `boolean` | `bool` |
+| `array` | `list` |
+| `object` | `dict` |
+| `any` | `Any` |
 
 ## Inputs are native objects
 

--- a/examples/nested/README.md
+++ b/examples/nested/README.md
@@ -28,12 +28,13 @@ pflow --validate-only examples/nested/document-processor.pflow.md
 ### process_title
 - type: workflow
 - workflow: ./to-uppercase.pflow.md
-- text: ${title}
+- inputs:
+    text: ${title}
 ```
 
 - `type: workflow` tells pflow this is a nested workflow call
 - `workflow:` points to the child workflow file (or a saved workflow name)
-- All other params (`text`) are passed as child inputs
+- Child inputs are passed via the `inputs:` dict — every key must be declared on the child's `## Inputs`
 - Child outputs are available as `${process_title.result}` (via the namespace system)
 
 ## Storage Modes

--- a/examples/output_validation_demo.pflow.md
+++ b/examples/output_validation_demo.pflow.md
@@ -40,4 +40,4 @@ The LLM response.
 
 A dynamically written key that cannot be traced.
 
-- type: object
+- type: any

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -14,6 +14,7 @@ src/pflow/core/
 ├── diagnostic.py            # Diagnostic type, exception conversion, dedup
 ├── diagnostic_render.py     # format_diagnostic text renderer
 ├── ir_schema.py             # IR schema definition and validation
+├── types.py                 # TypeSpec, CANONICAL_TYPES, PYTHON_ALIASES_AT_S1 — single source of truth for S1 vocabulary
 ├── json_utils.py            # Shared JSON parsing (try_parse_json, parse_json_or_original)
 ├── llm_config.py            # LLM model resolution, env injection, provider detection
 ├── markdown_parser.py       # .pflow.md → IR dict parser
@@ -290,11 +291,15 @@ Detects file path references in node params and batch items, reads the files, an
 
 **Provenance**: Records original file paths in `node["_source_files"]` dict for error attribution.
 
+### types.py
+
+Single source of truth for the workflow-IR `type:` vocabulary. `CANONICAL_TYPES` = the 7 valid names (`string | number | integer | boolean | array | object | any`). `TypeSpec.parse(raw)` is the only entry point — raises `TypeVocabularyError` with structured context (fuzzy suggestions, Python-alias replacements) for the diagnostic pipeline. `TypeSpec.accepts(value)` is reserved for Task 120 (strict runtime enforcement); no production callers yet. Python annotations in code blocks use Python names, not these — see the S1↔S2 bridge in `src/pflow/guide/core.md`.
+
 ### param_coercion.py
 
 **Two functions for different pipeline stages** — easy to confuse:
 - `coerce_param_for_node(value, expected_type)`: For node execution. Intentionally narrow — only converts dict/list → JSON string when declared type is `"str"`. All other values pass through unchanged.
-- `coerce_workflow_input(value, declared_type)`: For CLI/env inputs entering a workflow. Full bidirectional coercion via dispatch table (str↔int, str↔bool, str↔JSON). **Lenient**: warns on failure instead of erroring — lets downstream validation catch it with full context.
+- `coerce_workflow_input(value, declared_type)`: For CLI/env inputs entering a workflow. `declared_type` is one of the 7 canonical S1 names; dispatch table maps each to a coercion function (e.g., `"integer"` → parse int from string). **Lenient**: warns on failure instead of erroring — lets downstream validation catch it. Python aliases are rejected upstream by `validate_ir`, so this function never sees them.
 
 ### security_utils.py
 

--- a/src/pflow/core/diagnostic_render.py
+++ b/src/pflow/core/diagnostic_render.py
@@ -212,6 +212,11 @@ def _format_available_fields_block(context: dict[str, Any]) -> list[str]:
     contains (e.g. "outputs", "nodes", "inputs", "parameters"). The fallback
     ``"fields"`` is deliberately generic so it is never technically wrong —
     producers that want accurate wording must set the label explicitly.
+
+    Truncation policy: for small closed sets (≤10 items) show every entry —
+    truncating hurts agent UX (e.g., hiding 2 of 7 canonical types forces the
+    agent to guess or pivot to JSON output). For larger sets, truncate to 5
+    and note how many more exist.
     """
     available = context.get("available_fields")
     if not available:
@@ -219,14 +224,20 @@ def _format_available_fields_block(context: dict[str, Any]) -> list[str]:
 
     label = context.get("available_fields_label", "fields")
     total = context.get("available_fields_total", len(available))
+
+    # Show all entries for small closed sets; truncate only when the full list
+    # would genuinely overwhelm the error output.
+    show_all = len(available) <= 10
+    shown_count = len(available) if show_all else 5
+
     lines = [
         "",
-        f"  Available {label} (showing {min(len(available), 5)} of {total}):",
+        f"  Available {label} (showing {shown_count} of {total}):",
     ]
-    for field_name in available[:5]:
+    for field_name in available[:shown_count]:
         lines.append(f"    - {field_name}")
-    if len(available) > 5:
-        lines.append(f"    ... and {len(available) - 5} more (in error details)")
+    if not show_all:
+        lines.append(f"    ... and {len(available) - shown_count} more (in error details)")
     return lines
 
 

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from pflow.core.diagnostic import Diagnostic, Severity
@@ -151,12 +152,30 @@ class SchemaValidationError(PflowError):
         message: The validation error message
         path: Dotted path to the invalid field (e.g., "nodes[0].type")
         suggestion: Optional suggestion for fixing the error
+        similar_names: Optional fuzzy-match suggestions
+        available_fields: Optional list of valid alternatives
+        available_fields_label: Optional noun for the alternatives block
+        suggestions_list: Optional multi-suggestion list
     """
 
-    def __init__(self, message: str, path: str = "", suggestion: str = ""):
+    def __init__(
+        self,
+        message: str,
+        path: str = "",
+        suggestion: str = "",
+        *,
+        similar_names: list[str] | None = None,
+        available_fields: list[str] | None = None,
+        available_fields_label: str | None = None,
+        suggestions_list: list[str] | None = None,
+    ):
         self.message = message
         self.path = path
         self.suggestion = suggestion
+        self.similar_names = similar_names or []
+        self.available_fields = available_fields or []
+        self.available_fields_label = available_fields_label
+        self.suggestions_list = suggestions_list or []
 
         full_message = "Validation error"
         if path:
@@ -171,12 +190,26 @@ class SchemaValidationError(PflowError):
         ctx: dict[str, Any] = {"category": "validation"}
         if self.path:
             ctx["path"] = self.path
+        if self.similar_names:
+            ctx["similar_names"] = self.similar_names
+        if self.available_fields:
+            ctx["available_fields"] = self.available_fields
+        if self.available_fields_label:
+            ctx["available_fields_label"] = self.available_fields_label
+
+        if self.suggestions_list:
+            suggestions = self.suggestions_list
+        elif self.suggestion:
+            suggestions = [self.suggestion]
+        else:
+            suggestions = None
+
         return [
             Diagnostic(
                 severity=Severity.ERROR,
                 message=self.message,
                 title="Validation Error",
-                suggestions=[self.suggestion] if self.suggestion else None,
+                suggestions=suggestions,
                 source="validation",
                 context=ctx,
             )
@@ -272,7 +305,21 @@ class CompilationError(PflowError):
 
     def to_diagnostics(self) -> list[Diagnostic]:
         if self.wrapped_diagnostics:
-            return list(self.wrapped_diagnostics)
+            # Wrapped diagnostics carry inner structure (e.g. SchemaValidationError's
+            # similar_names / available_fields). This CompilationError contributes
+            # container context (sub_workflow_path). Merge the latter into each
+            # wrapped diagnostic's context so both render — wrapped context wins
+            # on conflict, mirroring dict.setdefault semantics.
+            sub_workflow_path = self.details.get("sub_workflow_path")
+            if sub_workflow_path is None:
+                return list(self.wrapped_diagnostics)
+            return [
+                replace(
+                    d,
+                    context={"sub_workflow_path": sub_workflow_path, **(d.context or {})},
+                )
+                for d in self.wrapped_diagnostics
+            ]
         return [
             Diagnostic(
                 severity=Severity.ERROR,

--- a/src/pflow/core/ir_schema.py
+++ b/src/pflow/core/ir_schema.py
@@ -72,6 +72,7 @@ from jsonschema import Draft7Validator
 from jsonschema import ValidationError as JsonSchemaValidationError
 
 from pflow.core.exceptions import SchemaValidationError as ValidationError
+from pflow.core.types import CANONICAL_TYPES
 
 # JSON Schema for batch configuration on nodes
 # Enables sequential or parallel processing of multiple items through a single node
@@ -232,23 +233,8 @@ FLOW_IR_SCHEMA: dict[str, Any] = {
                     "required": {"type": "boolean", "default": True, "description": "Whether input is required"},
                     "type": {
                         "type": "string",
-                        "enum": [
-                            # JSON Schema canonical types
-                            "string",
-                            "number",
-                            "boolean",
-                            "object",
-                            "array",
-                            # Python type aliases
-                            "str",
-                            "int",
-                            "integer",
-                            "float",
-                            "bool",
-                            "dict",
-                            "list",
-                        ],
-                        "description": "Data type hint (accepts JSON Schema or Python type names)",
+                        "enum": list(CANONICAL_TYPES),
+                        "description": f"Data type: one of {', '.join(CANONICAL_TYPES)}",
                     },
                     "default": {"description": "Default value if not provided"},
                     "stdin": {
@@ -270,23 +256,8 @@ FLOW_IR_SCHEMA: dict[str, Any] = {
                     "description": {"type": "string", "description": "Human-readable description"},
                     "type": {
                         "type": "string",
-                        "enum": [
-                            # JSON Schema canonical types
-                            "string",
-                            "number",
-                            "boolean",
-                            "object",
-                            "array",
-                            # Python type aliases
-                            "str",
-                            "int",
-                            "integer",
-                            "float",
-                            "bool",
-                            "dict",
-                            "list",
-                        ],
-                        "description": "Data type hint (accepts JSON Schema or Python type names)",
+                        "enum": list(CANONICAL_TYPES),
+                        "description": f"Data type: one of {', '.join(CANONICAL_TYPES)}",
                     },
                     "source": {
                         "type": "string",
@@ -403,29 +374,71 @@ def _get_output_suggestion(error: JsonSchemaValidationError, path_str: str) -> s
             "  - source: ${generate_story.response}"
         )
 
-    # Case 3: Invalid type enum value
-    if error.validator == "enum" and "type" in path_str:
-        valid_types = "string, number, boolean, object, array (or Python aliases: str, int, float, bool, dict, list)"
-        return f"Type must be one of: {valid_types}"
-
     return ""
 
 
-def _get_suggestion(error: JsonSchemaValidationError) -> str:
+def _suggest_for_invalid_type(offending: Any) -> tuple[str, dict[str, Any]]:
+    """Return an actionable suggestion and structured context for invalid S1 types."""
+    from pflow.core.types import TypeSpec, TypeVocabularyError
+
+    # YAML `- type: null` parses to Python None — map to the 'null' string so
+    # TypeSpec.parse produces the actionable "Use 'any' if the value may be None"
+    # suggestion instead of the generic fallback.
+    if offending is None:
+        offending = "null"
+
+    if not isinstance(offending, str):
+        text = f"Type must be one of: {', '.join(CANONICAL_TYPES)}"
+        return text, {
+            "available_fields": list(CANONICAL_TYPES),
+            "available_fields_label": "types",
+        }
+
+    try:
+        TypeSpec.parse(offending)
+    except TypeVocabularyError as exc:
+        context: dict[str, Any] = {
+            "available_fields": exc.available_fields,
+            "available_fields_label": exc.available_fields_label,
+        }
+        if exc.similar_names:
+            context["similar_names"] = exc.similar_names
+        if exc.suggestions_list:
+            context["suggestions_list"] = exc.suggestions_list
+        return str(exc), context
+
+    return (
+        f"Type must be one of: {', '.join(CANONICAL_TYPES)}",
+        {
+            "available_fields": list(CANONICAL_TYPES),
+            "available_fields_label": "types",
+        },
+    )
+
+
+def _get_suggestion(error: JsonSchemaValidationError) -> tuple[str, dict[str, Any]]:
     """Get a helpful suggestion based on the validation error.
 
     Args:
         error: The jsonschema validation error
 
     Returns:
-        Suggestion string for fixing the error
+        Tuple of suggestion string and structured context kwargs
     """
-    # Get path for context-specific suggestions
+    path_list = list(error.absolute_path)
     path_str = str(error.absolute_path)
 
-    # OUTPUT-SPECIFIC ERROR HANDLING
+    # Type-vocabulary errors: any failure at `inputs.<name>.type` or `outputs.<name>.type`
+    # — covers invalid strings (validator='enum', e.g. 'str') AND non-string values
+    # (validator='type', e.g. `- type: null` which YAML parses to Python None).
+    # List-based path check avoids matching `nodes[N].type` via substring.
+    is_type_vocab_path = len(path_list) >= 3 and path_list[0] in ("inputs", "outputs") and path_list[-1] == "type"
+    if is_type_vocab_path:
+        return _suggest_for_invalid_type(error.instance)
+
+    # OUTPUT-SPECIFIC ERROR HANDLING (non-type fields: additionalProperties, shape)
     if "outputs" in path_str:
-        return _get_output_suggestion(error, path_str)
+        return _get_output_suggestion(error, path_str), {}
 
     # GENERAL ERROR HANDLING (existing cases)
     if error.validator == "required":
@@ -433,21 +446,21 @@ def _get_suggestion(error: JsonSchemaValidationError) -> str:
         match = error.message.split("'")
         if len(match) >= 2:
             field_name = match[1]
-            return f"Add the required field '{field_name}'"
-        return "Add the missing required field"
+            return f"Add the required field '{field_name}'", {}
+        return "Add the missing required field", {}
     elif error.validator == "type":
         expected = error.validator_value
         actual = type(error.instance).__name__
-        return f"Change type from '{actual}' to '{expected}'"
+        return f"Change type from '{actual}' to '{expected}'", {}
     elif error.validator == "pattern":
         if "ir_version" in path_str:
-            return "Use semantic versioning format, e.g., '0.1.0'"
+            return "Use semantic versioning format, e.g., '0.1.0'", {}
     elif error.validator == "additionalProperties":
-        return "Remove unknown properties or check field names"
+        return "Remove unknown properties or check field names", {}
     elif error.validator == "minItems":
-        return "Add at least one node to the workflow"
+        return "Add at least one node to the workflow", {}
 
-    return ""
+    return "", {}
 
 
 def validate_ir(data: Union[dict[str, Any], str]) -> None:
@@ -517,9 +530,14 @@ def validate_ir(data: Union[dict[str, Any], str]) -> None:
     # Format the first error with helpful message
     error = errors[0]
     path = _format_path(list(error.absolute_path))
-    suggestion = _get_suggestion(error)
+    suggestion, context_kwargs = _get_suggestion(error)
 
-    raise ValidationError(message=error.message, path=path, suggestion=suggestion)
+    raise ValidationError(
+        message=error.message,
+        path=path,
+        suggestion=suggestion,
+        **context_kwargs,
+    )
 
 
 def _validate_node_references(data: dict[str, Any]) -> None:

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -144,7 +144,7 @@ _SECTION_SYNTAX_HINTS: dict[_SectionType, str] = {
         "Inputs must use ### heading syntax:\n\n"
         "    ### input-name\n\n"
         "    Description of the input.\n\n"
-        "    - type: str\n"
+        "    - type: string\n"
         "    - required: true"
     ),
     _SectionType.STEPS: (

--- a/src/pflow/core/param_coercion.py
+++ b/src/pflow/core/param_coercion.py
@@ -11,27 +11,6 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Type aliases for normalization (consistent with type_checker.py)
-_TYPE_ALIASES = {
-    "str": "string",
-    "int": "integer",
-    "float": "number",
-    "bool": "boolean",
-    "dict": "object",
-    "list": "array",
-}
-
-
-def _normalize_type(type_name: str) -> str:
-    """Normalize type name to canonical form.
-
-    Known type aliases are normalized to their canonical form.
-    Unknown types preserve their original case to support future
-    custom/user-defined types.
-    """
-    normalized = _TYPE_ALIASES.get(type_name.lower())
-    return normalized if normalized else type_name  # Preserve case for unknowns
-
 
 def coerce_param_for_node(
     value: Any,
@@ -47,6 +26,12 @@ def coerce_param_for_node(
     This function does NOT perform general type coercion (e.g., str→int).
     At this pipeline stage, values are already in their intended form from
     template resolution or the shared store.
+
+    Note on vocabulary: ``expected_type`` here is the S3 node-Interface type
+    (Python-aliased — ``"str"``, ``"dict"``), NOT the S1 workflow-IR vocabulary.
+    This is why ``"str"``/``"string"`` are both accepted below, even though
+    ``coerce_workflow_input`` (the S1 entry point) rejects Python aliases. See
+    ``src/pflow/core/types.py`` module docstring for the surface split.
 
     Args:
         value: The resolved value to potentially coerce
@@ -222,6 +207,11 @@ def _coerce_to_array(value: Any, log_context: dict[str, Any]) -> Any:
     return value
 
 
+def _coerce_to_any(value: Any, log_context: dict[str, Any]) -> Any:
+    """Passthrough coercion for `type: any`."""
+    return value
+
+
 # Dispatch table for type coercion
 _COERCION_DISPATCH = {
     "string": _coerce_to_string,
@@ -230,6 +220,7 @@ _COERCION_DISPATCH = {
     "boolean": _coerce_to_boolean,
     "object": _coerce_to_object,
     "array": _coerce_to_array,
+    "any": _coerce_to_any,
 }
 
 
@@ -284,11 +275,10 @@ def coerce_workflow_input(
     if declared_type is None:
         return value
 
-    normalized_type = _normalize_type(declared_type)
     log_context: dict[str, Any] = {"input": input_name} if input_name else {}
 
     # Use dispatch table for coercion
-    coercer = _COERCION_DISPATCH.get(normalized_type)
+    coercer = _COERCION_DISPATCH.get(declared_type)
     if coercer:
         return coercer(value, log_context)
 

--- a/src/pflow/core/types.py
+++ b/src/pflow/core/types.py
@@ -1,0 +1,211 @@
+"""Canonical workflow input/output type vocabulary for authored workflows.
+
+This module defines the Surface 1 (S1) type system for workflow-authored
+``## Inputs`` / ``## Outputs`` declarations. It intentionally differs from the
+Python annotation vocabulary used inside code blocks and node Interface
+docstrings.
+
+The Claude Code node's ``output_schema`` is a deliberate fourth surface that
+continues to use Python-aliased names (``str``, ``int``, ``bool``, ``list``,
+``dict``). Those names are embedded literally into LLM prompt construction by
+``nodes/claude/claude_code.py::_build_schema_prompt`` — migrating them would
+change the LLM's instruction wording. Not in scope for the S1 vocabulary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Final, NoReturn
+
+from pflow.core.suggestion_utils import find_similar_items
+
+CANONICAL_TYPES: Final[tuple[str, ...]] = (
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "array",
+    "object",
+    "any",
+)
+
+PYTHON_ALIASES_AT_S1: Final[dict[str, str]] = {
+    "str": "string",
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+    "dict": "object",
+    "list": "array",
+}
+
+
+@dataclass
+class TypeVocabularyError(ValueError):
+    """Raised when an authored workflow uses an invalid S1 type name."""
+
+    message: str
+    offending: str
+    similar_names: list[str] = field(default_factory=list)
+    available_fields: list[str] = field(default_factory=lambda: list(CANONICAL_TYPES))
+    available_fields_label: str = "types"
+    suggestions_list: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True)
+class TypeSpec:
+    """Canonical representation of a workflow-authored S1 type.
+
+    ``accepts()`` follows strict JSON-Schema-style semantics for future callers:
+    ``integer`` rejects ``True`` even though Python treats ``bool`` as an
+    ``int`` subclass. This intentionally differs from the Python-side code-node
+    annotation semantics.
+    """
+
+    name: str
+
+    def __post_init__(self) -> None:
+        if self.name not in CANONICAL_TYPES:
+            raise ValueError(f"TypeSpec.name must be in {CANONICAL_TYPES}, got {self.name!r}")
+
+    @classmethod
+    def parse(cls, raw: str) -> TypeSpec:
+        """Parse an authored workflow type string into a canonical TypeSpec."""
+        if not isinstance(raw, str):
+            raise TypeVocabularyError("Type must be a non-empty string", offending=repr(raw))
+
+        stripped = raw.strip()
+        if not stripped:
+            raise TypeVocabularyError("Type must be a non-empty string", offending=raw)
+
+        if "[" in stripped:
+            _raise_parameterized_generic_error(raw, stripped)
+
+        if any(char.isspace() for char in stripped):
+            raise TypeVocabularyError(
+                "Whitespace not allowed inside type names.",
+                offending=raw,
+            )
+
+        if stripped in CANONICAL_TYPES:
+            return cls(stripped)
+
+        if stripped in PYTHON_ALIASES_AT_S1:
+            _raise_alias_error(raw, stripped)
+
+        if stripped == "null":
+            raise TypeVocabularyError(
+                "Use 'any' if the value may be None — it accepts null alongside other values. "
+                "(Nullable-only types require union syntax, which pflow does not yet support.)",
+                offending=raw,
+                suggestions_list=["Use 'any' if the value may be None"],
+            )
+
+        _raise_unknown_type_error(raw, stripped)
+
+    def accepts(self, value: Any) -> bool:
+        """Return whether a Python value satisfies this type."""
+        if self.name == "any":
+            return True
+        if self.name == "string":
+            return isinstance(value, str)
+        if self.name == "integer":
+            return isinstance(value, int) and not isinstance(value, bool)
+        if self.name == "number":
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        if self.name == "boolean":
+            return isinstance(value, bool)
+        if self.name == "array":
+            return isinstance(value, list)
+        if self.name == "object":
+            return isinstance(value, dict)
+        return False
+
+    def is_wildcard(self) -> bool:
+        """Return True only for the explicit wildcard type."""
+        return self.name == "any"
+
+    def to_json_schema(self) -> dict[str, str]:
+        """Return a minimal JSON Schema representation for this type."""
+        if self.name == "any":
+            return {}
+        return {"type": self.name}
+
+    def __str__(self) -> str:
+        return self.name
+
+
+def _raise_parameterized_generic_error(raw: str, stripped: str) -> NoReturn:
+    """Raise the canonical error for unsupported parameterized generics."""
+    base = stripped.split("[", 1)[0].strip()
+    if base in PYTHON_ALIASES_AT_S1:
+        canonical = PYTHON_ALIASES_AT_S1[base]
+        suggestion = (
+            f"Use '{canonical}' — parameterized generics not supported at `## Inputs` / `## Outputs` (got {raw!r})"
+        )
+    elif base in CANONICAL_TYPES:
+        suggestion = f"Use '{base}' — parameterized generics not supported at `## Inputs` / `## Outputs` (got {raw!r})"
+    else:
+        suggestion = (
+            f"Use the base type — parameterized generics not supported at `## Inputs` / `## Outputs` (got {raw!r})"
+        )
+
+    raise TypeVocabularyError(
+        f"Parameterized generics not supported in `## Inputs` / `## Outputs`. Got: {raw!r}. {suggestion}.",
+        offending=raw,
+        suggestions_list=[suggestion],
+    )
+
+
+def _raise_alias_error(raw: str, stripped: str) -> NoReturn:
+    """Raise the canonical error for deprecated Python aliases at S1.
+
+    Alias errors carry the canonical replacement via ``suggestions_list`` — the
+    "known fix" channel. ``similar_names`` is reserved for genuinely uncertain
+    typo cases (fuzzy match on unknown names) where "Did you mean" framing fits.
+    """
+    canonical = PYTHON_ALIASES_AT_S1[stripped]
+    if stripped == "dict":
+        raise TypeVocabularyError(
+            "Use 'object' instead of 'dict'. Use 'any' if the value can be any type.",
+            offending=raw,
+            suggestions_list=[
+                "Use 'object' if the value is a dict: - type: object",
+                "Use 'any' if the value can be any type: - type: any",
+            ],
+        )
+
+    suggestion = f"Use '{canonical}' instead of '{stripped}'"
+    raise TypeVocabularyError(
+        suggestion,
+        offending=raw,
+        suggestions_list=[suggestion],
+    )
+
+
+def _raise_unknown_type_error(raw: str, stripped: str) -> NoReturn:
+    """Raise the canonical error for unknown S1 types."""
+    similar_names = find_similar_items(
+        stripped,
+        list(CANONICAL_TYPES),
+        method="fuzzy",
+        cutoff=0.6,
+        max_results=1,
+    )
+    if similar_names:
+        closest = similar_names[0]
+        raise TypeVocabularyError(
+            f"Unknown type '{stripped}'. Did you mean '{closest}'? Valid types: {', '.join(CANONICAL_TYPES)}",
+            offending=raw,
+            similar_names=similar_names,
+        )
+
+    raise TypeVocabularyError(
+        f"Unknown type '{stripped}'. Valid types: {', '.join(CANONICAL_TYPES)}",
+        offending=raw,
+    )

--- a/src/pflow/core/workflow/CLAUDE.md
+++ b/src/pflow/core/workflow/CLAUDE.md
@@ -10,7 +10,7 @@ core/workflow/
 ├── manager.py               # WorkflowManager: save/load/list/delete workflows (folder-based)
 ├── save_service.py          # Shared save operations for CLI + MCP (with dependency bundling)
 ├── dependency_discovery.py  # Recursive file dependency scanner for bundling
-├── sub_workflow_resolver.py # Shared sub-workflow resolution (inline IR, file, saved name)
+├── sub_workflow_resolver.py # Shared sub-workflow resolution (file path or saved name)
 ├── validator.py             # Unified 10-step validation orchestrator
 ├── data_flow.py             # Execution order (topological sort) and dependency validation
 ├── mermaid/                 # Mermaid flowchart generation from workflow IR

--- a/src/pflow/guide/core.md
+++ b/src/pflow/guide/core.md
@@ -297,7 +297,7 @@ What this output contains.
 - source: ${final_node.output}
 `````
 
-**Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false — only one input can have this), description as prose.
+**Input fields**: `type` (string|number|integer|boolean|array|object|any), `required` (true|false), `default` (only when required: false), `stdin` (true|false — only one input can have this), description as prose.
 
 **Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false — at most one output may set this; marks the output that streams to stdout in text mode), description as prose.
 
@@ -615,6 +615,22 @@ The prompt file uses `${concept_brief}` and `${creative_direction}` — resolved
 
 ### Parameter Types - Complete Guide
 
+### Type Vocabulary - Two Surfaces
+
+Workflow `## Inputs` / `## Outputs` use canonical JSON-Schema-style names. Python code blocks use Python annotations. Same meaning, different spelling.
+
+| Workflow `type:` | Python annotation | Notes |
+|---|---|---|
+| `string` | `str` | |
+| `integer` | `int` | Rejects floats |
+| `number` | `int \| float` or `float` | |
+| `boolean` | `bool` | |
+| `array` | `list` | |
+| `object` | `dict` | Dict only, not wildcard |
+| `any` | `Any` | `Any` is auto-injected in code blocks |
+
+Code blocks follow modern Python syntax — use lowercase generics (`list[T]`, `dict[K, V]`) and pipe unions (`int | str`), not `List[T]` / `Union[A, B]`. See `pflow guide code` for the full type annotation syntax table.
+
 ```markdown
 ## Inputs
 
@@ -627,11 +643,19 @@ Any text value. String is the most common type.
 
 ### count
 
+Whole number only.
+
+- type: integer
+- required: false
+- default: 10
+
+### ratio
+
 Numeric value — integers or floats.
 
 - type: number
 - required: false
-- default: 10
+- default: 0.5
 
 ### verbose
 
@@ -651,11 +675,18 @@ List of tags. Array input.
 
 ### config
 
-Configuration object. Complex structure.
+Configuration object. Must be a dict.
 
 - type: object
 - required: false
 - default: {"key": "value"}
+
+### payload
+
+Explicit wildcard. Use when the value can be any shape, including `null`.
+
+- type: any
+- required: false
 
 ### data
 
@@ -774,4 +805,3 @@ Format: `verb-noun-qualifier`
 - Examples: `fetch-api-data`, `process-csv-files`, `analyze-slack-messages`
 - Max 30 chars, lowercase, hyphens only
 - Specific enough to find, generic enough to reuse
-

--- a/src/pflow/guide/features/sub-workflows.md
+++ b/src/pflow/guide/features/sub-workflows.md
@@ -4,7 +4,7 @@
 
 - Child inputs are passed via the top-level `inputs:` dict on the workflow node
 - Child workflow must declare `## Inputs` (for required params) and `## Outputs` (for exposed results)
-- `workflow:` accepts a file path (`./child.pflow.md`) or a saved workflow name (`my-saved-workflow`)
+- `workflow:` accepts a file path (`./child.pflow.md`), a saved workflow name (`my-saved-workflow`), or a template that resolves to one at runtime (see Dynamic Child Selection below)
 - Nesting depth limited to 10 levels (configurable via `max_depth` param)
 - Parent→child boundary is strict — every key in `inputs:` must be declared on the child's `## Inputs`; typos are rejected at parse time
 
@@ -72,6 +72,39 @@ Combine the processed title and body into a single output.
 - type: shell
 - command: printf "Title: %s\nBody: %s" "${process_title.result}" "${process_body.result}"
 ````
+
+### Dynamic Child Selection (Template References)
+
+`workflow:` can be a template (`${var}`) that resolves at runtime — from CLI input, an upstream node's output, or a batch item field. The child is loaded and validated when the parent node executes, not at parent-parse time.
+
+**Use when**: the same parent node needs to dispatch to different children per batch item or per run.
+
+**Example** — fan out over three review aspects, each specifying which child workflow to run:
+
+`````markdown
+### reviews
+
+Review the combined analysis from three critical perspectives. Each batch item picks which child workflow to run.
+
+- type: workflow
+- workflow: ${item.workflow}
+- inputs:
+    summary: ${combine.result}
+    aspect: ${item.aspect}
+
+```yaml batch
+items:
+  - aspect: accuracy
+    workflow: ./review-aspect.pflow.md
+  - aspect: completeness
+    workflow: ./review-aspect.pflow.md
+  - aspect: clarity
+    workflow: ./review-aspect.pflow.md
+parallel: true
+```
+`````
+
+**Trade-off**: invalid children surface as runtime compile errors, not at `--validate-only`. Prefer the static-path form when the child is known at authoring time; reserve the template form for genuine runtime dispatch.
 
 ### Pattern: Heterogeneous Batch over Sub-Workflows
 

--- a/src/pflow/guide/nodes/code.md
+++ b/src/pflow/guide/nodes/code.md
@@ -60,7 +60,29 @@ result: dict = {
 - Templates go in `- inputs:` param, NEVER in the `python code` block (code is literal Python, not a template)
 - All inputs and `result` MUST have type annotations: `data: list`, `result: dict = ...`
 - Upstream JSON is auto-parsed before your code runs — if source is JSON, declare `dict`/`list` not `str`
-- Use `object` as type when you don't know the type (skips validation)
+- Use `Any` as the type when you don't want type validation (see syntax table below — auto-injected, no import needed)
 - Single output via `result` variable — use dict for structured output
 - Downstream access: `${node.result}` or `${node.result.field}` for dict results
 
+### Type annotation syntax
+
+Type annotations in code blocks are Python. pflow follows modern Python style (PEP 585 + PEP 604):
+
+| For... | Write | Example |
+|---|---|---|
+| Any type (wildcard) | `Any` | `x: Any` |
+| Built-in scalars | `str`, `int`, `float`, `bool`, `bytes` | `x: str` |
+| List | `list[T]` | `x: list[str]` |
+| Dict | `dict[K, V]` | `x: dict[str, int]` |
+| Tuple | `tuple[T, ...]` | `x: tuple[int, str]` |
+| Set | `set[T]` | `x: set[str]` |
+| Union | `A \| B` (pipe syntax) | `x: int \| str` |
+| Optional | `Optional[T]` or `T \| None` | `x: str \| None` |
+
+**Auto-injected** (no import needed): `Any`, `Optional`, and the `typing` module.
+
+**Requires** `from typing import X` at the top of your code block: `Literal`, `TypeVar`, `Callable`, `Final`, `ClassVar`, `Iterable`, `Iterator`, `Sequence`, `Mapping`.
+
+**Not allowed**: `List[T]`, `Dict[K, V]`, `Union[A, B]`, and other uppercase typing-module generics — use the modern lowercase / pipe forms above. pflow's NameError suggestions point at the canonical replacement.
+
+Only the outer type is enforced at prep time (e.g. `list[dict]` checks `isinstance(x, list)` but not element types).

--- a/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
@@ -833,7 +833,7 @@ metadata:
 - Templates go in `- inputs:` param, NEVER in the `python code` block (code is literal Python, not a template)
 - All inputs and `result` MUST have type annotations: `data: list`, `result: dict = ...`
 - Upstream JSON is auto-parsed before your code runs — if source is JSON, declare `dict`/`list` not `str`
-- Use `object` as type when you don't know the type (skips validation)
+- Type annotations follow modern Python (PEP 585 + PEP 604): lowercase generics (`list[T]`, `dict[K, V]`), pipe unions (`A | B`). `Any`, `Optional`, and the `typing` module are auto-injected; other typing names require `from typing import X`. Do NOT use `List[T]` / `Union[A, B]` — pflow rejects them with a canonical-replacement hint.
 - Single output via `result` variable — use dict for structured output
 - Downstream access: `${node.result}` or `${node.result.field}` for dict results
 
@@ -1003,7 +1003,7 @@ What this output contains.
 - source: ${final_node.output}
 `````
 
-**Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false -- only one input can have this), description as prose.
+**Input fields**: `type` (string|number|integer|boolean|array|object|any), `required` (true|false), `default` (only when required: false), `stdin` (true|false -- only one input can have this), description as prose.
 
 **Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false -- at most one output may set this; marks the output that streams to stdout in text mode). Single-output workflows don't need a marker. Multi-output workflows without a marker stream the first declared output and emit a stderr warning.
 
@@ -1263,6 +1263,22 @@ cat ~/.pflow/reports/my-workflow/01-fetch.md
 
 ### Parameter Types - Complete Guide
 
+### Type Vocabulary - Two Surfaces
+
+Workflow `## Inputs` / `## Outputs` use canonical JSON-Schema-style names. Python code blocks use Python annotations. Same meaning, different spelling.
+
+| Workflow `type:` | Python annotation | Notes |
+|---|---|---|
+| `string` | `str` | |
+| `integer` | `int` | Rejects floats |
+| `number` | `int \| float` or `float` | |
+| `boolean` | `bool` | |
+| `array` | `list` | |
+| `object` | `dict` | Dict only, not wildcard |
+| `any` | `Any` | `Any` is auto-injected in code blocks |
+
+Code blocks follow modern Python syntax — use lowercase generics (`list[T]`, `dict[K, V]`) and pipe unions (`int | str`), not `List[T]` / `Union[A, B]`. See `pflow guide code` for the full type annotation syntax table.
+
 ```markdown
 ## Inputs
 
@@ -1275,11 +1291,19 @@ Any text value. String is the most common type.
 
 ### count
 
+Whole number only.
+
+- type: integer
+- required: false
+- default: 10
+
+### ratio
+
 Numeric value — integers or floats.
 
 - type: number
 - required: false
-- default: 10
+- default: 0.5
 
 ### verbose
 
@@ -1299,11 +1323,18 @@ List of tags. Array input.
 
 ### config
 
-Configuration object. Complex structure.
+Configuration object. Must be a dict.
 
 - type: object
 - required: false
 - default: {"key": "value"}
+
+### payload
+
+Explicit wildcard. Use when the value can be any shape, including `null`.
+
+- type: any
+- required: false
 
 ### data
 

--- a/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
@@ -819,7 +819,7 @@ metadata:
 - Templates go in `- inputs:` param, NEVER in the `python code` block (code is literal Python, not a template)
 - All inputs and `result` MUST have type annotations: `data: list`, `result: dict = ...`
 - Upstream JSON is auto-parsed before your code runs — if source is JSON, declare `dict`/`list` not `str`
-- Use `object` as type when you don't know the type (skips validation)
+- Type annotations follow modern Python (PEP 585 + PEP 604): lowercase generics (`list[T]`, `dict[K, V]`), pipe unions (`A | B`). `Any`, `Optional`, and the `typing` module are auto-injected; other typing names require `from typing import X`. Do NOT use `List[T]` / `Union[A, B]` — pflow rejects them with a canonical-replacement hint.
 - Single output via `result` variable — use dict for structured output
 - Downstream access: `${node.result}` or `${node.result.field}` for dict results
 
@@ -985,7 +985,7 @@ What this output contains.
 - source: ${final_node.output}
 `````
 
-**Input fields**: `type` (string|number|boolean|array|object), `required` (true|false), `default` (only when required: false), `stdin` (true|false -- only one input can have this), description as prose.
+**Input fields**: `type` (string|number|integer|boolean|array|object|any), `required` (true|false), `default` (only when required: false), `stdin` (true|false -- only one input can have this), description as prose.
 
 **Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false -- at most one output may set this; marks the output that streams to stdout in text mode). Single-output workflows don't need a marker. Multi-output workflows without a marker stream the first declared output and emit a stderr warning.
 
@@ -1245,6 +1245,22 @@ registry_run(
 
 ### Parameter Types - Complete Guide
 
+### Type Vocabulary - Two Surfaces
+
+Workflow `## Inputs` / `## Outputs` use canonical JSON-Schema-style names. Python code blocks use Python annotations. Same meaning, different spelling.
+
+| Workflow `type:` | Python annotation | Notes |
+|---|---|---|
+| `string` | `str` | |
+| `integer` | `int` | Rejects floats |
+| `number` | `int \| float` or `float` | |
+| `boolean` | `bool` | |
+| `array` | `list` | |
+| `object` | `dict` | Dict only, not wildcard |
+| `any` | `Any` | `Any` is auto-injected in code blocks |
+
+Code blocks follow modern Python syntax — use lowercase generics (`list[T]`, `dict[K, V]`) and pipe unions (`int | str`), not `List[T]` / `Union[A, B]`. See `pflow guide code` for the full type annotation syntax table.
+
 ```markdown
 ## Inputs
 
@@ -1257,11 +1273,19 @@ Any text value. String is the most common type.
 
 ### count
 
+Whole number only.
+
+- type: integer
+- required: false
+- default: 10
+
+### ratio
+
 Numeric value — integers or floats.
 
 - type: number
 - required: false
-- default: 10
+- default: 0.5
 
 ### verbose
 
@@ -1281,11 +1305,18 @@ List of tags. Array input.
 
 ### config
 
-Configuration object. Complex structure.
+Configuration object. Must be a dict.
 
 - type: object
 - required: false
 - default: {"key": "value"}
+
+### payload
+
+Explicit wildcard. Use when the value can be any shape, including `null`.
+
+- type: any
+- required: false
 
 ### data
 

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -35,6 +35,7 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Optional
 
 from pflow.core.node import Node
+from pflow.nodes.file.exceptions import NonRetriableError
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,134 @@ def _get_outer_type(type_str: str) -> type | tuple[type, ...] | None:
 
     base = type_str.split("[")[0].strip()
     return _TYPE_MAP.get(base)
+
+
+# Typing-module names that have a modern lowercase built-in generic (PEP 585).
+# pflow prefers these over the typing-module spellings.
+_MODERN_GENERIC_NAMES = frozenset({"List", "Dict", "Tuple", "Set", "FrozenSet", "Type"})
+
+# Typing-module names that genuinely require explicit import (no modern built-in replacement).
+_REQUIRES_TYPING_IMPORT = frozenset({
+    "Literal",
+    "TypeVar",
+    "Callable",
+    "Final",
+    "ClassVar",
+    "Iterable",
+    "Iterator",
+    "Sequence",
+    "Mapping",
+})
+
+# Union of the three typing-name families pflow proactively rejects inside
+# annotations. Rejecting at AST-walk time (prep) keeps the opinionated guidance
+# reachable across Python versions: PEP 649 (3.14+) defers annotation evaluation,
+# so the NameError fallback in `_format_exec_error` never fires for code like
+# `x: Union[int, str] = 1`. Typing names used as *values* (`x = Union[int, str]`)
+# still hit the NameError path — eager evaluation there is unchanged.
+_REJECTED_ANNOTATION_NAMES = _MODERN_GENERIC_NAMES | {"Union"} | _REQUIRES_TYPING_IMPORT
+
+
+def _suggest_for_nameerror(var_name: str) -> str:
+    """Return an opinionated, canonical fix suggestion for a NameError.
+
+    pflow auto-injects `Any`, `Optional`, and the `typing` module — other
+    typing names produce a NameError. Rather than listing multiple options,
+    this emits ONE canonical fix per case, preferring modern Python (PEP 585
+    lowercase generics, PEP 604 pipe unions) over typing-module spellings.
+    """
+    if var_name in _MODERN_GENERIC_NAMES:
+        lower = var_name.lower()
+        return (
+            f"  - Use '{lower}[...]' instead — Python 3.9+ supports lowercase built-in generics (PEP 585).\n"
+            f"    Example: 'x: {lower}[str]' instead of 'x: {var_name}[str]'."
+        )
+    if var_name == "Union":
+        return (
+            "  - Use pipe syntax instead: 'A | B' (PEP 604, Python 3.10+).\n"
+            "    Example: 'x: int | str' instead of 'x: Union[int, str]'."
+        )
+    if var_name in _REQUIRES_TYPING_IMPORT:
+        return (
+            f"  - Add 'from typing import {var_name}' at the top of your code block.\n"
+            "    (pflow auto-injects 'Any' and 'Optional' — other typing names need explicit import.)"
+        )
+    # Not a known typing name — fall back to the input-variable suggestions.
+    return (
+        f'  - Add \'{var_name}\' to the inputs dict: "inputs": {{"{var_name}": ...}}\n'
+        f"  - Or define '{var_name}' in the code before use\n"
+        "  - Check for typos in variable names"
+    )
+
+
+def _extract_imported_names(code: str) -> frozenset[str]:
+    """Return names bound by top-level ``import`` / ``from ... import`` statements.
+
+    Used by ``_check_annotation_vocabulary`` to avoid rejecting typing names that
+    the user imported explicitly (e.g., ``from typing import Literal``).
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return frozenset()
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                imported.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.asname or alias.name.split(".")[0])
+    return frozenset(imported)
+
+
+def _check_annotation_vocabulary(code: str, annotations: dict[str, str]) -> None:
+    """Reject lowercase ``any`` and forgotten typing-module imports in annotations.
+
+    Walks each annotation as an AST so nested occurrences
+    (``list[any]``, ``dict[str, any]``, ``int | any``) are caught — not just the
+    outermost token. String literals like ``Literal['any']`` stay as
+    ``ast.Constant`` and are correctly ignored.
+
+    Rejects ``Union`` / ``List`` / ``Literal`` etc. eagerly (at prep) when they
+    aren't imported, because PEP 649 (Python 3.14+) defers annotation evaluation
+    — the NameError fallback in ``_format_exec_error`` only catches these names
+    when used as *values*, not annotations. Users who explicitly
+    ``from typing import X`` are left alone; the nudge targets forgotten imports.
+    """
+    imported = _extract_imported_names(code)
+    for var_name, annotation in annotations.items():
+        try:
+            tree = ast.parse(annotation, mode="eval")
+        except SyntaxError:
+            # Malformed annotations surface via the existing NameError path at exec time.
+            continue
+        # Unwrap string forward-reference annotations (`x: "list[any]"`) so the
+        # inner type is walked, not treated as an opaque ast.Constant. Without this
+        # the outer string hides nested violations — which PEP 649 (3.14+) leaves
+        # uncaught at runtime too, since the annotation is never evaluated.
+        if isinstance(tree.body, ast.Constant) and isinstance(tree.body.value, str):
+            try:
+                tree = ast.parse(tree.body.value, mode="eval")
+            except SyntaxError:
+                continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Name):
+                continue
+            if node.id == "any":
+                raise NonRetriableError(
+                    f"Invalid type annotation for '{var_name}': 'any' (lowercase).\n\n"
+                    "Use 'Any' (capitalized) in Python code blocks. "
+                    "pflow auto-injects `typing.Any` — no import needed.\n"
+                    f"  {var_name}: Any\n\n"
+                    "Note: lowercase 'any' is the legal spelling in `## Inputs` / `## Outputs` "
+                    "sections (e.g., `- type: any`), but Python annotations must use 'Any' (capitalized)."
+                )
+            if node.id in _REJECTED_ANNOTATION_NAMES and node.id not in imported:
+                raise NonRetriableError(
+                    f"Invalid type annotation for '{var_name}': '{node.id}' is not defined.\n\n"
+                    f"{_suggest_for_nameerror(node.id)}"
+                )
 
 
 def extract_optional_input_keys(code: str, input_keys: set[str]) -> set[str]:
@@ -272,6 +401,7 @@ class PythonCodeNode(Node):
 
         # Detect type annotations accidentally written in YAML inputs (#148)
         self._check_input_annotation_syntax(inputs, annotations)
+        _check_annotation_vocabulary(code, annotations)
 
         # Validate result or next annotation exists
         has_result = "result" in annotations
@@ -322,6 +452,7 @@ class PythonCodeNode(Node):
         namespace: dict[str, Any] = {"__builtins__": __builtins__}
         namespace["typing"] = _typing_module
         namespace["Optional"] = _typing_module.Optional
+        namespace["Any"] = _typing_module.Any
         namespace.update(inputs)
 
         # Execute in thread with stdout/stderr capture.
@@ -594,7 +725,8 @@ class PythonCodeNode(Node):
                     f"Input '{var_name}' expects {type_str} but received {actual}\n\n"
                     f"Suggestions:\n"
                     f"  - Change the type annotation to: {var_name}: {actual}\n"
-                    f"  - Or convert the input value to {type_str}"
+                    f"  - Or convert the input value to {type_str}\n"
+                    f"  - Or use `Any` to accept any type: {var_name}: Any"
                 )
 
     @staticmethod
@@ -622,12 +754,8 @@ class PythonCodeNode(Node):
             msg = f"Undefined variable '{var_name}'"
             if location:
                 msg += f"\n{location}"
-            msg += (
-                f"\n\nSuggestions:\n"
-                f'  - Add \'{var_name}\' to the inputs dict: "inputs": {{"{var_name}": ...}}\n'
-                f"  - Or define '{var_name}' in the code before use\n"
-                f"  - Check for typos in variable names"
-            )
+            suggestion = _suggest_for_nameerror(var_name)
+            msg += f"\n\nSuggestions:\n{suggestion}"
             return msg
         if isinstance(exc, ImportError):
             module = getattr(exc, "name", str(exc))

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import Any, ClassVar, Optional
 
 from pflow.core.diagnostic import Diagnostic, format_child_provenance
+from pflow.core.exceptions import PflowError
 from pflow.core.file_resolver import is_workflow_file_reference
+from pflow.core.ir_schema import normalize_ir, validate_ir
 from pflow.core.node import BaseNode
 from pflow.registry import Registry
 from pflow.runtime import CompilationError, compile_workflow
@@ -194,11 +196,36 @@ class WorkflowExecutor(BaseNode):
         if registry is not None and not isinstance(registry, Registry):
             registry = None
 
+        compiled = self._validate_and_compile_child(workflow_ir, workflow_path, registry, child_params, cacheable)
+        if cacheable:
+            cache[workflow_path] = compiled
+        return compiled
+
+    @staticmethod
+    def _validate_and_compile_child(
+        workflow_ir: dict[str, Any],
+        workflow_path: str,
+        registry: Optional[Registry],
+        child_params: dict[str, Any],
+        cacheable: bool,
+    ) -> Any:
+        """Validate the child IR and compile it, wrapping errors with sub-workflow path.
+
+        Template-referenced children (``workflow: ${var}``) skip parent-time
+        ``validate_ir`` because the resolver returns None for ``${...}``. Running it
+        here closes the bypass so every path to ``compile_workflow`` goes through
+        schema validation — keeping S1 vocabulary enforcement uniform.
+        ``normalize_ir`` mirrors the parent validator path (fills in
+        ``ir_version``/``edges`` often omitted by programmatic and
+        resolved-at-runtime IRs).
+        """
         try:
             params = dict(child_params)  # Copy — don't mutate caller's dict
             if cacheable:
                 params["_pflow_workflow_file"] = str(Path(workflow_path).resolve())
-            compiled = compile_workflow(
+            normalize_ir(workflow_ir)
+            validate_ir(workflow_ir)
+            return compile_workflow(
                 copy.deepcopy(workflow_ir),  # Protect against concurrent mutation in parallel batch
                 registry=registry or Registry(),
                 initial_params=params,
@@ -208,6 +235,18 @@ class WorkflowExecutor(BaseNode):
                 e.details = {}
             e.details["sub_workflow_path"] = str(workflow_path)
             raise
+        except PflowError as e:
+            # Self-describing errors (e.g. SchemaValidationError from validate_ir)
+            # already carry structured context — similar_names, available_fields,
+            # suggestions_list — consumed by the unified renderer. Pass their
+            # diagnostics through verbatim; CompilationError.to_diagnostics will
+            # merge sub_workflow_path into each diagnostic's context.
+            raise CompilationError(
+                f"Failed to compile sub-workflow at {workflow_path}: {e!s}",
+                phase="sub_workflow_compilation",
+                details={"sub_workflow_path": str(workflow_path)},
+                wrapped_diagnostics=e.to_diagnostics(),
+            ) from e
         except Exception as e:
             raise CompilationError(
                 f"Failed to compile sub-workflow at {workflow_path}: {e!s}",
@@ -215,10 +254,6 @@ class WorkflowExecutor(BaseNode):
                 details={"sub_workflow_path": str(workflow_path)},
                 suggestion=getattr(e, "suggestion", None),
             ) from e
-
-        if cacheable:
-            cache[workflow_path] = compiled
-        return compiled
 
     def exec(self, prep_res: dict[str, Any]) -> dict[str, Any]:
         """Compile and execute the sub-workflow."""

--- a/tests/test_cli/test_find.py
+++ b/tests/test_cli/test_find.py
@@ -18,8 +18,8 @@ def test_find_returns_matching_workflow() -> None:
             "description": "Analyzes GitHub pull requests",
             "version": "1.0.0",
             "ir": {
-                "inputs": {"repo": {"type": "str", "required": True, "description": "Repository name"}},
-                "outputs": {"analysis": {"type": "str", "description": "Analysis result"}},
+                "inputs": {"repo": {"type": "string", "required": True, "description": "Repository name"}},
+                "outputs": {"analysis": {"type": "string", "description": "Analysis result"}},
             },
         },
     )

--- a/tests/test_core/test_ir_schema.py
+++ b/tests/test_core/test_ir_schema.py
@@ -4,6 +4,7 @@ import pytest
 
 from pflow.core import FLOW_IR_SCHEMA, validate_ir
 from pflow.core.exceptions import SchemaValidationError
+from pflow.core.types import CANONICAL_TYPES
 
 
 class TestSchemaStructure:
@@ -367,11 +368,11 @@ class TestErrorMessages:
 
 
 class TestInputTypeAliases:
-    """Test that input type field accepts both JSON Schema and Python type names."""
+    """Test the canonical workflow input/output type vocabulary."""
 
     def test_json_schema_types_accepted(self):
-        """JSON Schema canonical types should be accepted."""
-        for type_name in ["string", "number", "boolean", "object", "array"]:
+        """Canonical types should be accepted for inputs."""
+        for type_name in CANONICAL_TYPES:
             ir = {
                 "ir_version": "0.1.0",
                 "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
@@ -379,13 +380,13 @@ class TestInputTypeAliases:
             }
             validate_ir(ir)  # Should not raise
 
-    def test_python_type_aliases_accepted(self):
-        """Python type aliases should be accepted for user convenience."""
-        for type_name in ["str", "int", "integer", "float", "bool", "dict", "list"]:
+    def test_output_types_accepted(self):
+        """Canonical types should be accepted for outputs."""
+        for type_name in CANONICAL_TYPES:
             ir = {
                 "ir_version": "0.1.0",
                 "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
-                "inputs": {"param": {"type": type_name, "required": True}},
+                "outputs": {"result": {"type": type_name, "source": "${n1.result}"}},
             }
             validate_ir(ir)  # Should not raise
 
@@ -399,6 +400,207 @@ class TestInputTypeAliases:
         with pytest.raises(SchemaValidationError) as exc_info:
             validate_ir(ir)
         assert "inputs.param.type" in exc_info.value.path
+        assert "Valid types" in exc_info.value.suggestion
+
+    @pytest.mark.parametrize(
+        ("raw", "canonical"),
+        [
+            ("str", "string"),
+            ("int", "integer"),
+            ("float", "number"),
+            ("bool", "boolean"),
+            ("list", "array"),
+        ],
+    )
+    def test_alias_rejected_with_fix_suggestion(self, raw: str, canonical: str):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": raw, "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.suggestion == f"Use '{canonical}' instead of '{raw}'"
+
+    def test_dict_alias_rejected_with_wildcard_hint(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "dict", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.suggestions_list == [
+            "Use 'object' if the value is a dict: - type: object",
+            "Use 'any' if the value can be any type: - type: any",
+        ]
+
+    def test_any_now_accepted(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "any", "required": True}},
+        }
+        validate_ir(ir)
+
+    def test_integer_now_accepted_and_bridges_to_int(self):
+        from pflow.registry import Registry
+        from pflow.runtime import WorkflowEngine, compile_workflow
+
+        ir = {
+            "ir_version": "0.1.0",
+            "edges": [],
+            "nodes": [
+                {
+                    "id": "compute",
+                    "type": "code",
+                    "purpose": "Increment the integer input",
+                    "params": {
+                        "inputs": {"value": "${value}"},
+                        "code": "value: int\nresult: int = value + 1",
+                    },
+                }
+            ],
+            "inputs": {"value": {"type": "integer", "required": True, "description": "Integer input"}},
+        }
+        validate_ir(ir)
+
+        workflow = compile_workflow(ir, registry=Registry(), initial_params={"value": 5})
+        shared = dict(workflow.resolved_defaults)
+        shared["value"] = 5
+        result = WorkflowEngine().run(workflow, shared)
+
+        assert result == "default"
+        assert shared["compute"]["result"] == 6
+
+    def test_null_still_rejected(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "null", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.suggestion.startswith("Use 'any'")
+
+    def test_null_as_python_none_rejected_with_same_suggestion(self):
+        # YAML `- type: null` parses to Python None, not the string "null".
+        # That path hits jsonschema's `type` validator (not `enum`), but must
+        # reach the same "Use 'any'" suggestion as the string-"null" path.
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": None, "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.suggestion.startswith("Use 'any'")
+        assert exc_info.value.suggestions_list == ["Use 'any' if the value may be None"]
+
+    def test_parameterized_generic_rejected_list(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "list[str]", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert "Use 'array'" in exc_info.value.suggestion
+
+    def test_parameterized_generic_rejected_dict(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "dict[str, int]", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert "Use 'object'" in exc_info.value.suggestion
+
+    def test_unknown_type_fuzzy_suggestion(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "strin", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.similar_names == ["string"]
+
+    def test_unknown_type_no_false_positive_fuzzy(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "pool", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.similar_names == []
+
+    def test_outputs_apply_same_rules(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "outputs": {"result": {"type": "str", "source": "${n1.result}"}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+        assert exc_info.value.suggestion == "Use 'string' instead of 'str'"
+
+    def test_json_output_contains_structured_context(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"param": {"type": "str", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+
+        diagnostic = exc_info.value.to_diagnostics()[0].to_dict()
+        # Alias errors use suggestions (known-fix channel), not similar_names.
+        assert diagnostic["context"].get("similar_names", []) == []
+        assert diagnostic["context"]["available_fields"] == list(CANONICAL_TYPES)
+        assert diagnostic["context"]["available_fields_label"] == "types"
+        assert diagnostic["suggestions"] == ["Use 'string' instead of 'str'"]
+
+    def test_full_render_pipeline_for_type_vocabulary_error(self):
+        """End-to-end regression guard through the full diagnostic pipeline:
+        ``validate_ir`` → ``SchemaValidationError`` → ``to_diagnostics`` →
+        ``format_diagnostic``.
+
+        Pins Task 154's central user-facing contract — the exact rendered text
+        an agent sees when writing ``- type: str`` in a workflow. Every layer
+        has its own unit test; this one pins the full chain.
+
+        Failure modes this catches:
+        - Renderer refactor drops ``suggestions_list`` preemption so the full
+          prose no longer reaches the rendered output.
+        - Suggestion wording lowercase regression (``Use`` → ``use``) breaking
+          the case-sensitive contract from poll P3.
+        - Available-fields truncation policy revert re-introducing the
+          "5 of 7 ... and 2 more" hostile UX for a 7-item closed set.
+        - Alias suggestion erroneously routed back through ``similar_names``
+          (which says "Did you mean" — the wrong framing for a known canonical).
+        """
+        from pflow.core.diagnostic_render import format_diagnostic
+
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "n1", "type": "test", "purpose": "Test node"}],
+            "inputs": {"x": {"type": "str", "required": True}},
+        }
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validate_ir(ir)
+
+        rendered = format_diagnostic(exc_info.value.to_diagnostics()[0])
+
+        assert "Use 'string' instead of 'str'" in rendered
+        assert "Available types (showing 7 of 7)" in rendered
+        for canonical_name in CANONICAL_TYPES:
+            assert f"- {canonical_name}" in rendered
+        # Alias errors use the directive "To fix this" / "→ Use ..." channel,
+        # not the "Did you mean" channel (reserved for genuine typos / fuzzy match).
+        assert "Did you mean" not in rendered
 
 
 class TestEdgeCases:

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -457,7 +457,7 @@ class TestEntityParsing:
 
             A message.
 
-            - type: str
+            - type: string
 
             ## Inputs
 
@@ -465,7 +465,7 @@ class TestEntityParsing:
 
             A name.
 
-            - type: str
+            - type: string
 
             ## Steps
 
@@ -2165,7 +2165,7 @@ echo step {i}
             ## Inputs
 
             message:
-              type: str
+              type: string
               description: A message
               required: true
 
@@ -2242,7 +2242,7 @@ echo step {i}
 
             A message.
 
-            - type: str
+            - type: string
 
             ## Steps
 
@@ -2272,14 +2272,14 @@ echo step {i}
 
             ```yaml
             message:
-              type: str
+              type: string
             ```
 
             ### actual-input
 
             A real input.
 
-            - type: str
+            - type: string
 
             ## Steps
 
@@ -2333,7 +2333,7 @@ echo step {i}
             ## Inputs
 
             message:
-              type: str
+              type: string
 
             ## Steps
 
@@ -2352,7 +2352,7 @@ echo step {i}
         err = exc_info.value
         assert err.suggestion is not None
         assert "### input-name" in err.suggestion
-        assert "- type: str" in err.suggestion
+        assert "- type: string" in err.suggestion
 
 
 # ===========================================================================

--- a/tests/test_core/test_output_source_validation.py
+++ b/tests/test_core/test_output_source_validation.py
@@ -100,7 +100,7 @@ class TestOutputSourceValidation:
             "ir_version": "0.1.0",
             "nodes": [{"id": "node1", "type": "shell", "params": {}}],
             "edges": [],
-            "inputs": {"data": {"type": "dict", "description": "A dict with a field"}},
+            "inputs": {"data": {"type": "object", "description": "A dict with a field"}},
             "outputs": {"result": {"source": "${data.field}"}},
         }
 
@@ -117,7 +117,7 @@ class TestOutputSourceValidation:
             "ir_version": "0.1.0",
             "nodes": [{"id": "node1", "type": "shell", "params": {}}],
             "edges": [],
-            "inputs": {"data": {"type": "dict", "description": "A dict"}},
+            "inputs": {"data": {"type": "object", "description": "A dict"}},
             "outputs": {"result": {"source": "data.field"}},
         }
 

--- a/tests/test_core/test_param_coercion.py
+++ b/tests/test_core/test_param_coercion.py
@@ -201,13 +201,6 @@ class TestInputCoercionIntToString:
 
         assert result is original  # Same object
 
-    def test_type_alias_str_works(self):
-        """Type alias 'str' should work like 'string'."""
-        result = coerce_workflow_input(42, "str")
-
-        assert isinstance(result, str)
-        assert result == "42"
-
 
 class TestInputCoercionStringToInt:
     """Test string → int coercion for workflow inputs."""
@@ -239,13 +232,6 @@ class TestInputCoercionStringToInt:
 
         assert result == "hello"  # Unchanged
 
-    def test_type_alias_int_works(self):
-        """Type alias 'int' should work like 'integer'."""
-        result = coerce_workflow_input("99", "int")
-
-        assert isinstance(result, int)
-        assert result == 99
-
 
 class TestInputCoercionStringToNumber:
     """Test string → float coercion for workflow inputs."""
@@ -263,13 +249,6 @@ class TestInputCoercionStringToNumber:
 
         assert isinstance(result, float)
         assert result == 42.0
-
-    def test_type_alias_float_works(self):
-        """Type alias 'float' should work like 'number'."""
-        result = coerce_workflow_input("2.718", "float")
-
-        assert isinstance(result, float)
-        assert result == 2.718
 
 
 class TestInputCoercionStringToBool:
@@ -297,12 +276,6 @@ class TestInputCoercionStringToBool:
         """Bool stays bool when already correct type."""
         assert coerce_workflow_input(True, "boolean") is True
         assert coerce_workflow_input(False, "boolean") is False
-
-    def test_type_alias_bool_works(self):
-        """Type alias 'bool' should work like 'boolean'."""
-        result = coerce_workflow_input("yes", "bool")
-
-        assert result is True
 
 
 class TestInputCoercionStringToObject:
@@ -341,12 +314,6 @@ class TestInputCoercionStringToObject:
 
         assert result is original
 
-    def test_type_alias_dict_works(self):
-        """Type alias 'dict' should work like 'object'."""
-        result = coerce_workflow_input('{"a": 1}', "dict")
-
-        assert isinstance(result, dict)
-
 
 class TestInputCoercionStringToArray:
     """Test string → list coercion for workflow inputs."""
@@ -378,12 +345,6 @@ class TestInputCoercionStringToArray:
         result = coerce_workflow_input(original, "array")
 
         assert result is original
-
-    def test_type_alias_list_works(self):
-        """Type alias 'list' should work like 'array'."""
-        result = coerce_workflow_input("[4, 5]", "list")
-
-        assert isinstance(result, list)
 
 
 class TestInputCoercionNoType:
@@ -424,3 +385,32 @@ class TestInputCoercionUnknownType:
         result = coerce_workflow_input(42, "")
 
         assert result == 42
+
+
+class TestAnyTypeCoercion:
+    def test_any_accepts_str_unchanged(self):
+        assert coerce_workflow_input("hello", "any") == "hello"
+
+    def test_any_accepts_int_unchanged(self):
+        assert coerce_workflow_input(42, "any") == 42
+
+    def test_any_accepts_float_unchanged(self):
+        assert coerce_workflow_input(3.14, "any") == 3.14
+
+    def test_any_accepts_bool_unchanged(self):
+        assert coerce_workflow_input(True, "any") is True
+
+    def test_any_accepts_dict_unchanged(self):
+        original = {"key": "value"}
+        assert coerce_workflow_input(original, "any") is original
+
+    def test_any_accepts_list_unchanged(self):
+        original = [1, 2, 3]
+        assert coerce_workflow_input(original, "any") is original
+
+    def test_any_accepts_none_unchanged(self):
+        assert coerce_workflow_input(None, "any") is None
+
+    def test_any_accepts_nested_complex(self):
+        original = {"items": [{"id": 1}, {"id": 2}], "meta": {"ok": True}}
+        assert coerce_workflow_input(original, "any") is original

--- a/tests/test_core/test_types.py
+++ b/tests/test_core/test_types.py
@@ -1,0 +1,192 @@
+"""Tests for the canonical workflow input/output type vocabulary."""
+
+import pytest
+
+from pflow.core.types import CANONICAL_TYPES, TypeSpec, TypeVocabularyError
+
+
+class TestTypeSpecParse:
+    def test_parse_legal_types(self) -> None:
+        for type_name in CANONICAL_TYPES:
+            parsed = TypeSpec.parse(type_name)
+            assert parsed == TypeSpec(type_name)
+            assert str(parsed) == type_name
+
+    @pytest.mark.parametrize(
+        ("raw", "canonical"),
+        [
+            ("str", "string"),
+            ("int", "integer"),
+            ("float", "number"),
+            ("bool", "boolean"),
+            ("list", "array"),
+        ],
+    )
+    def test_parse_rejects_python_aliases(self, raw: str, canonical: str) -> None:
+        with pytest.raises(TypeVocabularyError, match=f"Use '{canonical}' instead of '{raw}'"):
+            TypeSpec.parse(raw)
+
+    def test_parse_rejects_dict_with_wildcard_hint(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("dict")
+
+        message = str(exc_info.value)
+        assert "Use 'object' instead of 'dict'" in message
+        assert "Use 'any'" in message
+
+    def test_parse_rejects_parameterized_generics(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("list[str]")
+        assert "Parameterized generics not supported" in str(exc_info.value)
+        # suggestions_list entry must be self-contained — carries both the canonical
+        # replacement AND the 'generics not supported' reason, so JSON/CLI consumers
+        # get a full explanation in the single suggestion (not just the bare 'Use array').
+        assert len(exc_info.value.suggestions_list) == 1
+        assert "Use 'array'" in exc_info.value.suggestions_list[0]
+        assert "parameterized generics not supported" in exc_info.value.suggestions_list[0].lower()
+
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("dict[str, int]")
+        assert "Parameterized generics not supported" in str(exc_info.value)
+        assert "Use 'object'" in exc_info.value.suggestions_list[0]
+        assert "parameterized generics not supported" in exc_info.value.suggestions_list[0].lower()
+
+    def test_parse_rejects_null(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("null")
+        assert "Use 'any'" in str(exc_info.value)
+        assert "union syntax" in str(exc_info.value).lower()
+        # Parity with alias errors: null rejection must carry a pasteable suggestion
+        # in suggestions_list so JSON/MCP consumers get the same structured shape.
+        assert exc_info.value.suggestions_list == ["Use 'any' if the value may be None"]
+
+    def test_parse_rejects_unknown_with_fuzzy_suggestion(self) -> None:
+        with pytest.raises(TypeVocabularyError, match="Did you mean 'string'"):
+            TypeSpec.parse("strin")
+
+    def test_parse_rejects_unknown_no_fuzzy_match(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("zzz")
+        assert "Valid types:" in str(exc_info.value)
+        assert "Did you mean" not in str(exc_info.value)
+
+    def test_parse_rejects_uppercase(self) -> None:
+        with pytest.raises(TypeVocabularyError):
+            TypeSpec.parse("String")
+
+    def test_parse_strips_whitespace(self) -> None:
+        assert TypeSpec.parse("  object  ") == TypeSpec("object")
+
+
+class TestTypeSpecAccepts:
+    def test_string_accepts_str_only(self) -> None:
+        spec = TypeSpec("string")
+        assert spec.accepts("x") is True
+        assert spec.accepts(1) is False
+        assert spec.accepts({}) is False
+        assert spec.accepts(None) is False
+
+    def test_integer_accepts_int_rejects_bool(self) -> None:
+        spec = TypeSpec("integer")
+        assert spec.accepts(5) is True
+        assert spec.accepts(5.5) is False
+        assert spec.accepts(True) is False
+
+    def test_number_accepts_int_and_float_rejects_bool(self) -> None:
+        spec = TypeSpec("number")
+        assert spec.accepts(5) is True
+        assert spec.accepts(5.5) is True
+        assert spec.accepts(True) is False
+
+    def test_boolean_accepts_bool_only(self) -> None:
+        spec = TypeSpec("boolean")
+        assert spec.accepts(True) is True
+        assert spec.accepts(1) is False
+
+    def test_object_accepts_dict_only(self) -> None:
+        spec = TypeSpec("object")
+        assert spec.accepts({}) is True
+        assert spec.accepts([]) is False
+        assert spec.accepts("x") is False
+        assert spec.accepts(1) is False
+
+    def test_array_accepts_list_only(self) -> None:
+        spec = TypeSpec("array")
+        assert spec.accepts([]) is True
+        assert spec.accepts({}) is False
+        assert spec.accepts("x") is False
+
+    def test_any_accepts_everything(self) -> None:
+        spec = TypeSpec("any")
+        for value in ({}, [], "x", 1, True, 1.5, None):
+            assert spec.accepts(value) is True
+
+
+class TestTypeSpecIsWildcard:
+    def test_any_is_wildcard(self) -> None:
+        assert TypeSpec("any").is_wildcard() is True
+
+    def test_others_are_not_wildcard(self) -> None:
+        for type_name in CANONICAL_TYPES:
+            if type_name == "any":
+                continue
+            assert TypeSpec(type_name).is_wildcard() is False
+
+
+class TestTypeSpecToJsonSchema:
+    def test_simple_types(self) -> None:
+        assert TypeSpec("string").to_json_schema() == {"type": "string"}
+
+    def test_any_returns_empty_dict(self) -> None:
+        assert TypeSpec("any").to_json_schema() == {}
+
+
+class TestTypeSpecRoundtrip:
+    def test_str_roundtrip(self) -> None:
+        for type_name in CANONICAL_TYPES:
+            assert str(TypeSpec.parse(type_name)) == type_name
+
+    def test_equality_and_hash(self) -> None:
+        left = TypeSpec.parse("object")
+        right = TypeSpec.parse("object")
+        assert left == right
+        assert {left: "ok"}[right] == "ok"
+
+
+class TestTypeVocabularyErrorFields:
+    def test_structured_fields_on_alias_error(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("str")
+
+        error = exc_info.value
+        assert error.offending == "str"
+        # Alias errors carry the canonical via suggestions_list (known-fix channel),
+        # not similar_names (reserved for typo / "Did you mean" cases).
+        assert error.similar_names == []
+        assert error.available_fields == list(CANONICAL_TYPES)
+        assert error.available_fields_label == "types"
+        assert error.suggestions_list == ["Use 'string' instead of 'str'"]
+
+    def test_structured_fields_on_dict_alias_includes_two_suggestions(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("dict")
+
+        assert exc_info.value.suggestions_list == [
+            "Use 'object' if the value is a dict: - type: object",
+            "Use 'any' if the value can be any type: - type: any",
+        ]
+
+    def test_structured_fields_on_fuzzy_match(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("strin")
+        assert exc_info.value.similar_names == ["string"]
+
+    def test_structured_fields_on_unknown(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("foobar")
+        assert exc_info.value.similar_names == []
+
+    def test_case_sensitive_use_capital_u(self) -> None:
+        with pytest.raises(TypeVocabularyError) as exc_info:
+            TypeSpec.parse("str")
+        assert "Use '" in str(exc_info.value)

--- a/tests/test_core/test_workflow_manager.py
+++ b/tests/test_core/test_workflow_manager.py
@@ -30,8 +30,8 @@ def sample_ir():
     """Sample workflow IR for testing."""
     return {
         "ir_version": "0.1.0",
-        "inputs": {"text": {"type": "str", "description": "Input text"}},
-        "outputs": {"result": {"type": "str", "description": "Processed result"}},
+        "inputs": {"text": {"type": "string", "description": "Input text"}},
+        "outputs": {"result": {"type": "string", "description": "Processed result"}},
         "nodes": [{"id": "node1", "type": "shell", "config": {"message": "Hello"}}],
         "edges": [],
     }

--- a/tests/test_core/test_workflow_validator_outputs.py
+++ b/tests/test_core/test_workflow_validator_outputs.py
@@ -151,7 +151,7 @@ class TestOutputTemplateValidation:
         workflow = {
             "ir_version": "0.1.0",
             "nodes": [{"id": "echo_it", "type": "shell", "params": {}}],
-            "inputs": {"data": {"type": "dict", "description": "A dict with a field"}},
+            "inputs": {"data": {"type": "object", "description": "A dict with a field"}},
             "outputs": {"x": {"source": "${data.field}"}},
         }
 
@@ -169,7 +169,7 @@ class TestOutputTemplateValidation:
         workflow = {
             "ir_version": "0.1.0",
             "nodes": [{"id": "n1", "type": "shell", "params": {}}],
-            "inputs": {"items": {"type": "list", "description": "A list"}},
+            "inputs": {"items": {"type": "array", "description": "A list"}},
             "outputs": {"first": {"source": "${items[0]}"}},
         }
 

--- a/tests/test_execution/test_runner.py
+++ b/tests/test_execution/test_runner.py
@@ -101,7 +101,7 @@ def test_declared_defaults_applied_without_user_params():
     """
     workflow_ir = {
         "inputs": {
-            "greeting": {"type": "str", "default": "hello-from-default", "description": "A greeting"},
+            "greeting": {"type": "string", "default": "hello-from-default", "description": "A greeting"},
         },
         "nodes": [
             {"id": "greet", "type": "shell", "params": {"command": "echo ${greeting}"}},
@@ -124,7 +124,7 @@ def test_user_params_override_declared_defaults():
     """
     workflow_ir = {
         "inputs": {
-            "greeting": {"type": "str", "default": "hello-from-default", "description": "A greeting"},
+            "greeting": {"type": "string", "default": "hello-from-default", "description": "A greeting"},
         },
         "nodes": [
             {"id": "greet", "type": "shell", "params": {"command": "echo ${greeting}"}},

--- a/tests/test_integration/test_branch_convergence.py
+++ b/tests/test_integration/test_branch_convergence.py
@@ -201,7 +201,7 @@ _CONVERGENCE_WORKFLOW_MD = _md("""\
 
     The routing threshold value.
 
-    - type: int
+    - type: integer
 
     ## Steps
 
@@ -305,7 +305,7 @@ class TestBranchConvergenceMarkdown:
 
             The routing threshold value.
 
-            - type: int
+            - type: integer
 
             ## Steps
 

--- a/tests/test_integration/test_workflow_manager_integration.py
+++ b/tests/test_integration/test_workflow_manager_integration.py
@@ -48,8 +48,8 @@ def workflow_manager(temp_workflows_dir):
 def sample_ir():
     """Sample workflow IR for testing."""
     return {
-        "inputs": {"text": {"type": "str", "description": "Input text"}},
-        "outputs": {"result": {"type": "str", "description": "Processed result"}},
+        "inputs": {"text": {"type": "string", "description": "Input text"}},
+        "outputs": {"result": {"type": "string", "description": "Processed result"}},
         "nodes": [
             {
                 "id": "echo1",
@@ -71,8 +71,8 @@ def sample_markdown(sample_ir):
 def another_ir():
     """Another sample workflow IR for testing multiple workflows."""
     return {
-        "inputs": {"name": {"type": "str", "description": "User name"}},
-        "outputs": {"greeting": {"type": "str", "description": "Greeting message"}},
+        "inputs": {"name": {"type": "string", "description": "User name"}},
+        "outputs": {"greeting": {"type": "string", "description": "Greeting message"}},
         "nodes": [
             {
                 "id": "greet1",

--- a/tests/test_mcp_server/test_registry_template.py
+++ b/tests/test_mcp_server/test_registry_template.py
@@ -21,7 +21,7 @@ def test_runner_resolves_template_in_single_node_ir() -> None:
     """
     synthetic_ir: dict = {
         "inputs": {
-            "greeting": {"type": "str", "description": "A greeting word"},
+            "greeting": {"type": "string", "description": "A greeting word"},
         },
         "nodes": [
             {

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -6,6 +6,7 @@ internal implementation structure (prep/exec/post).
 
 import pytest
 
+from pflow.nodes.file.exceptions import NonRetriableError
 from pflow.nodes.python.python_code import (
     PythonCodeNode,
     _extract_error_location,
@@ -321,6 +322,67 @@ class TestSafetyAndErrors:
         )
         assert action == "error"
         assert "undefined_var" in shared["error"]
+
+    def test_union_in_annotation_rejected_with_pipe_syntax_hint(self):
+        """Union in an annotation should be rejected at prep with a PEP 604 hint.
+
+        AST-walk detection runs at validation time, so the opinionated guidance
+        reaches the user consistently — including Python 3.14+ where PEP 649
+        defers annotation evaluation and the runtime NameError never fires.
+        """
+        shared: dict = {}
+        with pytest.raises(NonRetriableError) as exc_info:
+            run_code_node(
+                shared,
+                code="x: Union[int, str] = 1\nresult: int = x",
+                inputs={},
+            )
+        msg = str(exc_info.value)
+        assert "pipe syntax" in msg
+        assert "int | str" in msg
+        # Opinionated: Union does NOT suggest import — modern syntax is the canonical fix.
+        assert "from typing import Union" not in msg
+
+    def test_list_in_annotation_rejected_with_lowercase_generic_hint(self):
+        """List/Dict/Tuple in an annotation should be rejected at prep with a PEP 585 hint."""
+        shared: dict = {}
+        with pytest.raises(NonRetriableError) as exc_info:
+            run_code_node(
+                shared,
+                code="x: List[int] = [1, 2]\nresult: int = len(x)",
+                inputs={},
+            )
+        msg = str(exc_info.value)
+        assert "list[...]" in msg or "list[str]" in msg
+        assert "PEP 585" in msg
+        # Opinionated: List does NOT suggest `from typing import List` — lowercase is canonical.
+        assert "from typing import List" not in msg
+
+    def test_literal_in_annotation_rejected_with_import_hint(self):
+        """Literal (no modern alternative) should be rejected at prep with an import hint."""
+        shared: dict = {}
+        with pytest.raises(NonRetriableError) as exc_info:
+            run_code_node(
+                shared,
+                code='x: Literal["a", "b"] = "a"\nresult: str = x',
+                inputs={},
+            )
+        assert "from typing import Literal" in str(exc_info.value)
+
+    def test_typing_name_in_annotation_accepted_when_imported(self):
+        """Typing names ARE accepted when the user explicitly imports them.
+
+        The AST walker only rejects forgotten imports — it must not block users
+        who follow the `from typing import Literal` suggestion.
+        """
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code='from typing import Literal\nx: Literal["a", "b"] = "a"\nresult: str = x',
+            inputs={},
+        )
+        assert action == "default"
+        assert shared["result"] == "a"
 
     def test_import_error_identifies_module(self):
         """ImportError message includes the missing module name."""
@@ -938,3 +1000,147 @@ class TestOptionalTypeSupport:
         code = "x: typing.Optional[str]\nresult: str = x or 'default'"
         result = extract_optional_input_keys(code, {"x"})
         assert result == {"x"}
+
+
+class TestAnyAutoInjection:
+    def test_any_without_import_works(self):
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="x: Any\nresult: int = len(x)",
+            inputs={"x": "hello"},
+        )
+        assert action == "default"
+        assert shared["result"] == 5
+
+    def test_any_in_result_annotation_works(self):
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="result: Any = {'nested': [1, 2, 3]}",
+            inputs={},
+        )
+        assert action == "default"
+        assert shared["result"] == {"nested": [1, 2, 3]}
+
+    def test_typing_any_dotted_form_works(self):
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="x: typing.Any\nresult: int = 1",
+            inputs={"x": "hello"},
+        )
+        assert action == "default"
+        assert shared["result"] == 1
+
+    @pytest.mark.parametrize("value", [{"k": 1}, [1, 2], "text", 4, True, None])
+    def test_any_accepts_all_input_types(self, value):
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="x: Any\nresult: int = 1",
+            inputs={"x": value},
+        )
+        assert action == "default"
+        assert shared["result"] == 1
+
+    def test_any_union_none_works(self):
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="x: Any | None\nresult: int = 1",
+            inputs={"x": None},
+        )
+        assert action == "default"
+        assert shared["result"] == 1
+
+    def test_explicit_typing_import_still_works(self):
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="from typing import Any\nx: Any\nresult: int = len(x)",
+            inputs={"x": "hello"},
+        )
+        assert action == "default"
+        assert shared["result"] == 5
+
+    def test_lowercase_any_rejected(self):
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="Use 'Any'"):
+            run_code_node(
+                shared,
+                code="x: any\nresult: int = 1",
+                inputs={"x": "hello"},
+            )
+
+    def test_lowercase_any_in_result_rejected(self):
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="## Inputs"):
+            run_code_node(
+                shared,
+                code="result: any = 1",
+                inputs={},
+            )
+
+    def test_lowercase_any_in_list_generic_rejected(self):
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="Use 'Any'"):
+            run_code_node(
+                shared,
+                code="x: list[any]\nresult: int = 1",
+                inputs={"x": [1, 2]},
+            )
+
+    def test_lowercase_any_in_forward_reference_rejected(self):
+        """String forward-reference annotations (`x: "list[any]"`) must be unwrapped.
+
+        Without this, `ast.unparse` preserves the quotes, the re-parse sees an
+        ast.Constant (not ast.Name), the check silently passes, and on Python 3.14+
+        PEP 649 leaves the annotation unevaluated at runtime too — the user never
+        learns their 'any' is wrong.
+        """
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="Use 'Any'"):
+            run_code_node(
+                shared,
+                code='x: "list[any]" = [1, 2]\nresult: int = len(x)',
+                inputs={"x": [1, 2]},
+            )
+
+    def test_lowercase_any_in_dict_value_rejected(self):
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="Use 'Any'"):
+            run_code_node(
+                shared,
+                code="x: dict[str, any]\nresult: int = 1",
+                inputs={"x": {"k": "v"}},
+            )
+
+    def test_lowercase_any_in_pipe_union_rejected(self):
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="Use 'Any'"):
+            run_code_node(
+                shared,
+                code="x: int | any\nresult: int = 1",
+                inputs={"x": 5},
+            )
+
+    def test_lowercase_any_in_optional_rejected(self):
+        shared: dict = {}
+        with pytest.raises(NonRetriableError, match="Use 'Any'"):
+            run_code_node(
+                shared,
+                code="x: Optional[any]\nresult: int = 1",
+                inputs={"x": "hello"},
+            )
+
+    def test_literal_string_any_not_rejected(self):
+        """`Literal['any']` is a string constant, not a type name — keep it working."""
+        shared: dict = {}
+        action = run_code_node(
+            shared,
+            code="from typing import Literal\nx: Literal['any']\nresult: int = 1",
+            inputs={"x": "any"},
+        )
+        assert action == "default"
+        assert shared["result"] == 1

--- a/tests/test_runtime/test_cache_integration.py
+++ b/tests/test_runtime/test_cache_integration.py
@@ -190,7 +190,7 @@ def test_template_input_change_invalidation(tmp_path: Any) -> None:
             {"id": "step-2", "type": "shell", "params": {"command": "printf '%s' fixed"}},
         ],
         "edges": [{"from": "step-1", "to": "step-2"}],
-        "inputs": {"input_val": {"type": "str", "description": "Test input"}},
+        "inputs": {"input_val": {"type": "string", "description": "Test input"}},
     }
 
     # First run with input_val=A
@@ -312,7 +312,7 @@ def test_key_value_override_cache_interaction(tmp_path: Any) -> None:
             {"id": "step-2", "type": "shell", "params": {"command": "printf '%s' static"}},
         ],
         "edges": [{"from": "step-1", "to": "step-2"}],
-        "inputs": {"input_val": {"type": "str", "description": "Test input"}},
+        "inputs": {"input_val": {"type": "string", "description": "Test input"}},
     }
 
     # Run 1: input_val=A

--- a/tests/test_runtime/test_compile_once_regression.py
+++ b/tests/test_runtime/test_compile_once_regression.py
@@ -263,7 +263,7 @@ def test_parallel_batch_items_produce_distinct_output(tmp_path: Path):
     child_md = tmp_path / "child.pflow.md"
     child_md.write_text(
         "# Child\n\nA child workflow.\n\n"
-        "## Inputs\n\n### text\n\nText input.\n\n- type: str\n- required: true\n\n"
+        "## Inputs\n\n### text\n\nText input.\n\n- type: string\n- required: true\n\n"
         "## Steps\n\n### echo\n\nEcho the text.\n\n- type: shell\n- command: echo MARKER_${text}_END\n",
         encoding="utf-8",
     )
@@ -495,10 +495,10 @@ def test_resolved_defaults_do_not_leak_between_batch_items(tmp_path: Path):
         "# Child\n\nA child workflow.\n\n"
         "## Inputs\n\n"
         "### text\n\nThe text to echo.\n\n"
-        "- type: str\n"
+        "- type: string\n"
         "- required: true\n\n"
         "### prefix\n\nOptional prefix.\n\n"
-        "- type: str\n"
+        "- type: string\n"
         "- required: false\n"
         "- default: DEFAULT\n\n"
         "## Steps\n\n"

--- a/tests/test_runtime/test_initial_params_override_removal.py
+++ b/tests/test_runtime/test_initial_params_override_removal.py
@@ -54,7 +54,7 @@ class TestSharedStoreIsOnlyDataSource:
         ir = {
             "ir_version": "0.1.0",
             "inputs": {
-                "greeting": {"type": "str", "default": "hello", "required": False, "description": "A greeting"},
+                "greeting": {"type": "string", "default": "hello", "required": False, "description": "A greeting"},
             },
             "nodes": [
                 {
@@ -89,7 +89,7 @@ class TestSharedStoreIsOnlyDataSource:
         ir = {
             "ir_version": "0.1.0",
             "inputs": {
-                "name": {"type": "str", "required": True},
+                "name": {"type": "string", "required": True},
             },
             "nodes": [
                 {

--- a/tests/test_runtime/test_memoization_integration.py
+++ b/tests/test_runtime/test_memoization_integration.py
@@ -137,7 +137,7 @@ def test_memo_cache_miss_on_different_input(tmp_path: Any) -> None:
             {"id": "diff-input", "type": "shell", "params": {"command": "printf '%s' '${input_val}'"}},
         ],
         "edges": [],
-        "inputs": {"input_val": {"type": "str", "description": "Test input"}},
+        "inputs": {"input_val": {"type": "string", "description": "Test input"}},
     }
 
     # First run with input_val="hello"

--- a/tests/test_runtime/test_prepare_inputs_coercion.py
+++ b/tests/test_runtime/test_prepare_inputs_coercion.py
@@ -181,22 +181,6 @@ class TestPrepareInputsCoercionEdgeCases:
         # Original value not in defaults because coercion returned same value
         assert "count" not in defaults
 
-    def test_type_aliases_work(self):
-        """Type aliases like 'str', 'int' should work."""
-        workflow_ir = {
-            "inputs": {
-                "id": {"type": "str", "required": True},  # alias for string
-                "num": {"type": "int", "required": True},  # alias for integer
-            }
-        }
-        provided_params = {"id": 123, "num": "456"}
-
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
-
-        assert errors == []
-        assert defaults["id"] == "123"
-        assert defaults["num"] == 456
-
 
 class TestPrepareInputsIntegrationWithDefaults:
     """Test coercion interacts correctly with default values."""

--- a/tests/test_runtime/test_template_validation/test_batch_item_validation.py
+++ b/tests/test_runtime/test_template_validation/test_batch_item_validation.py
@@ -514,8 +514,8 @@ class TestBatchItemFieldValidation:
             "nodes": [{"id": "step", "type": "llm", "params": {"prompt": "hi"}}],
             "edges": [],
             "outputs": {
-                "content": {"type": "str"},
-                "source_type": {"type": "str"},
+                "content": {"type": "string"},
+                "source_type": {"type": "string"},
             },
         }
         child_path = tmp_path / "fetch_child.pflow.md"
@@ -552,8 +552,8 @@ class TestBatchItemFieldValidation:
             "nodes": [{"id": "step", "type": "llm", "params": {"prompt": "hi"}}],
             "edges": [],
             "outputs": {
-                "content": {"type": "str"},
-                "source_type": {"type": "str"},
+                "content": {"type": "string"},
+                "source_type": {"type": "string"},
             },
         }
         child_path = tmp_path / "fetch_child.pflow.md"
@@ -593,7 +593,7 @@ class TestBatchItemFieldValidation:
         workflow_ir = {
             "inputs": {
                 "sources": {"type": "array", "required": True},
-                "workflow_path": {"type": "str", "required": True},
+                "workflow_path": {"type": "string", "required": True},
             },
             "nodes": [
                 {

--- a/tests/test_runtime/test_template_validation/test_type_checker.py
+++ b/tests/test_runtime/test_template_validation/test_type_checker.py
@@ -196,13 +196,13 @@ class TestTemplateTypeInference:
         """Infer type from workflow inputs."""
         workflow_ir = {
             "enable_namespacing": True,
-            "inputs": {"api_key": {"type": "str", "description": "API key"}},
+            "inputs": {"api_key": {"type": "string", "description": "API key"}},
             "nodes": [],
         }
         node_outputs = {}
 
         result = infer_template_type("api_key", workflow_ir, node_outputs)
-        assert result == "str"
+        assert result == "string"
 
     def test_infer_non_traversable_type(self):
         """Non-traversable types return None for nested access."""

--- a/tests/test_runtime/test_template_validation/test_unused_inputs.py
+++ b/tests/test_runtime/test_template_validation/test_unused_inputs.py
@@ -230,7 +230,7 @@ def test_input_used_with_indexed_access(mock_registry, tmp_path):
     output_path = str(tmp_path / "output.txt")
     workflow_ir = {
         "inputs": {
-            "items": {"type": "list", "description": "List of items to process"},
+            "items": {"type": "array", "description": "List of items to process"},
         },
         "nodes": [
             {

--- a/tests/test_runtime/test_template_validation/test_validator.py
+++ b/tests/test_runtime/test_template_validation/test_validator.py
@@ -1283,9 +1283,9 @@ class TestBatchWorkflowNodeValidation:
         """Unused-input diagnostics should keep their sorted input list in context."""
         workflow_ir = {
             "inputs": {
-                "used_one": {"type": "str"},
-                "unused_one": {"type": "str"},
-                "unused_two": {"type": "str"},
+                "used_one": {"type": "string"},
+                "unused_one": {"type": "string"},
+                "unused_two": {"type": "string"},
             },
             "nodes": [
                 {

--- a/tests/test_runtime/test_trace_integration.py
+++ b/tests/test_runtime/test_trace_integration.py
@@ -63,7 +63,7 @@ class TestTemplateResolutionsInTrace:
                 },
             ],
             "edges": [],
-            "inputs": {"name": {"type": "str", "description": "Name input"}},
+            "inputs": {"name": {"type": "string", "description": "Name input"}},
         }
 
         shared, collector = _run_with_trace(ir, initial_params={"name": "World"})

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor.py
@@ -389,3 +389,136 @@ class TestExecErrorActionDetection:
         assert "banana" in msg
         assert "no successor edge matches" in msg
         assert "child.pflow.md" in msg
+
+
+class TestTemplateRefSubWorkflowValidation:
+    """Pin the invariant that every IR reaching compile_workflow has been validated.
+
+    Template-referenced children (``workflow: ${var}``) skip the parent's recursive
+    validation because the resolver can't resolve the reference statically. Previously
+    this meant child IRs with Python aliases (``type: str``) silently normalized via
+    a defense-in-depth map. Now ``_compile_sub_workflow`` runs ``validate_ir`` itself,
+    so the contract ``"Python aliases are hard errors"`` holds on every path.
+    """
+
+    def test_compile_rejects_python_alias_in_child_ir(self):
+        """A child IR declaring ``type: str`` must fail at the validation step.
+
+        ``_compile_sub_workflow`` wraps the underlying ``SchemaValidationError``
+        in ``CompilationError`` so parent-side error handling is consistent
+        regardless of whether the failure is structural, schematic, or
+        compiler-internal.
+        """
+        from pflow.core.exceptions import CompilationError
+
+        node = WorkflowExecutor()
+        node.set_params({})
+
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "step", "type": "shell", "params": {"command": "echo hi"}}],
+            "inputs": {"x": {"type": "str", "required": True}},
+        }
+
+        with pytest.raises(CompilationError) as exc_info:
+            node._compile_sub_workflow(child_ir, "<inline>", {"x": "hello"})
+
+        assert "Use 'string' instead of 'str'" in str(exc_info.value)
+
+    def test_compile_accepts_canonical_type_in_child_ir(self):
+        """A child IR declaring ``type: string`` compiles successfully."""
+        node = WorkflowExecutor()
+        node.set_params({})
+
+        child_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "step", "type": "shell", "params": {"command": "echo hi"}}],
+            "inputs": {"x": {"type": "string", "required": True}},
+        }
+
+        compiled = node._compile_sub_workflow(child_ir, "<inline>", {"x": "hello"})
+        assert compiled is not None
+
+    def test_template_ref_bypass_close_end_to_end_through_runner(self, tmp_path):
+        """End-to-end: parent with ``workflow: ${child_ref}`` pointing to a child
+        with a Python alias must fail with the canonical suggestion.
+
+        The direct ``_compile_sub_workflow`` tests above prove the function
+        validates. This test proves the full dispatch chain — parent validator
+        skips template refs → runtime resolver loads child → compile path
+        routes through ``_compile_sub_workflow`` → ``normalize_ir`` +
+        ``validate_ir`` reject → ``CompilationError`` propagates.
+
+        Two regressions this catches that the unit tests miss:
+        1. Runtime refactor that bypasses ``_compile_sub_workflow`` (unit
+           tests still pass; real pipeline breaks).
+        2. Removal of ``normalize_ir(workflow_ir)`` call (unit tests use IRs
+           that include ``ir_version`` explicitly; parsed-markdown children
+           don't — the markdown parser does not inject it).
+        """
+        from pflow.execution.result import RunnerConfig
+        from pflow.execution.runner import WorkflowRunner
+        from tests.shared.markdown_utils import write_workflow_file
+
+        child_path = tmp_path / "child.pflow.md"
+        write_workflow_file(
+            {
+                "nodes": [{"id": "echo", "type": "shell", "params": {"command": "echo ${message}"}}],
+                "inputs": {"message": {"type": "str", "required": True}},
+                "outputs": {"out": {"source": "${echo.stdout}"}},
+            },
+            child_path,
+        )
+
+        parent_ir = {
+            "nodes": [
+                {
+                    "id": "call_child",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": "${child_path}",
+                        "inputs": {"message": "hello"},
+                    },
+                }
+            ],
+            "inputs": {"child_path": {"type": "string", "required": True}},
+        }
+
+        result = WorkflowRunner().run(
+            parent_ir,
+            {"child_path": str(child_path)},
+            RunnerConfig(),
+        )
+
+        assert result.success is False
+
+        # Structured context from SchemaValidationError must survive the
+        # CompilationError wrap (wrapped_diagnostics carries the rich fields),
+        # and sub_workflow_path must be merged in by CompilationError.to_diagnostics.
+        # Without this, a prior regression flattened the structured context into the
+        # exception's string message — passing a substring assertion while losing
+        # the "Did you mean / Available types" rendering blocks agents rely on.
+        vocab_diag = next(
+            (d for d in result.diagnostics if d.context.get("path") == "inputs.message.type"),
+            None,
+        )
+        assert vocab_diag is not None, (
+            "expected a diagnostic for the child IR's inputs.message.type vocab error; "
+            f"got: {[d.context for d in result.diagnostics]}"
+        )
+        # Rich "Available types" rendering block survives.
+        assert vocab_diag.context["available_fields"] == [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "object",
+            "any",
+        ]
+        assert vocab_diag.context["available_fields_label"] == "types"
+        # Container context (sub_workflow_path) is merged in by CompilationError.to_diagnostics.
+        assert vocab_diag.context["sub_workflow_path"] == str(child_path)
+        # Opinionated canonical fix survives as a structured suggestion,
+        # not a flattened substring in .message.
+        assert vocab_diag.suggestions == ["Use 'string' instead of 'str'"]

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
@@ -279,9 +279,9 @@ class TestWorkflowExecutorComprehensive:
         child_workflow_ir = {
             "ir_version": "0.1.0",
             "inputs": {
-                "config": {"type": "dict"},
-                "tags": {"type": "list"},
-                "nested": {"type": "dict"},
+                "config": {"type": "object"},
+                "tags": {"type": "array"},
+                "nested": {"type": "object"},
             },
             "nodes": [{"id": "test", "type": "tests.shared.mock_nodes", "params": {}}],
             "edges": [],
@@ -486,8 +486,10 @@ class TestWorkflowExecutorComprehensive:
             "__registry__": None,
         })
 
+        # Use a valid IR so validate_ir passes; the mocked compile_workflow is what
+        # raises — that's the path this test pins.
         prep_res = {
-            "child_ir": {"invalid": "ir"},
+            "child_ir": simple_workflow_ir,
             "workflow_path": "test.json",
             "child_params": {},
             "storage_mode": "mapped",


### PR DESCRIPTION
Fixes #291

## Summary

Shrink the workflow IR `## Inputs` / `## Outputs` `type:` field from 12 silent synonyms to 7 canonical JSON Schema names. Make `object` mean dict-only (documented — runtime enforcement deferred to Task 120). Introduce `any` as the explicit wildcard. Auto-inject `typing.Any` / `Optional` / `typing` into code-block exec namespaces. Breaking change shipped atomically.

## Task

154 — Type Vocabulary Coherence Refactor

## Changes

- **S1 vocabulary shrink**: `## Inputs` / `## Outputs` `type:` now accepts exactly `string | number | integer | boolean | array | object | any`. Python aliases (`str`/`int`/`float`/`bool`/`dict`/`list`) become hard errors with canonical-replacement suggestions (`"Use 'string' instead of 'str'"`).
- **Semantic fix**: `type: object` documented as dict-only (runtime coercion remains lenient; strict enforcement deferred to Task 120). `type: any` is the new explicit wildcard.
- **Code-block ergonomics**: `Any`, `Optional`, and the `typing` module auto-injected — no `from typing import Any` ceremony. Lowercase `x: any` in code annotations rejected with a focused error teaching the two-surface model.
- **Opinionated NameError hints**: `List[T]` → `"Use 'list[T]' (PEP 585 lowercase built-in generics)"`, `Union` → `"Use pipe syntax: 'A | B' (PEP 604)"`, `Literal`/`TypeVar`/etc. → `"Add 'from typing import X'"`. One canonical fix per case, no menu.
- **Parameterized generics rejected**: `type: list[str]` at S1 produces `"Use 'array' — parameterized generics not supported at '## Inputs' / '## Outputs' (got 'list[str]')"`. Full prose survives the renderer.
- **New `TypeSpec` class** in `src/pflow/core/types.py`: single source of truth for vocabulary, structured-context error type, fuzzy-match suggestions. Designed as the entry point for Task 120 (strict validation), union syntax, and complex schemas.
- **Structured diagnostic context**: `SchemaValidationError` extended with four keyword-only kwargs (`similar_names`, `available_fields`, `available_fields_label`, `suggestions_list`). CLI, JSON, and MCP consumers all flow through the unified `format_diagnostic()` pipeline.
- **Canonical syntax table** in `pflow guide code`; MCP agent instructions teach modern Python (lowercase generics, pipe unions). Three-vocabulary coexistence (S1 / S2 / S3) documented as intentional.
- **Renderer polish**: `_format_available_fields_block` shows all entries when ≤10 (no more "showing 5 of 7 ... and 2 more" truncation on small closed sets).

## Explanation

The root bug: authoring `.pflow.md` files was quietly dragged down by three compounding incoherences. (1) The IR schema accepted both JSON Schema names and Python aliases as silent synonyms (12 names for 6 concepts), but only the JSON Schema names were documented — agents pattern-matched whatever they saw first. (2) `type: object` silently accepted any value (strings, lists, ints), creating false confidence. (3) `type: any` was rejected at the declaration layer; the natural wildcard name was illegal while the unnatural one (`object`) did the wildcard's job silently. Code-block annotations using bare `Any` produced a misleading error telling agents to add `Any` to the inputs dict.

Polls of 4 authoring agents plus 2 external reviewers resolved the vocabulary design: separate S1 (contract) and S2 (Python implementation) with an explicit bridge. The shipped state: S1 has 7 canonical JSON Schema names, S2 remains Python with modern PEP 585 / PEP 604 encouraged. A separate scope boundary preserved: runtime coercion stays lenient (Task 120 owns strict enforcement).

After implementation, a code review with 4 specialized agents (impact-completeness, agent-ux, feature-interactions, validation-consistency) found 10 issues — 1 critical, 7 warnings, 2 disputed. The critical finding (parameterized-generic prose lost at the renderer because `suggestions_list` preempts `suggestion` in `to_diagnostics()`) was fixed with a self-contained `suggestions_list` entry. All 10 confirmed findings were addressed; 6 were deliberately deferred with documented rationale. One bonus simplification landed during verification (null-through-markdown routing — YAML `- type: null` parses to Python `None`, which needed list-based path check in `_get_suggestion` to reach the same canonical-suggestion path).

One high-value cross-layer regression test added (`test_full_render_pipeline_for_type_vocabulary_error`) that would have caught the critical finding. In-process, ~3ms — covers every consumer (CLI, JSON, MCP) since all three flow through the same `format_diagnostic()` entry point per `core/CLAUDE.md`.

## Created Docs

- `.taskmaster/tasks/task_154/task-154.md` — task spec (problem, solution, scope, rationale)
- `.taskmaster/tasks/task_154/implementation/implementation-plan.md` — full implementation plan (1,466 lines; 5-agent plan review applied)
- `.taskmaster/tasks/task_154/implementation/progress-log.md` — epistemic trail (planning journey, reviewer findings that reshaped plan, implementer traps, per-pass live log)
- `.taskmaster/tasks/task_154/task-review.md` — post-implementation review for future AI agents (patterns, pitfalls, extension points for Task 120)

User-facing documentation updated: `docs/changelog.mdx` (new entry with migration notes), `docs/reference/nodes/code.mdx` (updated type section + bridge), `src/pflow/guide/core.md` (bridge table + pointer), `src/pflow/guide/nodes/code.md` (canonical syntax table), MCP instruction files (modern Python guidance). Architecture references updated: `architecture/reference/ir-schema.md`, `template-variables.md`, `enhanced-interface-format.md`.

## Testing

Run `make test` — 4,846 tests pass (+5 new regression guards: null-through-markdown contract, opinionated `List` hint, opinionated `Literal` import hint, alias-map drift guard, full-render-pipeline cross-layer guard). `make check` clean (ruff, ruff-format, mypy, deptry).

Manual verification ran every probe in `scratchpads/type-vocabulary-incoherence/repro-files/` plus the case-sensitive error-wording spot checks from plan §10.3 — all match expected post-refactor outputs.


---

## Round-2 update (commit `9a75f458`)

Post-merge-review delta on this branch. Closes the one remaining incoherence the first round deferred and removes the dual-map machinery that was defending it.

**Code changes:**
- `workflow_executor.py` — `normalize_ir` + `validate_ir` before `compile_workflow`, closing the template-ref sub-workflow bypass (`workflow: ${var}` path skipped parent-time validation; now validated at runtime compile).
- `param_coercion.py` — delete `_TYPE_ALIASES` + `_normalize_type` (provably dead after bypass close).
- `types.py` — `_raise_alias_error` drops `similar_names`; reserved for the fuzzy-typo "Did you mean" channel. Aliases carry the canonical fix via `suggestions_list` only. Aligns with 14 of 15 existing `similar_names` producers.
- `types.py` — delete `TypeSpec.python_type()` (zero production callers; `isinstance`-unsafe for `bool` vs `int`/`number`; Task 120 uses `accepts()`).
- `python_code.py::_check_annotation_vocabulary` — rewrite as `ast.walk` looking for `ast.Name(id="any")`. Catches `list[any]`, `dict[str, any]`, `int | any`, `Optional[any]` at any depth. Correctly skips `Literal['any']`, `Annotated[int, 'any']`, `typing.any`, and substring identifiers (`T_any`, `any_var`). Closes the "no runtime safety net" limitation documented in progress-log §2.9.
- `types.py` module docstring — note Claude Code `output_schema` as deliberate fourth Python-aliased surface (embedded literally into LLM prompts by `_build_schema_prompt`).
- `guide/features/sub-workflows.md` — document the template-ref form (`workflow: ${var}`). Previously undocumented despite production use (`examples/nested/deep-research/deep-research.pflow.md:72`); round-2 `validate_ir` serves this path.

**Tests:** 4,849 pass (net +3 from round 1: +5 nested-`any` AST tests + 2 template-ref regression guards − 2 vacuous drift-guards − 1 defense-in-depth pin − 1 `python_type` pin). Net code delta is deletions > additions.

**Verification (beyond `make test`):**
- All 14 authoritative probes in `scratchpads/type-vocabulary-incoherence/repro-files/` pass the `bug-report.md:450-504` post-fix contract.
- 16-case AST edge probe: forward refs, `Annotated` metadata, attribute access, deep generics — all correct.
- Template-ref bypass close verified end-to-end via custom parent/child workflows through the real CLI (not just unit tests).
- Examples regression sweep: 39 pass / 10 fail pre-change; identical 10 fail post-change. Zero Task 154 regressions.

**Follow-ups filed (pre-existing, not caused by this PR):**
- #292 — `pflow describe` raises uncaught `MarkdownParseError` Python traceback on malformed saved workflows. Likely related to #224.
- #293 — 8 example workflows fail `pflow --validate-only` but pass CI because `test_example_validation.py` runs `validate_ir()` only, not the full 10-step `WorkflowValidator.validate()`. Examples are rotting undetected.

