### PR TITLE
fix: repair 7 stale example workflows and tighten validation test (fixes #293)

### DIFF
--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -27,8 +27,14 @@ examples/
 
 ## Test Dependencies
 
-- `tests/test_docs/test_example_validation.py` — validates all `.pflow.md` files in `examples/` parse correctly and `examples/invalid/` fail correctly
+- `tests/test_docs/test_example_validation.py` — runs the full `WorkflowValidator.validate()` 10-step pipeline (same as `pflow --validate-only`) on every `.pflow.md` under `examples/` that isn't in `invalid/` or `legacy/`, plus asserts `examples/invalid/` files fail parsing or schema validation.
 - `tests/test_core/test_ir_examples.py` — similar validation of example files
 - `tests/test_integration/test_failed_node_invariant.py` — executes each fixture in `examples/error-handling/` end-to-end via `WorkflowRunner` and asserts on rendered diagnostic text (source lines, paste-able fixes, structured failure blocks). See `examples/error-handling/README.md` for the per-fixture contract.
 
 **Don't rename/move/delete files in `core/`, `advanced/`, `error-handling/`, or `invalid/` without checking these tests.**
+
+### Environment-dependent examples
+
+`test_example_validation.py` skips workflows whose ONLY unregistered node types match `mcp-*` — MCP tools supplied by user-configured servers (`mcp-filesystem`, `mcp-http/example-workflow`, `real-workflows/*` that reference Slack/Discord MCP tools). Workflows with any non-MCP unregistered type (typo like `wrte-file`, removed node type) still fail so regressions get caught.
+
+Skip logic walks only top-level `node.type`. If a parent workflow references a sub-workflow file whose own nodes include unregistered MCP types, the recursive validator inside `WorkflowValidator._validate_sub_workflows` will still fail — the pre-scan won't see it. No shipped example currently has that shape; add a directory-level skip if it arises.

--- a/examples/advanced/content-pipeline.pflow.md
+++ b/examples/advanced/content-pipeline.pflow.md
@@ -3,6 +3,43 @@
 Read, backup, process, validate, save, and archive content files
 with a full audit trail of validation reports.
 
+## Inputs
+
+### source_dir
+
+Directory containing the source file.
+
+- type: string
+- required: true
+
+### source_file
+
+Filename of the source content to process.
+
+- type: string
+- required: true
+
+### output_file
+
+Filename for the processed content.
+
+- type: string
+- required: true
+
+### timestamp
+
+Timestamp used in backup and report filenames.
+
+- type: string
+- default: "unknown"
+
+### date
+
+Date folder name used by the archive step.
+
+- type: string
+- default: "unknown"
+
 ## Steps
 
 ### read_source
@@ -18,7 +55,7 @@ Create a timestamped backup of the original file before any processing.
 
 - type: copy-file
 - source_path: ${source_dir}/${source_file}
-- dest_path: backups/${timestamp_}${source_file}
+- dest_path: backups/${timestamp}_${source_file}
 
 ### process_content
 
@@ -52,7 +89,7 @@ Save the processed content to the output directory.
 Write a validation report for audit purposes.
 
 - type: write-file
-- file_path: reports/validation_${timestamp.txt}
+- file_path: reports/validation_${timestamp}.txt
 
 ### retry_processing
 

--- a/examples/advanced/file-migration.pflow.md
+++ b/examples/advanced/file-migration.pflow.md
@@ -3,6 +3,134 @@
 Migrate files between directories following a manifest, with backup,
 reporting, cleanup, and error logging.
 
+## Inputs
+
+### migration_dir
+
+Directory containing the migration manifest.
+
+- type: string
+- required: true
+
+### destination_dir
+
+Directory that new files are copied into.
+
+- type: string
+- required: true
+
+### backup_dir
+
+Directory used to back up the destination before the migration.
+
+- type: string
+- required: true
+
+### source_dir
+
+Directory containing the new files.
+
+- type: string
+- required: true
+
+### archive_dir
+
+Directory that superseded files are moved into.
+
+- type: string
+- required: true
+
+### temp_dir
+
+Directory holding temporary files that must be cleaned up.
+
+- type: string
+- default: /tmp
+
+### reports_dir
+
+Directory where the migration report is written.
+
+- type: string
+- default: ./reports
+
+### logs_dir
+
+Directory where migration errors are logged.
+
+- type: string
+- default: ./logs
+
+### timestamp
+
+Timestamp used in backup, report, and log filenames.
+
+- type: string
+- default: "unknown"
+
+### timestamp_destination
+
+Timestamp-based directory name used under backup_dir for this run.
+
+- type: string
+- default: "unknown"
+
+### current_file
+
+Filename in source_dir to copy during this run.
+
+- type: string
+- required: true
+
+### old_file
+
+Filename in destination_dir to archive during this run.
+
+- type: string
+- required: true
+
+### temp_file
+
+Filename to remove from temp_dir during cleanup.
+
+- type: string
+- required: true
+
+### copied_count
+
+Number of files copied — typically supplied by an outer pipeline.
+
+- type: integer
+- default: 0
+
+### moved_count
+
+Number of files moved — typically supplied by an outer pipeline.
+
+- type: integer
+- default: 0
+
+### error_count
+
+Number of errors observed — typically supplied by an outer pipeline.
+
+- type: integer
+- default: 0
+
+### error_message
+
+Message recorded by the error handler.
+
+- type: string
+- default: ""
+
+### current_operation
+
+Name of the operation that triggered the error.
+
+- type: string
+- default: ""
+
 ## Steps
 
 ### read_manifest
@@ -58,7 +186,7 @@ Remove temporary files created during the migration.
 Write a summary report of the migration results.
 
 - type: write-file
-- file_path: ${reports_dir}/migration_${timestamp.log}
+- file_path: ${reports_dir}/migration_${timestamp}.log
 - content: "Migration completed at ${timestamp}\nFiles copied: ${copied_count}\nFiles moved: ${moved_count}\nErrors: ${error_count}"
 
 ### handle_error
@@ -66,6 +194,6 @@ Write a summary report of the migration results.
 Log errors that occur during migration for later investigation.
 
 - type: write-file
-- file_path: ${logs_dir}/error_${timestamp.log}
+- file_path: ${logs_dir}/error_${timestamp}.log
 - content: "Error during migration: ${error_message}\nTimestamp: ${timestamp}\nCurrent operation: ${current_operation}"
 - append: true

--- a/examples/advanced/file-migration.pflow.md
+++ b/examples/advanced/file-migration.pflow.md
@@ -3,6 +3,14 @@
 Migrate files between directories following a manifest, with backup,
 reporting, cleanup, and error logging.
 
+> **Structural demo, not a runnable pipeline.** Several inputs below
+> (`copied_count`, `moved_count`, `error_count`, `error_message`,
+> `current_operation`) are declared as workflow inputs with defaults
+> so the file validates, but in a real workflow these would flow from
+> earlier node outputs (`${process_files.stdout}`, etc.). Treat this
+> file as a layout reference for multi-step file operations, not a
+> template to copy verbatim.
+
 ## Inputs
 
 ### migration_dir

--- a/examples/core/template-variables.pflow.md
+++ b/examples/core/template-variables.pflow.md
@@ -5,6 +5,78 @@ and referencing workflow inputs. Variables appear in file paths, API
 endpoints, email subjects, and multi-line content strings — showing
 how a single workflow adapts to different inputs at runtime.
 
+## Inputs
+
+### input_file
+
+Path to the file to read.
+
+- type: string
+- required: true
+
+### file_encoding
+
+Encoding for the file reader.
+
+- type: string
+- default: utf-8
+
+### api_token
+
+Bearer token for the API call.
+
+- type: string
+- required: true
+
+### api_endpoint
+
+URL of the API to call.
+
+- type: string
+- required: true
+
+### backup_dir
+
+Directory to copy the input file into.
+
+- type: string
+- default: ./backups
+
+### backup_name
+
+Filename to use for the backup copy.
+
+- type: string
+- required: true
+
+### output_dir
+
+Directory for the processed output file.
+
+- type: string
+- default: ./output
+
+### output_file
+
+Filename for the processed output.
+
+- type: string
+- required: true
+
+### timestamp
+
+Timestamp included in the output file. Typically provided by the caller.
+
+- type: string
+- default: "unknown"
+
+### recipient_email
+
+Address used in the notification message.
+
+- type: string
+- required: true
+
 ## Steps
 
 ### reader
@@ -43,7 +115,7 @@ Shows template variables embedded in multi-line content strings.
 
 - type: write-file
 - file_path: ${output_dir}/${output_file}
-- content: "Processed on: ${timestamp}\nOriginal file: ${input_file}\n\n${file_content}"
+- content: "Processed on: ${timestamp}\nOriginal file: ${input_file}\n\n${reader.content}"
 
 ### notifier
 

--- a/examples/nodes/claude-code/README.md
+++ b/examples/nodes/claude-code/README.md
@@ -1,271 +1,160 @@
 # Claude Code Node Examples
 
-This document provides comprehensive examples for using the Claude Code agentic node in pflow workflows.
+Examples for the `claude-code` node: an agentic super node that integrates with the Claude Agent SDK for AI-assisted development tasks.
 
-## Overview
+Features:
 
-The Claude Code node (`claude-code`) is a powerful "super node" that integrates with Claude's AI-assisted development capabilities. It features:
 - Dynamic schema-driven output for structured responses
-- Comprehensive development task execution
-- Metadata capture (cost, duration, usage)
-- Tool usage (Read, Write, Edit, Bash)
-- Dual authentication support (API key or CLI)
+- Metadata capture (cost, duration, token usage) in `llm_usage`
+- Tool use (Read, Write, Edit, Bash, Glob, Grep, LS, WebFetch, WebSearch)
+- Dual authentication: API key or Claude Pro/Max CLI
 
-## Basic Examples
+## Examples
 
-### 1. Simple Code Generation (`claude-code-basic.json`)
-
-Generate code with cost tracking:
+### 1. Simple code generation — `claude-code-basic.pflow.md`
 
 ```bash
-pflow run examples/nodes/claude-code/claude-code-basic.json
+pflow examples/nodes/claude-code/claude-code-basic.pflow.md
 ```
 
-**Features demonstrated:**
-- Basic task execution
+Demonstrates:
+
+- Basic task execution via the `prompt` parameter
 - Accessing generated text via `${node.result}`
 - Cost tracking via `${node.llm_usage.cost_usd}`
-- Duration and token usage tracking
+- Duration and token usage
 
-### 2. Structured Code Review (`claude-code-schema.json`)
-
-Perform code review with structured JSON output:
+### 2. Structured code review — `claude-code-schema.pflow.md`
 
 ```bash
-pflow run examples/nodes/claude-code/claude-code-schema.json --file_path your_script.py
+pflow examples/nodes/claude-code/claude-code-schema.pflow.md file_path=your_script.py
 ```
 
-**Features demonstrated:**
-- Schema-driven output with specific fields
-- Structured data access via `${node.result.field_name}`
-- Input parameters for dynamic workflows
-- Multiple output files from single analysis
+Demonstrates:
 
-**Schema benefits:**
-- Predictable output structure
-- Type validation
-- Direct field access without parsing
-- Fallback to text if JSON parsing fails
+- `output_schema` for structured outputs
+- Field access via `${node.result.field_name}`
+- Declared workflow inputs referenced as `${file_path}`
+- Multiple output files from a single analysis
 
-### 3. Debugging Assistant (`claude-code-debug.json`)
-
-Analyze errors and get debugging assistance:
+### 3. Debugging assistant — `claude-code-debug.pflow.md`
 
 ```bash
-pflow run examples/nodes/claude-code/claude-code-debug.json --error_message "TypeError: ..."
+pflow examples/nodes/claude-code/claude-code-debug.pflow.md error_message="TypeError: ..."
 ```
 
-**Features demonstrated:**
+Demonstrates:
+
 - Error analysis with structured output
-- Root cause analysis and solutions
-- Confidence scoring
-- Prevention tips
+- Optional inputs (`code_context`, `stack_trace`)
+- Confidence scoring and prevention tips
 
-## Advanced Examples
-
-### 4. Git Workflow Integration (`claude-code-git-workflow.json`)
-
-Analyze git changes and generate PR descriptions:
+### 4. Git workflow integration — `claude-code-git-workflow.pflow.md`
 
 ```bash
-pflow run examples/nodes/claude-code/claude-code-git-workflow.json
+pflow examples/nodes/claude-code/claude-code-git-workflow.pflow.md
 ```
 
-**Features demonstrated:**
-- Integration with git nodes
-- Multi-stage analysis pipeline
-- Context passing between Claude calls
-- Cost aggregation across multiple calls
+Demonstrates:
+
+- Multi-stage analysis pipeline (shell → claude-code → claude-code → write-file)
+- Passing upstream node output into the prompt via `${node_id.field}` interpolation
 - System prompts for specific personas
+- Cost aggregation across multiple calls
 
-## Key Features
+## Schema-driven output
 
-### Schema-Driven Output
+When you provide `output_schema`, the result is parsed into a structured dict:
 
-When you provide an `output_schema`, Claude's response is automatically parsed into a structured dict:
-
-```json
-{
-  "output_schema": {
-    "summary": {"type": "str", "description": "Brief summary"},
-    "score": {"type": "int", "description": "Score from 1-10"},
-    "items": {"type": "list", "description": "List of items"}
-  }
-}
+```yaml output_schema
+summary:
+  type: str
+  description: Brief summary
+score:
+  type: int
+  description: Score from 1-10
+items:
+  type: list
+  description: List of items
 ```
 
-Access values directly:
-- `${node.result.summary}`
-- `${node.result.score}`
-- `${node.result.items}`
+Access fields directly: `${node.result.summary}`, `${node.result.score}`, `${node.result.items}`.
 
-### Metadata Access
+If JSON parsing fails, the raw text is available at `${node.result}` and an error message at `${node._schema_error}`.
 
-Every execution captures valuable metadata in `llm_usage`:
+## Passing context into the prompt
 
-```json
-{
-  "model": "claude-sonnet-4-5",
-  "input_tokens": 1234,
-  "output_tokens": 567,
-  "total_tokens": 1801,
-  "cache_creation_input_tokens": 0,
-  "cache_read_input_tokens": 890,
-  "cost_usd": 0.165,
-  "duration_ms": 4805,
-  "num_turns": 2,
-  "session_id": "..."
-}
+The node has no dedicated `context` parameter. Embed upstream data directly in the prompt using template interpolation:
+
+````markdown
+```prompt
+Analyze these changes.
+
+Diff:
+${git_diff.stdout}
+
+Commits:
+${git_log.stdout}
+```
+````
+
+This works for any template reference: workflow inputs (`${input_name}`), prior node outputs (`${node_id.field}`), and structured results (`${other_node.result.field}`).
+
+## Metadata in `llm_usage`
+
+Every execution captures:
+
+```
+${node.llm_usage.model}                         # Model identifier
+${node.llm_usage.input_tokens}                  # Non-cached input tokens
+${node.llm_usage.output_tokens}                 # Output tokens
+${node.llm_usage.total_tokens}                  # Sum of input + output
+${node.llm_usage.cache_creation_input_tokens}   # Cache-creation tokens
+${node.llm_usage.cache_read_input_tokens}       # Cache-read tokens
+${node.llm_usage.cost_usd}                      # Cost in USD
+${node.llm_usage.duration_ms}                   # Wall-clock duration
+${node.llm_usage.num_turns}                     # Conversation turns used
+${node.llm_usage.session_id}                    # Resumable session ID
 ```
 
-Access in templates:
-- `${node.llm_usage.cost_usd}`
-- `${node.llm_usage.input_tokens}`
+## Authentication
 
-### Context Parameter
+- **API key**: `export ANTHROPIC_API_KEY=sk-ant-...` — billed to your Anthropic Console account.
+- **Claude Pro/Max subscription**: `claude setup-token` (or `claude auth login`) — uses subscription entitlements.
 
-Pass complex context as a dict:
+## Parameters
 
-```json
-{
-  "context": {
-    "code": "${read_file.content}",
-    "config": "${read_config.data}",
-    "history": "${git_log.commits}"
-  }
-}
-```
+| Parameter             | Default             | Description                                                 |
+|-----------------------|---------------------|-------------------------------------------------------------|
+| `prompt`              | required            | Prompt to send to Claude                                    |
+| `output_schema`       | None                | Schema for structured output (see above)                    |
+| `cwd`                 | `os.getcwd()`       | Working directory                                           |
+| `model`               | `claude-sonnet-4-5` | Claude model identifier                                     |
+| `allowed_tools`       | All tools           | Permitted tool names (e.g., `["Read", "Write"]`)            |
+| `disallowed_tools`    | None                | Tool names or patterns to deny (e.g., `"Bash(git:*)"`)      |
+| `max_turns`           | 50                  | Maximum conversation turns                                  |
+| `max_thinking_tokens` | 8000                | Maximum tokens for extended reasoning                       |
+| `timeout`             | 300                 | Execution timeout in seconds (30–3600)                      |
+| `system_prompt`       | None                | System instructions                                         |
+| `resume`              | None                | Session ID to resume a previous conversation                |
+| `sandbox`             | None                | Sandbox configuration (see node docstring for full schema)  |
 
-### Authentication Options
+## Best practices
 
-1. **API Key (Console billing)**:
-   ```bash
-   export ANTHROPIC_API_KEY=sk-ant-...
-   pflow run workflow.json
-   ```
-
-2. **CLI Authentication (Pro/Max subscription)**:
-   ```bash
-   claude auth login
-   pflow run workflow.json
-   ```
-
-### Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `task` | Required | Development task description |
-| `context` | None | Additional context (string or dict) |
-| `output_schema` | None | JSON schema for structured output |
-| `working_directory` | `os.getcwd()` | Project root directory |
-| `model` | `claude-sonnet-4-20250514` | Claude model identifier |
-| `allowed_tools` | `["Read", "Write", "Edit", "Bash"]` | Permitted tools |
-| `max_turns` | 50 | Maximum conversation turns |
-| `max_thinking_tokens` | 8000 | Maximum tokens for reasoning |
-| `system_prompt` | None | System instructions for Claude |
-
-## Best Practices
-
-### 1. Use Schemas for Predictable Output
-When you need specific data fields, always use `output_schema`:
-```json
-{
-  "output_schema": {
-    "field_name": {"type": "type", "description": "What this field contains"}
-  }
-}
-```
-
-### 2. Set Appropriate max_turns
-- Simple tasks: `max_turns: 1`
-- Code review: `max_turns: 2-3`
-- Complex debugging: `max_turns: 5-10`
-
-### 3. Track Costs
-Always log costs for expensive operations:
-```json
-{
-  "type": "shell",
-  "params": {
-    "command": "echo Cost: $${node.llm_usage.cost_usd}"
-  }
-}
-```
-
-### 4. Use Context Wisely
-Pass structured context for complex tasks:
-```json
-{
-  "context": {
-    "requirements": "...",
-    "constraints": "...",
-    "examples": "..."
-  }
-}
-```
-
-### 5. Handle Schema Failures
-Check for `_schema_error` when using schemas:
-```bash
-# In a conditional node (future feature)
-if ${node._schema_error}:
-  echo "Failed to parse JSON, raw text available in ${node.result}"
-```
-
-## Error Handling
-
-The node provides user-friendly error messages for common issues:
-- CLI not installed → Installation instructions
-- Authentication failed → Auth command guidance
-- Rate limits → Retry suggestions
-- Timeouts → Task complexity hints
-
-## Performance Tips
-
-1. **Minimize turns**: Each turn costs money and time
-2. **Use specific prompts**: Clear instructions reduce iterations
-3. **Cache when possible**: Reuse results across workflows
-4. **Monitor costs**: Track `cost_usd` for budget management
-5. **Set timeouts**: Default is 300s, adjust for long tasks
-
-## Integration Patterns
-
-### Code Quality Pipeline
-```
-read-file → claude-code (review) → write-file (report) → git-commit
-```
-
-### Documentation Generation
-```
-git-diff → claude-code (analyze) → claude-code (document) → write-file
-```
-
-### Test Generation
-```
-read-file (code) → claude-code (generate tests) → write-file (tests) → shell (run tests)
-```
-
-### Refactoring Workflow
-```
-read-file → claude-code (analyze) → claude-code (refactor) → write-file → git-diff
-```
+- Use `output_schema` whenever you need specific fields — it eliminates regex parsing.
+- Set `max_turns` proportional to task complexity: 1 for simple generation, 2–3 for review, 5–10 for multi-step debugging.
+- Track `${node.llm_usage.cost_usd}` for budget visibility.
+- Interpolate context directly into the `prompt` — there is no `context` parameter.
+- Check `${node._schema_error}` after structured calls if downstream logic depends on parsed fields.
 
 ## Troubleshooting
 
-**Issue**: "Claude not outputting JSON despite schema"
-- **Solution**: Ensure `max_turns` > 1, as Claude may need multiple turns
+- **"Claude not outputting JSON despite schema"** — increase `max_turns` so Claude has room to refine.
+- **High cost** — reduce `max_turns`, tighten the prompt, or restrict `allowed_tools`.
+- **Timeouts** — break complex tasks into smaller steps or raise `timeout`.
+- **Authentication failed** — run `claude doctor` or verify `ANTHROPIC_API_KEY`.
 
-**Issue**: "High costs"
-- **Solution**: Reduce `max_turns`, use smaller context, batch operations
+## See also
 
-**Issue**: "Timeout errors"
-- **Solution**: Break complex tasks into smaller steps, increase timeout
-
-**Issue**: "Authentication failed"
-- **Solution**: Check `claude doctor` or verify `ANTHROPIC_API_KEY`
-
-## See Also
-
-- [Claude Code SDK Documentation](https://github.com/anthropics/claude-code-sdk)
-- [pflow Documentation](../../README.md)
-- [Other Examples](../../README.md)
+- [Claude Agent SDK documentation](https://docs.anthropic.com/en/api/claude-agent-sdk)
+- `pflow guide` — top-level guide for workflow authoring

--- a/examples/nodes/claude-code/README.md
+++ b/examples/nodes/claude-code/README.md
@@ -131,7 +131,7 @@ ${node.llm_usage.session_id}                    # Resumable session ID
 | `cwd`                 | `os.getcwd()`       | Working directory                                           |
 | `model`               | `claude-sonnet-4-5` | Claude model identifier                                     |
 | `allowed_tools`       | All tools           | Permitted tool names (e.g., `["Read", "Write"]`)            |
-| `disallowed_tools`    | None                | Tool names or patterns to deny (e.g., `"Bash(git:*)"`)      |
+| `disallowed_tools`    | None                | Tool names or patterns to deny (e.g., `["Bash(git:*)"]`)    |
 | `max_turns`           | 50                  | Maximum conversation turns                                  |
 | `max_thinking_tokens` | 8000                | Maximum tokens for extended reasoning                       |
 | `timeout`             | 300                 | Execution timeout in seconds (30–3600)                      |

--- a/examples/nodes/claude-code/claude-code-debug.pflow.md
+++ b/examples/nodes/claude-code/claude-code-debug.pflow.md
@@ -35,7 +35,7 @@ Full stack trace if available.
 Analyze the error and provide structured debugging assistance.
 
 - type: claude-code
-- prompt: "Analyze this error and provide debugging assistance:\n\nError message:\n${input.error_message}\n\nCode context (if available):\n${input.code_context}\n\nStack trace (if available):\n${input.stack_trace}"
+- prompt: "Analyze this error and provide debugging assistance:\n\nError message:\n${error_message}\n\nCode context (if available):\n${code_context}\n\nStack trace (if available):\n${stack_trace}"
 - max_turns: 2
 - system_prompt: You are an expert debugger. Be concise but thorough. Focus on practical solutions.
 

--- a/examples/nodes/claude-code/claude-code-git-workflow.pflow.md
+++ b/examples/nodes/claude-code/claude-code-git-workflow.pflow.md
@@ -32,11 +32,6 @@ Analyze the git changes and commit history to understand what was implemented.
 - type: claude-code
 - max_turns: 3
 
-```yaml context
-diff: ${git_diff.stdout}
-commits: ${git_log.stdout}
-```
-
 ```yaml output_schema
 summary:
   type: str
@@ -55,7 +50,15 @@ testing_suggestions:
   description: Suggested test scenarios
 ```
 
-- prompt: Analyze these git changes and commit history to understand what was implemented
+```prompt
+Analyze these git changes and commit history to understand what was implemented.
+
+Diff:
+${git_diff.stdout}
+
+Recent commits:
+${git_log.stdout}
+```
 
 ### generate_pr
 
@@ -64,12 +67,6 @@ Generate a comprehensive pull request description based on the analysis.
 - type: claude-code
 - max_turns: 2
 - system_prompt: You are a senior developer writing clear, professional PR descriptions. Use markdown formatting and be concise but thorough.
-- prompt: Generate a comprehensive pull request description based on this analysis
-
-```yaml context
-analysis: ${analyze_changes.result}
-diff_stats: ${git_diff.stdout}
-```
 
 ```yaml output_schema
 title:
@@ -81,6 +78,16 @@ description:
 checklist:
   type: list
   description: PR checklist items
+```
+
+```prompt
+Generate a comprehensive pull request description based on this analysis.
+
+Analysis:
+${analyze_changes.result}
+
+Diff stats:
+${git_diff.stdout}
 ```
 
 ### save_pr

--- a/examples/nodes/claude-code/claude-code-schema.pflow.md
+++ b/examples/nodes/claude-code/claude-code-schema.pflow.md
@@ -20,7 +20,7 @@ Path to the Python file to review.
 Read the Python source file for review.
 
 - type: read-file
-- file_path: ${input.file_path}
+- file_path: ${file_path}
 
 ### review
 
@@ -56,12 +56,12 @@ refactored_code:
 Save the review report as a markdown file.
 
 - type: write-file
-- file_path: ${input.file_path}.review.md
+- file_path: ${file_path}.review.md
 
 ```text content
 # Code Review Report
 
-**File:** ${input.file_path}
+**File:** ${file_path}
 **Date:** $(date)
 
 ## Overall Assessment
@@ -87,5 +87,5 @@ ${review.result.refactored_code}
 Save the improved code to a separate file.
 
 - type: write-file
-- file_path: ${input.file_path}.improved.py
+- file_path: ${file_path}.improved.py
 - content: ${review.result.refactored_code}

--- a/examples/output_validation_demo.pflow.md
+++ b/examples/output_validation_demo.pflow.md
@@ -19,7 +19,7 @@ Summarize the text content using an LLM.
 - type: llm
 
 ```prompt
-Summarize this text: ${content}
+Summarize this text: ${read.content}
 ```
 
 ## Outputs

--- a/tests/test_docs/test_example_validation.py
+++ b/tests/test_docs/test_example_validation.py
@@ -19,9 +19,11 @@ MCP types, the validator will recurse and fail; the pre-scan won't know to skip.
 No shipped example currently has that shape.
 """
 
+import copy
 from pathlib import Path
 
 import pytest
+import yaml
 
 from pflow.core.diagnostic import Severity
 from pflow.core.exceptions import MarkdownParseError, SchemaValidationError
@@ -95,7 +97,7 @@ class TestExampleValidation:
         registered_types = set(registry.load().keys())
 
         skipped: list[tuple[Path, set[str]]] = []
-        failures: list[str] = []
+        failures: list[tuple[Path, str]] = []
 
         for pflow_file, ir_data in valid_workflow_files:
             used_types = _collect_used_node_types(ir_data)
@@ -104,32 +106,44 @@ class TestExampleValidation:
                 skipped.append((pflow_file, missing_types))
                 continue
 
+            # Deep-copy before mutation: the class-scoped fixture shares IR dicts
+            # across tests, and resolve_file_references writes in place. Copying
+            # isolates each test's view.
+            ir_local = copy.deepcopy(ir_data)
+            rel_path = pflow_file.relative_to(EXAMPLES_DIR)
+
             # Fill declared required inputs with dummy values — mirrors CLI
             # `--validate-only`, which runs structural validation with placeholders
             # rather than real user input.
-            dummy_params = generate_dummy_parameters(ir_data.get("inputs", {}))
+            dummy_params = generate_dummy_parameters(ir_local.get("inputs", {}))
             dummy_params["_pflow_workflow_file"] = str(pflow_file)
 
             # Resolve external file refs (e.g., `- prompt: ./prompts/x.md`) in place
             # so template validation sees the real content, matching CLI behavior.
-            resolve_file_references(ir_data, get_base_dir(dummy_params))
+            # A broken file ref in one example would otherwise crash the whole
+            # test run and mask regressions in every other example.
+            try:
+                resolve_file_references(ir_local, get_base_dir(dummy_params))
+            except (FileNotFoundError, OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+                failures.append((rel_path, f"file resolution failed: {exc}"))
+                continue
 
             diagnostics = WorkflowValidator.validate(
-                ir_data,
+                ir_local,
                 extracted_params=dummy_params,
                 registry=registry,
                 workflow_file=pflow_file,
             )
             errors = [d for d in diagnostics if d.severity == Severity.ERROR]
-            if errors:
-                rel_path = pflow_file.relative_to(EXAMPLES_DIR)
-                for err in errors:
-                    failures.append(f"  {rel_path}: {err.message}")
+            for err in errors:
+                failures.append((rel_path, err.message))
 
         if failures:
+            unique_files = {path for path, _ in failures}
+            rendered = "\n".join(f"  {path}: {msg}" for path, msg in failures)
             pytest.fail(
                 f"Full validation failed for {len(failures)} diagnostic(s) across "
-                f"{len({f.split(':')[0] for f in failures})} file(s):\n" + "\n".join(failures)
+                f"{len(unique_files)} file(s):\n{rendered}"
             )
 
     def test_invalid_examples_fail_parsing_or_validation(self, invalid_workflow_files: list[Path]) -> None:

--- a/tests/test_docs/test_example_validation.py
+++ b/tests/test_docs/test_example_validation.py
@@ -1,27 +1,43 @@
-"""Validate that shipped example workflows conform to IR schema.
+"""Validate that shipped example workflows conform to the full validator contract.
 
 This test suite ensures:
-1. Valid .pflow.md examples in examples/ parse and pass IR schema validation
-2. Invalid .pflow.md examples in examples/invalid/ correctly fail parsing or validation
-3. Examples remain valid as the IR schema evolves
+1. Valid .pflow.md examples in examples/ pass the 10-step WorkflowValidator pipeline
+   (not just IR schema). This catches stale examples that reference undeclared inputs,
+   non-existent node outputs, removed params, etc. — rot that accumulated when the
+   suite only ran validate_ir().
+2. Invalid .pflow.md examples in examples/invalid/ correctly fail parsing or validation.
+3. Examples remain valid as the validator and IR schema evolve.
 
-Speed optimized:
-- Single directory scan (cached at class scope)
-- Lightweight schema validation only (no compilation)
-- Batch assertions with clear failure reporting
-- All files validated in <100ms
+Skip contract: workflows whose ONLY unregistered node types are `mcp-*` (MCP tools
+supplied by user-configured servers) are skipped with a recorded reason. Workflows
+with any non-MCP unregistered type (typos, removed node types) still fail — that's
+the rot we want to catch.
+
+Latent gap: the skip predicate pre-scans only top-level `node.type` strings. If a
+parent workflow references a sub-workflow file whose own nodes include unregistered
+MCP types, the validator will recurse and fail; the pre-scan won't know to skip.
+No shipped example currently has that shape.
 """
 
 from pathlib import Path
 
 import pytest
 
-from pflow.core import validate_ir
+from pflow.core.diagnostic import Severity
 from pflow.core.exceptions import MarkdownParseError, SchemaValidationError
-from pflow.core.ir_schema import normalize_ir
+from pflow.core.file_resolver import get_base_dir, resolve_file_references
+from pflow.core.ir_schema import normalize_ir, validate_ir
 from pflow.core.markdown_parser import parse_markdown
+from pflow.core.validation_utils import generate_dummy_parameters
+from pflow.core.workflow.validator import WorkflowValidator
+from pflow.registry import Registry
 
 EXAMPLES_DIR = Path(__file__).parent.parent.parent / "examples"
+
+
+def _collect_used_node_types(ir_data: dict) -> set[str]:
+    """Return the set of node type strings referenced directly by this workflow."""
+    return {node.get("type") for node in ir_data.get("nodes", []) if node.get("type")}
 
 
 class TestExampleValidation:
@@ -62,20 +78,59 @@ class TestExampleValidation:
 
         return list(invalid_dir.glob("*.pflow.md"))
 
-    def test_valid_examples_pass_schema_validation(self, valid_workflow_files: list[tuple[Path, dict]]) -> None:
-        """All valid example workflows should pass IR schema validation."""
+    def test_valid_examples_pass_full_validation(self, valid_workflow_files: list[tuple[Path, dict]]) -> None:
+        """All valid examples must pass the full 10-step WorkflowValidator pipeline.
+
+        Schema-only validation (validate_ir) missed real user-facing rot:
+        undeclared inputs, ${input.x} syntax, stale node-output references, removed
+        params. This test runs the same validation the CLI runs.
+
+        Files whose ONLY unregistered types are `mcp-*` are skipped (they depend on
+        user-configured external servers). Any non-MCP unregistered type still fails
+        so typos and removed node types surface as errors.
+        """
         assert valid_workflow_files, "No valid example files found"
 
-        failures = []
+        registry = Registry()
+        registered_types = set(registry.load().keys())
+
+        skipped: list[tuple[Path, set[str]]] = []
+        failures: list[str] = []
+
         for pflow_file, ir_data in valid_workflow_files:
-            try:
-                validate_ir(ir_data)
-            except SchemaValidationError as e:
+            used_types = _collect_used_node_types(ir_data)
+            missing_types = used_types - registered_types
+            if missing_types and all(t.startswith("mcp-") for t in missing_types):
+                skipped.append((pflow_file, missing_types))
+                continue
+
+            # Fill declared required inputs with dummy values — mirrors CLI
+            # `--validate-only`, which runs structural validation with placeholders
+            # rather than real user input.
+            dummy_params = generate_dummy_parameters(ir_data.get("inputs", {}))
+            dummy_params["_pflow_workflow_file"] = str(pflow_file)
+
+            # Resolve external file refs (e.g., `- prompt: ./prompts/x.md`) in place
+            # so template validation sees the real content, matching CLI behavior.
+            resolve_file_references(ir_data, get_base_dir(dummy_params))
+
+            diagnostics = WorkflowValidator.validate(
+                ir_data,
+                extracted_params=dummy_params,
+                registry=registry,
+                workflow_file=pflow_file,
+            )
+            errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+            if errors:
                 rel_path = pflow_file.relative_to(EXAMPLES_DIR)
-                failures.append(f"  {rel_path}: {e}")
+                for err in errors:
+                    failures.append(f"  {rel_path}: {err.message}")
 
         if failures:
-            pytest.fail(f"Schema validation failed for {len(failures)} file(s):\n" + "\n".join(failures))
+            pytest.fail(
+                f"Full validation failed for {len(failures)} diagnostic(s) across "
+                f"{len({f.split(':')[0] for f in failures})} file(s):\n" + "\n".join(failures)
+            )
 
     def test_invalid_examples_fail_parsing_or_validation(self, invalid_workflow_files: list[Path]) -> None:
         """All invalid example workflows should fail during parsing or validation."""


### PR DESCRIPTION
## Summary

Eight example `.pflow.md` files in `examples/` failed `pflow --validate-only` with real user-facing errors but passed CI. Root cause: `tests/test_docs/test_example_validation.py` only ran `validate_ir()` (IR schema only), not the full `WorkflowValidator.validate()` 10-step pipeline that the CLI runs. Examples rotted undetected across several breaking changes (the Claude Agent SDK migration, `${input.x}` namespace cleanup, template-variable declaration requirement).

## Changes

**Example fixes (7 `.pflow.md` files):**
- `advanced/file-migration.pflow.md`, `advanced/content-pipeline.pflow.md`, `core/template-variables.pflow.md`: added `## Inputs` sections for referenced template variables; fixed `${timestamp.log}` / `${timestamp_}` typos so the regex parses var + literal separator correctly.
- `output_validation_demo.pflow.md`: `${content}` → `${read.content}` (namespaced node output).
- `nodes/claude-code/claude-code-debug.pflow.md` and `claude-code-schema.pflow.md`: `${input.x}` → `${x}` (stale namespacing).
- `nodes/claude-code/claude-code-git-workflow.pflow.md`: removed the ` \`\`\`yaml context ` fence — the `context` param was removed in commit `8f848255` (Claude Agent SDK migration). Context is now inlined into the `prompt` fence per the commit's own migration guidance.
- `nodes/claude-code/README.md`: rewrote for current API (`.pflow.md` not `.json`, `prompt` not `task`, `cwd` not `working_directory`, no `context` param, correct `llm_usage` field list).

**Test tightened (`tests/test_docs/test_example_validation.py`):**
- Switched from `validate_ir()` (schema only) to `WorkflowValidator.validate()` (full 10-step pipeline), mirroring `pflow --validate-only`: fills declared inputs with `generate_dummy_parameters`, resolves external file references, passes `workflow_file` for sub-workflow resolution.
- Skip predicate: files with unregistered node types are skipped **only** when every missing type matches `mcp-*` (user-configured MCP servers). Non-MCP typos like `wrte-file` still fail loudly.

**Docs:**
- `examples/CLAUDE.md`: documented the new validator contract, the MCP-only skip predicate, and the latent gap around sub-workflow pre-scanning.

## Explanation

The issue claimed three rot categories (A: undeclared inputs, B: missing `llm_usage` output, C: `${input.x}` syntax). Fresh registry scan revealed **Category B was a local registry staleness artifact** — the current claude-code source correctly writes `shared[\"llm_usage\"]` and the registry advertises it. `claude-code-basic.pflow.md` was already valid. That leaves 7 real rot cases plus one new category (D) discovered during investigation: `claude-code-git-workflow` uses a removed `context` parameter.

The skip predicate tightening is load-bearing — an earlier draft skipped **any** file with unregistered types, which would have silently hidden typos like `wrte-file`. Mutation test: introducing `type: wrte-file` into `core/minimal.pflow.md` now produces `Unknown node type: 'wrte-file'` instead of being silently skipped.

Two environment-dependent files (`mcp-filesystem.pflow.md`, `mcp-http/example-workflow.pflow.md`) and the two `real-workflows/` that reference Slack/Discord MCP tools are skipped by design — they depend on user-configured servers. Skip classification verified: 45 files validated, 4 skipped (all legitimate MCP).

## Testing

- `make check` passes (ruff, mypy, deptry).
- `make test` passes: 4859 passed, 0 failed.
- `tests/test_docs/test_example_validation.py` — mutation-verified end to end (reverting any individual fix makes the test fail with the exact diagnostic the issue described).
- Sweep: `pflow --validate-only` on all 45 validated files returns `✓ Workflow is valid`.

## Known limitations (not blocking)

- `file-migration.pflow.md` declares `copied_count` / `moved_count` / `error_count` / `error_message` / `current_operation` as workflow inputs with defaults. Semantically these should be outputs from earlier nodes; the original example was structurally broken and the minimal fix keeps it that way. Redesigning the example is out of scope.
- Validation was verified; compile-time and runtime checks were not exercised (LLM/Claude examples require env credentials).
- Skip predicate walks only top-level `node.type`. A parent workflow whose sub-workflow has unregistered MCP types would still fail. No shipped example currently has that shape.