### PR TITLE
fix: error pipeline silent failures cluster (fixes #292, #288)

### DIFF
--- a/src/pflow/cli/main.py
+++ b/src/pflow/cli/main.py
@@ -10,6 +10,8 @@ from typing import Any, ClassVar
 
 import click
 
+from pflow.cli.error_output import output_error
+from pflow.core.exceptions import PflowError
 from pflow.guide import render_entry_content
 
 
@@ -53,9 +55,6 @@ class PflowCLI(click.Group):
         # Python tracebacks. The `run` command has its own boundary with
         # full --output-format / metrics parity; it never lets PflowError
         # escape, so this override is inert for that path.
-        from pflow.cli.error_output import output_error
-        from pflow.core.exceptions import PflowError
-
         try:
             return super().invoke(ctx)
         except PflowError as e:

--- a/src/pflow/cli/main.py
+++ b/src/pflow/cli/main.py
@@ -6,7 +6,7 @@ import signal
 import sys
 from contextlib import suppress
 from importlib.metadata import version as pkg_version
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import click
 
@@ -45,6 +45,28 @@ class PflowCLI(click.Group):
             ctx.exit(1)
 
         return "run", self.get_command(ctx, "run"), args
+
+    def invoke(self, ctx: click.Context) -> Any:
+        # Group-level error boundary: route uncaught PflowError subclasses
+        # through the unified diagnostic pipeline so subcommands (describe,
+        # history, save, etc.) render structured errors instead of raw
+        # Python tracebacks. The `run` command has its own boundary with
+        # full --output-format / metrics parity; it never lets PflowError
+        # escape, so this override is inert for that path.
+        from pflow.cli.error_output import output_error
+        from pflow.core.exceptions import PflowError
+
+        try:
+            return super().invoke(ctx)
+        except PflowError as e:
+            obj = ctx.obj or {}
+            output_error(
+                ctx,
+                exception=e,
+                output_format=obj.get("output_format", "text"),
+                verbose=obj.get("verbose", False),
+            )
+            ctx.exit(1)
 
     def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         formatter.write_usage(ctx.command_path, "[OPTIONS] COMMAND [ARGS]...")

--- a/src/pflow/core/workflow/manager.py
+++ b/src/pflow/core/workflow/manager.py
@@ -274,7 +274,13 @@ class WorkflowManager:
             return loaded
 
         except MarkdownParseError as e:
-            raise WorkflowValidationError(f"Invalid workflow '{name}': {e}") from e
+            # Preserve structured diagnostics — don't flatten to a string.
+            # The CLI boundary (PflowCLI.invoke) renders validation_errors
+            # via format_diagnostic, matching --validate-only output.
+            raise WorkflowValidationError(
+                f"Invalid workflow '{name}'",
+                validation_errors=e.to_diagnostics(),
+            ) from e
         except Exception as e:
             if isinstance(e, WorkflowValidationError):
                 raise

--- a/src/pflow/guide/__init__.py
+++ b/src/pflow/guide/__init__.py
@@ -215,8 +215,18 @@ def _try_load_saved_workflow(name: str) -> dict | None:
     except WorkflowNotFoundError:
         return None
     except Exception as e:
+        # Preserve structured diagnostics — WorkflowValidationError now carries
+        # validation_errors (task 153 shape), str(e) is just the summary.
+        from pflow.core.exceptions import WorkflowValidationError
+
+        detail = str(e)
+        if isinstance(e, WorkflowValidationError) and e.validation_errors:
+            from pflow.core.diagnostic_render import format_diagnostic
+
+            rendered = "\n".join(format_diagnostic(d) for d in e.validation_errors)
+            detail = f"{e.summary}\n{rendered}"
         raise GuideError(
-            f"Saved workflow '{name}' failed to load: {e}\nUse explicit topics instead: `pflow guide <topics...>`"
+            f"Saved workflow '{name}' failed to load: {detail}\nUse explicit topics instead: `pflow guide <topics...>`"
         ) from e
 
 

--- a/src/pflow/runtime/compilation/ir_preparation.py
+++ b/src/pflow/runtime/compilation/ir_preparation.py
@@ -174,18 +174,38 @@ def _coerce_provided_input(
     return coerced_value, was_coerced
 
 
+def _is_framework_param_key(key: str) -> bool:
+    """Whether ``key`` matches the documented framework-key conventions.
+
+    Two patterns are recognized, matching what the Runner / compiler actually
+    inject into ``initial_params`` before ``prepare_inputs`` runs:
+
+    - ``_pflow_*`` — single-underscore framework namespace
+      (e.g. ``_pflow_workflow_file``, ``_pflow_depth``, ``_pflow_stack``).
+    - ``__*__`` — dunder-wrapped metadata keys
+      (e.g. ``__template_resolution_mode__``, ``__registry__``).
+
+    Any other underscore-prefixed name (e.g. ``_foo``) is treated as
+    user-authored. Keeps user typos like ``_foo`` for declared ``foo``
+    visible as extras errors, and catches framework-key typos like
+    ``_pflow_workflo_file`` as unknown inputs instead of silently dropping
+    them. ``is_valid_parameter_name`` already rejects ``__*__`` user names
+    at schema validation, so a user cannot collide with the dunder form.
+    """
+    return key.startswith("_pflow_") or (key.startswith("__") and key.endswith("__"))
+
+
 def _check_undeclared_extras(declared_names: set[str], provided_params: dict[str, Any]) -> list[tuple[str, str, str]]:
     """Detect keys in ``provided_params`` that are not declared as workflow inputs.
 
-    Framework-internal keys (starting with ``_``, covering ``_pflow_*`` and
-    ``__*__``) are compiler/runtime-injected and never user-authored, so they
-    are filtered from the extras set. Symmetric with the sub-workflow check in
+    Framework-internal keys are filtered via :func:`_is_framework_param_key`.
+    Symmetric with the sub-workflow check in
     ``WorkflowValidator._check_required_inputs`` (GH #288 / task 153).
 
     Returns a list of ``(message, path, suggestion)`` tuples consumed by
     ``_raise_input_validation_errors``.
     """
-    user_provided = [k for k in provided_params if not k.startswith("_")]
+    user_provided = [k for k in provided_params if not _is_framework_param_key(k)]
     extras = sorted(set(user_provided) - declared_names)
     if not extras:
         return []

--- a/src/pflow/runtime/compilation/ir_preparation.py
+++ b/src/pflow/runtime/compilation/ir_preparation.py
@@ -174,6 +174,40 @@ def _coerce_provided_input(
     return coerced_value, was_coerced
 
 
+def _check_undeclared_extras(declared_names: set[str], provided_params: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """Detect keys in ``provided_params`` that are not declared as workflow inputs.
+
+    Framework-internal keys (starting with ``_``, covering ``_pflow_*`` and
+    ``__*__``) are compiler/runtime-injected and never user-authored, so they
+    are filtered from the extras set. Symmetric with the sub-workflow check in
+    ``WorkflowValidator._check_required_inputs`` (GH #288 / task 153).
+
+    Returns a list of ``(message, path, suggestion)`` tuples consumed by
+    ``_raise_input_validation_errors``.
+    """
+    user_provided = [k for k in provided_params if not k.startswith("_")]
+    extras = sorted(set(user_provided) - declared_names)
+    if not extras:
+        return []
+
+    from pflow.core.suggestion_utils import find_similar_items
+
+    errors: list[tuple[str, str, str]] = []
+    sorted_declared = sorted(declared_names)
+    for extra in extras:
+        if sorted_declared:
+            similar = find_similar_items(extra, sorted_declared, max_results=2, method="fuzzy")
+            message = f"Unknown input '{extra}' — not declared by this workflow."
+            suggestion = (
+                f"Did you mean '{similar[0]}'?" if similar else f"Available inputs: {', '.join(sorted_declared)}"
+            )
+        else:
+            message = f"Unknown input '{extra}' — this workflow declares no inputs."
+            suggestion = "Remove the parameter, or declare it in ## Inputs."
+        errors.append((message, f"inputs.{extra}", suggestion))
+    return errors
+
+
 def validate_ir_structure(ir_dict: dict[str, Any]) -> None:
     """Validate basic IR structure (nodes, edges arrays).
 
@@ -263,7 +297,11 @@ def prepare_inputs(
     # Extract input declarations (backward compatible with workflows without inputs)
     inputs = workflow_ir.get("inputs", {})
 
-    # If no inputs declared, nothing to validate
+    # Reject undeclared extras (GH #288, symmetric with sub-workflow check in
+    # WorkflowValidator._check_required_inputs).
+    errors.extend(_check_undeclared_extras(set(inputs.keys()), provided_params))
+
+    # If no inputs declared, nothing else to validate
     if not inputs:
         logger.debug("No inputs declared for workflow", extra={"phase": "input_validation"})
         return errors, defaults, env_param_names

--- a/tests/test_cli/test_cli_error_boundary.py
+++ b/tests/test_cli/test_cli_error_boundary.py
@@ -1,0 +1,267 @@
+"""Tests for the CLI error boundary at PflowCLI.invoke().
+
+The boundary catches PflowError subclasses escaping subcommand callbacks
+and routes them through output_error() → format_diagnostic() so CLI
+errors render structured diagnostics instead of Python tracebacks.
+
+See GH #292 and tests/test_cli/CLAUDE.md for test patterns.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import click
+import pytest
+from click.testing import CliRunner
+
+# Invalid workflow: output "out" has no description paragraph between the
+# heading and the `- source:` param. parse_markdown raises MarkdownParseError
+# at line 23 ("Entity 'out' (line 23) is missing a description.").
+PARSE_ERROR_WORKFLOW = """\
+# Bug Repro
+
+## Inputs
+
+### x
+
+A message.
+
+- type: string
+- required: true
+
+## Steps
+
+### echo
+
+Echo it.
+
+- type: shell
+- command: echo "${x}"
+
+## Outputs
+
+### out
+
+- source: ${echo.stdout}
+"""
+
+
+def _skip_uv_sandbox_panic(result: subprocess.CompletedProcess) -> None:
+    """Skip when the uv subprocess panics in a restricted sandbox."""
+    if result.returncode == 101 and "Attempted to create a NULL object" in (result.stderr or ""):
+        pytest.skip("uv subprocess panics in this sandbox before pflow starts")
+
+
+def _run_pflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess:
+    """Run pflow via the in-repo Python module, capturing both streams."""
+    # Don't inherit PYTEST_CURRENT_TEST — causes configure_logging to short-circuit
+    # and partial-line filters to skip install. See tests/CLAUDE.md #10.
+    clean_env = {k: v for k, v in env.items() if k != "PYTEST_CURRENT_TEST"}
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "pflow.cli", *args],
+        capture_output=True,
+        text=True,
+        env=clean_env,
+        timeout=60,
+    )
+
+
+def _save_broken_workflow(home_dir, name: str) -> None:
+    """Write PARSE_ERROR_WORKFLOW as a saved workflow under HOME/.pflow/workflows/."""
+    workflow_dir = home_dir / ".pflow" / "workflows" / name
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / f"{name}.pflow.md").write_text(PARSE_ERROR_WORKFLOW)
+
+
+class TestDescribeParseError:
+    """Primary guards for GH #292 — pflow describe must not crash with a traceback."""
+
+    def test_describe_parse_error_renders_via_diagnostic_pipeline(self, tmp_path, prepared_subprocess_env):
+        """pflow describe <workflow-with-parse-error> renders a structured diagnostic, not a traceback."""
+        env = dict(prepared_subprocess_env)
+        env["HOME"] = str(tmp_path)
+        (tmp_path / ".pflow").mkdir(exist_ok=True)
+        _save_broken_workflow(tmp_path, "__boundary_parse_err")
+
+        result = _run_pflow(["describe", "__boundary_parse_err"], env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 1, f"expected exit 1, got {result.returncode}\nstderr: {result.stderr!r}"
+        assert "Traceback" not in result.stderr, (
+            f"Boundary must catch PflowError; stderr still has a traceback:\n{result.stderr}"
+        )
+        # Structured diagnostic markers
+        assert "Parse Error" in result.stderr, f"missing 'Parse Error' title:\n{result.stderr}"
+        assert "line 23" in result.stderr, f"missing source line ref:\n{result.stderr}"
+        # Suggestion block surfaced (from MarkdownParseError.suggestion)
+        assert "Add a text paragraph" in result.stderr, f"missing suggestion block:\n{result.stderr}"
+
+    def test_history_also_uses_boundary_for_parse_errors(self, tmp_path, prepared_subprocess_env):
+        """Architectural check: boundary is not describe-specific.
+
+        pflow history (a sibling command that also calls WorkflowManager.load())
+        must render the same structured diagnostic. Protects against anyone
+        later wiring per-command handlers and silently regressing the boundary.
+        """
+        env = dict(prepared_subprocess_env)
+        env["HOME"] = str(tmp_path)
+        (tmp_path / ".pflow").mkdir(exist_ok=True)
+        _save_broken_workflow(tmp_path, "__boundary_history_err")
+
+        result = _run_pflow(["history", "__boundary_history_err"], env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 1
+        assert "Traceback" not in result.stderr
+        assert "Parse Error" in result.stderr
+        assert "line 23" in result.stderr
+
+    def test_describe_and_validate_only_produce_same_diagnostic(self, tmp_path, prepared_subprocess_env):
+        """Symmetry guard: describe and file --validate-only produce the same diagnostic content.
+
+        For parse errors, resolve_workflow() raises MarkdownParseError BEFORE
+        --validate-only's pipeline takes effect, so both commands hit
+        PflowCLI.invoke → display_exception_text → format_diagnostic. This
+        test verifies the group boundary renders consistently for both
+        entry points. (It does NOT exercise validate-only's
+        format_validation_failure rendering — that path is unreachable for
+        parse errors because resolve_workflow short-circuits.)
+
+        Locks in Change 2: preserving structured diagnostics through
+        WorkflowValidationError.validation_errors reaches both paths
+        identically.
+        """
+        env = dict(prepared_subprocess_env)
+        env["HOME"] = str(tmp_path)
+        (tmp_path / ".pflow").mkdir(exist_ok=True)
+        _save_broken_workflow(tmp_path, "__boundary_symmetry")
+
+        # Also write a copy as a standalone file for the --validate-only path
+        standalone = tmp_path / "standalone.pflow.md"
+        standalone.write_text(PARSE_ERROR_WORKFLOW)
+
+        describe_result = _run_pflow(["describe", "__boundary_symmetry"], env)
+        validate_result = _run_pflow([str(standalone), "--validate-only"], env)
+        _skip_uv_sandbox_panic(describe_result)
+        _skip_uv_sandbox_panic(validate_result)
+
+        assert describe_result.returncode == 1
+        assert validate_result.returncode == 1
+
+        # The rendered diagnostic body must match. Both paths use the same
+        # MarkdownParseError.to_diagnostics() → format_diagnostic() pipeline.
+        for marker in (
+            "Error: Parse Error",
+            "Entity 'out' (line 23) is missing a description.",
+            "At: line 23",
+            "Add a text paragraph between the heading and the parameters",
+        ):
+            assert marker in describe_result.stderr, f"describe missing '{marker}':\n{describe_result.stderr}"
+            assert marker in validate_result.stderr, f"validate missing '{marker}':\n{validate_result.stderr}"
+
+
+class TestBoundaryNarrowCatch:
+    """Negative control: the boundary catches PflowError only, not generic Exception.
+
+    Genuine bugs (RuntimeError, AssertionError) must still produce tracebacks
+    for debugging. Uses CliRunner for in-process assertion because we're
+    testing control flow (exception propagation), not stderr coherence.
+    """
+
+    def test_cli_boundary_does_not_catch_runtime_error(self):
+        """A non-PflowError raised by a subcommand must propagate out of the CLI."""
+        from pflow.cli.main import cli
+
+        @click.command(name="__test_runtime_error__")
+        def raiser() -> None:
+            raise RuntimeError("genuine bug — must not be swallowed")
+
+        cli.add_command(raiser)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["__test_runtime_error__"], catch_exceptions=True)
+
+            # CliRunner captures the uncaught exception in result.exception.
+            # If the boundary incorrectly widened to `except Exception`, this
+            # would be None and exit_code would be 1 via the boundary path.
+            assert result.exception is not None, (
+                f"RuntimeError should have propagated — boundary must not catch it.\noutput: {result.output}"
+            )
+            assert isinstance(result.exception, RuntimeError)
+            assert "genuine bug" in str(result.exception)
+        finally:
+            cli.commands.pop("__test_runtime_error__", None)
+
+    def test_cli_boundary_catches_pflow_error(self):
+        """Positive control: an arbitrary PflowError raised by a subcommand is caught."""
+        from pflow.cli.main import cli
+        from pflow.core.exceptions import WorkflowNotFoundError
+
+        @click.command(name="__test_pflow_error__")
+        def raiser() -> None:
+            raise WorkflowNotFoundError("imaginary-workflow")
+
+        cli.add_command(raiser)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["__test_pflow_error__"], catch_exceptions=True)
+
+            # Boundary caught → no uncaught exception, clean exit 1, rendered output
+            assert result.exception is None or isinstance(result.exception, SystemExit), (
+                f"Boundary should have caught PflowError; exception={result.exception!r}"
+            )
+            assert result.exit_code == 1
+            # output + stderr both captured into result.output by CliRunner
+            assert "Workflow Not Found" in result.output or "imaginary-workflow" in result.output
+        finally:
+            cli.commands.pop("__test_pflow_error__", None)
+
+
+class TestRunCommandUnchanged:
+    """Regression guard: run has its own boundary; the group boundary must not interfere."""
+
+    def test_run_shell_failure_still_renders_via_own_pipeline(self, tmp_path, prepared_subprocess_env):
+        """A failing shell workflow still routes through run's output_error() with full context."""
+        workflow_content = """\
+# Fail
+
+## Steps
+
+### boom
+
+Runs a failing command.
+
+- type: shell
+
+```shell command
+exit 1
+```
+
+## Outputs
+
+### out
+
+The stdout.
+
+- source: ${boom.stdout}
+"""
+        workflow_file = tmp_path / "fail.pflow.md"
+        workflow_file.write_text(workflow_content)
+
+        result = _run_pflow([str(workflow_file), "--no-trace"], prepared_subprocess_env)
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode != 0, f"workflow should fail:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "Traceback" not in result.stderr, f"run should not traceback:\n{result.stderr}"
+        # Assertions below are run-pipeline-specific — the group boundary
+        # (PflowCLI.invoke) would never emit these. They prove run's own
+        # output_error() path fired, not a fallthrough to the boundary.
+        assert "Executing workflow" in result.stderr, (
+            f"run's execution-progress line missing — likely group boundary caught the error instead of run's pipeline:\n{result.stderr}"
+        )
+        assert "Shell details:" in result.stderr, (
+            f"category-aware shell rendering missing — failed-node diagnostic not routed through run's executor_service:\n{result.stderr}"
+        )
+        assert "At: node 'boom'" in result.stderr, f"node-specific attribution missing:\n{result.stderr}"

--- a/tests/test_integration/test_template_system_e2e.py
+++ b/tests/test_integration/test_template_system_e2e.py
@@ -80,6 +80,11 @@ def test_template_with_path_traversal():
         # Create workflow that uses path traversal
         workflow_ir = {
             "ir_version": "0.1.0",
+            "inputs": {
+                "paths": {"type": "object", "description": "Path bundle", "required": True},
+                "data": {"type": "object", "description": "Data bundle", "required": True},
+                "config": {"type": "object", "description": "Config bundle", "required": True},
+            },
             "nodes": [
                 {
                     "id": "writer",
@@ -120,6 +125,9 @@ def test_template_fallback_to_shared_store():
         # Workflow that expects content from shared store
         workflow_ir = {
             "ir_version": "0.1.0",
+            "inputs": {
+                "output_path": {"type": "string", "description": "Output path", "required": True},
+            },
             "nodes": [
                 {
                     "id": "writer",
@@ -153,6 +161,9 @@ def test_template_priority_initial_params_over_shared():
     with tempfile.TemporaryDirectory() as tmpdir:
         workflow_ir = {
             "ir_version": "0.1.0",
+            "inputs": {
+                "message": {"type": "string", "description": "Message body", "required": True},
+            },
             "nodes": [
                 {
                     "id": "writer",
@@ -184,6 +195,11 @@ def test_workflow_reusability():
         # Define reusable workflow
         workflow_ir = {
             "ir_version": "0.1.0",
+            "inputs": {
+                "output_file": {"type": "string", "description": "Output file path", "required": True},
+                "user_name": {"type": "string", "description": "User name", "required": True},
+                "task_id": {"type": "string", "description": "Task ID", "required": True},
+            },
             "nodes": [
                 {
                     "id": "writer",

--- a/tests/test_runtime/test_prepare_inputs_extras.py
+++ b/tests/test_runtime/test_prepare_inputs_extras.py
@@ -1,0 +1,260 @@
+"""Tests for undeclared-extras rejection in prepare_inputs (GH #288).
+
+Symmetric with the sub-workflow extras check in
+``WorkflowValidator._check_required_inputs`` (task 153). The compiler-layer
+check fires at every callsite that compiles: CLI ``run``, MCP
+``execute_workflow``, programmatic. ``--validate-only`` is deliberately
+structural-only and does not call ``prepare_inputs``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from pflow.runtime.compilation.ir_preparation import prepare_inputs
+
+
+class TestExtrasRejection:
+    """Root-level: keys in provided_params not in declared inputs → error."""
+
+    def test_no_declared_inputs_rejects_any_extra(self):
+        """Case A from #288: workflow with no ## Inputs + provided BOGUS → error."""
+        errors, _, _ = prepare_inputs({"inputs": {}}, {"BOGUS": "X"})
+
+        assert len(errors) == 1
+        msg, path, suggestion = errors[0]
+        assert msg == "Unknown input 'BOGUS' — this workflow declares no inputs."
+        assert path == "inputs.BOGUS"
+        assert "Remove the parameter" in suggestion or "declare it in ## Inputs" in suggestion
+
+    def test_declared_inputs_rejects_unknown_extra(self):
+        """Case B from #288: declared 'a' + {a: ok, BOGUS: X} → error naming BOGUS."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "First input", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"a": "ok", "BOGUS": "X"})
+
+        extras_errors = [e for e in errors if "Unknown input 'BOGUS'" in e[0]]
+        assert len(extras_errors) == 1
+        msg, path, suggestion = extras_errors[0]
+        assert msg == "Unknown input 'BOGUS' — not declared by this workflow."
+        assert path == "inputs.BOGUS"
+        # When no fuzzy match, suggestion lists available inputs
+        assert "Available inputs: a" in suggestion
+
+    def test_fuzzy_suggestion_for_close_typo(self):
+        """Close typo (aa vs a) produces 'Did you mean' suggestion."""
+        workflow_ir = {"inputs": {"lyrics": {"type": "string", "description": "Lyrics", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"lyrics": "ok", "lyric": "typo"})
+
+        extras = [e for e in errors if "Unknown input 'lyric'" in e[0]]
+        assert len(extras) == 1
+        _, _, suggestion = extras[0]
+        assert "Did you mean 'lyrics'?" in suggestion
+
+    def test_missing_required_and_extra_both_surface(self):
+        """Case C from #288: missing required + extra provided → BOTH errors reported."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "Required", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"BOGUS": "X"})
+
+        # Aggregated error list should contain both findings (one unknown + one missing)
+        assert len(errors) == 2
+        messages = [e[0] for e in errors]
+        assert any("Unknown input 'BOGUS'" in m for m in messages), messages
+        assert any("Workflow requires input 'a'" in m for m in messages), messages
+
+    def test_valid_inputs_produce_no_errors(self):
+        """Positive control: providing exactly the declared inputs is not an extra."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "Input A", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"a": "value"})
+        assert errors == []
+
+    def test_framework_keys_exempted_from_extras_check(self):
+        """Internal ``_pflow_*`` keys injected by the Runner/compiler are not extras."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "Input A", "required": True}}}
+        # _pflow_workflow_file is injected by Runner before compile (runner.py:141).
+        errors, _, _ = prepare_inputs(
+            workflow_ir,
+            {"a": "value", "_pflow_workflow_file": "/path/to/wf.pflow.md"},
+        )
+        assert errors == []
+
+    def test_template_resolution_mode_framework_key_exempt(self):
+        """Production invariant: ``__template_resolution_mode__`` (injected by
+        ``compile_validation.py:165`` before ``prepare_inputs`` runs) must be
+        exempted from the extras check. Regressing this breaks every workflow
+        compile, so test against the REAL injected key, not a synthetic one."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "Input A", "required": True}}}
+        errors, _, _ = prepare_inputs(
+            workflow_ir,
+            {"a": "value", "__template_resolution_mode__": "strict"},
+        )
+        assert errors == []
+
+    def test_multiple_extras_all_reported(self):
+        """More than one extra → every one surfaces."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "A", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"a": "ok", "x": "1", "y": "2", "z": "3"})
+
+        extras_msgs = [e[0] for e in errors if "Unknown input" in e[0]]
+        assert len(extras_msgs) == 3
+        assert any("'x'" in m for m in extras_msgs)
+        assert any("'y'" in m for m in extras_msgs)
+        assert any("'z'" in m for m in extras_msgs)
+
+    def test_extras_sorted_deterministically(self):
+        """Extras list is emitted in sorted order for deterministic error output."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "A", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"a": "ok", "zebra": "1", "apple": "2"})
+
+        extras_keys = [e[1].removeprefix("inputs.") for e in errors if "Unknown input" in e[0]]
+        assert extras_keys == sorted(extras_keys)
+
+
+class TestOptionalInputExtras:
+    """Optional (non-required) declared inputs are fine; extras not in the declared
+    set are still rejected regardless of whether declared ones are required."""
+
+    def test_extra_rejected_even_with_only_optional_declared(self):
+        workflow_ir = {
+            "inputs": {
+                "mode": {
+                    "type": "string",
+                    "description": "Mode",
+                    "required": False,
+                    "default": "normal",
+                },
+            }
+        }
+        errors, _, _ = prepare_inputs(workflow_ir, {"BOGUS": "X"})
+
+        extras = [e for e in errors if "Unknown input 'BOGUS'" in e[0]]
+        assert len(extras) == 1
+
+    def test_optional_declared_provided_is_fine(self):
+        workflow_ir = {
+            "inputs": {
+                "mode": {
+                    "type": "string",
+                    "description": "Mode",
+                    "required": False,
+                    "default": "normal",
+                },
+            }
+        }
+        errors, _, _ = prepare_inputs(workflow_ir, {"mode": "custom"})
+        # No extras error; value passes through as provided (no coercion needed)
+        assert not any("Unknown input" in e[0] for e in errors)
+
+
+class TestValidateOnlyGap:
+    """Locked-in regression test documenting the intentional `--validate-only` parity gap.
+
+    `WorkflowRunner.validate()` does NOT call `prepare_inputs`, so the extras
+    check added in GH #288 does NOT fire for `pflow <wf> BOGUS=X --validate-only`.
+    This is an accepted architectural trade-off from the #288 design discussion:
+    extras check lives at the compiler layer (where root missing-required also
+    lives), not the validator layer (where sub-workflow extras lives).
+
+    The proper fix is tracked in GH #297 — unify all input-shape checks in
+    WorkflowValidator. When that refactor lands, this test should be
+    **deliberately flipped** to assert `valid is False` / `len(errors) >= 1`.
+    A silent pass/fail flip during an unrelated refactor would indicate the
+    parity gap was closed accidentally, not by design.
+    """
+
+    def test_validate_only_does_not_catch_root_extras(self):
+        """See GH #297. Documents: `--validate-only` is structural, not runtime-shape."""
+        from pflow.execution.runner import WorkflowRunner
+
+        workflow_ir = {
+            "ir_version": "0.1.0",
+            "inputs": {"a": {"type": "string", "description": "Required input", "required": True}},
+            "nodes": [
+                {"id": "echo", "type": "shell", "params": {"command": "echo ${a}"}},
+            ],
+            "edges": [],
+        }
+
+        # Extras passed to validate() → currently silent (valid=True). The
+        # extras check only fires at compile-time via prepare_inputs.
+        result = WorkflowRunner().validate(workflow_ir, params={"a": "ok", "BOGUS": "X"})
+
+        assert result.valid is True, (
+            "Extras now caught by --validate-only. This is likely the GH #297 refactor "
+            "landing — flip this test to `result.valid is False` with an explicit "
+            "Diagnostic check, and delete this docstring."
+        )
+        assert not any("Unknown input" in d.message for d in result.diagnostics), (
+            "A diagnostic for 'Unknown input' appeared — GH #297 may have landed. Flip this test deliberately."
+        )
+
+
+def _skip_uv_sandbox_panic(result: subprocess.CompletedProcess) -> None:
+    if result.returncode == 101 and "Attempted to create a NULL object" in (result.stderr or ""):
+        pytest.skip("uv subprocess panics in this sandbox before pflow starts")
+
+
+class TestCliEndToEnd:
+    """End-to-end smoke: CLI renders the extras error via the diagnostic pipeline.
+
+    Proves the logic wired through SchemaValidationError → diagnostic_render
+    produces the user-facing text from GH #288's motivating cases. The unit
+    tests above cover the logic exhaustively; this one verifies the render
+    path at the CLI surface.
+    """
+
+    _WORKFLOW = """\
+# Root with one declared input
+
+## Inputs
+
+### lyrics
+
+The lyrics input.
+
+- type: string
+- required: true
+
+## Steps
+
+### echo
+
+Echo the lyrics.
+
+- type: shell
+
+```shell command
+echo "lyrics=${lyrics}"
+```
+
+## Outputs
+
+### out
+
+The output.
+
+- source: ${echo.stdout}
+"""
+
+    def test_cli_rejects_typo_with_fuzzy_suggestion(self, tmp_path, prepared_subprocess_env):
+        """Typo 'lyric' for declared 'lyrics' → 'Did you mean' hint rendered to stderr."""
+        workflow_file = tmp_path / "wf.pflow.md"
+        workflow_file.write_text(self._WORKFLOW)
+
+        # Clean env to avoid CliRunner-style logger suppression
+        env = {k: v for k, v in prepared_subprocess_env.items() if k != "PYTEST_CURRENT_TEST"}
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "pflow.cli", str(workflow_file), "lyrics=song", "lyric=typo"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+        _skip_uv_sandbox_panic(result)
+
+        assert result.returncode == 1, f"expected exit 1, got {result.returncode}\nstderr: {result.stderr!r}"
+        assert "Traceback" not in result.stderr
+        assert "Unknown input 'lyric'" in result.stderr
+        assert "Did you mean 'lyrics'?" in result.stderr

--- a/tests/test_runtime/test_prepare_inputs_extras.py
+++ b/tests/test_runtime/test_prepare_inputs_extras.py
@@ -92,6 +92,31 @@ class TestExtrasRejection:
         )
         assert errors == []
 
+    def test_single_underscore_user_key_not_exempted(self):
+        """User-authored ``_foo`` must NOT be silently filtered as framework.
+
+        The filter matches explicit conventions (``_pflow_*``, ``__*__``)
+        only — bare underscore-prefixed names surface as extras so typos
+        like ``_foo`` for declared ``foo`` produce a clear error instead
+        of a cryptic "missing required 'foo'"."""
+        workflow_ir = {"inputs": {"foo": {"type": "string", "description": "Foo", "required": True}}}
+        errors, _, _ = prepare_inputs(workflow_ir, {"foo": "value", "_foo": "typo"})
+
+        extras = [e for e in errors if "Unknown input '_foo'" in e[0]]
+        assert len(extras) == 1
+
+    def test_framework_prefix_typo_surfaces_as_extra(self):
+        """Typo in a framework key (``_pflow_workflo_file``) is not silently
+        accepted. The tighter explicit-prefix filter matches ``_pflow_*``
+        specifically; mistyped framework keys surface as extras, signaling
+        a bug in the injection site rather than silently corrupting params."""
+        workflow_ir = {"inputs": {"a": {"type": "string", "description": "A", "required": True}}}
+        # Missing underscore after workflo: typo of `_pflow_workflow_file`.
+        errors, _, _ = prepare_inputs(workflow_ir, {"a": "value", "_pflowworkflowfile": "/x"})
+
+        extras = [e for e in errors if "Unknown input '_pflowworkflowfile'" in e[0]]
+        assert len(extras) == 1
+
     def test_multiple_extras_all_reported(self):
         """More than one extra → every one surfaces."""
         workflow_ir = {"inputs": {"a": {"type": "string", "description": "A", "required": True}}}

--- a/tests/test_runtime/test_template_integration.py
+++ b/tests/test_runtime/test_template_integration.py
@@ -107,6 +107,10 @@ class TestCompilerIntegration:
                 }
             ],
             "edges": [],
+            "inputs": {
+                "endpoint": {"type": "string", "description": "API endpoint URL", "required": True},
+                "count": {"type": "integer", "description": "Number of items", "required": True},
+            },
         }
 
         initial_params = {"endpoint": "https://api.example.com", "count": 10}
@@ -197,6 +201,14 @@ class TestCompilerIntegration:
                 },
             ],
             "edges": [{"from": "producer", "to": "consumer"}],
+            "inputs": {
+                "provided_param": {"type": "string", "description": "Provided param", "required": True},
+                "shared_store_var": {
+                    "type": "string",
+                    "description": "Placeholder for producer output",
+                    "required": True,
+                },
+            },
         }
 
         # Provide CLI parameter and shared_store_var as a placeholder to satisfy
@@ -342,6 +354,10 @@ class TestMultiNodeWorkflow:
                 },
             ],
             "edges": [{"from": "producer", "to": "consumer"}],
+            "inputs": {
+                "initial_url": {"type": "string", "description": "Initial URL", "required": True},
+                "video_data": {"type": "string", "description": "Placeholder for producer output", "required": True},
+            },
         }
 
         # video_data is a producer output key (not a node ID). Include it in
@@ -460,6 +476,11 @@ class TestRealWorldWorkflows:
                 },
             ],
             "edges": [{"from": "fetch", "to": "summarize"}, {"from": "summarize", "to": "save"}],
+            "inputs": {
+                "url": {"type": "string", "description": "YouTube URL", "required": True},
+                "transcript_data": {"type": "string", "description": "Placeholder for fetch output", "required": True},
+                "summary": {"type": "string", "description": "Placeholder for summarize output", "required": True},
+            },
         }
 
         # Parameters extracted from natural language by planner.
@@ -522,7 +543,11 @@ class TestEdgeCases:
 
     def test_circular_references(self, mock_registry):
         """Test handling of circular references (last write wins)."""
-        ir = {"nodes": [{"id": "node1", "type": "mock-node", "params": {"value": "${circular}"}}], "edges": []}
+        ir = {
+            "nodes": [{"id": "node1", "type": "mock-node", "params": {"value": "${circular}"}}],
+            "edges": [],
+            "inputs": {"circular": {"type": "string", "description": "Circular ref", "required": True}},
+        }
 
         # Initial params and shared store both have 'circular'
         initial_params = {"circular": "from_params"}
@@ -542,7 +567,11 @@ class TestEdgeCases:
         validator (recognizes 'a' as a valid reference root) and the
         template resolver (traverses the nested path at runtime).
         """
-        ir = {"nodes": [{"id": "node1", "type": "mock-node", "params": {"deep": "${a.b.c.d.e.f.g}"}}], "edges": []}
+        ir = {
+            "nodes": [{"id": "node1", "type": "mock-node", "params": {"deep": "${a.b.c.d.e.f.g}"}}],
+            "edges": [],
+            "inputs": {"a": {"type": "any", "description": "Nested data", "required": True}},
+        }
 
         nested_data = {"b": {"c": {"d": {"e": {"f": {"g": "deeply_nested_value"}}}}}}
         shared = _compile_and_run(ir, mock_registry, initial_params={"a": nested_data})


### PR DESCRIPTION
## Summary

Cluster fix for two agent-hostile silent-failure / crash bugs in pflow's
error pipeline, both surfaced during task 148 + 153 verification. Each
issue gets its own commit for commit-by-commit review even though this
PR squash-merges.

## Changes

### Commit 1 — `fix: route subcommand PflowErrors through diagnostic pipeline (fixes #292)`
- **`PflowCLI.invoke()` boundary** — catch `PflowError` at the group level, route through the existing `output_error()` → `format_diagnostic()` pipeline. Covers every non-`run` CLI command in one place. `run` keeps its own boundary (full JSON/metrics parity).
- **`WorkflowManager.load()`** — stop flattening `MarkdownParseError` into a string; thread structured diagnostics through `WorkflowValidationError.validation_errors` so `pflow describe` renders identically to `pflow <file> --validate-only`.
- **`pflow guide <broken-saved-workflow>`** — restore rich detail after the `WorkflowManager.load()` summary shape change.
- 6 tests guarding the boundary, symmetry, narrow catch, and run's own pipeline.

### Commit 2 — `fix: reject undeclared CLI inputs at compile time (fixes #288)`
- **`_check_undeclared_extras()` helper in `prepare_inputs()`** — reuses task 153's set-diff algebra + `find_similar_items` for fuzzy suggestions. Framework keys (`_pflow_*`, `__*__`) filtered via `startswith("_")`.
- Aggregates with existing missing-required check — typo + missing (Case C from the issue) surfaces both errors together.
- 12 new tests + 9 pre-existing test fixtures updated (they were relying on the silent-drop bug to compile without declaring inputs they used).

## Explanation

The design infrastructure was already in place from prior work — `output_error()` (task 137), `format_diagnostic()` (task 148), `PflowError` hierarchy (task 141). What was missing was **wiring**: subcommands bypassed the diagnostic pipeline because nobody connected them. Both fixes are structural (wire up the boundary; reuse the existing set-diff algebra) rather than patch-per-symptom.

### Architectural note — intentional trade-off documented as GH #297

The extras check lives at the compiler layer (next to the existing root missing-required check) rather than the validator layer (where task 153's sub-workflow extras check lives). This means `--validate-only` does NOT catch extras today — a known parity gap. Option B (move to validator) was rejected during design because it would violate the explicit "validate-only checks structure, not runtime values" doctrine and create a split root-check (missing at compiler, extras at validator).

A locked-in regression test (`test_validate_only_does_not_catch_root_extras`) documents the gap. The proper fix — unifying all input-shape checks in `WorkflowValidator` — is tracked in #297 with full context.

### Deferred

- **#284** (`error_action: continue` doesn't catch prep-time errors) — split to a separate PR. Different subsystem (engine execution semantics, not CLI error rendering), different design decisions still open, different risk profile. Didn't belong in a cluster primarily about error-pipeline rendering.

## Review

Code review pass ran 4 specialized agents (silent-failures, feature-interactions, impact-completeness, test-fidelity). All critical findings addressed:
- **`guide/__init__.py` regression** (impact-completeness W1) — fixed in this PR
- **`test_run_shell_failure` weak assertions** (test-fidelity #1) — strengthened with run-pipeline-specific markers
- **`test_describe_and_validate_only` misleading docstring** (test-fidelity #2) — rewritten to reflect actual coverage
- **`test_dunder_framework_keys` synthetic key** (test-fidelity #3) — rewritten to test real `__template_resolution_mode__` injection
- **`--validate-only` parity gap** (feature-interactions #1) — filed as GH #297 with full context; locked-in test shipped

Other review findings flagged as follow-ups (three-layer extras duplication, `find`/`manager.load` generic flattening, probe/read-fields `--output-format` stashing) are not blockers and fold into GH #297 / #224 / task 117.

## Testing

- `make test` — 4878 pass, 1 unrelated warning
- `make check` — clean (ruff, ruff-format, mypy, deptry)
- New tests: 19 across 2 files (6 CLI boundary + 13 extras + 1 validate-only gap guard)
- Manual verification: all four cases from #288 issue repro correctly; #292 repro produces structured `Parse Error` diagnostic with exit 1, no traceback, byte-identical to `--validate-only`.