### PR TITLE
fix: consolidate mermaid ref resolution (fixes #283, #263)

### DIFF
--- a/.taskmaster/tasks/task_155/task-155.md
+++ b/.taskmaster/tasks/task_155/task-155.md
@@ -1,0 +1,245 @@
+# Task 155: Extract Workflow Graph Model for Multi-Renderer Support
+
+## Description
+
+Refactor the mermaid visualizer to build an intermediate **semantic graph model**, then render from that model. This separates "what to draw" (IR-walking logic) from "how to draw it" (mermaid syntax), enabling a future React Flow (or equivalent) web UI to reuse the IR walker unchanged.
+
+Positioned as a **pre-step** to the planned web-based interactive visualizer: done just before UI work begins so the UI effort only needs a new renderer, not a reimplementation of graph construction.
+
+**Builds on Option X** (the `Scope` + unified `resolve_ref` consolidation done on branch `fix/cluster-mermaid-visualizer-fidelity`, which closed GH #283 and #263). Task 155 assumes that baseline: `Scope` exists, ref resolution is centralized, `_RESERVED_PARAMS` and `_SOURCE_NODE_FIELD_RE` are gone. The remaining architectural gap is the absence of an intermediate data layer — what this task extracts.
+
+## Status
+
+not started
+
+## Priority
+
+medium
+
+## Problem
+
+### Architectural debt: text-in-text-out
+
+The current mermaid package (`src/pflow/core/workflow/mermaid/`, ~1500 lines across 5 files) is text-oriented end to end. Every function appends strings to `ctx.lines`. There is **no intermediate data structure** between workflow IR and mermaid syntax. As a result:
+
+- Adding a second renderer (React Flow, Cytoscape, DOT, JSON API) requires duplicating every IR-walking decision (which node renders as what, which edges exist, how sub-workflows nest, how batch items fan out).
+- Parsing the mermaid output back into structured data is not viable (mermaid syntax is lossy for our purposes, and `classDef` + shape directives are write-only).
+- Task 145's review explicitly anticipated this: *"Mermaid ships fast and doesn't compete with building a browser visualizer later — the same IR-to-graph logic feeds both."* The design intent was documented; the code never realized it.
+
+### No separation between graph construction and rendering
+
+Option X consolidated reference resolution behind a single `Scope.resolve()` primitive and fixed the two fidelity bugs it had caused. What it did **not** change is the text-in-text-out shape of the package: every structural decision about the diagram is made by a function that immediately appends mermaid syntax to `ctx.lines`. The IR-walking logic and the rendering logic are interleaved in the same call stack.
+
+That shape is the remaining blocker for a second renderer. To ship a React Flow (or Cytoscape, or DOT, or a JSON API) view, there is currently no choice but to parse mermaid text back into structured data (lossy and brittle) or reimplement every IR-walking decision from scratch in a parallel package — duplicating sub-workflow expansion, batch item fan-out, external IO wrapping, cycle detection, data-flow edge inference, and the `outgoing_routes` / `fork_join_map` / `data_flow_targets` interaction rules.
+
+Task 145's review anticipated exactly this: *"Mermaid ships fast and doesn't compete with building a browser visualizer later — the same IR-to-graph logic feeds both."* The design intent was recorded; the code never realized it.
+
+## Solution
+
+### Two-layer architecture
+
+```
+   IR  →  build_graph()  →  GraphModel  ─┬─→  render_mermaid()   →  str
+                                         ├─→  render_react_flow() →  {nodes, edges}    (future)
+                                         ├─→  render_dot()        →  str                (future)
+                                         └─→  as_json()           →  API payload        (future)
+```
+
+**Layer 1 — IR-walking & graph construction**: one pass over the workflow IR (including sub-workflow expansion, batch item expansion, ref resolution) produces a `GraphModel` — a pure data object. All decisions about "what should be drawn" live here.
+
+**Layer 2 — Renderers**: each renderer consumes `GraphModel` and emits its target format. Mermaid is the first (and currently only) renderer. Future renderers (React Flow, etc.) do not touch IR; they only translate the model.
+
+### Consolidated reference resolution
+
+Introduce a `Scope` object representing everything named at one workflow level: nodes, inputs, outgoing routes, batch source. One method — `Scope.resolve(root, field) -> Optional[str]` — handles the three-case resolution, used by every edge emitter in the IR walker. Eliminates `_resolve_ref_source`, the open-coded loop in `_connect_sources_to_output`, and the scattered nested-dict descents.
+
+### Semantic, not syntactic, model
+
+`GraphModel` describes **what nodes are** (kind, shape category, label, purpose, batch metadata), not **how mermaid draws them**. No `classdef="shell"` strings, no mermaid-specific shape brackets, no inline style directives in the model. Each renderer maps semantic fields to its own vocabulary.
+
+This is the load-bearing constraint: if the model leaks mermaid syntax, a React Flow renderer becomes a translation layer over a mermaid-shaped thing — worse than not refactoring at all.
+
+## Design Decisions
+
+- **Do the full refactor, not the smaller Scope-only consolidation.** The Scope refactor (fixing both bugs by consolidating ref resolution) was considered as a cheaper middle ground. Rejected because the web UI is a near-term plan; the Scope refactor would need to be redone as part of the GraphModel extraction later. Doing the full thing once avoids rework.
+
+- **Pre-step, not co-step.** Done *before* web UI work begins, not concurrently. The UI effort then only needs to write a new renderer against a stable `GraphModel`; no co-evolution risk.
+
+- **Semantic model, enforced.** Model fields describe node kind / role / shape-category, never mermaid-specific strings. Renderer maps semantics → mermaid vocabulary at render time. This discipline is what makes the model actually reusable.
+
+- **Public API `generate_mermaid(ir, ...)` signature preserved.** Internal restructure only; all existing CLI callers, tests, and consumers continue to work unchanged.
+
+- **No new runtime dependencies.** `GraphModel` is plain dataclasses. Renderers emit strings (or dicts for structured formats) using stdlib only. Any future web-UI payload would use `dataclasses.asdict` + `json.dumps`.
+
+- **Keep `MermaidContext`'s load-bearing invariants in the IR walker.** The `outgoing_routes` / `has_expanded_outputs` split, the `suppress_io` flag for external IO, and the fork/join map all represent real structural facts about the graph — they become fields on `GraphModel` subgraph/node records, not stripped away.
+
+## Dependencies
+
+- **Option X consolidation** (branch `fix/cluster-mermaid-visualizer-fidelity`) — introduces `Scope` + unified `resolve_ref`, deletes `_RESERVED_PARAMS` / `_SOURCE_NODE_FIELD_RE`, closes GH #283 and #263. Must land before 155 starts. Task 155 assumes that baseline.
+
+Task 155 is itself a prerequisite for the planned (not yet filed) web-based interactive visualizer task.
+
+## Requirements
+
+### GraphModel (semantic data layer)
+
+- Pure dataclasses. No mermaid strings, no classDef names, no shape brackets in field values.
+- Node records carry: `id`, `kind` (e.g. `"llm"`, `"shell"`, `"code"`, `"workflow"`, `"input"`, `"output"`, `"decision"`), `shape` (e.g. `"rect"`, `"diamond"`, `"parallelogram"`, `"stack"`), `label`, `purpose` (optional), `batch_suffix` (optional), `parent_subgraph_id` (optional).
+- Edge records carry: `source` (mermaid-id-equivalent stable ID), `target`, `kind` (`"structural"` | `"data_flow"` | `"error"`), optional `label`.
+- Subgraph records carry: `id`, `label`, `nesting_depth`, `kind` (`"workflow"` | `"batch"` | `"input_wrapper"` | `"output_wrapper"`), `parent_subgraph_id` (optional).
+- Stable IDs use the existing convention (`{prefix}{node_id}`, `{prefix}{node_id}__in_{name}`, etc.) — don't invent a new ID scheme, since the convention is already load-bearing.
+
+### Scope (inherited from Option X)
+
+- `Scope` type already consolidated by X: one `Scope.resolve(root, field) -> Optional[str]` handling batch / node / input cases. Task 155 does not redesign it; it reuses Scope as graph-construction state.
+
+### IR walker (`build_graph`)
+
+- One entry: `build_graph(ir, resolve_child=..., base_path=..., max_depth=..., descriptions=...) -> GraphModel`.
+- Handles sub-workflow recursive expansion (with cycle detection via recursion stack, as today).
+- Handles batch item expansion and fork/join fan-out.
+- Handles external IO wrappers for expanded sub-workflows.
+- Handles data-flow edge inference from `${ref}` templates via `Scope.resolve`.
+- Emits zero mermaid syntax. Produces `GraphModel` records only.
+
+### Mermaid renderer
+
+- `render_mermaid(graph: GraphModel, *, direction: str = "LR") -> str`.
+- Consumes the semantic model; emits mermaid syntax.
+- Maps `kind` / `shape` to mermaid classDef names and shape brackets at render time.
+- Output matches current generator byte-for-byte for IR shapes that aren't affected by #283/#263 (see Verification).
+
+### Public API
+
+- `generate_mermaid(ir, ...)` signature unchanged. Internally implemented as `render_mermaid(build_graph(ir, ...))`.
+- All `tests/test_core/test_mermaid.py`, `test_mermaid_golden.py`, `tests/test_cli/test_visualize.py` continue to pass (with golden regeneration for #283/#263 affected files).
+
+### Extension seam for future renderers
+
+- `GraphModel` is importable from `pflow.core.workflow.mermaid` (or a better-named module — see Implementation Notes).
+- `build_graph` and `render_mermaid` are both importable separately, not only as the combined `generate_mermaid`.
+- A future `render_react_flow(graph: GraphModel) -> dict` can be added without touching `build_graph`. Verified by writing a throwaway 20-line sketch during implementation (not committed — just to confirm the model is sufficient).
+
+## Implementation Notes
+
+### Current architecture (what's being replaced)
+
+- `src/pflow/core/workflow/mermaid/` — 5 files, ~1500 lines.
+- `_render.py` (470 lines) — pipeline orchestration (`generate_mermaid`, `_render_workflow`, `_render_node`, batch, subgraph, end nodes).
+- `_edges.py` (293 lines) — structural edge routing, data-flow edge generation, ref resolution.
+- `_io.py` (351 lines) — input/output rendering (top-level, sub-workflow, external wrappers).
+- `_context.py` (289 lines) — `MermaidConfig`, `MermaidContext`, constants, utilities.
+- `MermaidContext` currently mixes per-level routing state (`outgoing_routes`, `incoming_map`, `data_flow_targets`, `fork_join_map`) with rendering concerns (`ctx.lines`, `ctx.indent`). After the refactor, most of these routing maps move into `GraphModel`-construction state; only a thin `RenderContext` holding `lines` and `indent` remains in the renderer.
+
+### Mapping current features to new layers
+
+| Current responsibility | New home |
+|---|---|
+| Sub-workflow resolution & cycle detection (`_try_resolve_child`) | IR walker |
+| Batch item expansion, fork/join map | IR walker → `GraphModel.subgraphs` (kind=`"batch"`) |
+| External IO wrappers (`_render_external_inputs/outputs`) | IR walker → `GraphModel.subgraphs` (kind=`"input_wrapper"`/`"output_wrapper"`) |
+| Data-flow edge generation (`_generate_data_flow_edges`, `_generate_batch_item_data_flow`) | IR walker, using `Scope.resolve` |
+| Output source parsing (`_connect_sources_to_output`) | IR walker, using `Scope.resolve` |
+| Top-level input → consumer wiring (`_connect_top_level_inputs`) | IR walker, using `Scope.resolve` + nearest-consumer heuristic preserved |
+| Edge dedup, decision detection, terminal detection | IR walker (pre-graph preprocessing) |
+| Structural edge suppression when data-flow covers (`data_flow_targets`) | Either recorded on edges (`Edge.suppressed_by_dataflow: bool`) or resolved at model-build time |
+| Shape & class mapping (`_SHAPE_MAP`, `_CLASSDEF_STYLES`) | Mermaid renderer only |
+| `@{ shape: procs }` directive | Mermaid renderer only (maps from semantic `shape="stack"`) |
+| Subgraph nesting opacity (`_SUBGRAPH_OPACITIES`) | Mermaid renderer only (reads `nesting_depth` from model) |
+| `.md` wrapping with title/description | `cli/commands/visualize.py` — unchanged |
+
+### Semantic vocabulary (starting sketch)
+
+```python
+class NodeKind(str, Enum):
+    LLM = "llm"; SHELL = "shell"; CODE = "code"; WRITE_FILE = "write_file"
+    WORKFLOW = "workflow"; MCP = "mcp"
+    INPUT = "input"; OUTPUT = "output"
+    DECISION = "decision"; END = "end"
+
+class NodeShape(str, Enum):
+    RECT = "rect"; DOUBLE_RECT = "double_rect"
+    ROUND_RECT = "round_rect"; STADIUM = "stadium"
+    DIAMOND = "diamond"; HEXAGON = "hexagon"
+    PARALLELOGRAM = "parallelogram"; CYLINDER = "cylinder"
+    STACK = "stack"  # maps to mermaid @{ shape: procs }
+
+class EdgeKind(str, Enum):
+    STRUCTURAL = "structural"
+    DATA_FLOW = "data_flow"
+    ERROR = "error"
+```
+
+This vocabulary is a starting point, not a spec. Finalize during implementation — add/rename as the renderer mapping reveals what's actually needed.
+
+### Order of work (suggested)
+
+1. Define `GraphModel` dataclasses. No rendering yet.
+2. Write `build_graph` that produces a `GraphModel` from IR, walking the same structure as today but emitting model records instead of mermaid lines. Reuse `Scope` from X. Verify via small unit tests that the model is well-formed.
+3. Write `render_mermaid(graph)` that consumes the model and produces mermaid syntax. Target: byte-identical output on all existing goldens.
+4. Rewire `generate_mermaid` to be `render_mermaid(build_graph(...))`. Run full mermaid test suite — must pass without golden regeneration.
+5. Write the 20-line throwaway React Flow renderer sketch to confirm the model is sufficient. Discard after.
+
+### Module layout consideration
+
+Current layout has `mermaid/` as a package. After extraction, `build_graph` and `GraphModel` are not mermaid-specific. Two options:
+
+- **A**: Keep everything under `mermaid/` for now, pragmatically named (e.g., `mermaid/graph.py`, `mermaid/render.py`). Move later if/when a second renderer ships.
+- **B**: Rename to `visualize/` (or `graph/`) with `graph.py`, `scope.py`, `renderers/mermaid.py`, `renderers/react_flow.py` (later).
+
+Defer this decision to implementation time — don't prematurely commit to B before knowing what the actual code looks like. Option A is the lower-risk default.
+
+### Load-bearing invariants to preserve
+
+From Task 146 review and mermaid CLAUDE.md, these must survive the refactor:
+
+- Recursion-stack `seen` set (add-on-enter, discard-on-exit) for cycle detection — not global visited set.
+- Mermaid ID convention (`{prefix}{node_id}`, `{prefix}{node_id}__in_{name}`, `{prefix}{node_id}__out_{name}`) is load-bearing for every lookup; don't change it.
+- Top-level inputs connect to **nearest consumer only** (not all consumers) — long-range edges destroy dagre layout.
+- `outgoing_routes` and `has_expanded_outputs` are written together (two-field invariant). In the new model, either collapse into a single field or preserve the invariant explicitly with a helper.
+- Structural edge suppression when data-flow covers the same connection.
+
+## Verification
+
+### Functional parity (highest priority — this task has NO intended output changes)
+
+- All tests in `tests/test_core/test_mermaid.py`, `tests/test_core/test_mermaid_golden.py`, and `tests/test_cli/test_visualize.py` pass **without golden regeneration**. If a golden changes, investigate — the refactor should be behavior-preserving.
+- `make check` clean.
+
+### Architectural criteria
+
+- `GraphModel` dataclasses contain no strings matching `classDef|@{|:::|fill:|stroke:` — i.e. no mermaid syntax leaked into the model. Grep check.
+- `build_graph` emits zero mermaid lines (no `ctx.lines.append`, no string formatting with mermaid syntax). Grep check.
+- `render_mermaid` consumes `GraphModel` and touches no workflow IR fields directly. Grep check.
+- Throwaway React Flow sketch: ~20 lines, consumes `GraphModel`, produces `{nodes: [...], edges: [...]}` matching React Flow's expected shape. Not committed — verifies the model is sufficient for a second renderer.
+
+## References
+
+### GitHub issues (historical context, not scope)
+
+- **GH #283**: Mermaid visualizer: data-flow edges lose fidelity when child inputs use `inputs:` dict. Closed by Option X on branch `fix/cluster-mermaid-visualizer-fidelity`.
+- **GH #263**: Mermaid output wiring ignores input-root output sources. Closed by Option X on the same branch.
+
+Both bugs are historical evidence that fragmented ref resolution hides correctness gaps — part of the motivation Option X acted on. Task 155 does not re-fix them; it assumes they are already fixed and preserves that fix through the architectural split.
+
+### Prior tasks (context)
+
+- `fix/cluster-mermaid-visualizer-fidelity` branch — Option X consolidation (Scope, unified resolve_ref). Direct predecessor.
+- `.taskmaster/tasks/task_145/task-review.md` — initial mermaid generator (sub-workflow resolver extraction + mermaid flowchart + `visualize` CLI). Contains the original design note: *"the same IR-to-graph logic feeds both"* mermaid and a future browser visualizer — the intent task 155 finally realizes.
+- `.taskmaster/tasks/task_146/task-review.md` — rich mermaid visualization (data-flow edges, external IO, batch item expansion, `procs` shape, 163 → 1444 lines). Current architecture's load-bearing invariants are documented here.
+- `.taskmaster/tasks/task_153/task-review.md` — `inputs:` dict canonical form. Motivating context for why Scope was needed.
+
+### Code to read before starting
+
+- `src/pflow/core/workflow/mermaid/CLAUDE.md` — file map, function-to-file map, context state table, common pitfalls, testing commands.
+- `src/pflow/core/workflow/mermaid/_render.py` — pipeline orchestration (start with `generate_mermaid`, then `_render_workflow`, then `_render_node`).
+- `src/pflow/core/workflow/mermaid/_context.py` — `MermaidContext`, constants, utilities.
+- `src/pflow/core/workflow/mermaid/_edges.py` — ref resolution, data-flow edges.
+- `src/pflow/core/workflow/mermaid/_io.py` — input/output rendering, the call sites that need unification.
+- `tests/test_core/golden_mermaid/deep-research-TD.mmd` — reference golden (current coarse form; will be regenerated).
+- `examples/nested/deep-research/deep-research.pflow.md` — canonical test workflow exercising `inputs:` dict + batch + sub-workflow.
+
+### External
+
+- React Flow data model (for sketch verification): https://reactflow.dev/learn (nodes/edges shape).
+- Mermaid flowchart syntax (renderer target): https://mermaid.js.org/syntax/flowchart.html.

--- a/src/pflow/core/workflow/mermaid/CLAUDE.md
+++ b/src/pflow/core/workflow/mermaid/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Generates Mermaid flowchart diagrams from workflow IR. Handles sub-workflow expansion (recursive), batch item rendering, data-flow edge inference, and structural edge routing.
 
+Reference resolution (*"given `${x.y}`, what mermaid ID does it point to?"*) goes through a single primitive: `Scope.resolve` in `_scope.py`. Three cases: batch item / sibling node (optionally routed through an output field) / declared input. All ref-consuming sites in the package use it.
+
 ## Public API
 
 ```python
@@ -25,13 +27,14 @@ Consumers: `cli/commands/visualize.py`, `tests/test_core/test_mermaid.py`, `test
 mermaid/
 ├── __init__.py    # Re-exports generate_mermaid + 5 test-visible helpers
 ├── _context.py    # MermaidConfig (frozen), MermaidContext (mutable), constants, pure utilities
+├── _scope.py      # Scope — single primitive for template-ref → mermaid-ID resolution
 ├── _edges.py      # Edge dedup/detection, routing resolution, data-flow edge generation
 ├── _io.py         # Input/output node rendering (top-level, sub-workflow, external wrappers)
 ├── _render.py     # Core pipeline: generate_mermaid → _render_workflow → _render_node
 └── CLAUDE.md
 ```
 
-**Import DAG** (no cycles): `_context` ← `_edges`, `_io` ← `_render` ← `__init__`. No cross-calls between `_edges` and `_io`.
+**Import DAG** (no cycles): `_context` ← `_scope` ← {`_edges`, `_io`} ← `_render` ← `__init__`. No cross-calls between `_edges` and `_io`.
 
 ## Function-to-File Map
 
@@ -53,7 +56,9 @@ mermaid/
 | `_generate_data_flow_edges` | `_edges.py` | Parse `${ref}` in params → edges to sub-workflow inputs |
 | `_generate_batch_item_data_flow` | `_edges.py` | Data-flow edges from parent params to expanded batch items |
 | `_extract_batch_source` | `_edges.py` | Extract source node ID from batch items template ref |
-| `_resolve_ref_source` | `_edges.py` | Resolve a template ref name to a mermaid source ID |
+| `Scope` / `Scope.resolve` | `_scope.py` | Resolve a template ref (root, field) to a mermaid source ID |
+| `Scope.refs_in` | `_scope.py` | Extract (root, field) pairs from a template binding |
+| `Scope.source_refs_in` | `_scope.py` | Extract (root, field) pairs from an output source (handles coalesce) |
 | `_render_inputs` | `_io.py` | Top-level workflow input parallelograms |
 | `_connect_top_level_inputs` | `_io.py` | Connect inputs to actual consuming nodes via param analysis |
 | `_render_top_level_outputs` | `_io.py` | Top-level output wrapper subgraph at bottom |
@@ -64,7 +69,7 @@ mermaid/
 | `_connect_sources_to_output` | `_io.py` | Parse source expression → connect producing nodes to output |
 | `MermaidConfig` | `_context.py` | Frozen config dataclass (resolve_child, max_depth, etc.) |
 | `MermaidContext` | `_context.py` | Mutable per-level state (routing maps, indent, prefix) |
-| Pure utilities (13) | `_context.py` | `_to_mermaid_id`, `_escape_label`, `_get_node_shape`, `_format_label`, `_first_sentence`, `_classdef_to_style`, `_subgraph_style`, `_get_item_label`, `_dynamic_batch_label`, `_format_node_type`, `_refs_input`, `_collect_param_refs`, `_render_classdefs` |
+| Pure utilities (11) | `_context.py` | `_to_mermaid_id`, `_escape_label`, `_get_node_shape`, `_format_label`, `_first_sentence`, `_classdef_to_style`, `_subgraph_style`, `_get_item_label`, `_dynamic_batch_label`, `_format_node_type`, `_render_classdefs` |
 
 ## Two Kinds of Edges
 
@@ -89,8 +94,8 @@ The output has **structural edges** (from the IR's `edges` list — execution or
 
 | Field | Type | Purpose | Readers |
 |-------|------|---------|---------|
-| `outgoing_routes` | `dict[str, dict[str, str]]` | Edge routing — maps mermaid IDs to `{output_name: output_mermaid_id}` | `_resolve_edge_endpoints`, `_render_edge`, `_resolve_ref_source` (routing) |
-| `has_expanded_outputs` | `set[str]` | Skip signal — "this node has expanded outputs, structural edges handle it" | `_resolve_ref_source` (line 115), `_render_edge` (line 186) |
+| `outgoing_routes` | `dict[str, dict[str, str]]` | Edge routing — maps mermaid IDs to `{output_name: output_mermaid_id}` | `_resolve_edge_endpoints`, `_render_edge`, `Scope.resolve` (sibling output routing) |
+| `has_expanded_outputs` | `set[str]` | Skip signal — "this node has expanded outputs, structural edges handle it" | `Scope.resolve` (batch item skip), `_render_edge` |
 
 Exactly **two write sites**: `_render_external_outputs` (`_io.py:348-349`) and `_render_batch_inline` (`_render.py:272-275`).
 
@@ -143,7 +148,7 @@ uv run pflow visualize <workflow> [flags] -o tests/test_core/golden_mermaid/<nam
 
 ## Common Pitfalls
 
-1. **Don't remove routing maps.** They look redundant with external IO. They're not — `has_expanded_outputs` is a shared signal for `_resolve_ref_source`. Removing entries creates cascading failures.
+1. **Don't remove routing maps.** They look redundant with external IO. They're not — `has_expanded_outputs` is a shared signal read by `Scope.resolve`. Removing entries creates cascading failures.
 2. **Don't change the mermaid ID convention.** `{prefix}{node_id}__in_{name}` and `__out_{name}` are referenced by every routing mechanism.
 3. **`suppress_io` and end nodes are coupled.** Changing one without the other causes end node regression.
 4. **`_render_workflow` return value is essential.** Returns `outgoing_routes` for nested output routing. Ignoring it causes edges to connect to subgraph boxes.

--- a/src/pflow/core/workflow/mermaid/_context.py
+++ b/src/pflow/core/workflow/mermaid/_context.py
@@ -39,9 +39,6 @@ _CLASSDEF_STYLES: dict[str, str] = {
     "output": "fill:#E8E8E8,stroke:#666666,color:#000",
 }
 
-# Regex patterns (used outside `_scope.py` — e.g. `_extract_batch_source`)
-_PARAM_REF_RE = re.compile(r"\$\{([a-zA-Z0-9_-]+)(?:\.|\})")
-
 # Workflow types eligible for sub-workflow expansion
 _WORKFLOW_TYPES = {"workflow", "pflow.runtime.workflow_executor"}
 
@@ -251,10 +248,11 @@ def _dynamic_batch_label(batch: Optional[dict[str, Any]]) -> str:
     """
     if not batch or not isinstance(batch.get("items"), str):
         return ""
-    items_ref = batch["items"]
-    # Extract first segment from ${ref.field...}
-    match = _PARAM_REF_RE.search(items_ref)
-    source_name = match.group(1) if match else "N"
+    # Extract the first template ref's root as a display hint
+    from pflow.core.workflow.mermaid._scope import Scope
+
+    refs = Scope.refs_in(batch["items"])
+    source_name = refs[0][0] if refs else "N"
     parallel_prefix = "parallel " if batch.get("parallel", False) else ""
     return f" ({parallel_prefix}x|{source_name}|)"
 

--- a/src/pflow/core/workflow/mermaid/_context.py
+++ b/src/pflow/core/workflow/mermaid/_context.py
@@ -26,9 +26,6 @@ _SHAPE_MAP: dict[str, tuple[str, str, str]] = {
 _LABEL_KEYS = ("name", "label", "focus", "lens")
 _SKIP_KEYS = ("workflow", "prompt", "command", "model")
 
-# Reserved workflow params (not child inputs)
-_RESERVED_PARAMS = {"workflow", "storage_mode", "type"}
-
 # Style declarations
 _CLASSDEF_STYLES: dict[str, str] = {
     "code": "fill:#D5E8D4,stroke:#82B366,color:#000",
@@ -42,8 +39,7 @@ _CLASSDEF_STYLES: dict[str, str] = {
     "output": "fill:#E8E8E8,stroke:#666666,color:#000",
 }
 
-# Regex patterns
-_SOURCE_NODE_FIELD_RE = re.compile(r"(?:^|[\s{?])([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)")
+# Regex patterns (used outside `_scope.py` — e.g. `_extract_batch_source`)
 _PARAM_REF_RE = re.compile(r"\$\{([a-zA-Z0-9_-]+)(?:\.|\})")
 
 # Workflow types eligible for sub-workflow expansion
@@ -261,26 +257,6 @@ def _dynamic_batch_label(batch: Optional[dict[str, Any]]) -> str:
     source_name = match.group(1) if match else "N"
     parallel_prefix = "parallel " if batch.get("parallel", False) else ""
     return f" ({parallel_prefix}x|{source_name}|)"
-
-
-def _refs_input(value: str, input_name: str) -> bool:
-    """Check if a string value references a top-level input by name."""
-    return f"${{{input_name}}}" in value or f"${{{input_name}." in value
-
-
-def _collect_param_refs(params: dict[str, Any]) -> list[str]:
-    """Collect all string values from params, including one level of nested dicts.
-
-    Code nodes store declared inputs at ``params.inputs`` (a nested dict),
-    so we recurse one level to find those refs too.
-    """
-    refs: list[str] = []
-    for value in params.values():
-        if isinstance(value, str):
-            refs.append(value)
-        elif isinstance(value, dict):
-            refs.extend(v for v in value.values() if isinstance(v, str))
-    return refs
 
 
 def _render_classdefs(ctx: MermaidContext) -> None:

--- a/src/pflow/core/workflow/mermaid/_edges.py
+++ b/src/pflow/core/workflow/mermaid/_edges.py
@@ -3,12 +3,11 @@
 from typing import Any, Optional
 
 from pflow.core.workflow.mermaid._context import (
-    _PARAM_REF_RE,
-    _RESERVED_PARAMS,
     MermaidContext,
     _escape_label,
     _to_mermaid_id,
 )
+from pflow.core.workflow.mermaid._scope import Scope
 
 # ---------------------------------------------------------------------------
 # Edge preprocessing (pure — no ctx)
@@ -91,41 +90,9 @@ def _extract_batch_source(node: dict[str, Any], ctx: MermaidContext) -> Optional
     items = batch.get("items")
     if not isinstance(items, str):
         return None
-    for ref in _PARAM_REF_RE.findall(items):
-        if str(ref) in ctx.sibling_node_ids:
-            return str(ref)
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Reference resolution
-# ---------------------------------------------------------------------------
-
-
-def _resolve_ref_source(
-    ref_name: str,
-    batch_source: Optional[str],
-    ctx: MermaidContext,
-) -> Optional[str]:
-    """Resolve a template ref name to a mermaid source ID."""
-    if ref_name == "item":
-        if not batch_source:
-            return None
-        # Skip if source has outputs — name-matched structural edge handles it
-        if _to_mermaid_id(ctx.prefix + batch_source) in ctx.has_expanded_outputs:
-            return None
-        return _to_mermaid_id(ctx.prefix + batch_source)
-    if ref_name in ctx.sibling_node_ids:
-        mermaid_id = _to_mermaid_id(ctx.prefix + ref_name)
-        # If sibling has outputs, route through them instead of subgraph box
-        out_dict = ctx.outgoing_routes.get(mermaid_id)
-        if out_dict and len(out_dict) == 1:
-            return next(iter(out_dict.values()))
-        return mermaid_id
-    if ref_name in ctx.parent_inputs:
-        if not ctx.prefix:
-            return None  # Depth 0: handled by _connect_top_level_inputs
-        return _to_mermaid_id(f"{ctx.prefix}in_{ref_name}")
+    for root, _field in Scope.refs_in(items):
+        if root in ctx.sibling_node_ids:
+            return root
     return None
 
 
@@ -221,10 +188,13 @@ def _generate_data_flow_edges(
 ) -> bool:
     """Generate edges from upstream nodes to sub-workflow input nodes.
 
-    Parses template refs in the parent node's ``params`` to find which
-    sibling nodes or parent inputs feed each child input.  For example,
-    ``creative_direction: ${creative-direction.response}`` generates an
-    edge from ``creative-direction`` to the child's ``in_creative_direction``.
+    Walks the parent node's ``params["inputs"]`` (the canonical location for
+    child-input bindings post-task-153) and emits one edge per template ref
+    to the matching ``{child_prefix}in_<name>`` node.
+
+    Opaque templates (e.g. ``inputs: ${item.inputs}`` — a whole-dict reference)
+    are skipped: the ``inputs`` key isn't a dict, so no per-input edges can be
+    statically drawn.  Runtime resolves these per batch item.
 
     Returns True if at least one data-flow edge was generated.
     """
@@ -232,19 +202,26 @@ def _generate_data_flow_edges(
     if not child_inputs:
         return False
 
-    params = node.get("params", {})
-    batch_source = _extract_batch_source(node, ctx)
+    inputs_dict = node.get("params", {}).get("inputs")
+    if not isinstance(inputs_dict, dict):
+        return False
+
+    scope = Scope.for_level(ctx, batch_source=_extract_batch_source(node, ctx))
     generated = False
 
-    for param_name, param_value in params.items():
-        if param_name in _RESERVED_PARAMS or param_name not in child_inputs:
+    for input_name, binding in inputs_dict.items():
+        if input_name not in child_inputs:
             continue
-        if not isinstance(param_value, str) or "${" not in param_value:
+        if not isinstance(binding, str) or "${" not in binding:
             continue
 
-        target_mid = _to_mermaid_id(f"{child_prefix}in_{param_name}")
-        for ref_name in _PARAM_REF_RE.findall(param_value):
-            source_mid = _resolve_ref_source(ref_name, batch_source, ctx)
+        target_mid = _to_mermaid_id(f"{child_prefix}in_{input_name}")
+        for root, field in Scope.refs_in(binding):
+            # At depth 0, top-level input refs are handled by _connect_top_level_inputs
+            # (nearest-consumer layout heuristic).  Skip to avoid double emission.
+            if ctx.current_depth == 0 and root in ctx.parent_inputs:
+                continue
+            source_mid = scope.resolve(root, field)
             if source_mid:
                 ctx.lines.append(f"{ctx.indent}{source_mid} --> {target_mid}")
                 generated = True
@@ -257,44 +234,44 @@ def _generate_batch_item_data_flow(
     expanded_items: list[tuple[str, dict[str, Any]]],
     ctx: MermaidContext,
 ) -> set[str]:
-    """Generate data-flow edges from parent params to each expanded batch item's inputs.
+    """Generate data-flow edges from parent inputs to each expanded batch item.
 
-    For a batch workflow node like ``emotional-reviews`` with params
-    ``lyrics: ${write-lyrics.response}``, generates edges from ``write-lyrics``
-    to each item's ``in_lyrics`` node (emotional-architecture, narrative, imagery).
+    Walks the parent node's ``params["inputs"]``.  For each binding that
+    references a sibling node (not a batch item), emits an edge to that input
+    on each expanded item that declares it.
 
-    Skips ``${item.*}`` refs (those come from the batch items themselves).
+    Skips ``${item.*}`` refs (batch item values — these come from the batch
+    items list, not a sibling node).
 
-    Returns set of item mermaid IDs that received data-flow edges (for
-    structural edge suppression in the fork/join).
+    Returns the set of item mermaid IDs that received data-flow edges, so the
+    caller can suppress duplicate structural edges through the fork/join map.
     """
     node_id = node["id"]
-    params = node.get("params", {})
+    inputs_dict = node.get("params", {}).get("inputs")
+    if not isinstance(inputs_dict, dict):
+        return set()
+
     child_prefix_base = ctx.prefix + node_id + "__"
     items_with_data_flow: set[str] = set()
 
-    for param_name, param_value in params.items():
-        if param_name in _RESERVED_PARAMS:
+    for input_name, binding in inputs_dict.items():
+        if not isinstance(binding, str) or "${" not in binding:
             continue
-        if not isinstance(param_value, str) or "${" not in param_value:
-            continue
-        if "${item" in param_value:
-            continue  # Skip batch item refs
+        if "${item" in binding:
+            continue  # Batch item refs come from the items list, not a sibling
 
-        # Find source node from template ref
-        for ref_name in _PARAM_REF_RE.findall(param_value):
-            if ref_name not in ctx.sibling_node_ids:
+        for root, _field in Scope.refs_in(binding):
+            if root not in ctx.sibling_node_ids:
                 continue
-            source_mid = _to_mermaid_id(ctx.prefix + ref_name)
+            source_mid = _to_mermaid_id(ctx.prefix + root)
 
-            # Generate edge to each expanded item's input (if it has this input)
             for item_label, child_ir in expanded_items:
                 child_inputs = child_ir.get("inputs", {})
-                if param_name not in child_inputs:
+                if input_name not in child_inputs:
                     continue
                 item_mermaid_id = _to_mermaid_id(child_prefix_base + item_label)
                 item_prefix = child_prefix_base + item_label + "__"
-                target_mid = _to_mermaid_id(f"{item_prefix}in_{param_name}")
+                target_mid = _to_mermaid_id(f"{item_prefix}in_{input_name}")
                 ctx.lines.append(f"{ctx.indent}{source_mid} --> {target_mid}")
                 items_with_data_flow.add(item_mermaid_id)
 

--- a/src/pflow/core/workflow/mermaid/_io.py
+++ b/src/pflow/core/workflow/mermaid/_io.py
@@ -3,12 +3,11 @@
 from typing import Any, Optional
 
 from pflow.core.workflow.mermaid._context import (
-    _SOURCE_NODE_FIELD_RE,
     MermaidContext,
     _escape_label,
-    _refs_input,
     _to_mermaid_id,
 )
+from pflow.core.workflow.mermaid._scope import Scope
 
 # ---------------------------------------------------------------------------
 # Top-level input nodes
@@ -78,30 +77,36 @@ def _connect_input_from_params(
     connected: set[str],
     ctx: MermaidContext,
 ) -> None:
-    """Connect top-level inputs referenced in node params."""
+    """Connect top-level inputs referenced in node params.
+
+    Walks ``params`` and one level of nested dicts (for the ``params["inputs"]``
+    form used by workflow + code nodes).  For each template ref to a declared
+    top-level input, emits an edge to the consumer — routed through the
+    consumer's input wrapper when the ref lives under a matching child-input
+    key (task-146 nearest-consumer heuristic).
+    """
     params = node.get("params", {})
+    # (child_param_name, ref_value) pairs — child_param_name used for in_dict target routing
+    values_to_check: list[tuple[str, str]] = []
     for param_name, param_value in params.items():
-        # Check direct string values
-        values_to_check = []
         if isinstance(param_value, str):
             values_to_check.append((param_name, param_value))
         elif isinstance(param_value, dict):
-            # Nested dicts (e.g., code node inputs: {name: "${ref}"})
             for nested_name, nested_val in param_value.items():
                 if isinstance(nested_val, str):
                     values_to_check.append((nested_name, nested_val))
 
-        for child_param_name, ref_value in values_to_check:
-            for input_name in inputs:
-                if not _refs_input(ref_value, input_name):
-                    continue
-                # Route through input wrapper if the child param name matches
-                target = in_dict.get(child_param_name, in_dict.get(input_name, mermaid_id))
-                source = _to_mermaid_id(f"input_{input_name}")
-                edge_key = f"{source}->{target}"
-                if edge_key not in connected:
-                    ctx.lines.append(f"    {source} --> {target}")
-                    connected.add(edge_key)
+    for child_param_name, ref_value in values_to_check:
+        for root, _field in Scope.refs_in(ref_value):
+            if root not in inputs:
+                continue
+            # Route through input wrapper if the child param name matches
+            target = in_dict.get(child_param_name, in_dict.get(root, mermaid_id))
+            source = _to_mermaid_id(f"input_{root}")
+            edge_key = f"{source}->{target}"
+            if edge_key not in connected:
+                ctx.lines.append(f"    {source} --> {target}")
+                connected.add(edge_key)
 
 
 def _connect_input_from_batch(
@@ -112,16 +117,15 @@ def _connect_input_from_batch(
     connected: set[str],
     ctx: MermaidContext,
 ) -> None:
-    """Connect top-level inputs referenced in batch.items."""
+    """Connect top-level inputs referenced in ``batch.items``."""
     batch = node.get("batch")
     if not batch or not isinstance(batch.get("items"), str):
         return
-    items_ref = batch["items"]
-    for input_name in inputs:
-        if not _refs_input(items_ref, input_name):
+    for root, _field in Scope.refs_in(batch["items"]):
+        if root not in inputs:
             continue
         target = next(iter(in_dict.values())) if in_dict else mermaid_id
-        source = _to_mermaid_id(f"input_{input_name}")
+        source = _to_mermaid_id(f"input_{root}")
         edge_key = f"{source}->{target}"
         if edge_key not in connected:
             ctx.lines.append(f"    {source} --> {target}")
@@ -161,10 +165,13 @@ def _render_top_level_outputs(ir: dict[str, Any], ctx: MermaidContext) -> list[s
     ctx.lines.append("    end")
     ctx.lines.append("    style workflow-outputs fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4")
 
-    # Connect producing nodes to outputs
+    # Top-level inputs use the ``input_{name}`` convention
+    input_ids = {name: _to_mermaid_id(f"input_{name}") for name in ir.get("inputs", {})}
+
+    # Connect producing nodes (and input-root refs) to outputs
     for name, config in outputs.items():
         source = config.get("source", "") if isinstance(config, dict) else ""
-        _connect_sources_to_output(source, out_name_map[name], node_ids, "", ctx, ctx.outgoing_routes)
+        _connect_sources_to_output(source, out_name_map[name], node_ids, "", input_ids, ctx, ctx.outgoing_routes)
 
     return output_ids
 
@@ -179,31 +186,47 @@ def _connect_sources_to_output(
     out_mid: str,
     node_ids: set[str],
     id_prefix: str,
+    input_ids: dict[str, str],
     ctx: MermaidContext,
     *outgoing_maps: dict[str, dict[str, str]],
 ) -> None:
-    """Connect producing nodes to an output node by parsing a source expression.
+    """Connect producing sources to an output node by parsing a source expression.
 
-    Scans ``source`` for ``${node.field}`` refs and emits edges from each
-    producing node (or its output node, if expanded) to ``out_mid``.
+    Each root ref in ``source`` resolves to exactly one of:
+
+    - A declared **input** at this scope → edge from the input parallelogram.
+    - A **sibling node**, possibly with a specific output field → edge from
+      the node's output (if expanded) or the node box.
+    - Unknown → skipped (stale ref — caught elsewhere at validation time).
+
+    Handles coalesce expressions (``${a.x ?? b.y}``) and bare input refs
+    (``${data}`` without a field).  Both emit their respective edges.
 
     Args:
-        id_prefix: Prepended to source node IDs for mermaid ID lookup.
-        outgoing_maps: One or more outgoing maps, checked in order.
-            First map with a match wins (supports child→parent cascade).
+        node_ids: Declared node IDs in the source scope.
+        id_prefix: Prepended to source node IDs for mermaid ID construction.
+        input_ids: Input name → mermaid ID at this scope (``input_{name}``
+            at top level, ``{prefix}in_{name}`` in a sub-workflow).  Refs
+            matching an input key emit an edge from the input parallelogram.
+        outgoing_maps: Outgoing-routes maps checked in order.  First map with
+            a match wins (supports child→parent output cascade).
     """
-    for src_node, field in _SOURCE_NODE_FIELD_RE.findall(source):
-        if src_node not in node_ids:
+    for root, field in Scope.source_refs_in(source):
+        # Input-root refs (#263 fix): connect from the input parallelogram.
+        if root in input_ids:
+            ctx.lines.append(f"{ctx.indent}{input_ids[root]} --> {out_mid}")
             continue
-        src_mid = _to_mermaid_id(id_prefix + src_node)
-        # Find the first outgoing map that has this source
+
+        if root not in node_ids:
+            continue
+        src_mid = _to_mermaid_id(id_prefix + root)
         child_outputs: dict[str, str] = {}
         for omap in outgoing_maps:
             found = omap.get(src_mid)
             if found:
                 child_outputs = found
                 break
-        if field in child_outputs:
+        if field and field in child_outputs:
             ctx.lines.append(f"{ctx.indent}{child_outputs[field]} --> {out_mid}")
         elif len(child_outputs) == 1:
             ctx.lines.append(f"{ctx.indent}{next(iter(child_outputs.values()))} --> {out_mid}")
@@ -250,6 +273,8 @@ def _render_subworkflow_outputs(ir: dict[str, Any], ctx: MermaidContext) -> list
         return []
 
     node_ids = {n["id"] for n in ir.get("nodes", [])}
+    # Sub-workflow inputs use the ``{prefix}in_{name}`` convention
+    input_ids = {name: _to_mermaid_id(f"{ctx.prefix}in_{name}") for name in ir.get("inputs", {})}
     output_ids: list[str] = []
 
     for name, config in outputs.items():
@@ -259,7 +284,7 @@ def _render_subworkflow_outputs(ir: dict[str, Any], ctx: MermaidContext) -> list
         output_ids.append(out_mid)
 
         source = config.get("source", "") if isinstance(config, dict) else ""
-        _connect_sources_to_output(source, out_mid, node_ids, ctx.prefix, ctx, ctx.outgoing_routes)
+        _connect_sources_to_output(source, out_mid, node_ids, ctx.prefix, input_ids, ctx, ctx.outgoing_routes)
 
     return output_ids
 
@@ -356,10 +381,12 @@ def _render_external_outputs(
     # Check child_outgoing_routes first (nested sub-workflow outputs from
     # the child's own _render_workflow), then fall back to parent outgoing_routes.
     _child_out = child_outgoing_routes or {}
+    # Child-scope inputs use the ``{child_prefix}in_{name}`` convention
+    input_ids = {name: _to_mermaid_id(f"{child_prefix}in_{name}") for name in child_ir.get("inputs", {})}
     for name, config in outputs.items():
         source = config.get("source", "") if isinstance(config, dict) else ""
         _connect_sources_to_output(
-            source, out_name_map[name], node_ids, child_prefix, ctx, _child_out, ctx.outgoing_routes
+            source, out_name_map[name], node_ids, child_prefix, input_ids, ctx, _child_out, ctx.outgoing_routes
         )
 
     # Populate outgoing_routes for structural edge routing

--- a/src/pflow/core/workflow/mermaid/_io.py
+++ b/src/pflow/core/workflow/mermaid/_io.py
@@ -213,6 +213,11 @@ def _connect_sources_to_output(
     """
     for root, field in Scope.source_refs_in(source):
         # Input-root refs (#263 fix): connect from the input parallelogram.
+        # Precedence note: inputs checked before nodes.  WorkflowValidator
+        # does NOT enforce name-uniqueness between declared inputs and node
+        # IDs (see validator.py `valid_sources` union at :403), so a rare
+        # same-name collision would resolve to the input here.  Matches
+        # runtime template resolution behavior (shared store lookup).
         if root in input_ids:
             ctx.lines.append(f"{ctx.indent}{input_ids[root]} --> {out_mid}")
             continue

--- a/src/pflow/core/workflow/mermaid/_scope.py
+++ b/src/pflow/core/workflow/mermaid/_scope.py
@@ -1,0 +1,129 @@
+"""Reference resolution for mermaid generation.
+
+Consolidates "given a ``${x.y}`` template ref, what mermaid ID does it resolve to?"
+into a single primitive. Three resolution cases, exhaustive:
+
+1. ``${item}`` / ``${item.field}`` — batch item source.
+2. ``${node}`` / ``${node.field}`` — sibling node, optionally routed through an
+   output in ``ctx.outgoing_routes``.
+3. ``${input_name}`` / ``${input_name.field}`` — declared input at this scope.
+
+``Scope`` holds a reference to the live ``MermaidContext`` — it does NOT
+snapshot. Sibling ``outgoing_routes`` are populated incrementally during
+``_render_workflow`` (as each node is rendered), so resolution must read ctx
+state at call time.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from pflow.core.workflow.mermaid._context import (
+    MermaidContext,
+    _to_mermaid_id,
+)
+
+# Data-flow bindings: each template is one ref.  "${producer.response}" → (producer, response).
+# Matches ``${root}`` (no field group) or ``${root.field}`` (field group captured).
+# Deeper refs like ``${a.b.c}`` capture only the first field segment (a, b) — matches
+# pre-consolidation semantics, which only used the root + first field.
+_DATA_FLOW_REF_PATTERN = re.compile(r"\$\{([a-zA-Z0-9_-]+)(?:\.([a-zA-Z0-9_-]+))?")
+
+# Output sources: extract refs from INSIDE ``${...}`` blocks only, so literal text
+# (validator-rejected but defensively handled) never produces false positives.
+# Two-stage scan: find each ``${...}`` block, then within each block capture every
+# ``root`` (optionally ``.field``).  Handles coalesce (``${a.x ?? b.y}`` — two refs
+# per block) and bare input refs (``${data}`` — no field).
+_BRACE_BLOCK_RE = re.compile(r"\$\{([^}]*)\}")
+_REF_IN_BLOCK_RE = re.compile(r"(?:^|[\s?])([a-zA-Z0-9_-]+)(?:\.([a-zA-Z0-9_-]+))?")
+
+
+@dataclass
+class Scope:
+    """Per-level reference resolver over live :class:`MermaidContext` state.
+
+    Attributes:
+        ctx: Live context reference.  Scope reads ``sibling_node_ids``,
+            ``outgoing_routes``, and ``has_expanded_outputs`` at resolve-time.
+        input_ids: Name → mermaid ID for declared inputs at this scope.
+            Top-level convention: ``input_{name}``.  Sub-workflow convention:
+            ``{prefix}in_{name}``.  Build via :meth:`for_level` or pass directly.
+        batch_source: Sibling node ID that produces the batch items list, or
+            ``None`` if the current edge-generation pass is not inside a batch.
+    """
+
+    ctx: MermaidContext
+    input_ids: dict[str, str]
+    batch_source: Optional[str] = None
+
+    def resolve(self, root: str, field: Optional[str]) -> Optional[str]:
+        """Resolve a template ref root (and optional field) to a mermaid ID.
+
+        Returns ``None`` when the root is not a recognized name in this scope,
+        or when a recognized source intentionally suppresses its edge (batch
+        item whose source has expanded outputs — the structural edge routes
+        through the outputs instead).
+        """
+        # Batch item
+        if root == "item":
+            if not self.batch_source:
+                return None
+            src_mid = _to_mermaid_id(self.ctx.prefix + self.batch_source)
+            if src_mid in self.ctx.has_expanded_outputs:
+                return None
+            return src_mid
+
+        # Sibling node (with optional output-field routing)
+        if root in self.ctx.sibling_node_ids:
+            mermaid_id = _to_mermaid_id(self.ctx.prefix + root)
+            out_dict = self.ctx.outgoing_routes.get(mermaid_id)
+            if out_dict:
+                if field and field in out_dict:
+                    return out_dict[field]
+                if len(out_dict) == 1:
+                    return next(iter(out_dict.values()))
+            return mermaid_id
+
+        # Declared input at this scope
+        if root in self.input_ids:
+            return self.input_ids[root]
+
+        return None
+
+    @classmethod
+    def for_level(cls, ctx: MermaidContext, batch_source: Optional[str] = None) -> "Scope":
+        """Build a Scope for the current workflow level using the ID convention.
+
+        - Top level (depth 0): inputs at ``input_{name}``.
+        - Sub-workflow (depth > 0): inputs at ``{prefix}in_{name}``.
+        """
+        if ctx.current_depth == 0:
+            input_ids = {name: _to_mermaid_id(f"input_{name}") for name in ctx.parent_inputs}
+        else:
+            input_ids = {name: _to_mermaid_id(f"{ctx.prefix}in_{name}") for name in ctx.parent_inputs}
+        return cls(ctx=ctx, input_ids=input_ids, batch_source=batch_source)
+
+    @staticmethod
+    def refs_in(value: str) -> list[tuple[str, Optional[str]]]:
+        """Extract ``(root, field)`` pairs from template refs in a binding.
+
+        Use for data-flow bindings where each template expression is one ref
+        (e.g. ``"${producer.response}"``).  Returns ``field=None`` for bare
+        refs like ``"${data}"``.
+        """
+        return [(m.group(1), m.group(2)) for m in _DATA_FLOW_REF_PATTERN.finditer(value)]
+
+    @staticmethod
+    def source_refs_in(source: str) -> list[tuple[str, Optional[str]]]:
+        """Extract ``(root, field)`` pairs from output source expressions.
+
+        Two-stage: find each ``${...}`` block, then capture every ref inside
+        it.  Handles coalesce (``${a.x ?? b.y}`` — two refs in one block) and
+        bare refs (``${data}`` — no field).  Literal text outside ``${...}``
+        never produces matches.
+        """
+        refs: list[tuple[str, Optional[str]]] = []
+        for block in _BRACE_BLOCK_RE.finditer(source):
+            for m in _REF_IN_BLOCK_RE.finditer(block.group(1)):
+                refs.append((m.group(1), m.group(2)))
+        return refs

--- a/src/pflow/core/workflow/mermaid/_scope.py
+++ b/src/pflow/core/workflow/mermaid/_scope.py
@@ -23,17 +23,12 @@ from pflow.core.workflow.mermaid._context import (
     _to_mermaid_id,
 )
 
-# Data-flow bindings: each template is one ref.  "${producer.response}" → (producer, response).
-# Matches ``${root}`` (no field group) or ``${root.field}`` (field group captured).
-# Deeper refs like ``${a.b.c}`` capture only the first field segment (a, b) — matches
-# pre-consolidation semantics, which only used the root + first field.
-_DATA_FLOW_REF_PATTERN = re.compile(r"\$\{([a-zA-Z0-9_-]+)(?:\.([a-zA-Z0-9_-]+))?")
-
-# Output sources: extract refs from INSIDE ``${...}`` blocks only, so literal text
-# (validator-rejected but defensively handled) never produces false positives.
-# Two-stage scan: find each ``${...}`` block, then within each block capture every
-# ``root`` (optionally ``.field``).  Handles coalesce (``${a.x ?? b.y}`` — two refs
-# per block) and bare input refs (``${data}`` — no field).
+# Extract refs from INSIDE ``${...}`` blocks only, so literal text (validator-rejected
+# but defensively handled) never produces false positives.  Two-stage scan: find each
+# ``${...}`` block, then within each block capture every ``root`` (optionally
+# ``.field``).  Handles coalesce (``${a.x ?? b.y}`` — two refs per block) in any
+# template context (bindings and output sources alike — ``??`` is a general-purpose
+# template operator, not output-only).  Handles bare refs (``${data}`` — no field).
 _BRACE_BLOCK_RE = re.compile(r"\$\{([^}]*)\}")
 _REF_IN_BLOCK_RE = re.compile(r"(?:^|[\s?])([a-zA-Z0-9_-]+)(?:\.([a-zA-Z0-9_-]+))?")
 
@@ -63,6 +58,10 @@ class Scope:
         or when a recognized source intentionally suppresses its edge (batch
         item whose source has expanded outputs — the structural edge routes
         through the outputs instead).
+
+        ``"item"`` is reserved for batch item refs: outside a batch context
+        (``batch_source`` is None) it always returns ``None`` — a sibling
+        node literally named ``item`` is unreachable by design.
         """
         # Batch item
         if root == "item":
@@ -105,22 +104,25 @@ class Scope:
 
     @staticmethod
     def refs_in(value: str) -> list[tuple[str, Optional[str]]]:
-        """Extract ``(root, field)`` pairs from template refs in a binding.
+        """Extract ``(root, field)`` pairs from every template ref in ``value``.
 
-        Use for data-flow bindings where each template expression is one ref
-        (e.g. ``"${producer.response}"``).  Returns ``field=None`` for bare
-        refs like ``"${data}"``.
+        Use for data-flow bindings.  Handles multiple templates, bare refs
+        (``${data}`` — no field), and coalesce expressions
+        (``${a.x ?? b.y}`` — two refs in one block).  Literal text outside
+        ``${...}`` never produces matches.
+
+        Alias for :meth:`source_refs_in` — data-flow bindings and output
+        sources use the same template grammar (``??`` is a general-purpose
+        template operator, not output-only).
         """
-        return [(m.group(1), m.group(2)) for m in _DATA_FLOW_REF_PATTERN.finditer(value)]
+        return Scope.source_refs_in(value)
 
     @staticmethod
     def source_refs_in(source: str) -> list[tuple[str, Optional[str]]]:
-        """Extract ``(root, field)`` pairs from output source expressions.
+        """Extract ``(root, field)`` pairs from a template expression.
 
         Two-stage: find each ``${...}`` block, then capture every ref inside
-        it.  Handles coalesce (``${a.x ?? b.y}`` — two refs in one block) and
-        bare refs (``${data}`` — no field).  Literal text outside ``${...}``
-        never produces matches.
+        it.
         """
         refs: list[tuple[str, Optional[str]]] = []
         for block in _BRACE_BLOCK_RE.finditer(source):

--- a/tests/test_core/golden_mermaid/deep-research-LR.mmd
+++ b/tests/test_core/golden_mermaid/deep-research-LR.mmd
@@ -43,8 +43,9 @@ graph LR
         style analyze-sources__score-out fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
         analyze-sources__score__normalize --> analyze-sources__score__out_score
         analyze-sources__score__evaluate --> analyze-sources__score__out_reasoning
+        analyze-sources__extract --> analyze-sources__score__in_text
+        analyze-sources__in_focus --> analyze-sources__score__in_criteria
         analyze-sources__compile["compile (code)"]:::code
-        analyze-sources__extract --> analyze-sources__score
         analyze-sources__score__out_score --> analyze-sources__compile
         analyze-sources__score__out_reasoning --> analyze-sources__compile
     end
@@ -56,6 +57,8 @@ graph LR
     style analyze-sources-out fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
     analyze-sources__compile --> analyze-sources__out_analysis
     analyze-sources__score__out_score --> analyze-sources__out_quality_score
+    prepare --> analyze-sources__in_content
+    prepare --> analyze-sources__in_focus
     combine["combine (code)"]:::code
     subgraph reviews ["reviews (parallel x5)"]
         subgraph reviews__accuracy ["accuracy (workflow)"]
@@ -82,6 +85,8 @@ graph LR
         style reviews__dots fill:#FFF2CC,stroke:#D6B656,color:#000
     end
     style reviews fill:#808080,fill-opacity:0.14,stroke:#999
+    combine --> reviews__accuracy__in_summary
+    combine --> reviews__completeness__in_summary
     final-report["final-report (code)"]:::code
     input_sources --> prepare
     input_focus --> prepare
@@ -90,7 +95,6 @@ graph LR
     end
     style workflow-outputs fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
     final-report --> out_report
-    prepare --> analyze-sources
     analyze-sources__out_analysis --> combine
     analyze-sources__out_quality_score --> combine
     combine --> reviews__accuracy

--- a/tests/test_core/golden_mermaid/deep-research-TD.mmd
+++ b/tests/test_core/golden_mermaid/deep-research-TD.mmd
@@ -43,8 +43,9 @@ graph TD
         style analyze-sources__score-out fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
         analyze-sources__score__normalize --> analyze-sources__score__out_score
         analyze-sources__score__evaluate --> analyze-sources__score__out_reasoning
+        analyze-sources__extract --> analyze-sources__score__in_text
+        analyze-sources__in_focus --> analyze-sources__score__in_criteria
         analyze-sources__compile["compile (code)"]:::code
-        analyze-sources__extract --> analyze-sources__score
         analyze-sources__score__out_score --> analyze-sources__compile
         analyze-sources__score__out_reasoning --> analyze-sources__compile
     end
@@ -56,6 +57,8 @@ graph TD
     style analyze-sources-out fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
     analyze-sources__compile --> analyze-sources__out_analysis
     analyze-sources__score__out_score --> analyze-sources__out_quality_score
+    prepare --> analyze-sources__in_content
+    prepare --> analyze-sources__in_focus
     combine["combine (code)"]:::code
     subgraph reviews ["reviews (parallel x5)"]
         subgraph reviews__accuracy ["accuracy (workflow)"]
@@ -82,6 +85,8 @@ graph TD
         style reviews__dots fill:#FFF2CC,stroke:#D6B656,color:#000
     end
     style reviews fill:#808080,fill-opacity:0.14,stroke:#999
+    combine --> reviews__accuracy__in_summary
+    combine --> reviews__completeness__in_summary
     final-report["final-report (code)"]:::code
     input_sources --> prepare
     input_focus --> prepare
@@ -90,7 +95,6 @@ graph TD
     end
     style workflow-outputs fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
     final-report --> out_report
-    prepare --> analyze-sources
     analyze-sources__out_analysis --> combine
     analyze-sources__out_quality_score --> combine
     combine --> reviews__accuracy

--- a/tests/test_core/test_mermaid.py
+++ b/tests/test_core/test_mermaid.py
@@ -1359,9 +1359,12 @@ def test_opaque_template_inputs_fall_through_gracefully() -> None:
     # Must not raise
     out = generate_mermaid(parent_ir, resolve_child=resolver)
 
-    # No per-input data-flow edges emitted (statically unresolvable)
-    assert "consumer__in_x -->" in out or "consumer__in_x[/" in out  # input node still rendered
-    # But no edge INTO consumer__in_x from an external node
+    # Input node is still rendered (parallelogram) — opaque template doesn't
+    # prevent child input declaration
+    assert "consumer__in_x[/" in out, "child input node must be rendered"
+
+    # But no data-flow edge INTO consumer__in_x from an external node —
+    # we can't statically enumerate which parent value feeds which child input.
     external_to_input = [
         line
         for line in out.splitlines()
@@ -1415,6 +1418,45 @@ def test_batch_data_flow_with_inputs_dict() -> None:
     assert "combine --> reviews__clarity__in_summary" in out
     # aspect is ${item.*} — no external data-flow edge for it
     assert "combine --> reviews__accuracy__in_aspect" not in out
+
+
+def test_coalesce_in_data_flow_binding() -> None:
+    """Coalesce expressions in data-flow bindings emit edges for both operands.
+
+    Coalesce (``??``) is a general-purpose template operator — valid in any
+    template context, not just output sources.  ``refs_in`` must capture
+    every ref inside ``${...}`` blocks, including both sides of ``??``.
+    A regression where only the first operand is extracted would silently
+    drop half the data-flow edges.
+    """
+    child_ir = _ir(
+        nodes=[_node("step", "code")],
+        inputs={"val": {"type": "string"}},
+    )
+
+    def resolver(params: dict[str, Any], base: Optional[Path]) -> Optional[SubWorkflowResult]:
+        return SubWorkflowResult(ir=child_ir, path=Path("/fake/child.pflow.md"), warnings=())
+
+    parent_ir = _ir(
+        nodes=[
+            _node("primary", "llm"),
+            _node("fallback", "llm"),
+            {
+                "id": "consumer",
+                "type": "workflow",
+                "params": {
+                    "workflow": "child",
+                    "inputs": {"val": "${primary.response ?? fallback.response}"},
+                },
+            },
+        ],
+        edges=[{"from": "primary", "to": "consumer"}, {"from": "fallback", "to": "consumer"}],
+    )
+    out = generate_mermaid(parent_ir, resolve_child=resolver)
+
+    # Both operands of the coalesce must feed the consumer's val input
+    assert "primary --> consumer__in_val" in out, "first coalesce operand missing"
+    assert "fallback --> consumer__in_val" in out, "second coalesce operand missing"
 
 
 # ===========================================================================

--- a/tests/test_core/test_mermaid.py
+++ b/tests/test_core/test_mermaid.py
@@ -898,7 +898,13 @@ def test_subworkflow_linear_outputs_connected() -> None:
 
 
 def test_data_flow_edges_from_params() -> None:
-    """Param template refs generate data-flow edges to sub-workflow inputs."""
+    """Template refs in ``params["inputs"]`` generate per-input data-flow edges.
+
+    Regression for GH #283: child-input bindings live inside a nested
+    ``inputs:`` dict (canonical form post-task-153).  The edge generator
+    must descend into that dict — iterating top-level params misses every
+    binding.
+    """
     child_ir = _ir(
         nodes=[_node("process", "code")],
         inputs={"data": {"type": "string"}, "config": {"type": "object"}},
@@ -915,8 +921,10 @@ def test_data_flow_edges_from_params() -> None:
                 "type": "workflow",
                 "params": {
                     "workflow": "child",
-                    "data": "${producer.response}",
-                    "config": "${my_input}",
+                    "inputs": {
+                        "data": "${producer.response}",
+                        "config": "${my_input}",
+                    },
                 },
             },
         ],
@@ -927,8 +935,13 @@ def test_data_flow_edges_from_params() -> None:
 
     # Data-flow edge: producer → consumer's data input
     assert "producer --> consumer__in_data" in out
-    # Data-flow edge: parent input → consumer's config input
-    assert "input_my_input --> consumer__in_config" in out
+    # Data-flow edge: parent input → consumer's config input — exactly once.
+    # At depth 0, _connect_top_level_inputs emits this edge.  The data-flow
+    # generator must skip top-level input refs to avoid double emission.
+    assert out.count("input_my_input --> consumer__in_config") == 1, (
+        f"Double-emit: depth-0 input ref should be skipped by data-flow generator "
+        f"(output contains {out.count('input_my_input --> consumer__in_config')} copies)"
+    )
     # Structural edge routes through outputs (consumer has none, so subgraph box)
     assert "producer --> consumer" in out
 
@@ -949,14 +962,17 @@ def test_structural_edge_not_suppressed_when_subwf_inputs_are_only_from_parent()
     def resolver(params: dict[str, Any], base: Optional[Path]) -> Optional[SubWorkflowResult]:
         return SubWorkflowResult(ir=child_ir, path=Path("/fake/child.pflow.md"), warnings=())
 
-    # prepare → subwf, but subwf's only param references a workflow input (not prepare)
+    # prepare → subwf, but subwf's only input references a workflow input (not prepare)
     parent_ir = _ir(
         nodes=[
             _node("prepare", "code"),
             {
                 "id": "subwf",
                 "type": "workflow",
-                "params": {"workflow": "child", "config": "${my_setting}"},
+                "params": {
+                    "workflow": "child",
+                    "inputs": {"config": "${my_setting}"},
+                },
             },
         ],
         edges=[{"from": "prepare", "to": "subwf"}],
@@ -983,7 +999,10 @@ def test_data_flow_skips_item_refs() -> None:
             {
                 "id": "batch_wf",
                 "type": "workflow",
-                "params": {"workflow": "child", "text": "${item.content}"},
+                "params": {
+                    "workflow": "child",
+                    "inputs": {"text": "${item.content}"},
+                },
                 "batch": {"items": "${sources}", "parallel": True},
             },
         ],
@@ -1218,8 +1237,16 @@ def test_suppression_without_replacement_keeps_structural_edge() -> None:
 
     parent_ir = _ir(
         nodes=[
-            {"id": "sub-a", "type": "workflow", "params": {"workflow": "a.pflow.md", "x": "val"}},
-            {"id": "sub-b", "type": "workflow", "params": {"workflow": "b.pflow.md", "data": "${sub-a.result}"}},
+            {
+                "id": "sub-a",
+                "type": "workflow",
+                "params": {"workflow": "a.pflow.md", "inputs": {"x": "val"}},
+            },
+            {
+                "id": "sub-b",
+                "type": "workflow",
+                "params": {"workflow": "b.pflow.md", "inputs": {"data": "${sub-a.result}"}},
+            },
         ],
         edges=[{"from": "sub-a", "to": "sub-b"}],
     )
@@ -1251,7 +1278,11 @@ def test_external_io_does_not_duplicate_with_internal_io() -> None:
 
     parent_ir = _ir(
         nodes=[
-            {"id": "sub", "type": "workflow", "params": {"workflow": "child", "val": "x"}},
+            {
+                "id": "sub",
+                "type": "workflow",
+                "params": {"workflow": "child", "inputs": {"val": "x"}},
+            },
         ],
     )
     out = generate_mermaid(parent_ir, resolve_child=resolver)
@@ -1290,3 +1321,170 @@ def test_top_level_input_connects_to_actual_consumer() -> None:
     assert "input_settings --> step3" in out
     assert "input_settings --> step1" not in out
     assert "input_settings --> step2" not in out
+
+
+# ===========================================================================
+# GH #283 regression tests (canonical ``inputs:`` dict form)
+# ===========================================================================
+
+
+def test_opaque_template_inputs_fall_through_gracefully() -> None:
+    """Heterogeneous-batch ``inputs: ${item.inputs}`` (whole-dict template) does not crash.
+
+    When the ``inputs`` value is a template string rather than a dict, static
+    analysis cannot enumerate per-input bindings — runtime resolves them per
+    item.  The data-flow edge generator must skip this case without error.
+    """
+    child_ir = _ir(
+        nodes=[_node("step", "code")],
+        inputs={"x": {"type": "string"}},
+    )
+
+    def resolver(params: dict[str, Any], base: Optional[Path]) -> Optional[SubWorkflowResult]:
+        return SubWorkflowResult(ir=child_ir, path=Path("/fake/child.pflow.md"), warnings=())
+
+    parent_ir = _ir(
+        nodes=[
+            {
+                "id": "consumer",
+                "type": "workflow",
+                "params": {
+                    "workflow": "child",
+                    "inputs": "${item.inputs}",  # opaque whole-dict template
+                },
+                "batch": {"items": "${sources}", "parallel": False},
+            },
+        ],
+    )
+    # Must not raise
+    out = generate_mermaid(parent_ir, resolve_child=resolver)
+
+    # No per-input data-flow edges emitted (statically unresolvable)
+    assert "consumer__in_x -->" in out or "consumer__in_x[/" in out  # input node still rendered
+    # But no edge INTO consumer__in_x from an external node
+    external_to_input = [
+        line
+        for line in out.splitlines()
+        if "--> consumer__in_x" in line and "consumer-in" not in line  # skip wrapper → input edge
+    ]
+    assert external_to_input == [], f"Unexpected data-flow edges: {external_to_input}"
+
+
+def test_batch_data_flow_with_inputs_dict() -> None:
+    """Heterogeneous batch with per-item inputs in ``params["inputs"]`` dict.
+
+    Regression for GH #283 batch variant.  Parent-param refs in the nested
+    ``inputs:`` dict must emit edges to each expanded item's input node.
+    """
+    child_ir = _ir(
+        nodes=[_node("review", "llm")],
+        inputs={"summary": {"type": "string"}, "aspect": {"type": "string"}},
+    )
+
+    def resolver(params: dict[str, Any], base: Optional[Path]) -> Optional[SubWorkflowResult]:
+        return SubWorkflowResult(ir=child_ir, path=Path("/fake/review.pflow.md"), warnings=())
+
+    parent_ir = _ir(
+        nodes=[
+            _node("combine", "code"),
+            {
+                "id": "reviews",
+                "type": "workflow",
+                "params": {
+                    "workflow": "${item.workflow}",
+                    "inputs": {
+                        "summary": "${combine.result}",
+                        "aspect": "${item.aspect}",
+                    },
+                },
+                "batch": {
+                    "items": [
+                        {"aspect": "accuracy", "workflow": "/fake/review.pflow.md"},
+                        {"aspect": "clarity", "workflow": "/fake/review.pflow.md"},
+                    ],
+                    "parallel": True,
+                },
+            },
+        ],
+        edges=[{"from": "combine", "to": "reviews"}],
+    )
+    out = generate_mermaid(parent_ir, resolve_child=resolver)
+
+    # Per-item data-flow edge from combine → each item's summary input
+    assert "combine --> reviews__accuracy__in_summary" in out
+    assert "combine --> reviews__clarity__in_summary" in out
+    # aspect is ${item.*} — no external data-flow edge for it
+    assert "combine --> reviews__accuracy__in_aspect" not in out
+
+
+# ===========================================================================
+# GH #263 regression tests (output sources referencing workflow inputs)
+# ===========================================================================
+
+
+def test_output_source_from_declared_input() -> None:
+    """Output ``source: ${data.field}`` where ``data`` is a declared input.
+
+    Regression for GH #263: previously silently dropped (``_connect_sources_to_output``
+    only recognized node IDs as source roots).  The output node rendered
+    disconnected — no incoming edge from the input parallelogram.
+    """
+    ir = _ir(
+        nodes=[_node("process", "shell")],
+        inputs={"data": {"type": "object"}},
+    )
+    ir["outputs"] = {"result": {"source": "${data.field}"}}
+
+    out = generate_mermaid(ir)
+
+    assert "input_data --> out_result" in out
+
+
+def test_output_source_from_bare_input_ref() -> None:
+    """Output ``source: ${data}`` (no field) also resolves to the input.
+
+    Regression for GH #263: the old regex ``_SOURCE_NODE_FIELD_RE`` required
+    ``name.field`` form, so bare input refs didn't match at all and the
+    output silently disconnected.
+    """
+    ir = _ir(
+        nodes=[_node("process", "shell")],
+        inputs={"data": {"type": "string"}},
+    )
+    ir["outputs"] = {"result": {"source": "${data}"}}
+
+    out = generate_mermaid(ir)
+
+    assert "input_data --> out_result" in out
+
+
+def test_output_source_from_input_in_subworkflow() -> None:
+    """Sub-workflow output referencing its declared input also resolves.
+
+    The input at sub-workflow scope uses the ``{prefix}in_{name}`` convention
+    rather than top-level ``input_{name}``.  The fix must construct the right
+    ID at each scope.
+    """
+    child_ir = _ir(
+        nodes=[_node("passthrough", "code")],
+        inputs={"data": {"type": "string"}},
+    )
+    child_ir["outputs"] = {"echo": {"source": "${data}"}}
+
+    def resolver(params: dict[str, Any], base: Optional[Path]) -> Optional[SubWorkflowResult]:
+        return SubWorkflowResult(ir=child_ir, path=Path("/fake/child.pflow.md"), warnings=())
+
+    parent_ir = _ir(
+        nodes=[
+            {
+                "id": "sub",
+                "type": "workflow",
+                "params": {"workflow": "child", "inputs": {"data": "val"}},
+            },
+        ],
+    )
+    out = generate_mermaid(parent_ir, resolve_child=resolver)
+
+    # Within the sub-workflow scope, the input-root ref resolves to the
+    # sub-workflow's input wrapper, not a top-level ``input_*`` node.
+    assert "sub__in_data --> sub__out_echo" in out

--- a/tests/test_core/test_mermaid_golden.py
+++ b/tests/test_core/test_mermaid_golden.py
@@ -54,17 +54,7 @@ def _generate_from_file(
     ],
 )
 def test_golden_example_workflow(workflow_rel: str, golden_name: str, direction: str) -> None:
-    """Example workflow mermaid output matches golden file.
-
-    KNOWN REGRESSION (GH #283): sub-workflow goldens (``document-processor``,
-    ``deep-research-*``) encode a coarsened data-flow compared to pre-task-153
-    state. The renderer at ``src/pflow/core/workflow/mermaid/_edges.py``
-    traces templates only in top-level string params; after task 153 made
-    ``inputs:`` the canonical form, per-child-input edges nested inside that
-    dict became invisible. When #283 lands and descends into ``inputs:``
-    dicts, these goldens will need regeneration to restore the finer-grained
-    edges.
-    """
+    """Example workflow mermaid output matches golden file."""
     workflow_path = EXAMPLES_DIR / workflow_rel
     golden_path = GOLDEN_DIR / golden_name
 


### PR DESCRIPTION
## Summary

Consolidates reference resolution in the mermaid visualizer package (`src/pflow/core/workflow/mermaid/`) behind a single `Scope` primitive. Both open fidelity bugs (#283, #263) are fixed as structural byproducts of the consolidation.

## Task

Follow-up task filed: `.taskmaster/tasks/task_155/task-155.md` (GraphModel extraction, pre-step to planned web UI — builds on the `Scope` seam established here).

## Changes

### New primitive — `_scope.py`
- `Scope` dataclass holding a live `MermaidContext` reference (not a snapshot — sibling `outgoing_routes` grow incrementally during rendering).
- `Scope.resolve(root, field)` — three resolution cases: batch item / sibling node (with optional output-field routing) / declared input.
- `Scope.refs_in(value)` — extract `(root, field)` pairs from data-flow bindings.
- `Scope.source_refs_in(source)` — two-stage scan (find `${...}` blocks, then extract refs inside) to handle coalesce (`${a.x ?? b.y}`) and bare input refs (`${data}`) without false-positive matches on literal text.

### Bug fixes
- **#283**: `_generate_data_flow_edges` + `_generate_batch_item_data_flow` now iterate `params["inputs"]` (canonical post-task-153) instead of top-level `params.items()`. Opaque `inputs: ${item.inputs}` templates skipped gracefully.
- **#263**: `_connect_sources_to_output` takes `input_ids: dict[str, str]` from the caller's scope; input-root refs (including bare `${data}`) now emit edges from the input parallelogram.

### Dead code deleted
- `_RESERVED_PARAMS` (blocklist for the pre-task-153 dual-input-passing world)
- `_SOURCE_NODE_FIELD_RE` (alternate regex, superseded by `Scope.source_refs_in`)
- `_collect_param_refs` (orphan — zero callers)
- `_refs_input` (superseded by `Scope.refs_in`)
- `_resolve_ref_source` (inlined into sole call site)

### Goldens regenerated
- `tests/test_core/golden_mermaid/deep-research-TD.mmd`
- `tests/test_core/golden_mermaid/deep-research-LR.mmd`

Restored per-input edges (e.g. `prepare --> analyze-sources__in_content`, `combine --> reviews__accuracy__in_summary`) that were lost during the task-153 migration. `document-processor` golden unchanged (its bindings all reference top-level inputs, handled by `_connect_top_level_inputs`'s nearest-consumer heuristic).

`KNOWN REGRESSION (GH #283)` docstring at `test_mermaid_golden.py:59-66` removed.

### Tests
- 3 outdated tests migrated from pre-task-153 top-level-params IR shape to canonical `inputs:` dict shape.
- 5 new regression tests:
  - `test_opaque_template_inputs_fall_through_gracefully` — `inputs: ${item.inputs}` doesn't crash
  - `test_batch_data_flow_with_inputs_dict` — #283 batch variant
  - `test_output_source_from_declared_input` — #263 with field
  - `test_output_source_from_bare_input_ref` — #263 bare ref (no dot)
  - `test_output_source_from_input_in_subworkflow` — #263 at sub-workflow scope (`{prefix}in_{name}` convention)
- Counter-assertion added to `test_data_flow_edges_from_params` to guard the depth-0 double-emit skip (caught by mutation testing — the skip was previously load-bearing but untested).

## Explanation

Both bugs share one cause: the visualizer answered the question *"given a `${x.y}`, what mermaid ID does it resolve to?"* in seven different places with seven different levels of completeness. Fixing each function independently would preserve that fragmentation and keep the door open for the next similar bug.

The refactor collapses all seven call sites to route through `Scope.resolve`. Any ref-consuming site now knows about nodes AND declared inputs AND batch items — no "silently drops inputs" path remains.

Depth-0 double-emit concern: `_connect_top_level_inputs` emits `input_X → consumer__in_Y` at the top level using a layout-preserving nearest-consumer heuristic (from task 146 — long-range edges destroy dagre layout). `Scope.resolve` is pure (always resolves), so the two data-flow generators add a two-line caller-side skip for depth-0 top-level input refs to avoid duplicate emission.

## Created docs
- `.taskmaster/tasks/task_155/task-155.md` — follow-up task for GraphModel extraction (pre-step to planned React Flow or equivalent web UI). Builds on the `Scope` primitive.

## Testing

- 78 mermaid-specific tests pass (`tests/test_core/test_mermaid.py`, `test_mermaid_golden.py`, `tests/test_cli/test_visualize.py`).
- 4864 full suite pass (`make test`).
- `make check` clean (ruff, ruff-format, mypy, deptry).
- Mutation-tested: breaking the #283 fix, #263 fix, or depth-0 skip now fails dedicated assertions (the depth-0 skip was previously unguarded — added counter-assertion).
- Adversarial regex tested: empty / literal / coalesce / triple-coalesce / bare refs / hyphens / adjacent templates / malformed `${}`.

**Manual visual verification in mermaid.live is still recommended** for the regenerated `deep-research-TD.mmd` / `deep-research-LR.mmd` — string-level diffs miss visual breakage per `mermaid/CLAUDE.md`.