### PR TITLE
fix: validate inline-static batch items against child input contract (fixes #306)

### DIFF
--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -5,10 +5,11 @@ ensuring consistency between production, tests, and any other consumers.
 """
 
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Optional
 
-from pflow.core.diagnostic import Diagnostic, Severity, format_child_provenance
+from pflow.core.diagnostic import Diagnostic, Severity, deduplicate_diagnostics, format_child_provenance
 from pflow.core.exceptions import SchemaValidationError
 from pflow.registry import Registry
 from pflow.runtime.template_resolver import TemplateResolver
@@ -701,9 +702,6 @@ class WorkflowValidator:
         full validation on it. Catches parse errors, structural errors,
         missing required inputs, and cycles.
         """
-        from pflow.core.file_resolver import resolve_file_references
-        from pflow.core.ir_schema import normalize_ir
-        from pflow.core.validation_utils import generate_dummy_parameters
 
         diagnostics: list[Diagnostic] = []
         seen = _seen if _seen is not None else set()
@@ -718,77 +716,245 @@ class WorkflowValidator:
                 continue
 
             node_id = node.get("id", "unknown")
-            params = node.get("params", {})
 
-            # Load child workflow (file, saved name, or inline IR).
-            # already_seen=True means the child was loaded before — skip recursive
-            # validation (already done) but still check this node's provided inputs.
-            (
-                child_ir,
-                child_path,
-                ref_label,
-                load_errors,
-                already_seen,
-                child_parser_warnings,
-            ) = WorkflowValidator._load_child_workflow(node_id, params, seen, ir_cache, workflow_file)
-            diagnostics.extend(load_errors)
-            diagnostics.extend(_add_child_provenance(child_parser_warnings, node_id, ref_label))
-
-            if child_ir is None or "nodes" not in child_ir:
-                continue
-
-            if not already_seen:
-                # Normalize child IR (adds ir_version, edges) — same as CLI/save paths
-                normalize_ir(child_ir)
-
-                # Resolve file references so template validation sees variables
-                # inside external files (e.g. prompt files referenced in batch items).
-                # Matches the top-level pipeline: resolve → file_refs → validate.
-                if child_path:
-                    try:
-                        resolve_file_references(child_ir, child_path.parent)
-                    except (FileNotFoundError, OSError, UnicodeDecodeError) as e:
-                        diagnostics.append(
-                            Diagnostic(
-                                severity=Severity.ERROR,
-                                source="validator",
-                                title="Validation Error",
-                                node_id=node_id,
-                                message=f"In sub-workflow '{ref_label}' (step '{node_id}'): {e}",
-                                context={
-                                    "category": "validation",
-                                    "sub_workflow_path": ref_label,
-                                    "sub_workflow_step": node_id,
-                                },
-                            )
-                        )
-                        continue
-
-            # Static required-input check — always runs, even for already-seen children,
-            # because each parent node may provide different params.
-            # ``or {}`` mirrors the runtime defense at ``WorkflowExecutor._validate_child_params``;
-            # redundant with Step 1 schema validation but kept for symmetry at this boundary.
-            child_inputs = child_ir.get("inputs") or {}
-            diagnostics.extend(WorkflowValidator._check_required_inputs(node_id, ref_label, params, child_inputs))
-
-            # Recursive validation — skip if this child was already validated
-            if not already_seen:
-                dummy_params = generate_dummy_parameters(child_inputs)
-                if child_path:
-                    dummy_params["_pflow_workflow_file"] = str(child_path)
-
-                child_diagnostics = WorkflowValidator.validate(
-                    child_ir,
-                    extracted_params=dummy_params,
+            # A workflow-type node makes one or more child calls. The enumerator
+            # yields one call per batch item (or a single call for non-batch),
+            # with ``inputs_from_item`` telling us whether per-item inputs vary.
+            inputs_check_done = False
+            for effective_params, batch_item_index, inputs_from_item in WorkflowValidator._enumerate_child_calls(node):
+                # Invariant-inputs batches (literal dict at params level) would
+                # produce N identical input-check diagnostics if we ran the check
+                # per-item. Run once, then skip on subsequent iterations.
+                run_inputs_check = inputs_from_item or not inputs_check_done
+                call_diagnostics = WorkflowValidator._validate_one_child_call(
+                    node_id=node_id,
+                    effective_params=effective_params,
+                    batch_item_index=batch_item_index,
+                    inputs_from_item=inputs_from_item,
+                    run_inputs_check=run_inputs_check,
+                    seen=seen,
+                    ir_cache=ir_cache,
+                    workflow_file=workflow_file,
                     registry=registry,
                     skip_node_types=skip_node_types,
-                    workflow_file=child_path,
-                    _seen=seen,
-                    _ir_cache=ir_cache,
                 )
-                diagnostics.extend(_add_child_provenance(child_diagnostics, node_id, ref_label))
+                diagnostics.extend(call_diagnostics)
+                if run_inputs_check:
+                    inputs_check_done = True
+
+        # Dedup here (not just at the runner) because ``save_service`` and other
+        # callers invoke ``WorkflowValidator.validate()`` directly, bypassing the
+        # runner's dedup step. Per-item diagnostics carry a ``batch.items[N]``
+        # prefix and won't collapse; this is a safety net for truly-identical
+        # diagnostics (e.g. child-side parser warnings wrapped by
+        # ``_add_child_provenance`` from multiple caller sites).
+        return deduplicate_diagnostics(diagnostics)
+
+    @staticmethod
+    def _validate_one_child_call(
+        *,
+        node_id: str,
+        effective_params: dict[str, Any],
+        batch_item_index: Optional[int],
+        inputs_from_item: bool,
+        run_inputs_check: bool,
+        seen: set[str],
+        ir_cache: dict[str, tuple[dict[str, Any], Optional[Path]]],
+        workflow_file: Optional[Path],
+        registry: Optional[Registry],
+        skip_node_types: bool,
+    ) -> list[Diagnostic]:
+        """Validate a single parent→child call: load the child, check input
+        contract, recurse. Extracted from ``_validate_sub_workflows`` to keep
+        the outer loop within the cyclomatic-complexity budget.
+        """
+        from pflow.core.ir_schema import normalize_ir
+        from pflow.core.validation_utils import generate_dummy_parameters
+
+        diagnostics: list[Diagnostic] = []
+
+        child_ir, child_path, ref_label, load_errors, already_seen, child_parser_warnings = (
+            WorkflowValidator._load_child_workflow(
+                node_id, effective_params, seen, ir_cache, workflow_file, batch_item_index
+            )
+        )
+        diagnostics.extend(load_errors)
+        diagnostics.extend(_add_child_provenance(child_parser_warnings, node_id, ref_label))
+
+        if child_ir is None or "nodes" not in child_ir:
+            return diagnostics
+
+        if not already_seen:
+            normalize_ir(child_ir)
+            file_ref_error = WorkflowValidator._resolve_child_file_refs(
+                child_ir, child_path, ref_label, node_id, batch_item_index
+            )
+            if file_ref_error is not None:
+                diagnostics.append(file_ref_error)
+                return diagnostics
+
+        if run_inputs_check:
+            child_inputs = child_ir.get("inputs") or {}
+            inputs_item_idx = batch_item_index if inputs_from_item else None
+            diagnostics.extend(
+                WorkflowValidator._check_required_inputs(
+                    node_id, ref_label, effective_params, child_inputs, inputs_item_idx
+                )
+            )
+
+        if not already_seen:
+            dummy_params = generate_dummy_parameters(child_ir.get("inputs") or {})
+            if child_path:
+                dummy_params["_pflow_workflow_file"] = str(child_path)
+            child_diagnostics = WorkflowValidator.validate(
+                child_ir,
+                extracted_params=dummy_params,
+                registry=registry,
+                skip_node_types=skip_node_types,
+                workflow_file=child_path,
+                _seen=seen,
+                _ir_cache=ir_cache,
+            )
+            diagnostics.extend(_add_child_provenance(child_diagnostics, node_id, ref_label))
 
         return diagnostics
+
+    @staticmethod
+    def _resolve_child_file_refs(
+        child_ir: dict[str, Any],
+        child_path: Optional[Path],
+        ref_label: str,
+        node_id: str,
+        batch_item_index: Optional[int],
+    ) -> Optional[Diagnostic]:
+        """Resolve external ``@./file.ext`` refs inside the child IR so template
+        validation sees their contents. Returns an error diagnostic on failure,
+        ``None`` on success (including when there's no ``child_path``).
+        """
+        from pflow.core.file_resolver import resolve_file_references
+
+        if child_path is None:
+            return None
+        try:
+            resolve_file_references(child_ir, child_path.parent)
+            return None
+        except (FileNotFoundError, OSError, UnicodeDecodeError) as e:
+            item_context = {"batch_item_index": batch_item_index} if batch_item_index is not None else {}
+            return Diagnostic(
+                severity=Severity.ERROR,
+                source="validator",
+                title="Validation Error",
+                node_id=node_id,
+                message=f"In sub-workflow '{ref_label}' (step '{node_id}'): {e}",
+                context={
+                    "category": "validation",
+                    "sub_workflow_path": ref_label,
+                    "sub_workflow_step": node_id,
+                    **item_context,
+                },
+            )
+
+    @staticmethod
+    def _enumerate_child_calls(
+        node: dict[str, Any],
+    ) -> Iterator[tuple[dict[str, Any], Optional[int], bool]]:
+        """Yield ``(effective_params, batch_item_index, inputs_from_item)`` per
+        child call this node makes.
+
+        A workflow node conceptually makes one child call (non-batch) or N
+        (one per batch item — matches the runtime loop at
+        ``batch_executor._execute_batch_item``). For inline-static batches,
+        per-item template bindings are resolved so downstream helpers see
+        concrete ``workflow:`` paths and ``inputs:`` dicts; for template-items
+        batches, non-dict batches, or missing batches, a single yield returns
+        the raw params and the existing defer-to-runtime paths kick in
+        unchanged.
+
+        When ``params`` don't reference the batch alias at all (neither
+        ``workflow:`` nor ``inputs:`` use ``${<alias>...}``), every iteration
+        would produce an identical check. We short-circuit to a single yield
+        in that case — both to avoid N-1 duplicate diagnostics (which dedup
+        collapses, but with misleading ``items[0]`` provenance) and to validate
+        empty inline batches ``items: []`` the same way as non-batch calls.
+
+        ``inputs_from_item`` is ``True`` iff the raw ``params.inputs`` was a
+        template string (e.g. ``${item.inputs}``). That signal tells callers
+        whether an inputs-contract violation should be blamed on the specific
+        item (``batch.items[N].inputs``) or on the invariant params dict
+        (``params.inputs``).
+
+        Mirrors the runtime binding at ``batch_executor.py:286``
+        (``item_shared[alias] = item`` before per-item template resolution).
+        """
+        params = node.get("params", {})
+        batch = node.get("batch")
+
+        if not isinstance(batch, dict):
+            yield params, None, False
+            return
+
+        items = batch.get("items")
+        # ``items:`` may be a template string per IR schema ``oneOf``. When it's
+        # not a list, we can't statically enumerate — yield the raw params once
+        # and let the existing resolver return ``None`` for the template ref.
+        if not isinstance(items, list):
+            yield params, None, False
+            return
+
+        alias = batch.get("as", "item")
+        if not WorkflowValidator._params_reference_alias(params, alias):
+            # Params are invariant across iterations → single check suffices.
+            # Also covers empty-items batches with static refs, where we'd
+            # otherwise skip validation entirely.
+            yield params, None, False
+            return
+
+        # Note: when ``items == []`` AND params DO reference the alias, the
+        # loop below yields zero times — child validation is silently skipped.
+        # This matches runtime semantics (empty batch runs nothing) but means
+        # authoring errors in a never-executed child file go unreported at
+        # parse time. See ``test_empty_items_list_with_alias_refs_skips_validation``
+        # for the regression pin.
+
+        raw_inputs = params.get("inputs")
+        inputs_from_item = isinstance(raw_inputs, str) and "${" in raw_inputs
+        for idx, item in enumerate(items):
+            # Build a minimal resolution context matching the runtime shape. When
+            # item is a scalar, ``${alias}`` resolves naturally; ``${alias.key}``
+            # stays unresolved → ``_load_child_workflow`` defers.
+            context = {alias: item}
+            effective_params = TemplateResolver.resolve_nested(params, context)
+            yield effective_params, idx, inputs_from_item
+
+    @staticmethod
+    def _params_reference_alias(value: Any, alias: str) -> bool:
+        """Return True iff any ``${<alias>...}`` template reference appears
+        anywhere within ``value`` (strings, dicts, lists). Uses the template
+        extractor's own parse of variable roots rather than a substring needle
+        so single-character aliases (``as: i``) don't match unrelated variables
+        like ``${input.x}``.
+        """
+        if isinstance(value, str):
+            for var in TemplateResolver.extract_variables(value):
+                root = var.split(".", 1)[0].split("[", 1)[0]
+                if root == alias:
+                    return True
+            return False
+        if isinstance(value, dict):
+            return any(WorkflowValidator._params_reference_alias(v, alias) for v in value.values())
+        if isinstance(value, list):
+            return any(WorkflowValidator._params_reference_alias(v, alias) for v in value)
+        return False
+
+    @staticmethod
+    def _step_locator(node_id: str, batch_item_index: Optional[int]) -> str:
+        """Return ``Step 'X' (batch.items[N])`` when ``batch_item_index`` is set,
+        else ``Step 'X'``. This prefix is what makes per-item diagnostics survive
+        ``Diagnostic.__hash__`` dedup (hash includes message, excludes context).
+        """
+        if batch_item_index is not None:
+            return f"Step '{node_id}' (batch.items[{batch_item_index}])"
+        return f"Step '{node_id}'"
 
     @staticmethod
     def _check_required_inputs(
@@ -796,6 +962,7 @@ class WorkflowValidator:
         ref_label: str,
         parent_params: dict[str, Any],
         child_inputs: dict[str, Any],
+        batch_item_index: Optional[int] = None,
     ) -> list[Diagnostic]:
         """Check the parent→child input boundary in both directions.
 
@@ -804,11 +971,29 @@ class WorkflowValidator:
         * Undeclared extras: every key in the parent's ``inputs:`` dict must
           correspond to a declared child input (symmetric to the child-side
           "declared input never used as template variable" rule).
+
+        ``batch_item_index`` is the 0-based index of the batch item when this
+        call was produced by ``_enumerate_child_calls`` from an inline-static
+        batch; diagnostic paths are rooted at ``batch.items[N].inputs`` instead
+        of ``params.inputs`` so they point at the author's actual YAML location.
         """
         from pflow.core.suggestion_utils import find_similar_items
 
         diagnostics: list[Diagnostic] = []
         inputs_value = parent_params.get("inputs")
+
+        inputs_path_root = (
+            f"nodes[id={node_id}].batch.items[{batch_item_index}].inputs"
+            if batch_item_index is not None
+            else f"nodes[id={node_id}].params.inputs"
+        )
+        item_context = {"batch_item_index": batch_item_index} if batch_item_index is not None else {}
+        # Locator prefix survives ``Diagnostic.__hash__`` dedup (hash excludes
+        # ``context``), so two items with the same underlying bug against the
+        # same child produce two distinct user-visible diagnostics — not one
+        # misleadingly tagged to item 0. Same dedup-survival precedent as
+        # ``format_child_provenance`` in ``core/diagnostic.py``.
+        step_locator = WorkflowValidator._step_locator(node_id, batch_item_index)
 
         # Opaque template (e.g. ``inputs: '${item}'``) — keys aren't statically
         # knowable; defer to runtime ``_extract_child_inputs`` shape check.
@@ -824,7 +1009,7 @@ class WorkflowValidator:
                     title="Validation Error",
                     node_id=node_id,
                     message=(
-                        f"Step '{node_id}': 'inputs:' on workflow node '{ref_label}' must be a dict "
+                        f"{step_locator}: 'inputs:' on workflow node '{ref_label}' must be a dict "
                         f"of child inputs, got {type_name}."
                     ),
                     suggestions=["Use a mapping: ``- inputs:\\n    key: value``"],
@@ -832,8 +1017,9 @@ class WorkflowValidator:
                         "category": "validation",
                         "sub_workflow_path": ref_label,
                         "sub_workflow_step": node_id,
-                        "path": f"nodes[id={node_id}].params.inputs",
+                        "path": inputs_path_root,
                         "actual_type": type_name,
+                        **item_context,
                     },
                 )
             )
@@ -854,16 +1040,22 @@ class WorkflowValidator:
                         title="Validation Error",
                         node_id=node_id,
                         message=(
-                            f"Step '{node_id}': sub-workflow '{ref_label}' requires input '{input_name}' "
+                            f"{step_locator}: sub-workflow '{ref_label}' requires input '{input_name}' "
                             "but it is not provided."
                         ),
                         context={
                             "category": "validation",
                             "sub_workflow_path": ref_label,
                             "sub_workflow_step": node_id,
+                            # Path points at the inputs dict (the missing key is named in
+                            # ``message`` and ``available_fields``). For batch items this
+                            # is critical: without it an agent can't tell which of N items
+                            # omitted the required input.
+                            "path": inputs_path_root,
                             "available_fields": sorted_inputs,
                             "available_fields_total": len(sorted_inputs),
                             "available_fields_label": "required inputs",
+                            **item_context,
                         },
                     )
                 )
@@ -883,7 +1075,7 @@ class WorkflowValidator:
                         title="Validation Error",
                         node_id=node_id,
                         message=(
-                            f"Step '{node_id}': sub-workflow '{ref_label}' does not declare input "
+                            f"{step_locator}: sub-workflow '{ref_label}' does not declare input "
                             f"'{extra}' (passed via inputs: dict)."
                         ),
                         suggestions=[f"Did you mean '{similar[0]}'?"] if similar else None,
@@ -891,11 +1083,12 @@ class WorkflowValidator:
                             "category": "validation",
                             "sub_workflow_path": ref_label,
                             "sub_workflow_step": node_id,
-                            "path": f"nodes[id={node_id}].params.inputs.{extra}",
+                            "path": f"{inputs_path_root}.{extra}",
                             "available_fields": sorted_declared,
                             "available_fields_total": len(sorted_declared),
                             "available_fields_label": "declared inputs",
                             "similar_names": similar or None,
+                            **item_context,
                         },
                     )
                 )
@@ -909,8 +1102,13 @@ class WorkflowValidator:
         seen: set[str],
         ir_cache: dict[str, tuple[dict[str, Any], Optional[Path]]],
         workflow_file: Optional[Path] = None,
+        batch_item_index: Optional[int] = None,
     ) -> tuple[Optional[dict[str, Any]], Optional[Path], str, list[Diagnostic], bool, tuple[Diagnostic, ...]]:
         """Load a child workflow from a file reference or saved name.
+
+        ``batch_item_index`` is threaded into load-error diagnostics so per-item
+        resolution failures (e.g. broken child path in ``batch.items[2]``) carry
+        enough provenance for an agent to locate the offending item.
 
         Returns:
             (child_ir, child_path, ref_label, errors, already_seen, parser_warnings)
@@ -928,11 +1126,16 @@ class WorkflowValidator:
             result = resolve_sub_workflow(params, base_path=base_path)
         except Exception as e:
             logger.debug("Failed to load sub-workflow for step '%s'", node_id, exc_info=True)
+            # Batch-item suffix in the message so per-item load failures don't
+            # collapse under ``Diagnostic.__hash__`` dedup when multiple items
+            # reference the same missing file.
+            item_suffix = f", batch.items[{batch_item_index}]" if batch_item_index is not None else ""
             msg = (
-                f"In sub-workflow '{ref_label}' (step '{node_id}'): {e}"
+                f"In sub-workflow '{ref_label}' (step '{node_id}'{item_suffix}): {e}"
                 if ref_label
-                else f"Step '{node_id}': failed to load sub-workflow: {e}"
+                else f"Step '{node_id}'{item_suffix}: failed to load sub-workflow: {e}"
             )
+            item_context = {"batch_item_index": batch_item_index} if batch_item_index is not None else {}
             return (
                 None,
                 None,
@@ -948,6 +1151,7 @@ class WorkflowValidator:
                             "category": "validation",
                             "sub_workflow_path": ref_label or None,
                             "sub_workflow_step": node_id,
+                            **item_context,
                         },
                     )
                 ],

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -718,20 +718,17 @@ class WorkflowValidator:
             node_id = node.get("id", "unknown")
 
             # A workflow-type node makes one or more child calls. The enumerator
-            # yields one call per batch item (or a single call for non-batch),
-            # with ``inputs_from_item`` telling us whether per-item inputs vary.
-            inputs_check_done = False
+            # yields one call per batch item (or a single call for non-batch).
+            # Every call runs the full input-contract check — a previous iteration
+            # validating against child_a tells us nothing about child_b's contract.
+            # Truly-identical diagnostics (same child, same bug, N items) collapse
+            # at the ``deduplicate_diagnostics`` boundary below.
             for effective_params, batch_item_index, inputs_from_item in WorkflowValidator._enumerate_child_calls(node):
-                # Invariant-inputs batches (literal dict at params level) would
-                # produce N identical input-check diagnostics if we ran the check
-                # per-item. Run once, then skip on subsequent iterations.
-                run_inputs_check = inputs_from_item or not inputs_check_done
                 call_diagnostics = WorkflowValidator._validate_one_child_call(
                     node_id=node_id,
                     effective_params=effective_params,
                     batch_item_index=batch_item_index,
                     inputs_from_item=inputs_from_item,
-                    run_inputs_check=run_inputs_check,
                     seen=seen,
                     ir_cache=ir_cache,
                     workflow_file=workflow_file,
@@ -739,8 +736,6 @@ class WorkflowValidator:
                     skip_node_types=skip_node_types,
                 )
                 diagnostics.extend(call_diagnostics)
-                if run_inputs_check:
-                    inputs_check_done = True
 
         # Dedup here (not just at the runner) because ``save_service`` and other
         # callers invoke ``WorkflowValidator.validate()`` directly, bypassing the
@@ -757,7 +752,6 @@ class WorkflowValidator:
         effective_params: dict[str, Any],
         batch_item_index: Optional[int],
         inputs_from_item: bool,
-        run_inputs_check: bool,
         seen: set[str],
         ir_cache: dict[str, tuple[dict[str, Any], Optional[Path]]],
         workflow_file: Optional[Path],
@@ -793,14 +787,13 @@ class WorkflowValidator:
                 diagnostics.append(file_ref_error)
                 return diagnostics
 
-        if run_inputs_check:
-            child_inputs = child_ir.get("inputs") or {}
-            inputs_item_idx = batch_item_index if inputs_from_item else None
-            diagnostics.extend(
-                WorkflowValidator._check_required_inputs(
-                    node_id, ref_label, effective_params, child_inputs, inputs_item_idx
-                )
+        child_inputs = child_ir.get("inputs") or {}
+        inputs_item_idx = batch_item_index if inputs_from_item else None
+        diagnostics.extend(
+            WorkflowValidator._check_required_inputs(
+                node_id, ref_label, effective_params, child_inputs, inputs_item_idx
             )
+        )
 
         if not already_seen:
             dummy_params = generate_dummy_parameters(child_ir.get("inputs") or {})
@@ -881,7 +874,10 @@ class WorkflowValidator:
         template string (e.g. ``${item.inputs}``). That signal tells callers
         whether an inputs-contract violation should be blamed on the specific
         item (``batch.items[N].inputs``) or on the invariant params dict
-        (``params.inputs``).
+        (``params.inputs``). A literal dict whose VALUES happen to reference
+        the item (``inputs: {msg: "${item.x}"}``) is NOT ``inputs_from_item`` —
+        only the key set matters for the contract check, and keys in a literal
+        dict are invariant regardless of what values contain.
 
         Mirrors the runtime binding at ``batch_executor.py:286``
         (``item_shared[alias] = item`` before per-item template resolution).
@@ -936,8 +932,7 @@ class WorkflowValidator:
         """
         if isinstance(value, str):
             for var in TemplateResolver.extract_variables(value):
-                root = var.split(".", 1)[0].split("[", 1)[0]
-                if root == alias:
+                if TemplateResolver.extract_root_node_id(var) == alias:
                     return True
             return False
         if isinstance(value, dict):

--- a/tests/test_core/test_sub_workflow_validation.py
+++ b/tests/test_core/test_sub_workflow_validation.py
@@ -7,6 +7,8 @@ name resolution.
 
 from pathlib import Path
 
+import pytest
+
 from pflow.core.workflow.validator import WorkflowValidator
 from pflow.registry import Registry
 from tests.shared.diagnostic_helpers import split_validator_diagnostics
@@ -1350,3 +1352,552 @@ class TestNonDictInputsShape:
         assert len(shape_errors) == 1, f"Expected one shape error, got: {[e.message for e in errors]}"
         assert shape_errors[0].context is not None
         assert shape_errors[0].context.get("actual_type") == "list"
+
+
+class TestBatchItemValidation:
+    """Inline-static batch items get the same parent→child boundary check as
+    non-batch static calls.
+
+    Motivating pattern: heterogeneous batch fan-out
+    (``workflow: ${item.workflow}`` + ``inputs: ${item.inputs}`` + inline
+    ``items:`` list with concrete child paths and input dicts). Before this
+    fix, ``resolve_sub_workflow`` saw ``${item.workflow}`` and bailed — the
+    entire batch silently skipped validation even though every per-item
+    workflow ref and input dict was statically knowable from the IR.
+    """
+
+    def _child_declaring(self, path: Path, *input_names: str) -> None:
+        inputs_block = "\n\n".join(
+            f"### {name}\n\nInput {name}.\n\n- type: string\n- required: true" for name in input_names
+        )
+        refs = " ".join(f"${{{name}}}" for name in input_names)
+        write_pflow_md(
+            path,
+            f"# Child\n\nA child declaring {', '.join(input_names)}.\n\n"
+            f"## Inputs\n\n{inputs_block}\n\n"
+            f"## Steps\n\n### echo\n\nEcho inputs.\n\n- type: shell\n- command: echo {refs}\n",
+        )
+
+    def _hetero_batch_ir(self, items: list, alias: str = "item") -> dict:
+        """Parent IR using the guide's heterogeneous-batch pattern."""
+        batch: dict = {"items": items, "parallel": False}
+        if alias != "item":
+            batch["as"] = alias
+        return {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call-child",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": f"${{{alias}.workflow}}",
+                        "inputs": f"${{{alias}.inputs}}",
+                    },
+                    "batch": batch,
+                }
+            ],
+            "edges": [],
+        }
+
+    def test_inline_item_undeclared_input_rejected(self, tmp_path: Path) -> None:
+        """The motivating bug: ``extra_field`` in a static batch item is caught
+        at parse time with a diagnostic pointing at the specific item.
+        """
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[
+                {
+                    "workflow": str(child),
+                    "inputs": {"message": "hello", "extra_field": "bad"},
+                }
+            ],
+        )
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        extras = [e for e in errors if "'extra_field'" in e.message and "does not declare input" in e.message]
+        assert len(extras) == 1, f"Expected exactly one extras diagnostic, got: {[e.message for e in errors]}"
+        diag = extras[0]
+        assert diag.context is not None
+        assert diag.context.get("batch_item_index") == 0, (
+            f"Diagnostic must carry batch_item_index for agent recovery, got: {diag.context}"
+        )
+        assert diag.context.get("path") == "nodes[id=call-child].batch.items[0].inputs.extra_field", (
+            f"Path should point at the item, got: {diag.context.get('path')}"
+        )
+
+    def test_inline_item_missing_required_rejected(self, tmp_path: Path) -> None:
+        """Symmetric direction: missing required input in a static batch item."""
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message", "topic")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[
+                {
+                    "workflow": str(child),
+                    "inputs": {"message": "hello"},  # missing `topic`
+                }
+            ],
+        )
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        missing = [e for e in errors if "requires input 'topic'" in e.message]
+        assert len(missing) == 1, f"Expected missing-required diagnostic, got: {[e.message for e in errors]}"
+        assert missing[0].context is not None
+        assert missing[0].context.get("batch_item_index") == 0
+        # Path must point at the specific item's inputs dict, not at params.inputs —
+        # guards a mutation where the batch-path switch is dropped for missing-required.
+        assert missing[0].context.get("path") == "nodes[id=call-child].batch.items[0].inputs"
+
+    def test_heterogeneous_batch_validates_each_child(self, tmp_path: Path) -> None:
+        """Two items, two different children, different violations per item —
+        each item produces its own diagnostic tagged with the right index."""
+        child_a = tmp_path / "child-a.pflow.md"
+        child_b = tmp_path / "child-b.pflow.md"
+        self._child_declaring(child_a, "a_input")
+        self._child_declaring(child_b, "b_input")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[
+                {"workflow": str(child_a), "inputs": {"a_input": "v", "wrong_a": "x"}},
+                {"workflow": str(child_b), "inputs": {"b_input": "v", "wrong_b": "x"}},
+            ],
+        )
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        by_index = {
+            e.context.get("batch_item_index"): e for e in errors if e.context and "does not declare input" in e.message
+        }
+        assert 0 in by_index and 1 in by_index, f"Expected diagnostics for both items, got indexes: {list(by_index)}"
+        assert "'wrong_a'" in by_index[0].message
+        assert "'wrong_b'" in by_index[1].message
+
+    def test_items_template_deferred(self, tmp_path: Path) -> None:
+        """``items:`` as a template string (dynamic items from an upstream node)
+        cannot be statically enumerated — defer the whole batch to runtime.
+        """
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call-child",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": "${item.workflow}",
+                        "inputs": "${item.inputs}",
+                    },
+                    "batch": {"items": "${upstream.files}", "parallel": False},
+                }
+            ],
+            "edges": [],
+        }
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        extras_errors = [e for e in errors if "does not declare input" in e.message]
+        assert extras_errors == [], (
+            f"Template-items batch should defer to runtime, got parse-time errors: {extras_errors}"
+        )
+
+    def test_mixed_static_and_template_items(self, tmp_path: Path) -> None:
+        """Item 0 is fully static (bug → caught); item 1 has a template
+        workflow ref (ref unresolvable → defer). Only the static item fires."""
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[
+                {"workflow": str(child), "inputs": {"message": "hi", "bad_key": "x"}},
+                # Item 1: workflow is a template referring outside the item ctx
+                {"workflow": "${upstream.wf}", "inputs": {"message": "hi"}},
+            ],
+        )
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        extras = [e for e in errors if "'bad_key'" in e.message]
+        assert len(extras) == 1
+        assert extras[0].context and extras[0].context.get("batch_item_index") == 0
+
+        # No "does not declare" diagnostic for item 1 — ref unresolvable, deferred.
+        other = [
+            e
+            for e in errors
+            if e.context and e.context.get("batch_item_index") == 1 and "does not declare" in e.message
+        ]
+        assert other == []
+
+    def test_custom_alias_honored(self, tmp_path: Path) -> None:
+        """Custom ``batch.as:`` alias (e.g. ``songitem``) is used as the binding
+        key in ``${alias.*}`` templates, matching runtime behavior."""
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[{"workflow": str(child), "inputs": {"message": "hi", "stray": "x"}}],
+            alias="songitem",
+        )
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        extras = [e for e in errors if "'stray'" in e.message]
+        assert len(extras) == 1, (
+            f"Custom alias should bind ${{songitem.workflow}} → items[i]['workflow'], got: {[e.message for e in errors]}"
+        )
+
+    def test_invariant_inputs_batch_path_points_at_params_not_items(self, tmp_path: Path) -> None:
+        """When ``params.inputs`` is a literal dict (not per-item), the bug is
+        invariant across iterations — the diagnostic path must point at
+        ``params.inputs.X``, not ``batch.items[0].inputs.X``. Otherwise dedup
+        collapses N identical diagnostics into one misleadingly tagged to
+        iteration 0.
+        """
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call-child",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": "${item}",  # item is scalar path
+                        "inputs": {"message": "hi", "bad_key": "typo"},  # literal dict, not ${item.inputs}
+                    },
+                    "batch": {"items": [str(child), str(child)], "parallel": False},
+                }
+            ],
+            "edges": [],
+        }
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        extras = [e for e in errors if "'bad_key'" in e.message]
+        assert len(extras) == 1, (
+            f"Invariant-inputs bug repeats across N iterations; dedup collapses to 1, got: {[e.message for e in errors]}"
+        )
+        diag = extras[0]
+        assert diag.context is not None
+        assert diag.context.get("path") == "nodes[id=call-child].params.inputs.bad_key", (
+            f"Path must point at params.inputs (where the author wrote the bug), got: {diag.context.get('path')}"
+        )
+        assert "batch_item_index" not in (diag.context or {}), (
+            f"Invariant-inputs bug shouldn't be tagged to any specific iteration, got: {diag.context}"
+        )
+
+    def test_two_items_same_bug_both_survive_runner_dedup(self, tmp_path: Path) -> None:
+        """Regression for the dedup-collapse trap: two batch items failing in
+        exactly the same way (same child, same undeclared key) must produce
+        two distinct user-visible diagnostics after the runner's
+        ``deduplicate_diagnostics`` pass. Without the per-item ``batch.items[N]``
+        prefix in the message, ``Diagnostic.__hash__`` (which excludes context)
+        collapses them into one — the user fixes item 0, reruns, then discovers
+        item 1 was also broken.
+        """
+        from pflow.execution.runner import WorkflowRunner
+
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent = tmp_path / "parent.pflow.md"
+        parent.write_text(
+            "# Parent\n\n"
+            "## Steps\n\n"
+            "### call-child\n\n"
+            "Call child twice with same undeclared extra.\n\n"
+            "- type: workflow\n"
+            "- workflow: ${item.workflow}\n"
+            "- inputs: ${item.inputs}\n\n"
+            "```yaml batch\n"
+            "items:\n"
+            f"  - workflow: {child}\n"
+            "    inputs:\n"
+            '      message: "hi"\n'
+            '      extra_field: "bad"\n'
+            f"  - workflow: {child}\n"
+            "    inputs:\n"
+            '      message: "hi"\n'
+            '      extra_field: "bad"\n'
+            "parallel: false\n"
+            "```\n\n"
+            "## Outputs\n\n"
+            "### result\n\n"
+            "Output.\n\n"
+            "- source: ${call-child.results[0].echoed}\n",
+            encoding="utf-8",
+        )
+
+        vresult = WorkflowRunner().validate(str(parent), {})
+
+        extras = [e for e in vresult.errors if "'extra_field'" in e.message and "does not declare" in e.message]
+        assert len(extras) == 2, (
+            f"Both items must remain visible after runner dedup; got {len(extras)} "
+            f"extras diagnostic(s). All errors: {[e.message for e in vresult.errors]}"
+        )
+        # Distinct diagnostics tagged to distinct items
+        indices = sorted(e.context.get("batch_item_index") for e in extras if e.context)
+        assert indices == [0, 1], f"Expected batch_item_index 0 and 1, got: {indices}"
+        # Core invariant: two distinct ``Diagnostic.__hash__`` buckets so the
+        # runner's ``deduplicate_diagnostics`` can't collapse them. Assert on
+        # hash identity rather than message substring so the test stays green
+        # across harmless message-format refactors but fails the moment two
+        # items produce the same hash (the bug the reviewer flagged).
+        assert len({hash(e) for e in extras}) == 2, (
+            f"Expected two distinct diagnostic hashes for the two items; got one — "
+            f"dedup would collapse them. Messages: {[e.message for e in extras]}"
+        )
+
+    def test_item_load_error_carries_batch_item_index(self, tmp_path: Path) -> None:
+        """A broken workflow ref inside ``batch.items[N]`` surfaces the index
+        in the diagnostic context so an agent can locate the offending item.
+        """
+        good_child = tmp_path / "good.pflow.md"
+        self._child_declaring(good_child, "message")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[
+                {"workflow": str(good_child), "inputs": {"message": "hi"}},
+                {"workflow": str(tmp_path / "does-not-exist.pflow.md"), "inputs": {"message": "hi"}},
+            ],
+        )
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        load_errors = [e for e in errors if "Sub-workflow file not found" in e.message or "failed to load" in e.message]
+        assert len(load_errors) == 1, (
+            f"Expected one load error for the missing child, got: {[e.message for e in errors]}"
+        )
+        assert load_errors[0].context is not None
+        assert load_errors[0].context.get("batch_item_index") == 1, (
+            f"Load-error diagnostic must carry batch_item_index, got: {load_errors[0].context}"
+        )
+
+    def test_nested_batch_grandchild_bug_caught_with_provenance(self, tmp_path: Path) -> None:
+        """Parent batch → child batch → grandchild with undeclared-input bug.
+        Validator recurses through both batch layers; the deepest diagnostic
+        carries the grandchild's ``batch.items[N]`` path AND the parent-step
+        provenance (``In step 'X' sub-workflow:`` prefix).
+        """
+        from pflow.execution.runner import WorkflowRunner
+
+        grandchild = tmp_path / "grandchild.pflow.md"
+        self._child_declaring(grandchild, "greeting")
+
+        middle = tmp_path / "middle.pflow.md"
+        middle.write_text(
+            "# Middle\n\nA middle workflow batching the grandchild.\n\n"
+            "## Inputs\n\n### topic\n\nTopic.\n\n- type: string\n- required: true\n\n"
+            "## Steps\n\n### fan-out\n\nFan out to grandchild.\n\n"
+            "- type: workflow\n"
+            "- workflow: ${item.workflow}\n"
+            "- inputs: ${item.inputs}\n\n"
+            "```yaml batch\n"
+            "items:\n"
+            f"  - workflow: {grandchild}\n"
+            "    inputs:\n"
+            '      wrong_grandchild_key: "bad"\n'
+            "parallel: false\n"
+            "```\n\n"
+            "## Outputs\n\n### result\n\nResult.\n\n- source: ${fan-out.results[0].echoed}\n",
+            encoding="utf-8",
+        )
+
+        parent = tmp_path / "parent.pflow.md"
+        parent.write_text(
+            "# Parent\n\n## Steps\n\n### call-middle\n\nCall middle.\n\n"
+            "- type: workflow\n"
+            "- workflow: ${item.workflow}\n"
+            "- inputs: ${item.inputs}\n\n"
+            "```yaml batch\n"
+            "items:\n"
+            f"  - workflow: {middle}\n"
+            '    inputs: {topic: "T"}\n'
+            "parallel: false\n"
+            "```\n\n"
+            "## Outputs\n\n### result\n\nResult.\n\n- source: ${call-middle.results[0].result}\n",
+            encoding="utf-8",
+        )
+
+        vresult = WorkflowRunner().validate(str(parent), {})
+
+        # Grandchild's undeclared-key bug surfaces through 2 levels of batch recursion.
+        grand_errors = [e for e in vresult.errors if "wrong_grandchild_key" in e.message]
+        assert len(grand_errors) == 1, (
+            f"Expected grandchild bug surfaced via nested batch, got: {[e.message for e in vresult.errors]}"
+        )
+        # Provenance includes the deepest step (grandchild caller) wrapped by the
+        # middle step's ``In step 'call-middle' sub-workflow:`` prefix.
+        assert "call-middle" in grand_errors[0].message
+        assert grand_errors[0].context is not None
+        assert grand_errors[0].context.get("batch_item_index") == 0
+
+    def test_custom_alias_via_markdown_round_trip(self, tmp_path: Path) -> None:
+        """Custom ``as: songitem`` written in actual markdown (not raw IR) wires
+        up correctly through the parser → validator pipeline.
+        """
+        from pflow.execution.runner import WorkflowRunner
+
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent = tmp_path / "parent.pflow.md"
+        parent.write_text(
+            "# Parent\n\n## Steps\n\n### call-child\n\nCall child with custom alias.\n\n"
+            "- type: workflow\n"
+            "- workflow: ${songitem.workflow}\n"
+            "- inputs: ${songitem.inputs}\n\n"
+            "```yaml batch\n"
+            "as: songitem\n"
+            "items:\n"
+            f"  - workflow: {child}\n"
+            "    inputs:\n"
+            '      message: "hi"\n'
+            '      stray_field: "bad"\n'
+            "parallel: false\n"
+            "```\n\n"
+            "## Outputs\n\n### result\n\nResult.\n\n- source: ${call-child.results[0].echoed}\n",
+            encoding="utf-8",
+        )
+
+        vresult = WorkflowRunner().validate(str(parent), {})
+        extras = [e for e in vresult.errors if "'stray_field'" in e.message]
+        assert len(extras) == 1, (
+            f"Custom alias via markdown must bind ${{songitem.workflow}} → items[i]['workflow']; "
+            f"got: {[e.message for e in vresult.errors]}"
+        )
+        assert extras[0].context.get("batch_item_index") == 0
+
+    def test_empty_items_list_with_alias_refs_skips_validation(self, tmp_path: Path) -> None:
+        """Documenting intended behavior: when ``items: []`` (empty inline list)
+        AND ``params.workflow``/``inputs`` reference the alias, the enumerator
+        yields zero child calls — matching runtime's "empty batch runs nothing"
+        semantics. No validation fires for the referenced child. If this ever
+        changes (e.g. to surface child-file parse errors proactively), this
+        test should fail and the design decision re-examined.
+        """
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = self._hetero_batch_ir(items=[])
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+        # No child-related diagnostics — not loaded, not validated.
+        sub_errors = [e for e in errors if e.context and e.context.get("sub_workflow_path")]
+        assert sub_errors == [], (
+            f"Empty items list with alias refs should skip child validation; got: {[e.message for e in sub_errors]}"
+        )
+
+    @pytest.mark.parametrize("alias", ["__index__", "workflow", "inputs", "item", "i"])
+    def test_alias_collision_with_reserved_keys_does_not_crash(self, tmp_path: Path, alias: str) -> None:
+        """Custom ``as:`` aliases that collide with reserved / framework keys
+        (``__index__``, ``workflow``, ``inputs``) or single-character names
+        (``i``) must not crash the validator. Behavioral parity with runtime
+        for these edge cases is out of scope — this test pins "doesn't crash"
+        as the load-bearing invariant so future alias-handling changes don't
+        silently regress it.
+        """
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = self._hetero_batch_ir(
+            items=[{"workflow": str(child), "inputs": {"message": "hi"}}],
+            alias=alias,
+        )
+
+        # The contract is "this call succeeds and returns a list of diagnostics";
+        # any unhandled exception would be a regression.
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+        assert isinstance(errors, list)
+
+    def test_scalar_items_workflow_template_no_false_positive(self, tmp_path: Path) -> None:
+        """Items that are plain strings (``items: ["./child.pflow.md"]`` with
+        ``workflow: ${item}``) resolve the workflow ref but inputs stays as the
+        raw ``${item.inputs}`` template — opaque → defer, no false extras.
+        """
+        child = tmp_path / "child.pflow.md"
+        self._child_declaring(child, "message")
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call-child",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": "${item}",
+                        "inputs": "${item.inputs}",  # won't resolve — scalar item has no .inputs
+                    },
+                    "batch": {"items": [str(child)], "parallel": False},
+                }
+            ],
+            "edges": [],
+        }
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        # Opaque inputs → no extras diagnostic; no missing-required (child path
+        # loaded successfully so "failed to load" shouldn't fire either).
+        assert [e for e in errors if "does not declare input" in e.message] == []
+        assert [e for e in errors if "requires input" in e.message] == []

--- a/tests/test_core/test_sub_workflow_validation.py
+++ b/tests/test_core/test_sub_workflow_validation.py
@@ -1720,6 +1720,66 @@ class TestBatchItemValidation:
             f"Load-error diagnostic must carry batch_item_index, got: {load_errors[0].context}"
         )
 
+    def test_hetero_workflows_with_invariant_inputs_checks_each_child(self, tmp_path: Path) -> None:
+        """Regression for the ``inputs_check_done`` silent-bypass: when
+        ``params.workflow`` varies per item but ``params.inputs`` is a literal
+        dict, the invariant-inputs key set still has to be validated against
+        EACH child — not just the first. Child A may declare exactly those
+        keys while Child B declares something completely different.
+
+        Before the fix, iter 0 validated against child_a (clean), iter 1
+        short-circuited, and child_b's undeclared/missing violations were
+        invisible until runtime.
+        """
+        child_a = tmp_path / "child-a.pflow.md"
+        child_b = tmp_path / "child-b.pflow.md"
+        self._child_declaring(child_a, "x")
+        self._child_declaring(child_b, "y")
+
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": "${item.workflow}",
+                        "inputs": {"x": "v"},  # literal, invariant across items
+                    },
+                    "batch": {
+                        "items": [
+                            {"workflow": str(child_a)},  # declares x ✓
+                            {"workflow": str(child_b)},  # declares y only — x is extra, y missing
+                        ],
+                        "parallel": False,
+                    },
+                }
+            ],
+            "edges": [],
+        }
+
+        errors, _ = split_validator_diagnostics(
+            workflow_ir=parent_ir,
+            extracted_params={},
+            workflow_file=tmp_path / "parent.pflow.md",
+            skip_node_types=True,
+        )
+
+        # child_b's contract is violated in both directions — x is extra, y is missing.
+        b_extras = [e for e in errors if "'x'" in e.message and "does not declare" in e.message]
+        b_missing = [e for e in errors if "requires input 'y'" in e.message]
+        assert b_extras, (
+            f"child_b's undeclared-extra 'x' must be caught at parse time — "
+            f"silent bypass would show up as no extras diagnostic. All errors: "
+            f"{[e.message for e in errors]}"
+        )
+        assert b_missing, (
+            f"child_b's missing-required 'y' must be caught at parse time. All errors: {[e.message for e in errors]}"
+        )
+        # child_a is clean (x is exactly its declared input) — no diagnostic for it.
+        a_errors = [e for e in errors if "child-a" in e.message]
+        assert a_errors == [], f"child_a satisfies its contract; expected no errors, got: {a_errors}"
+
     def test_nested_batch_grandchild_bug_caught_with_provenance(self, tmp_path: Path) -> None:
         """Parent batch → child batch → grandchild with undeclared-input bug.
         Validator recurses through both batch layers; the deepest diagnostic


### PR DESCRIPTION
## Summary

Extends parse-time sub-workflow validation to walk inline-static batch items, closing a gap where the heterogeneous-batch pattern (`workflow: ${item.workflow}` with inline items) silently bypassed the strict-inputs check from task 153. Undeclared/missing child inputs that previously only surfaced at runtime (after upstream nodes had already run and consumed their LLM/network budget) now fail fast at `--validate-only`.

## Changes

- **`_enumerate_child_calls(node)`** yields one call per batch item with per-item template bindings applied via `TemplateResolver.resolve_nested(params, {alias: item})` — mirroring the runtime binding at `batch_executor.py:286`. Non-batch / template-items / alias-not-referenced paths yield once with raw params (unchanged defer semantics).
- **`_validate_one_child_call`** extracts the per-call body from `_validate_sub_workflows` to keep cyclomatic complexity in budget.
- **`_step_locator` prefix** (`Step 'X' (batch.items[N])`) on per-item diagnostic messages so two items with the same underlying bug against the same child produce two distinct diagnostics instead of collapsing under `Diagnostic.__hash__` dedup (which ignores `context`).
- **Path routing**: batch-item bugs get `nodes[id=X].batch.items[N].inputs.field`; invariant-inputs bugs (literal dict at params level, shared across iterations) keep `nodes[id=X].params.inputs.field`.
- **`_params_reference_alias`** uses `TemplateResolver.extract_variables` for word-boundary matching so single-character aliases (`as: i`) don't false-positive against unrelated variables like `${input.x}`.
- **Invariant-inputs short-circuit**: when `params.inputs` is a literal dict, run the input-contract check once instead of N times (avoids N identical diagnostics misleadingly tagged to item 0).

## Explanation

The validator's conceptual model was "one workflow node → one child call" — it read `params.workflow` once. The runtime's model is "one workflow node → N calls" (one per batch item). That divergence meant a recommended authoring pattern silently weakened a recent strict-inputs guarantee. The fix aligns the two models by having the validator iterate child calls the same way the runtime does, reusing the existing `_check_required_inputs` + `_load_child_workflow` primitives unchanged.

Reviewer findings (4 parallel review agents) drove several refinements: runner-dedup-survival for same-bug items (message prefix distinguishes them), save-service dedup safety net (`deduplicate_diagnostics` restored at `_validate_sub_workflows` return), and word-boundary alias detection.

## Test plan

18 tests in the new `TestBatchItemValidation` class, covering:
- Motivating bug reproduction (extras + missing-required per-item).
- Heterogeneous batch with distinct children.
- Template items / mixed static+template items (defer).
- Invariant inputs (params path, no item tag).
- Custom `as:` alias (raw IR + real markdown round-trip).
- Two items same bug both survive runner dedup (via `WorkflowRunner().validate()`).
- Nested batches (3-level, grandchild bug caught with full provenance).
- Empty items list + alias refs (intended behavior pin).
- Alias collision with reserved keys (parametrized: `__index__`, `workflow`, `inputs`, `item`, `i`).
- Per-item load errors carrying `batch_item_index`.
- Scalar items with opaque inputs (no false positives).

- [ ] `make test` — 4924 passing
- [ ] `make check` — ruff, ruff-format, mypy, deptry clean
- [ ] Manual: reproduction from issue #306 now rejects at `--validate-only` with per-item paths