### PR TITLE
fix: make branch-target routing errors actionable (fixes #308)

### DIFF
--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -517,7 +517,8 @@ def parse_markdown(content: str) -> MarkdownParseResult:  # noqa: C901
     _validate_routing_targets(ir["edges"], node_id_set)
 
     # Validate branch target routing (prevents silent fall-through)
-    _validate_branch_target_routing(ir["edges"], routing_metadata, ast_has_dynamic)
+    heading_lines = {e.id: e.heading_line for e in step_entities}
+    _validate_branch_target_routing(ir["edges"], routing_metadata, ast_has_dynamic, heading_lines)
 
     # Build outputs
     output_entities = [e for e in entities if e.section_type == _SectionType.OUTPUTS]
@@ -1181,27 +1182,93 @@ def _validate_dynamic_next_declarations(
 
 def _build_branch_target_routers(
     edges: list[dict[str, Any]],
-) -> dict[str, set[str]]:
-    """Build mapping of branch target node IDs to their router source node IDs.
+) -> tuple[dict[str, set[str]], dict[str, dict[str, list[str]]]]:
+    """Build branch-target router maps.
 
-    A "branch target" is any node reached via an edge with action not in {None, "default"}.
+    Returns two parallel structures:
+    - ``branch_target_routers``: target_id → set of router source node IDs.
+    - ``router_actions``: target_id → source_id → list of action values
+      (preserves routing mechanism per (router, target) pair, used for
+      annotating error messages with e.g. ``(on-error)``).
+
+    A "branch target" is any node reached via an edge with action not in
+    ``{None, "default"}``.
     """
     branch_target_routers: dict[str, set[str]] = {}
+    router_actions: dict[str, dict[str, list[str]]] = {}
     for edge in edges:
         action = edge.get("action")
         if action is not None and action != "default":
             target = edge["to"]
             source = edge["from"]
-            if target not in branch_target_routers:
-                branch_target_routers[target] = set()
-            branch_target_routers[target].add(source)
-    return branch_target_routers
+            branch_target_routers.setdefault(target, set()).add(source)
+            router_actions.setdefault(target, {}).setdefault(source, []).append(action)
+    return branch_target_routers, router_actions
+
+
+def _format_router_list(
+    routers: set[str],
+    target_id: str,
+    router_actions: dict[str, dict[str, list[str]]],
+) -> str:
+    """Format a router list with ``(on-error)`` annotation where unambiguous.
+
+    A router is annotated ``(on-error)`` only when all of its actions for this
+    target are ``"error"``. Mixed mechanisms are left unannotated — the edge
+    schema cannot distinguish dynamic-python routing from static multi-target
+    literal routing, so we only surface the distinction that IS reliable.
+    """
+    actions_for_target = router_actions.get(target_id, {})
+    parts = []
+    for r in sorted(routers):
+        actions = actions_for_target.get(r, [])
+        # `actions and` is load-bearing: without it, `all(... for [])` is
+        # vacuously True, so any missing (router, target) pair would
+        # silently annotate as (on-error). Today both maps are populated
+        # in lockstep by `_build_branch_target_routers`; this guard
+        # protects against drift.
+        if actions and all(a == "error" for a in actions):
+            parts.append(f"'{r}' (on-error)")
+        else:
+            parts.append(f"'{r}'")
+    return ", ".join(parts)
+
+
+def _infer_convergence_candidate(
+    edges: list[dict[str, Any]],
+    branch_target_routers: dict[str, set[str]],
+    source: str,
+) -> str | None:
+    """Infer a likely convergence node that a fall-through source should route to.
+
+    A convergence node is one that multiple branch targets explicitly route
+    into via ``- next:`` (edge with ``action="default"``). Returns the candidate
+    with the most branch-target voters, or ``None`` when evidence is weak
+    (fewer than 2 voters). Conservative by design: false negatives are fine,
+    false positives would mislead the user worse than the current behavior.
+    """
+    votes: dict[str, set[str]] = {}
+    for edge in edges:
+        if edge.get("action") == "default" and edge["from"] in branch_target_routers:
+            votes.setdefault(edge["to"], set()).add(edge["from"])
+
+    candidates = [
+        (len(voters), cid)
+        for cid, voters in votes.items()
+        if cid not in branch_target_routers and cid != source and len(voters) >= 2
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda c: (-c[0], c[1]))
+    return candidates[0][1]
 
 
 def _validate_branch_targets_have_next(
     edges: list[dict[str, Any]],
     routing_metadata: dict[str, dict[str, Any]],
     branch_target_routers: dict[str, set[str]],
+    router_actions: dict[str, dict[str, list[str]]],
+    heading_lines: dict[str, int],
 ) -> None:
     """Check that branch targets have explicit ``- next:`` directives."""
     doc_order_targets: dict[str, str] = {}
@@ -1212,32 +1279,40 @@ def _validate_branch_targets_have_next(
     for target_id in sorted(branch_target_routers):
         routers = branch_target_routers[target_id]
         routing = routing_metadata.get(target_id, {})
-        if "next" not in routing:
-            router_list = ", ".join(f"'{r}'" for r in sorted(routers))
-            doc_successor = doc_order_targets.get(target_id)
-            if doc_successor:
-                raise MarkdownParseError(
-                    f"Node '{target_id}' is a routing target of {router_list} but has no "
-                    f"'- next:' directive. Without explicit routing, it will fall through "
-                    f"to '{doc_successor}' via document order.\n\n"
-                    f"Fix: Add '- next: end' to terminate the branch, or "
-                    f"'- next: <node-id>' to continue to a specific node:\n\n"
-                    f"    ### {target_id}\n"
-                    f"    - next: end"
-                )
-            else:
-                raise MarkdownParseError(
-                    f"Node '{target_id}' is a routing target of {router_list} but has no "
-                    f"'- next:' directive. Branch targets must have explicit routing.\n\n"
-                    f"Fix: Add '- next: end' to make termination explicit:\n\n"
-                    f"    ### {target_id}\n"
-                    f"    - next: end"
-                )
+        if "next" in routing:
+            continue
+
+        router_list = _format_router_list(routers, target_id, router_actions)
+        doc_successor = doc_order_targets.get(target_id)
+
+        if doc_successor:
+            context = (
+                f"Without it, execution would fall through to '{doc_successor}' "
+                f"via document order — pflow rejects this to prevent silent routing bugs."
+            )
+            fix_body = (
+                f"Fix — add '- next:' to '### {target_id}'. "
+                f"Either continue to the next step:\n\n"
+                f"    - next: {doc_successor}\n\n"
+                f"Or terminate the branch:\n\n"
+                f"    - next: end"
+            )
+        else:
+            context = "Branch targets must declare their exit explicitly to prevent silent routing bugs."
+            fix_body = f"Fix — add an explicit terminator to '### {target_id}':\n\n    - next: end"
+
+        raise MarkdownParseError(
+            f"Node '{target_id}' is a routing target of {router_list} but has no "
+            f"'- next:' directive. {context}\n\n{fix_body}",
+            line=heading_lines.get(target_id),
+        )
 
 
 def _validate_no_fallthrough_into_branch_targets(
     edges: list[dict[str, Any]],
     branch_target_routers: dict[str, set[str]],
+    router_actions: dict[str, dict[str, list[str]]],
+    heading_lines: dict[str, int],
 ) -> None:
     """Check that non-router nodes don't fall through into branch targets."""
     for edge in edges:
@@ -1247,15 +1322,27 @@ def _validate_no_fallthrough_into_branch_targets(
             if target in branch_target_routers:
                 routers = branch_target_routers[target]
                 if source not in routers:
-                    router_list = ", ".join(f"'{r}'" for r in sorted(routers))
+                    router_list = _format_router_list(routers, target, router_actions)
+                    convergence = _infer_convergence_candidate(edges, branch_target_routers, source)
+
+                    if convergence:
+                        fix_body = (
+                            f"Fix — add '- next:' to '### {source}'. "
+                            f"Either continue past the branch section to the convergence point "
+                            f"(inferred: '{convergence}' is where other branch targets route):\n\n"
+                            f"    - next: {convergence}\n\n"
+                            f"Or terminate the flow:\n\n"
+                            f"    - next: end"
+                        )
+                    else:
+                        fix_body = f"Fix — add an explicit '- next:' to '### {source}':\n\n    - next: end"
+
                     raise MarkdownParseError(
                         f"Node '{source}' flows into '{target}' via document order, but "
                         f"'{target}' is a routing target of {router_list}. Main flow nodes "
-                        f"should not fall through into branch targets.\n\n"
-                        f"Fix: Add '- next: end' to terminate the flow before the branch "
-                        f"section:\n\n"
-                        f"    ### {source}\n"
-                        f"    - next: end"
+                        f"must not silently fall through into branch targets.\n\n"
+                        f"{fix_body}",
+                        line=heading_lines.get(source),
                     )
 
 
@@ -1263,6 +1350,7 @@ def _validate_branch_target_routing(
     edges: list[dict[str, Any]],
     routing_metadata: dict[str, dict[str, Any]],
     ast_has_dynamic: set[str],
+    heading_lines: dict[str, int],
 ) -> None:
     """Validate that branch targets have explicit routing to prevent fall-through.
 
@@ -1276,12 +1364,12 @@ def _validate_branch_target_routing(
     """
     _validate_dynamic_next_declarations(routing_metadata, ast_has_dynamic)
 
-    branch_target_routers = _build_branch_target_routers(edges)
+    branch_target_routers, router_actions = _build_branch_target_routers(edges)
     if not branch_target_routers:
         return  # No branch targets — nothing to validate
 
-    _validate_branch_targets_have_next(edges, routing_metadata, branch_target_routers)
-    _validate_no_fallthrough_into_branch_targets(edges, branch_target_routers)
+    _validate_branch_targets_have_next(edges, routing_metadata, branch_target_routers, router_actions, heading_lines)
+    _validate_no_fallthrough_into_branch_targets(edges, branch_target_routers, router_actions, heading_lines)
 
 
 def _build_node_dict(entity: _Entity) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -1246,6 +1246,12 @@ def _infer_convergence_candidate(
     with the most branch-target voters, or ``None`` when evidence is weak
     (fewer than 2 voters). Conservative by design: false negatives are fine,
     false positives would mislead the user worse than the current behavior.
+
+    The threshold is 2 because a single vote is indistinguishable from
+    incidental coincidence — any branch target with a ``- next:`` declaration
+    produces one vote for its target, so a single voter is the baseline, not
+    evidence of convergence. Raising the threshold beyond 2 makes inference
+    rarer; lowering it to 1 crosses from inference into guessing.
     """
     votes: dict[str, set[str]] = {}
     for edge in edges:

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -1284,21 +1284,30 @@ def _validate_branch_targets_have_next(
 
         router_list = _format_router_list(routers, target_id, router_actions)
         doc_successor = doc_order_targets.get(target_id)
+        # Only suggest the successor as a continuation if it's not itself a
+        # branch target. Suggesting a branch target as a "next step" creates
+        # a cascade: applying the fix produces a new missing-`- next:` error
+        # on the successor, and iterated suggestions can form runtime cycles.
+        # Symmetric with `_infer_convergence_candidate`'s filter.
+        suggest_successor = doc_successor if doc_successor and doc_successor not in branch_target_routers else None
 
         if doc_successor:
             context = (
                 f"Without it, execution would fall through to '{doc_successor}' "
                 f"via document order — pflow rejects this to prevent silent routing bugs."
             )
+        else:
+            context = "Branch targets must declare their exit explicitly to prevent silent routing bugs."
+
+        if suggest_successor:
             fix_body = (
                 f"Fix — add '- next:' to '### {target_id}'. "
                 f"Either continue to the next step:\n\n"
-                f"    - next: {doc_successor}\n\n"
+                f"    - next: {suggest_successor}\n\n"
                 f"Or terminate the branch:\n\n"
                 f"    - next: end"
             )
         else:
-            context = "Branch targets must declare their exit explicitly to prevent silent routing bugs."
             fix_body = f"Fix — add an explicit terminator to '### {target_id}':\n\n    - next: end"
 
         raise MarkdownParseError(

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -3643,6 +3643,101 @@ class TestConditionalBranching:
         )
         assert "- next: end" in msg, "Fix snippet must still include '- next: end' as the safe fallback."
 
+    def test_missing_next_omits_doc_successor_when_successor_is_branch_target(self) -> None:
+        """When the document-order successor is itself a branch target, the
+        Fix snippet must NOT suggest it as a continuation.
+
+        Verified via adversarial end-to-end testing: applying such a
+        suggestion cascades into another missing-`- next:` error on the
+        successor, and iterated blind-apply can form runtime cycles
+        (caught by the loop guard but a wasted user iteration).
+
+        Symmetric with ``_infer_convergence_candidate``'s
+        ``cid not in branch_target_routers`` filter — keeps the
+        suggest-what-we-can-safely-infer invariant consistent across both
+        validators.
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### router-a
+
+            First router.
+
+            - type: code
+
+            ```python code
+            next: str = "handler-a"
+            result: int = 0
+            ```
+
+            ### fallback-a
+
+            Default.
+
+            - type: shell
+            - next: end
+
+            ```shell command
+            echo fa
+            ```
+
+            ### handler-a
+
+            Branch target missing - next:. Doc successor is handler-b (also a branch target).
+
+            - type: shell
+
+            ```shell command
+            echo ha
+            ```
+
+            ### handler-b
+
+            Doc successor of handler-a AND a branch target (of router-b).
+
+            - type: shell
+            - next: end
+
+            ```shell command
+            echo hb
+            ```
+
+            ### router-b
+
+            Makes handler-b a branch target.
+
+            - type: code
+            - next: end
+
+            ```python code
+            next: str = "handler-b"
+            result: int = 0
+            ```
+        """)
+        with pytest.raises(MarkdownParseError) as excinfo:
+            parse_markdown(content)
+        msg = str(excinfo.value)
+
+        # The fall-through warning in prose should still fire — useful
+        # diagnostic info even when we can't offer handler-b as a fix.
+        assert "fall through to 'handler-b'" in msg, (
+            f"Fall-through warning should still name the doc-order successor "
+            f"in prose even when we don't suggest it as a fix. Got:\n{msg}"
+        )
+        # But the fix snippet must not suggest handler-b as a continuation
+        # (applying it creates a cascade error and potential runtime loop).
+        fix_snippets = [line.strip() for line in msg.split("\n") if line.strip().startswith("- next:")]
+        assert fix_snippets == ["- next: end"], (
+            f"When doc_successor is itself a branch target, fix snippet must "
+            f"be exactly '- next: end' — no suggestion of handler-b. "
+            f"Got: {fix_snippets}\nFull message:\n{msg}"
+        )
+
     def test_missing_next_annotates_on_error_router(self) -> None:
         """When the router reaches the target via '- on-error:', the error
         message annotates the router as '(on-error)'.

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -3637,6 +3637,11 @@ class TestConditionalBranching:
             parse_markdown(content)
 
         msg = str(excinfo.value)
+        # Pins the `heading_lines` plumbing end-to-end: `MarkdownParseError`
+        # prepends "Line N: " when `line=` is populated. If this prefix is
+        # missing, the heading_line was lost somewhere between
+        # `parse_markdown` and the `raise` site.
+        assert msg.startswith("Line "), f"Expected 'Line N:' prefix from heading_lines plumbing. Got:\n{msg}"
         assert "- next: continuation" in msg, (
             "Fix snippet must include the document-order successor as the likely "
             f"continuation (regression guard for #308). Got:\n{msg}"

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -3573,6 +3573,121 @@ class TestConditionalBranching:
         with pytest.raises(MarkdownParseError, match=r"'handler'.*routing target.*no.*'- next:'"):
             parse_markdown(content)
 
+    def test_missing_next_fix_snippet_includes_doc_successor(self) -> None:
+        """Regression guard for #308: when a document-order successor exists,
+        the Fix snippet must offer ``- next: <doc_successor>`` as the likely
+        continuation — not only ``- next: end``.
+
+        Before the fix, prose named the successor but the code snippet only
+        showed ``- next: end``. Users who copy-pasted the snippet silently
+        converted a fall-through bug into a terminate bug (dropping the
+        successor from every run of that branch).
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### router
+
+            Route to branch.
+
+            - type: code
+
+            ```python code
+            next: str = "branch"
+            result: int = 0
+            ```
+
+            ### fallback
+
+            Default next.
+
+            - type: shell
+            - next: end
+
+            ```shell command
+            echo fallback
+            ```
+
+            ### branch
+
+            Branch target missing - next:, with doc-order successor.
+
+            - type: shell
+
+            ```shell command
+            echo branch
+            ```
+
+            ### continuation
+
+            Document-order successor of branch.
+
+            - type: shell
+            - next: end
+
+            ```shell command
+            echo continuation
+            ```
+        """)
+        with pytest.raises(MarkdownParseError) as excinfo:
+            parse_markdown(content)
+
+        msg = str(excinfo.value)
+        assert "- next: continuation" in msg, (
+            "Fix snippet must include the document-order successor as the likely "
+            f"continuation (regression guard for #308). Got:\n{msg}"
+        )
+        assert "- next: end" in msg, "Fix snippet must still include '- next: end' as the safe fallback."
+
+    def test_missing_next_annotates_on_error_router(self) -> None:
+        """When the router reaches the target via '- on-error:', the error
+        message annotates the router as '(on-error)'.
+
+        The on-error mechanism is the only routing distinction that's reliably
+        recoverable from edge data. Surfacing it in the message helps agents
+        understand *why* this node is a routing target without re-reading the
+        router.
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### step-a
+
+            Risky step.
+
+            - type: shell
+            - on-error: handler
+            - next: end
+
+            ```shell command
+            echo a
+            ```
+
+            ### handler
+
+            Error handler without - next:.
+
+            - type: shell
+
+            ```shell command
+            echo error
+            ```
+        """)
+        with pytest.raises(MarkdownParseError) as excinfo:
+            parse_markdown(content)
+        msg = str(excinfo.value)
+        assert "(on-error)" in msg, (
+            f"Router reaching target via '- on-error:' should be annotated '(on-error)' in the error. Got:\n{msg}"
+        )
+
     # --- Validation 3: Non-router node falling into branch target ---
 
     def test_non_router_falling_into_branch_target_raises(self) -> None:
@@ -3653,6 +3768,185 @@ class TestConditionalBranching:
         # Should not raise — router IS the source of the error edge to handler
         result = parse_markdown(content)
         assert result.ir is not None
+
+    def test_fallthrough_fix_includes_convergence_when_inferred(self) -> None:
+        """When multiple branch targets explicitly route to the same
+        non-branch-target node, that node is the likely convergence point.
+        The fall-through-into-branch-target error should offer it as the
+        likely-continuation fix alongside '- next: end'.
+
+        Analogous to the #308 fix for the sibling validator: when pflow can
+        infer the probable intent, the fix snippet should name it rather than
+        suggesting only the safe terminator.
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### step-a
+
+            First router with error handler.
+
+            - type: shell
+            - on-error: handler-a
+            - next: main-flow
+
+            ```shell command
+            echo a
+            ```
+
+            ### main-flow
+
+            Main flow node that falls through into handler-a.
+
+            - type: shell
+
+            ```shell command
+            echo main
+            ```
+
+            ### handler-a
+
+            First branch target, converges on 'merge'.
+
+            - type: shell
+            - next: merge
+
+            ```shell command
+            echo ha
+            ```
+
+            ### step-b
+
+            Second router with error handler.
+
+            - type: shell
+            - on-error: handler-b
+            - next: merge
+
+            ```shell command
+            echo b
+            ```
+
+            ### handler-b
+
+            Second branch target, also converges on 'merge'.
+
+            - type: shell
+            - next: merge
+
+            ```shell command
+            echo hb
+            ```
+
+            ### merge
+
+            Convergence point (not a branch target).
+
+            - type: shell
+            - next: end
+
+            ```shell command
+            echo merge
+            ```
+        """)
+        with pytest.raises(MarkdownParseError) as excinfo:
+            parse_markdown(content)
+        msg = str(excinfo.value)
+
+        assert "flows into" in msg, f"Expected the fall-through-into-branch-target error. Got:\n{msg}"
+        assert "- next: merge" in msg, (
+            f"Fix snippet must include the inferred convergence 'merge' as the "
+            f"likely continuation (regression guard: sibling-validator version "
+            f"of #308's trap). Got:\n{msg}"
+        )
+        assert "- next: end" in msg, "Fix snippet must still include '- next: end' as the safe fallback."
+
+    def test_fallthrough_fix_omits_convergence_when_not_inferable(self) -> None:
+        """When convergence evidence is weak (fewer than 2 branch targets
+        route to the same non-branch-target node), the fall-through error's
+        fix snippet must show ONLY '- next: end' — never fabricate a
+        plausible-looking candidate.
+
+        Guards the conservatism contract of ``_infer_convergence_candidate``
+        (docstring: 'false positives would mislead the user worse than the
+        current behavior'). A bug lowering the voter threshold to >=1 or
+        dropping the 'exclude branch targets' filter would pass the positive
+        convergence test but fail this one.
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### router
+
+            Single router with one handler — not enough voters for
+            convergence inference.
+
+            - type: shell
+            - on-error: handler
+            - next: end
+
+            ```shell command
+            echo route
+            ```
+
+            ### main-flow
+
+            Main flow node that falls through into handler.
+
+            - type: shell
+
+            ```shell command
+            echo main
+            ```
+
+            ### handler
+
+            The only branch target.
+
+            - type: shell
+            - next: tail
+
+            ```shell command
+            echo h
+            ```
+
+            ### tail
+
+            Non-branch-target; only 1 voter (handler), below threshold.
+
+            - type: shell
+            - next: end
+
+            ```shell command
+            echo tail
+            ```
+        """)
+        with pytest.raises(MarkdownParseError) as excinfo:
+            parse_markdown(content)
+        msg = str(excinfo.value)
+
+        assert "flows into" in msg, f"Expected the fall-through error. Got:\n{msg}"
+        # Extract only the code-snippet `- next:` lines and assert the sole
+        # suggestion is `end` — no fabricated candidate like `- next: tail`
+        # or `- next: handler` should leak into the fix block.
+        fix_snippets = [line.strip() for line in msg.split("\n") if line.strip().startswith("- next:")]
+        assert fix_snippets == ["- next: end"], (
+            f"When no convergence is inferable, fix snippet must be exactly "
+            f"'- next: end' with no fabricated candidate. Got: {fix_snippets}\n"
+            f"Full message:\n{msg}"
+        )
+        # Convergence language should not appear when no convergence is inferred.
+        assert "convergence point" not in msg, (
+            f"Convergence language must only appear when an actual convergence node was inferred. Got:\n{msg}"
+        )
 
     def test_next_multi_target_with_end(self) -> None:
         """'- next: step-3, end' creates edges for step-3 only, not for 'end'."""


### PR DESCRIPTION
## Summary

The parse-time error for a routing target missing `- next:` used to suggest only `- next: end` even when a document-order successor existed — a copy-paste trap that silently converted fall-through bugs into terminate bugs (same bug class the validator was trying to prevent, hiding in a different spot).

Fixed the reported instance and the structural reason it was possible. Bundled the same treatment for the sibling fall-through validator, plus line-number attribution and a routing-mechanism annotation.

## Changes

- Collapse `_validate_branch_targets_have_next` to one code path. When a document-order successor exists, offer both `- next: <doc_successor>` (likely continuation) and `- next: end` (safe fallback) as labeled snippets.
- Add convergence inference in `_validate_no_fallthrough_into_branch_targets`: when ≥2 branch targets explicitly route to the same non-branch-target node, offer that node as the likely continuation. Conservative by design — returns `None` when evidence is weak, never fabricates a candidate. Heuristic is surfaced in prose (`inferred: 'X' is where other branch targets route`) so agents can verify.
- Attach markdown heading line numbers to both validators via a `heading_lines` map threaded through `_validate_branch_target_routing`. Renders as `At: line N` via the diagnostic layer.
- Annotate routers as `(on-error)` in messages when all their actions for the target are `"error"`. The only routing-mechanism distinction that's reliably recoverable from edge data (dynamic python and multi-literal `- next:` are encoded identically, so those are left unannotated).
- Pin the vacuous-truth invariant in `_format_router_list` with an explanatory comment — the `actions and` guard is load-bearing; without it, any missing `(router, target)` pair would silently annotate as `(on-error)` via `all(... for a in [])`.

## Explanation

Issue #308 reported that the error snippet said `- next: end` even when the message's prose had already named a likely continuation. Rather than patch the single arm, collapsed the two near-duplicate `raise MarkdownParseError` arms — that eliminated the class of bug (snippet and prose could drift) rather than the instance.

A parallel analysis found `_validate_no_fallthrough_into_branch_targets` had the same single-suggestion shape. Bundled, but with honest constraint: convergence inference can only fire when multiple branches explicitly converge on a non-branch-target node. For single-handler / error-only patterns, it correctly returns `None` and the message falls back to `- next: end` alone (guarded by a new negative test).

Three review agents (agent-UX, silent-failures, test-fidelity) ran after implementation. One reviewer flagged a plausible multi-literal `- next: a, b` edge case in convergence inference. Mutation-testing showed the existing `cid not in branch_target_routers` filter already defends against it — the proposed additional filter was unreachable code, so it was reverted. Good reminder that review findings are hypotheses, not conclusions.

## Testing

`make test` → 4,929 passed (5 new regression guards in `TestConditionalBranching`).
`make check` → ruff, mypy, deptry all clean.

Regression guards:

- `test_missing_next_fix_snippet_includes_doc_successor` — the #308 fix itself
- `test_missing_next_annotates_on_error_router` — the `(on-error)` annotation
- `test_fallthrough_fix_includes_convergence_when_inferred` — sibling-validator convergence suggestion
- `test_fallthrough_fix_omits_convergence_when_not_inferable` — guards the conservatism contract (no fabricated candidates when evidence is weak)

Each test mutation-verified: reverting its corresponding production change causes it to fail.