### PR TITLE
feat: validate-time type check for code-node input annotations (fixes #309, #316)

### DIFF
--- a/examples/file-references/code-file-ref.pflow.md
+++ b/examples/file-references/code-file-ref.pflow.md
@@ -19,3 +19,5 @@ Transform input using external Python script.
 
 - type: code
 - code: ./scripts/transform.py
+- inputs:
+    text: ${input}

--- a/examples/file-references/scripts/transform.py
+++ b/examples/file-references/scripts/transform.py
@@ -1,4 +1,4 @@
 """Transform input text to uppercase."""
 
-text: str = "${input}"
+text: str
 result: str = text.upper()

--- a/examples/invalid/code-annotation-type-mismatch.pflow.md
+++ b/examples/invalid/code-annotation-type-mismatch.pflow.md
@@ -1,0 +1,36 @@
+# Code Annotation Type Mismatch (Invalid)
+
+Demonstrates validate-time code-node input type checking. This workflow must
+fail validation because the downstream annotation does not match its upstream
+source type.
+
+## Steps
+
+### upstream
+
+Produces a list.
+
+- type: code
+
+```python code
+result: list = [1, 2, 3]
+```
+
+### downstream
+
+Annotates dict but upstream is list.
+
+- type: code
+- inputs:
+    x: ${upstream.result}
+
+```python code
+x: dict
+result: str = str(x)
+```
+
+## Outputs
+
+### final
+Final result.
+- source: ${downstream.result}

--- a/src/pflow/guide/nodes/code.md
+++ b/src/pflow/guide/nodes/code.md
@@ -64,6 +64,38 @@ result: dict = {
 - Single output via `result` variable — use dict for structured output
 - Downstream access: `${node.result}` or `${node.result.field}` for dict results
 
+## Validate-Time Type Checking
+
+Three code-node input errors are now caught at validate time (`pflow
+--validate-only`) instead of runtime:
+
+1. **Input bound, annotation missing** — `inputs: {x: ${ref}}` with no `x:
+   <type>` in code. The suggestion uses the upstream's declared type when
+   known (`Add an annotation (in params.code): x: str  (inferred from ...)`).
+2. **Annotation declared, no input bound** — opinionated one-fix-per-case:
+   `Remove the annotation 'y: list' — it is never read in the code` for dead
+   annotations, `Add 'y' to the inputs dict` when the name is read in the
+   body, `Rename the annotation to 'items'` when a fuzzy-matched input key
+   exists (typo case).
+3. **Type mismatch** — `x: dict` bound to `${upstream.result}` that declares
+   `list`:
+
+    ```text
+    Input 'x' expects dict but receives list from ${upstream.result}.
+
+    To fix this:
+      1. Change the type annotation (in params.code): x: list
+      2. Or change ${upstream.result} to return dict
+      3. Or accept any type (in params.code): x: Any
+    ```
+
+Suggestions include locality hints (`in params.code` vs `in params.inputs`) so
+agents know which section to edit. Upstream type is read from the registry
+interface for standard nodes and from the code-block `result:` annotation for
+upstream code nodes (including batch code nodes — enrichment flows through
+`results[0].result` access paths). Use `Any` when you want to accept any
+upstream type deliberately.
+
 ### Type annotation syntax
 
 Type annotations in code blocks are Python. pflow follows modern Python style (PEP 585 + PEP 604):

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -194,18 +194,52 @@ def extract_code_annotation_type(code: str, key: str) -> Optional[str]:
     """Return the S1 canonical type name for ``key`` in a code block, or None.
 
     Returns None as a skip-check signal when the code is malformed, the key is
-    not annotated, or the annotation resolves to an unknown/non-S1 type.
+    not annotated at module scope, or the annotation resolves to an
+    unknown/non-S1 type. Uses top-level extraction — a function-local
+    ``y: int`` does not shadow a missing or different top-level ``y`` binding.
     """
-    try:
-        annotations = _extract_annotations(code)
-    except SyntaxError:
-        return None
-
+    annotations = extract_top_level_annotations(code)
     type_str = annotations.get(key)
     if type_str is None:
         return None
 
     return _get_outer_type_name(type_str)
+
+
+def extract_top_level_annotations(code: str) -> dict[str, str]:
+    """Like ``_extract_annotations`` but scoped to module-level names only.
+
+    ``_extract_annotations`` uses ``ast.walk`` which descends into function
+    and class bodies. For Pass 9's boundary checks (missing-input, orphan
+    annotation) we want ONLY the module-level annotations — a helper function
+    like ``def helper(): y: int = 1`` is a legitimate local variable, not a
+    candidate code-node input. Treating it as one produces spurious orphan
+    errors that block valid workflows.
+
+    Scope boundaries (skipped, not descended into):
+    ``FunctionDef``, ``AsyncFunctionDef``, ``ClassDef``, ``Lambda``.
+
+    Non-scope structures (descended into) include ``If``, ``For``, ``While``,
+    ``With``, ``Try`` — annotations inside these are still module-scoped per
+    Python's scoping rules (only the four types above introduce new scopes).
+
+    Returns an empty dict on SyntaxError (matches ``_extract_annotations``).
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return {}
+    annotations: dict[str, str] = {}
+    _SCOPE_BOUNDARIES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+    stack: list[ast.AST] = list(tree.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, _SCOPE_BOUNDARIES):
+            continue  # Don't descend into new scopes.
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            annotations[node.target.id] = ast.unparse(node.annotation)
+        stack.extend(ast.iter_child_nodes(node))
+    return annotations
 
 
 def extract_code_load_references(code: str) -> set[str]:

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -263,7 +263,18 @@ def extract_code_load_references(code: str) -> set[str]:
 # Reverse of _PYTHON_TO_S1_CANONICAL for display in code-node diagnostics.
 # Code-block annotations speak Python, so diagnostic messages and suggestions
 # must too — otherwise a user copy-pasting "x: array" gets a NameError.
+#
+# The reverse mapping requires PYTHON_ALIASES_AT_S1 to be injective — if a
+# future edit maps two Python names to the same S1 name (e.g. both ``int32``
+# and ``int`` to ``integer``), the reverse dict silently keeps only one and
+# display diverges. The module-load assertion catches this drift at import
+# time rather than at the point of a confusing error message.
 _S1_TO_PYTHON_DISPLAY: dict[str, str] = {v: k for k, v in _PYTHON_TO_S1_CANONICAL.items()}
+if len(_S1_TO_PYTHON_DISPLAY) != len(_PYTHON_TO_S1_CANONICAL):
+    raise RuntimeError(
+        "PYTHON_ALIASES_AT_S1 must be injective — two Python names map to the same S1 type. "
+        "The reverse map used for diagnostic display would silently drop entries."
+    )
 
 
 def s1_type_to_python_display(type_str: str) -> str:

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -35,6 +35,7 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Optional
 
 from pflow.core.node import Node
+from pflow.core.types import PYTHON_ALIASES_AT_S1
 from pflow.nodes.file.exceptions import NonRetriableError
 
 logger = logging.getLogger(__name__)
@@ -123,13 +124,31 @@ def _get_inner_optional_type(type_str: str) -> Optional[str]:
     return None
 
 
+def _annotation_outer_base(type_str: str) -> str:
+    """Return the outer base-name from an annotation string.
+
+    Strips generic parameters (``list[dict]`` → ``list``) and unwraps
+    forward-reference quotes (``'list'`` / ``"list"`` → ``list``). Forward
+    refs come through ``_extract_annotations`` as ``"'T'"`` because
+    ``ast.unparse`` preserves the quotes; mirror ``_check_annotation_vocabulary``'s
+    unwrap so the isinstance check and validate-time type inference both see
+    the inner type instead of silently skipping.
+    """
+    stripped = type_str.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ("'", '"'):
+        stripped = stripped[1:-1].strip()
+    return stripped.split("[")[0].strip()
+
+
 def _get_outer_type(type_str: str) -> type | tuple[type, ...] | None:
     """Resolve a type annotation string to a Python type for isinstance() checks.
 
     Strips generic parameters so ``list[dict[str, Any]]`` resolves to ``list``.
     Decomposes optional types: ``str | None`` resolves to ``(str, type(None))``.
-    Returns None for types not in ``_TYPE_MAP`` (e.g. user-defined classes),
-    which skips the isinstance check.
+    Unwraps forward-reference annotations (``x: "list"``) so the isinstance
+    check sees the inner type instead of silently skipping. Returns None for
+    types not in ``_TYPE_MAP`` (e.g. user-defined classes), which skips the
+    isinstance check.
     """
     # Handle optional types: extract inner type and add NoneType
     inner = _get_inner_optional_type(type_str)
@@ -141,8 +160,93 @@ def _get_outer_type(type_str: str) -> type | tuple[type, ...] | None:
             return (*inner_type, type(None))
         return (inner_type, type(None))
 
-    base = type_str.split("[")[0].strip()
-    return _TYPE_MAP.get(base)
+    return _TYPE_MAP.get(_annotation_outer_base(type_str))
+
+
+# S1 canonical type names for Python annotation base types that have a
+# workflow-vocabulary equivalent. Derived from the shared S1 alias mapping so
+# code-node validation stays aligned with the rest of the type system.
+_PYTHON_TO_S1_CANONICAL: dict[str, str] = dict(PYTHON_ALIASES_AT_S1)
+
+
+def _get_outer_type_name(type_str: str) -> Optional[str]:
+    """Resolve a type annotation string to its S1 canonical name, or None.
+
+    Returns None for types without an S1 equivalent: ``Any``, typing-module
+    names, user-defined classes, and the three Python primitives with no
+    workflow-vocabulary mapping (``set``, ``tuple``, ``bytes``). Runtime's
+    ``_check_input_types`` catches ``set``/``tuple``/``bytes`` via
+    ``_TYPE_MAP`` as defense-in-depth; validate-time skips them because S1
+    has no canonical name to compare against.
+
+    Strips generics (``list[dict]`` -> ``"array"``). Unwraps forward-ref
+    annotations (``"'list'"`` -> ``"array"``). Decomposes ``Optional[T]`` /
+    ``T | None`` to the inner type's name.
+    """
+    inner = _get_inner_optional_type(type_str)
+    if inner is not None:
+        return _get_outer_type_name(inner)
+
+    return _PYTHON_TO_S1_CANONICAL.get(_annotation_outer_base(type_str))
+
+
+def extract_code_annotation_type(code: str, key: str) -> Optional[str]:
+    """Return the S1 canonical type name for ``key`` in a code block, or None.
+
+    Returns None as a skip-check signal when the code is malformed, the key is
+    not annotated, or the annotation resolves to an unknown/non-S1 type.
+    """
+    try:
+        annotations = _extract_annotations(code)
+    except SyntaxError:
+        return None
+
+    type_str = annotations.get(key)
+    if type_str is None:
+        return None
+
+    return _get_outer_type_name(type_str)
+
+
+def extract_code_load_references(code: str) -> set[str]:
+    """Return the set of variable names read (``ast.Load`` context) in ``code``.
+
+    Used by validate-time orphan-annotation checks to distinguish an unused
+    annotation (remove it) from a missing input binding (add it). An annotation
+    ``y: list`` paired with a later ``return y`` means the code author expected
+    ``y`` to be bound — the fix is to add ``y`` to the ``inputs`` dict. An
+    annotation with no Load reference is dead code; the fix is to remove it.
+
+    Returns an empty set on SyntaxError so callers fail-open at validate time.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return set()
+    return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)}
+
+
+# Reverse of _PYTHON_TO_S1_CANONICAL for display in code-node diagnostics.
+# Code-block annotations speak Python, so diagnostic messages and suggestions
+# must too — otherwise a user copy-pasting "x: array" gets a NameError.
+_S1_TO_PYTHON_DISPLAY: dict[str, str] = {v: k for k, v in _PYTHON_TO_S1_CANONICAL.items()}
+
+
+def s1_type_to_python_display(type_str: str) -> str:
+    """Map an S1 canonical type name to its Python annotation name for display.
+
+    Used when rendering code-node diagnostic messages and suggestions — users
+    write Python annotations (``list``, ``dict``), so inferred S1 names
+    (``array``, ``object``) from enriched upstream code-node outputs must be
+    translated before display. Pass-through for names already in Python
+    vocabulary (e.g. ``"str"`` from shell.stdout, ``"dict|str"`` unions).
+
+    Handles pipe-unions element-wise so ``"array|string"`` renders as
+    ``"list|str"``. Whitespace around ``|`` is preserved.
+    """
+    if "|" in type_str:
+        return "|".join(_S1_TO_PYTHON_DISPLAY.get(t.strip(), t.strip()) for t in type_str.split("|"))
+    return _S1_TO_PYTHON_DISPLAY.get(type_str, type_str)
 
 
 # Typing-module names that have a modern lowercase built-in generic (PEP 585).

--- a/src/pflow/runtime/template_validation/type_checker.py
+++ b/src/pflow/runtime/template_validation/type_checker.py
@@ -161,6 +161,14 @@ def infer_template_type(  # noqa: C901
                 output_type = output_info.get("type", "any")
                 return str(output_type)
 
+            # Indexed base access (e.g. `results[0].field`) descends into the
+            # item structure, not the top-level array structure. Mirrors the
+            # equivalent traversal in path_validation.py::_validate_array_access
+            # so that batch outputs get the same type visibility they already
+            # have for path existence checks.
+            if parts[1] != output_key_part and isinstance(output_info.get("items"), dict):
+                return _infer_nested_type(parts[2:], output_info["items"])
+
             # Nested path - traverse structure
             return _infer_nested_type(parts[2:], output_info)
 

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -541,6 +541,173 @@ def _build_orphan_code_annotation_diagnostics(
     return diagnostics
 
 
+def _build_simple_template_mismatch_diagnostic(
+    node_id: str,
+    key: str,
+    template: str,
+    annotation_str: str,
+    expected_canonical: str,
+    inferred_type: str,
+    annotation_is_optional: bool,
+    workflow_inputs: dict[str, Any],
+) -> Diagnostic:
+    """Build a Class 3 mismatch diagnostic for a single simple-template binding."""
+    from pflow.nodes.python.python_code import s1_type_to_python_display
+
+    display_inferred = s1_type_to_python_display(inferred_type)
+    display_expected = s1_type_to_python_display(expected_canonical)
+    suggested_annotation = f"{display_inferred} | None" if annotation_is_optional else display_inferred
+
+    # Tailor the "change the source" wording to the template's origin.
+    # Workflow inputs aren't "returned" by anything — telling the agent
+    # to change a non-existent upstream node wastes cycles.
+    root = TemplateResolver.extract_root_node_id(template) or template.split(".")[0]
+    if root in workflow_inputs:
+        source_fix = (
+            f"Or change the workflow input declaration for '{root}' "
+            f"to '- type: {display_expected}' (currently {display_inferred})"
+        )
+    else:
+        source_fix = f"Or change ${{{template}}} to return {annotation_str}"
+
+    return Diagnostic(
+        severity=Severity.ERROR,
+        source="validator",
+        title="Validation Error",
+        node_id=node_id,
+        message=(f"Input '{key}' expects {annotation_str} but receives {display_inferred} from ${{{template}}}."),
+        suggestions=[
+            f"Change the type annotation (in params.code): {key}: {suggested_annotation}",
+            source_fix,
+            f"Or accept any type (in params.code): {key}: Any",
+        ],
+        context={
+            "category": "validation",
+            "path": f"nodes[id={node_id}].params.inputs.{key}",
+            "node_type": "code",
+            "template": f"${{{template}}}",
+            "input_key": key,
+            "annotation": annotation_str,
+            "inferred_type": display_inferred,
+            "expected_type": display_expected,
+        },
+    )
+
+
+def _build_complex_template_str_coercion_diagnostic(
+    node_id: str,
+    key: str,
+    value: str,
+    annotation_str: str,
+    expected_canonical: str,
+    annotation_is_optional: bool,
+) -> Optional[Diagnostic]:
+    """Emit a diagnostic when a complex template resolves to str and violates a non-str target.
+
+    Runtime coerces ``"prefix ${x}"`` / ``"${a} ${b}"`` to str unconditionally
+    (no JSON auto-parse for multi-fragment templates). This check is stricter
+    than ``is_type_compatible("str", target)`` because the matrix treats
+    ``str → dict/list`` as compatible for the simple-template path; the
+    auto-parse doesn't apply here.
+
+    Returns None when the target (``string`` / ``any``) accepts the coerced
+    string — caller skips emission in that case.
+    """
+    from pflow.nodes.python.python_code import s1_type_to_python_display
+
+    if expected_canonical in ("string", "any"):
+        return None
+
+    display_inferred = "str"
+    display_expected = s1_type_to_python_display(expected_canonical)
+    suggested_annotation = f"{display_inferred} | None" if annotation_is_optional else display_inferred
+    return Diagnostic(
+        severity=Severity.ERROR,
+        source="validator",
+        title="Validation Error",
+        node_id=node_id,
+        message=(
+            f"Input '{key}' expects {annotation_str} but receives str from {value!r} "
+            f"(complex templates are coerced to string at runtime)."
+        ),
+        suggestions=[
+            f"Change the type annotation (in params.code): {key}: {suggested_annotation}",
+            "Or drop the surrounding text so only a single template remains in the value",
+            f"Or accept any type (in params.code): {key}: Any",
+        ],
+        context={
+            "category": "validation",
+            "path": f"nodes[id={node_id}].params.inputs.{key}",
+            "node_type": "code",
+            "template": value,
+            "input_key": key,
+            "annotation": annotation_str,
+            "inferred_type": display_inferred,
+            "expected_type": display_expected,
+        },
+    )
+
+
+def _check_one_code_input_binding(
+    node_id: str,
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+    code: str,
+    key: str,
+    value: Any,
+    annotation_str: str,
+    workflow_inputs: dict[str, Any],
+) -> list[Diagnostic]:
+    """Produce Class 3 diagnostics for one code-node input binding.
+
+    Splits the per-input analysis out of the main builder to keep the
+    orchestrator loop simple (below the cyclomatic-complexity limit).
+    Returns an empty list for bindings that should skip the check
+    (non-template values, Any targets, or compatible types).
+    """
+    from pflow.nodes.python.python_code import (
+        _is_optional_type,
+        extract_code_annotation_type,
+    )
+
+    if not isinstance(value, str) or not TemplateResolver.has_templates(value):
+        return []
+
+    expected_canonical = extract_code_annotation_type(code, key)
+    if expected_canonical is None:
+        return []
+    annotation_is_optional = _is_optional_type(annotation_str)
+
+    # Complex templates coerce to str at runtime — handle at the value level
+    # rather than per embedded ref.
+    if not TemplateResolver.is_simple_template(value):
+        diag = _build_complex_template_str_coercion_diagnostic(
+            node_id, key, value, annotation_str, expected_canonical, annotation_is_optional
+        )
+        return [diag] if diag is not None else []
+
+    out: list[Diagnostic] = []
+    for template in TemplateResolver.extract_variables(value):
+        inferred_type = infer_template_type(template, workflow_ir, node_outputs)
+        if not inferred_type or inferred_type == "any":
+            continue
+        if is_type_compatible(inferred_type, expected_canonical):
+            continue
+        out.append(
+            _build_simple_template_mismatch_diagnostic(
+                node_id,
+                key,
+                template,
+                annotation_str,
+                expected_canonical,
+                inferred_type,
+                annotation_is_optional,
+                workflow_inputs,
+            )
+        )
+    return out
+
+
 def _build_code_annotation_type_diagnostics(
     node_id: str,
     workflow_ir: dict[str, Any],
@@ -551,85 +718,17 @@ def _build_code_annotation_type_diagnostics(
     annotation_keys: set[str],
 ) -> list[Diagnostic]:
     """Build diagnostics for incompatible template source types."""
-    from pflow.nodes.python.python_code import (
-        _is_optional_type,
-        extract_code_annotation_type,
-        s1_type_to_python_display,
-    )
-
     diagnostics: list[Diagnostic] = []
     workflow_inputs = workflow_ir.get("inputs", {}) or {}
 
     for key, value in inputs.items():
         if key not in annotation_keys:
             continue
-        if not isinstance(value, str):
-            continue
-        if not TemplateResolver.has_templates(value):
-            continue
-
-        annotation_str = annotations[key]
-        expected_canonical = extract_code_annotation_type(code, key)
-        if expected_canonical is None:
-            continue
-        # Preserve `| None` in the suggested annotation when the original
-        # annotation is optional — otherwise an agent copy-pasting our fix
-        # silently drops the None-tolerance the user declared.
-        annotation_is_optional = _is_optional_type(annotation_str)
-
-        for template in TemplateResolver.extract_variables(value):
-            inferred_type = infer_template_type(template, workflow_ir, node_outputs)
-            if not inferred_type or inferred_type == "any":
-                continue
-            if is_type_compatible(inferred_type, expected_canonical):
-                continue
-
-            # Display the inferred type in Python vocabulary — code-block
-            # annotations speak Python, so "x: array" in a suggestion would be
-            # invalid. Internal matrix check stays in S1 via `expected_canonical`.
-            display_inferred = s1_type_to_python_display(inferred_type)
-            display_expected = s1_type_to_python_display(expected_canonical)
-            suggested_annotation = f"{display_inferred} | None" if annotation_is_optional else display_inferred
-
-            # Tailor the "change the source" wording to the template's origin.
-            # Workflow inputs aren't "returned" by anything — telling the agent
-            # to change a non-existent upstream node wastes cycles.
-            root = TemplateResolver.extract_root_node_id(template) or template.split(".")[0]
-            if root in workflow_inputs:
-                source_fix = (
-                    f"Or change the workflow input declaration for '{root}' "
-                    f"to '- type: {display_expected}' (currently {display_inferred})"
-                )
-            else:
-                source_fix = f"Or change ${{{template}}} to return {annotation_str}"
-
-            diagnostics.append(
-                Diagnostic(
-                    severity=Severity.ERROR,
-                    source="validator",
-                    title="Validation Error",
-                    node_id=node_id,
-                    message=(
-                        f"Input '{key}' expects {annotation_str} but receives {display_inferred} from ${{{template}}}."
-                    ),
-                    suggestions=[
-                        f"Change the type annotation (in params.code): {key}: {suggested_annotation}",
-                        source_fix,
-                        f"Or accept any type (in params.code): {key}: Any",
-                    ],
-                    context={
-                        "category": "validation",
-                        "path": f"nodes[id={node_id}].params.inputs.{key}",
-                        "node_type": "code",
-                        "template": f"${{{template}}}",
-                        "input_key": key,
-                        "annotation": annotation_str,
-                        "inferred_type": display_inferred,
-                        "expected_type": display_expected,
-                    },
-                )
+        diagnostics.extend(
+            _check_one_code_input_binding(
+                node_id, workflow_ir, node_outputs, code, key, value, annotations[key], workflow_inputs
             )
-
+        )
     return diagnostics
 
 
@@ -653,7 +752,9 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
     """
     # Lazy import follows the existing runtime -> nodes pattern used by the
     # compiler for code-node annotation introspection.
-    from pflow.nodes.python.python_code import _extract_annotations, extract_code_load_references
+    import ast as _ast
+
+    from pflow.nodes.python.python_code import extract_code_load_references, extract_top_level_annotations
 
     diagnostics: list[Diagnostic] = []
 
@@ -669,10 +770,20 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         if not isinstance(code, str) or not isinstance(inputs, dict):
             continue
 
+        # Skip Pass 9 entirely when the code has a SyntaxError — runtime
+        # surfaces a clean line-numbered error and Pass 9 emitting extra
+        # "missing annotation" / "orphan" diagnostics on top only obscures
+        # the real issue. `extract_top_level_annotations` fails open with
+        # `{}`, so without this check Pass 9 would proceed and over-report.
         try:
-            annotations = _extract_annotations(code)
+            _ast.parse(code)
         except SyntaxError:
             continue
+
+        # Module-level annotations only — function/class locals are not
+        # candidate code-node inputs. Using ``_extract_annotations`` here
+        # would flag every ``def helper(): y: int = 1`` as an orphan.
+        annotations = extract_top_level_annotations(code)
 
         input_keys = set(inputs.keys())
         # `result` / `next` are outputs / routing declarations, not inputs.

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -510,11 +510,11 @@ def _build_orphan_code_annotation_diagnostics(
         }
 
         if is_used:
-            similar = find_similar_items(key, sorted(input_keys), method="fuzzy", cutoff=0.6, max_results=3)
-            if similar:
-                fix = f"Rename the annotation to '{similar[0]}' to match the existing input binding."
-                context["similar_names"] = similar
-            elif batch_alias and key == batch_alias:
+            # Batch alias is deterministic metadata and must win over fuzzy
+            # matching. Otherwise a near-miss between `item` (the alias) and
+            # a user input like `items` produces "Rename to 'items'", which
+            # would break code that correctly reads the per-iteration `item`.
+            if batch_alias and key == batch_alias:
                 # The engine injects the batch alias into template resolution
                 # only — code-exec requires an explicit binding. The canonical
                 # fix is to route the alias through `inputs:` verbatim.
@@ -523,7 +523,12 @@ def _build_orphan_code_annotation_diagnostics(
                     f"(binds the batch alias into the code block)"
                 )
             else:
-                fix = f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}}"
+                similar = find_similar_items(key, sorted(input_keys), method="fuzzy", cutoff=0.6, max_results=3)
+                if similar:
+                    fix = f"Rename the annotation to '{similar[0]}' to match the existing input binding."
+                    context["similar_names"] = similar
+                else:
+                    fix = f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}}"
         else:
             fix = f"Remove the annotation '{key}: {annotation_str}' — it is never read in the code."
 

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -1,7 +1,8 @@
-"""Template type validation (Passes 6 and 7).
+"""Template type validation (Passes 6, 7, and 9).
 
 Pass 6: Validates template variable types match parameter expectations.
 Pass 7: Blocks structured data (dict/list) in shell command parameters.
+Pass 9: Validates code-node input annotations against template source types.
 """
 
 import re
@@ -389,6 +390,330 @@ def _generate_type_fix_suggestions(
         available_fields = [f"${{{template}.{field}}}" for field in matching_fields]
         return (suggestions, available_fields)
     return (["Access a nested field or serialize the value to JSON."], [])
+
+
+def _infer_missing_annotation_type(
+    key: str,
+    inputs: dict[str, Any],
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+) -> Optional[str]:
+    """Infer a Python-display type for a missing code-node input annotation.
+
+    Returns the inferred Python name (``"list"``, ``"dict"``, ``"str"``, …)
+    when ``inputs[key]`` is a **simple** template (``"${ref}"`` with nothing
+    else). Complex templates (``"prefix ${ref}"``) coerce to ``str`` at
+    runtime regardless of the source type, so the inferred runtime type is
+    always ``"str"`` in that case.
+
+    Returns ``None`` when the type can't be inferred — caller falls back to
+    the ``<type>`` placeholder in the suggestion.
+    """
+    from pflow.nodes.python.python_code import s1_type_to_python_display
+
+    value = inputs.get(key)
+    if not isinstance(value, str) or not TemplateResolver.has_templates(value):
+        return None
+
+    # Complex templates (text surrounding the template, or multiple templates)
+    # resolve to strings at runtime — preserve that contract in the suggestion.
+    if not TemplateResolver.is_simple_template(value):
+        return "str"
+
+    templates = TemplateResolver.extract_variables(value)
+    if not templates:
+        return None
+    for template in templates:
+        inferred = infer_template_type(template, workflow_ir, node_outputs)
+        if inferred and inferred != "any":
+            return s1_type_to_python_display(inferred)
+    return None
+
+
+def _build_missing_code_annotation_diagnostics(
+    node_id: str,
+    input_keys: set[str],
+    annotation_keys: set[str],
+    inputs: dict[str, Any],
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+) -> list[Diagnostic]:
+    """Build diagnostics for inputs that are missing code annotations.
+
+    When the upstream type can be inferred from the template binding, the
+    suggestion names a concrete annotation (``x: list``) instead of the
+    generic ``<type>`` placeholder — so agents can copy-paste the fix.
+    """
+    diagnostics: list[Diagnostic] = []
+    for key in sorted(input_keys - annotation_keys):
+        inferred_name = _infer_missing_annotation_type(key, inputs, workflow_ir, node_outputs)
+        if inferred_name is not None:
+            suggestion = f"Add an annotation (in params.code): {key}: {inferred_name}  (inferred from {inputs[key]})"
+        else:
+            suggestion = f"Add an annotation (in params.code): {key}: <type>"
+        context: dict[str, Any] = {
+            "category": "validation",
+            "path": f"nodes[id={node_id}].params.inputs.{key}",
+            "node_type": "code",
+            "input_key": key,
+        }
+        if inferred_name is not None:
+            context["inferred_type"] = inferred_name
+        diagnostics.append(
+            Diagnostic(
+                severity=Severity.ERROR,
+                source="validator",
+                title="Validation Error",
+                node_id=node_id,
+                message=f"Input '{key}' is missing a type annotation in the code block.",
+                suggestions=[suggestion],
+                context=context,
+            )
+        )
+    return diagnostics
+
+
+def _build_orphan_code_annotation_diagnostics(
+    node_id: str,
+    input_keys: set[str],
+    annotation_keys: set[str],
+    annotations: dict[str, str],
+    load_refs: set[str],
+    batch_alias: Optional[str],
+) -> list[Diagnostic]:
+    """Build diagnostics for annotations with no matching input binding.
+
+    Chooses a canonical single-fix suggestion per orphan (Task 154 pattern):
+
+    - Orphan key appears as ``ast.Name(ctx=Load())`` in the code body → the
+      author expected the variable to be bound at runtime. Canonical fix is
+      "Add to the inputs dict". Typo-level fuzzy matches against existing
+      input keys are surfaced via ``similar_names``.
+    - Orphan key has no Load reference → dead annotation. Canonical fix is
+      "Remove the annotation".
+
+    ``batch_alias`` (when present) narrows the "add to inputs" suggestion to
+    the exact source template (``${item}``) for the common batch-code pattern,
+    skipping the ``${<source>}`` placeholder.
+    """
+    from pflow.core.suggestion_utils import find_similar_items
+
+    diagnostics: list[Diagnostic] = []
+    for key in sorted(annotation_keys - input_keys):
+        annotation_str = annotations[key]
+        is_used = key in load_refs
+        context: dict[str, Any] = {
+            "category": "validation",
+            "path": f"nodes[id={node_id}].params.code",
+            "node_type": "code",
+            "annotation_key": key,
+        }
+
+        if is_used:
+            similar = find_similar_items(key, sorted(input_keys), method="fuzzy", cutoff=0.6, max_results=3)
+            if similar:
+                fix = f"Rename the annotation to '{similar[0]}' to match the existing input binding."
+                context["similar_names"] = similar
+            elif batch_alias and key == batch_alias:
+                # The engine injects the batch alias into template resolution
+                # only — code-exec requires an explicit binding. The canonical
+                # fix is to route the alias through `inputs:` verbatim.
+                fix = (
+                    f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{{key}}} "
+                    f"(binds the batch alias into the code block)"
+                )
+            else:
+                fix = f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}}"
+        else:
+            fix = f"Remove the annotation '{key}: {annotation_str}' — it is never read in the code."
+
+        diagnostics.append(
+            Diagnostic(
+                severity=Severity.ERROR,
+                source="validator",
+                title="Validation Error",
+                node_id=node_id,
+                message=f"Annotation '{key}: {annotation_str}' has no corresponding entry in 'inputs'.",
+                suggestions=[fix],
+                context=context,
+            )
+        )
+    return diagnostics
+
+
+def _build_code_annotation_type_diagnostics(
+    node_id: str,
+    workflow_ir: dict[str, Any],
+    node_outputs: dict[str, Any],
+    code: str,
+    inputs: dict[str, Any],
+    annotations: dict[str, str],
+    annotation_keys: set[str],
+) -> list[Diagnostic]:
+    """Build diagnostics for incompatible template source types."""
+    from pflow.nodes.python.python_code import (
+        _is_optional_type,
+        extract_code_annotation_type,
+        s1_type_to_python_display,
+    )
+
+    diagnostics: list[Diagnostic] = []
+    workflow_inputs = workflow_ir.get("inputs", {}) or {}
+
+    for key, value in inputs.items():
+        if key not in annotation_keys:
+            continue
+        if not isinstance(value, str):
+            continue
+        if not TemplateResolver.has_templates(value):
+            continue
+
+        annotation_str = annotations[key]
+        expected_canonical = extract_code_annotation_type(code, key)
+        if expected_canonical is None:
+            continue
+        # Preserve `| None` in the suggested annotation when the original
+        # annotation is optional — otherwise an agent copy-pasting our fix
+        # silently drops the None-tolerance the user declared.
+        annotation_is_optional = _is_optional_type(annotation_str)
+
+        for template in TemplateResolver.extract_variables(value):
+            inferred_type = infer_template_type(template, workflow_ir, node_outputs)
+            if not inferred_type or inferred_type == "any":
+                continue
+            if is_type_compatible(inferred_type, expected_canonical):
+                continue
+
+            # Display the inferred type in Python vocabulary — code-block
+            # annotations speak Python, so "x: array" in a suggestion would be
+            # invalid. Internal matrix check stays in S1 via `expected_canonical`.
+            display_inferred = s1_type_to_python_display(inferred_type)
+            display_expected = s1_type_to_python_display(expected_canonical)
+            suggested_annotation = f"{display_inferred} | None" if annotation_is_optional else display_inferred
+
+            # Tailor the "change the source" wording to the template's origin.
+            # Workflow inputs aren't "returned" by anything — telling the agent
+            # to change a non-existent upstream node wastes cycles.
+            root = TemplateResolver.extract_root_node_id(template) or template.split(".")[0]
+            if root in workflow_inputs:
+                source_fix = (
+                    f"Or change the workflow input declaration for '{root}' "
+                    f"to '- type: {display_expected}' (currently {display_inferred})"
+                )
+            else:
+                source_fix = f"Or change ${{{template}}} to return {annotation_str}"
+
+            diagnostics.append(
+                Diagnostic(
+                    severity=Severity.ERROR,
+                    source="validator",
+                    title="Validation Error",
+                    node_id=node_id,
+                    message=(
+                        f"Input '{key}' expects {annotation_str} but receives {display_inferred} from ${{{template}}}."
+                    ),
+                    suggestions=[
+                        f"Change the type annotation (in params.code): {key}: {suggested_annotation}",
+                        source_fix,
+                        f"Or accept any type (in params.code): {key}: Any",
+                    ],
+                    context={
+                        "category": "validation",
+                        "path": f"nodes[id={node_id}].params.inputs.{key}",
+                        "node_type": "code",
+                        "template": f"${{{template}}}",
+                        "input_key": key,
+                        "annotation": annotation_str,
+                        "inferred_type": display_inferred,
+                        "expected_type": display_expected,
+                    },
+                )
+            )
+
+    return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Pass 9: Code-node input annotation type matching
+# ---------------------------------------------------------------------------
+
+
+def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outputs: dict[str, Any]) -> list[Diagnostic]:
+    """Validate code-node input annotations against their template source types.
+
+    Closes the boundary between a code node's ``inputs`` mapping and its Python
+    code-block annotations:
+
+    1. Input bound but annotation missing
+    2. Annotation declared but no input bound
+    3. Annotation type incompatible with inferred template source type
+
+    Skip semantics intentionally mirror the runtime checks in
+    ``python_code.py``: unknown types and ``any`` silently skip validation.
+    """
+    # Lazy import follows the existing runtime -> nodes pattern used by the
+    # compiler for code-node annotation introspection.
+    from pflow.nodes.python.python_code import _extract_annotations, extract_code_load_references
+
+    diagnostics: list[Diagnostic] = []
+
+    for node in workflow_ir.get("nodes", []):
+        if node.get("type") != "code":
+            continue
+
+        node_id = node.get("id", "unknown")
+        params = node.get("params", {})
+        code = params.get("code")
+        inputs = params.get("inputs", {})
+
+        if not isinstance(code, str) or not isinstance(inputs, dict):
+            continue
+
+        try:
+            annotations = _extract_annotations(code)
+        except SyntaxError:
+            continue
+
+        input_keys = set(inputs.keys())
+        # `result` / `next` are outputs / routing declarations, not inputs.
+        # The batch alias (default "item") is NOT excluded here: the engine only
+        # injects it into template resolution, not into code exec. Code nodes
+        # using batch must explicitly bind `inputs: {item: ${item}}` or runtime
+        # fails with "Undefined variable 'item'". Pass 9 correctly flags the
+        # missing binding as Class 2 (orphan annotation with Load reference →
+        # "Add 'item' to the inputs dict").
+        annotation_keys = {key for key in annotations if key not in {"result", "next"}}
+        # Load references disambiguate orphan annotations: a name read in the
+        # body signals "add to inputs"; an unused annotation is dead code.
+        load_refs = extract_code_load_references(code)
+        # Batch alias is used to produce a specific `${alias}` suggestion when
+        # the orphan is the batch iteration variable.
+        batch_cfg = node.get("batch")
+        batch_alias: Optional[str] = (batch_cfg.get("as") or "item") if isinstance(batch_cfg, dict) else None
+
+        diagnostics.extend(
+            _build_missing_code_annotation_diagnostics(
+                node_id, input_keys, annotation_keys, inputs, workflow_ir, node_outputs
+            )
+        )
+        diagnostics.extend(
+            _build_orphan_code_annotation_diagnostics(
+                node_id, input_keys, annotation_keys, annotations, load_refs, batch_alias
+            )
+        )
+        diagnostics.extend(
+            _build_code_annotation_type_diagnostics(
+                node_id,
+                workflow_ir,
+                node_outputs,
+                code,
+                inputs,
+                annotations,
+                annotation_keys,
+            )
+        )
+
+    return diagnostics
 
 
 def _traverse_to_structure(structure: dict[str, Any], path: str) -> Optional[dict[str, Any]]:

--- a/src/pflow/runtime/template_validation/validator.py
+++ b/src/pflow/runtime/template_validation/validator.py
@@ -5,7 +5,7 @@ validation passes in sequence and aggregates errors/warnings.
 
 Validation passes are split by concern into separate modules:
 - path_validation: Pass 5 (path existence)
-- type_validation: Passes 6+7 (type matching, shell command types)
+- type_validation: Passes 6+7+9 (type matching, shell command types, code-node annotations)
 - batch_item_validation: Pass 8 (${item.field} validation)
 - utils: Shared infrastructure
 
@@ -26,6 +26,7 @@ from pflow.runtime.template_resolver import TemplateResolver
 from pflow.runtime.template_validation.batch_item_validation import validate_batch_item_fields
 from pflow.runtime.template_validation.path_validation import validate_template_paths
 from pflow.runtime.template_validation.type_validation import (
+    validate_code_node_input_annotations,
     validate_shell_command_types,
     validate_template_types,
 )
@@ -104,8 +105,12 @@ def validate_workflow_templates(
     unused_input_diagnostics = _validate_unused_inputs(workflow_ir, all_templates)
     diagnostics.extend(unused_input_diagnostics)
 
-    # If no templates, we can return early (after checking for unused inputs)
+    # If no templates exist anywhere in the workflow, most template passes can
+    # return early. Code-node annotation boundary checks still need to run,
+    # because "input missing annotation" / "orphan annotation" are meaningful
+    # even when inputs are literals or empty.
     if not all_templates:
+        diagnostics.extend(validate_code_node_input_annotations(workflow_ir, {}))
         return diagnostics
 
     # Get full output structure from nodes
@@ -126,6 +131,9 @@ def validate_workflow_templates(
 
     # Pass 8: Validate batch item field access (${item.field} against inferred structure)
     diagnostics.extend(validate_batch_item_fields(workflow_ir, node_outputs))
+
+    # Pass 9: Validate code-node input annotations against upstream template types
+    diagnostics.extend(validate_code_node_input_annotations(workflow_ir, node_outputs))
 
     errors = [d for d in diagnostics if d.severity == Severity.ERROR]
     warnings = [d for d in diagnostics if d.severity != Severity.ERROR]
@@ -401,6 +409,19 @@ def extract_node_outputs(
         # Check for batch configuration
         batch_config = node.get("batch")
 
+        # Pre-compute code-node annotations so both batch and non-batch output
+        # registration can enrich the `result` type uniformly.
+        code_annotations: Optional[dict[str, str]] = None
+        if node_type == "code":
+            code_param = node.get("params", {}).get("code")
+            if isinstance(code_param, str):
+                from pflow.nodes.python.python_code import _extract_annotations
+
+                try:
+                    code_annotations = _extract_annotations(code_param)
+                except SyntaxError:
+                    code_annotations = None
+
         if batch_config:
             # Batch node: register batch outputs instead of normal outputs
             _register_batch_outputs(
@@ -410,11 +431,19 @@ def extract_node_outputs(
                 enable_namespacing,
                 registry,
                 error_handling=batch_config.get("error_handling", "fail_fast"),
+                code_annotations=code_annotations,
             )
             _register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
         else:
             # Non-batch node: extract outputs from registry interface
-            _register_node_outputs_from_registry(node_outputs, node_id, node_type, enable_namespacing, registry)
+            _register_node_outputs_from_registry(
+                node_outputs,
+                node_id,
+                node_type,
+                enable_namespacing,
+                registry,
+                code_annotations=code_annotations,
+            )
 
     return node_outputs
 
@@ -618,6 +647,28 @@ def _get_inner_outputs_from_registry(node_type: str, registry: Registry) -> dict
     return inner_outputs
 
 
+def _enrich_code_result_output_type(
+    output_key: str,
+    output_info: dict[str, Any],
+    code_annotations: Optional[dict[str, str]],
+) -> dict[str, Any]:
+    """Override code-node `result` output type from its annotation when known."""
+    if not code_annotations or output_key != "result" or output_info.get("type") != "any":
+        return output_info
+
+    from pflow.nodes.python.python_code import _get_outer_type_name
+
+    annotation_str = code_annotations.get("result")
+    if not annotation_str:
+        return output_info
+
+    enriched_type = _get_outer_type_name(annotation_str)
+    if enriched_type is None:
+        return output_info
+
+    return {**output_info, "type": enriched_type}
+
+
 def _register_batch_outputs(
     node_outputs: dict[str, Any],
     node_id: str,
@@ -627,6 +678,7 @@ def _register_batch_outputs(
     inner_outputs_override: Optional[dict[str, Any]] = None,
     skip_results_structure: bool = False,
     error_handling: str = "fail_fast",
+    code_annotations: Optional[dict[str, str]] = None,
 ) -> None:
     """Register batch-specific outputs for a node with batch configuration.
 
@@ -653,6 +705,12 @@ def _register_batch_outputs(
         inner_outputs_structure = inner_outputs_override
     else:
         inner_outputs_structure = _get_inner_outputs_from_registry(node_type, registry)
+
+    if code_annotations and node_type == "code" and "result" in inner_outputs_structure:
+        inner_outputs_structure = {
+            **inner_outputs_structure,
+            "result": _enrich_code_result_output_type("result", inner_outputs_structure["result"], code_annotations),
+        }
 
     for output in BATCH_OUTPUTS:
         key = output["key"]
@@ -697,6 +755,7 @@ def _register_node_outputs_from_registry(
     node_type: str,
     enable_namespacing: bool,
     registry: Registry,
+    code_annotations: Optional[dict[str, str]] = None,
 ) -> None:
     """Register outputs from registry interface metadata for non-batch nodes.
 
@@ -719,18 +778,9 @@ def _register_node_outputs_from_registry(
     # Extract outputs with full structure
     for output in interface["outputs"]:
         if isinstance(output, str):
-            # Simple format: just the key, no structure
-            output_info = {"type": "any", "node_id": node_id, "node_type": node_type}
-
-            # Register under original key for backward compatibility
-            node_outputs[output] = output_info
-
-            # If namespacing is enabled, also register under node_id.output
-            if enable_namespacing:
-                namespaced_key = f"{node_id}.{output}"
-                node_outputs[namespaced_key] = output_info
+            key = output
+            output_info: dict[str, Any] = {"type": "any", "node_id": node_id, "node_type": node_type}
         else:
-            # Rich format: includes type and structure
             key = output["key"]
             output_info = {
                 "type": output.get("type", "any"),
@@ -739,10 +789,10 @@ def _register_node_outputs_from_registry(
                 "node_type": node_type,
             }
 
-            # Register under original key for backward compatibility
-            node_outputs[key] = output_info
+        output_info = _enrich_code_result_output_type(key, output_info, code_annotations)
 
-            # If namespacing is enabled, also register under node_id.output
-            if enable_namespacing:
-                namespaced_key = f"{node_id}.{key}"
-                node_outputs[namespaced_key] = output_info
+        node_outputs[key] = output_info
+
+        if enable_namespacing:
+            namespaced_key = f"{node_id}.{key}"
+            node_outputs[namespaced_key] = output_info

--- a/tests/test_docs/test_example_validation.py
+++ b/tests/test_docs/test_example_validation.py
@@ -151,6 +151,7 @@ class TestExampleValidation:
         if not invalid_workflow_files:
             pytest.skip("No invalid example files found")
 
+        registry = Registry()
         unexpected_passes = []
         for pflow_file in invalid_workflow_files:
             try:
@@ -159,8 +160,20 @@ class TestExampleValidation:
                 ir_data = result.ir
                 normalize_ir(ir_data)
                 validate_ir(ir_data)
-                # If we get here, the file unexpectedly passed
-                unexpected_passes.append(pflow_file.name)
+
+                dummy_params = generate_dummy_parameters(ir_data.get("inputs", {}))
+                dummy_params["_pflow_workflow_file"] = str(pflow_file)
+                resolve_file_references(ir_data, get_base_dir(dummy_params))
+
+                diagnostics = WorkflowValidator.validate(
+                    ir_data,
+                    extracted_params=dummy_params,
+                    registry=registry,
+                    workflow_file=pflow_file,
+                )
+                errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+                if not errors:
+                    unexpected_passes.append(pflow_file.name)
             except (MarkdownParseError, SchemaValidationError, ValueError):
                 pass  # Expected - invalid examples should fail
 

--- a/tests/test_integration/test_code_annotation_validation.py
+++ b/tests/test_integration/test_code_annotation_validation.py
@@ -1,0 +1,145 @@
+"""End-to-end validation of code-node input annotation checking."""
+
+from pathlib import Path
+
+import pytest
+
+from pflow.execution.result import RunnerConfig
+from pflow.execution.runner import WorkflowRunner
+
+
+def _write_t1_workflow(tmp_path: Path) -> Path:
+    """Write the mismatch probe used for validate-time coverage."""
+    path = tmp_path / "t1.pflow.md"
+    path.write_text(
+        """# T1
+Upstream code node produces list. Downstream annotates dict.
+
+## Steps
+
+### upstream
+
+Produces a list.
+
+- type: code
+
+```python code
+result: list = [1, 2, 3]
+```
+
+### downstream
+
+Annotates dict but upstream is list.
+
+- type: code
+- inputs:
+    x: ${upstream.result}
+
+```python code
+x: dict
+result: str = str(x)
+```
+
+## Outputs
+
+### final
+Final result.
+- source: ${downstream.result}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_valid_workflow(tmp_path: Path) -> Path:
+    """Write a matching variant for the positive path."""
+    path = tmp_path / "valid.pflow.md"
+    path.write_text(
+        """# Valid
+Upstream code node produces list. Downstream annotates list.
+
+## Steps
+
+### upstream
+
+Produces a list.
+
+- type: code
+
+```python code
+result: list = [1, 2, 3]
+```
+
+### downstream
+
+Annotates list and matches upstream.
+
+- type: code
+- inputs:
+    x: ${upstream.result}
+
+```python code
+x: list
+result: str = str(x)
+```
+
+## Outputs
+
+### final
+Final result.
+- source: ${downstream.result}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_t1_validate_only_catches_type_mismatch(tmp_path: Path) -> None:
+    """Validate-only should catch the mismatch before execution."""
+    path = _write_t1_workflow(tmp_path)
+    validation = WorkflowRunner().validate(str(path), params={})
+
+    assert not validation.valid
+    assert any("expects dict" in diagnostic.message for diagnostic in validation.errors), [
+        diagnostic.message for diagnostic in validation.errors
+    ]
+
+
+def test_valid_workflow_passes_validation_and_runs(tmp_path: Path) -> None:
+    """Matching annotations should pass both validation and execution."""
+    path = _write_valid_workflow(tmp_path)
+    runner = WorkflowRunner()
+
+    validation = runner.validate(str(path), params={})
+    assert validation.valid, [diagnostic.message for diagnostic in validation.errors]
+
+    result = runner.run(str(path), {}, RunnerConfig())
+    assert result.success, [diagnostic.message for diagnostic in result.diagnostics]
+
+
+def test_runtime_still_defends_when_validation_bypassed() -> None:
+    """Direct compile+run still fails at runtime when validation is skipped."""
+    from pflow.runtime import WorkflowEngine, compile_workflow
+    from tests.shared.registry_utils import ensure_test_registry
+
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "upstream", "type": "code", "params": {"code": "result: list = [1, 2, 3]"}},
+            {
+                "id": "downstream",
+                "type": "code",
+                "params": {
+                    "code": "x: dict\nresult: str = str(x)",
+                    "inputs": {"x": "${upstream.result}"},
+                },
+            },
+        ],
+        "edges": [{"from": "upstream", "to": "downstream"}],
+    }
+
+    registry = ensure_test_registry()
+    workflow = compile_workflow(ir, registry=registry, initial_params={})
+
+    with pytest.raises(TypeError, match=r"expects dict"):
+        WorkflowEngine().run(workflow, {})

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -17,6 +17,7 @@ from pflow.nodes.python.python_code import (
     extract_code_annotation_type,
     extract_code_load_references,
     extract_optional_input_keys,
+    extract_top_level_annotations,
     s1_type_to_python_display,
 )
 
@@ -473,6 +474,54 @@ class TestAnnotationExtractionHelper:
         assert _get_outer_type("'list'") is list
         assert _get_outer_type('"dict"') is dict
         assert _get_outer_type("'list[dict]'") is list
+
+    def test_top_level_annotations_excludes_function_locals(self):
+        """Function-local annotations must not surface at module scope."""
+        code = """
+def helper():
+    y: int = 1
+    return y
+
+x: dict
+result: int = helper()
+"""
+        annotations = extract_top_level_annotations(code)
+        assert annotations == {"x": "dict", "result": "int"}
+        assert "y" not in annotations
+
+    def test_top_level_annotations_excludes_class_body(self):
+        """Class body annotations must not surface at module scope."""
+        code = """
+class Config:
+    timeout: int
+    name: str
+
+x: dict
+"""
+        annotations = extract_top_level_annotations(code)
+        assert annotations == {"x": "dict"}
+        assert "timeout" not in annotations
+        assert "name" not in annotations
+
+    def test_top_level_annotations_includes_if_scoped(self):
+        """Non-scope structures (if/for/while) don't hide module-level annotations."""
+        code = """
+import os
+if os.environ.get("FLAG"):
+    y: int = 1
+else:
+    y: str = "2"
+
+x: dict
+"""
+        annotations = extract_top_level_annotations(code)
+        # `y` appears twice at module scope (one branch of `if`); last-write wins.
+        # The important fact: `y` is included because `if` is not a scope boundary.
+        assert "x" in annotations
+        assert "y" in annotations
+
+    def test_top_level_annotations_malformed_returns_empty(self):
+        assert extract_top_level_annotations("x: dict =") == {}
 
     def test_literal_in_annotation_rejected_with_import_hint(self):
         """Literal (no modern alternative) should be rejected at prep with an import hint."""

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -523,6 +523,23 @@ x: dict
     def test_top_level_annotations_malformed_returns_empty(self):
         assert extract_top_level_annotations("x: dict =") == {}
 
+    def test_python_to_s1_canonical_is_injective(self):
+        """Reverse mapping from S1 to Python requires injectivity.
+
+        `_S1_TO_PYTHON_DISPLAY` is built by reversing `_PYTHON_TO_S1_CANONICAL`.
+        A future edit that maps two Python names to the same S1 name would
+        silently drop one on the reverse. The module-load assertion guards
+        against this; this test pins the invariant for explicit coverage.
+        """
+        from pflow.nodes.python import python_code
+
+        forward = python_code._PYTHON_TO_S1_CANONICAL
+        reverse = python_code._S1_TO_PYTHON_DISPLAY
+        assert len(reverse) == len(forward), (
+            f"Forward map has {len(forward)} entries, reverse has {len(reverse)} — "
+            "PYTHON_ALIASES_AT_S1 must be injective for diagnostic display to round-trip"
+        )
+
     def test_literal_in_annotation_rejected_with_import_hint(self):
         """Literal (no modern alternative) should be rejected at prep with an import hint."""
         shared: dict = {}

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -12,8 +12,12 @@ from pflow.nodes.python.python_code import (
     _extract_error_location,
     _get_inner_optional_type,
     _get_outer_type,
+    _get_outer_type_name,
     _is_optional_type,
+    extract_code_annotation_type,
+    extract_code_load_references,
     extract_optional_input_keys,
+    s1_type_to_python_display,
 )
 
 
@@ -177,6 +181,22 @@ class TestTypeAnnotationContract:
         error = str(exc_info.value)
         assert "Suggestions:" in error
         assert "data: list" in error
+
+    def test_forward_reference_annotation_enforced_at_runtime(self):
+        """Forward-ref `x: "dict"` must enforce isinstance, not silently accept.
+
+        Pre-fix: `_get_outer_type("'dict'")` returned None (lookup miss on
+        quoted string), runtime skipped the isinstance check, wrong-typed
+        values passed through. Post-fix: forward refs are unwrapped and
+        enforced identically to bare annotations.
+        """
+        shared: dict = {}
+        with pytest.raises(TypeError, match=r"x.*expects .*dict.*received list"):
+            run_code_node(
+                shared,
+                code='x: "dict"\nresult: str = str(x)',
+                inputs={"x": [1, 2, 3]},
+            )
 
     def test_generic_type_validates_outer_only(self):
         """list[dict] checks isinstance(value, list), ignores element types.
@@ -357,6 +377,102 @@ class TestSafetyAndErrors:
         assert "PEP 585" in msg
         # Opinionated: List does NOT suggest `from typing import List` — lowercase is canonical.
         assert "from typing import List" not in msg
+
+
+class TestAnnotationExtractionHelper:
+    """Validate the shared helper used by validate-time type checking."""
+
+    def test_get_outer_type_name_returns_s1_canonical(self):
+        assert _get_outer_type_name("list") == "array"
+        assert _get_outer_type_name("dict") == "object"
+        assert _get_outer_type_name("str") == "string"
+        assert _get_outer_type_name("int") == "integer"
+        assert _get_outer_type_name("float") == "number"
+        assert _get_outer_type_name("bool") == "boolean"
+
+    def test_get_outer_type_name_strips_generics(self):
+        assert _get_outer_type_name("list[dict]") == "array"
+        assert _get_outer_type_name("dict[str, int]") == "object"
+
+    def test_get_outer_type_name_decomposes_optional(self):
+        assert _get_outer_type_name("str | None") == "string"
+        assert _get_outer_type_name("None | list") == "array"
+        assert _get_outer_type_name("Optional[dict]") == "object"
+
+    def test_get_outer_type_name_unknown_returns_none(self):
+        assert _get_outer_type_name("Any") is None
+        assert _get_outer_type_name("DataFrame") is None
+        assert _get_outer_type_name("set") is None
+        assert _get_outer_type_name("tuple") is None
+        assert _get_outer_type_name("bytes") is None
+
+    def test_extract_code_annotation_type_happy_path(self):
+        code = "x: list\ny: dict\nresult: str = str(x)"
+        assert extract_code_annotation_type(code, "x") == "array"
+        assert extract_code_annotation_type(code, "y") == "object"
+
+    def test_extract_code_annotation_type_missing_key(self):
+        assert extract_code_annotation_type("x: list", "missing") is None
+
+    def test_extract_code_annotation_type_malformed_code(self):
+        assert extract_code_annotation_type("x: dict =", "x") is None
+
+    def test_s1_to_python_display_reverses_canonical(self):
+        assert s1_type_to_python_display("array") == "list"
+        assert s1_type_to_python_display("object") == "dict"
+        assert s1_type_to_python_display("string") == "str"
+        assert s1_type_to_python_display("integer") == "int"
+        assert s1_type_to_python_display("number") == "float"
+        assert s1_type_to_python_display("boolean") == "bool"
+
+    def test_s1_to_python_display_passes_through_python_names(self):
+        """Already-Python names (e.g. registry-declared 'str') pass through."""
+        assert s1_type_to_python_display("str") == "str"
+        assert s1_type_to_python_display("list") == "list"
+        assert s1_type_to_python_display("any") == "any"
+
+    def test_s1_to_python_display_handles_unions(self):
+        assert s1_type_to_python_display("array|string") == "list|str"
+        assert s1_type_to_python_display("dict|str") == "dict|str"
+
+    def test_load_references_finds_reads_in_body(self):
+        code = "x: list\ny: dict\nresult: int = len(x)"
+        refs = extract_code_load_references(code)
+        # `x` is read; `y` is only annotated; `len` is a builtin read; `result` is Store.
+        assert "x" in refs
+        assert "y" not in refs
+        assert "len" in refs
+        assert "result" not in refs
+
+    def test_load_references_handles_nested_scopes(self):
+        code = "x: list\ndef inner():\n    return x\nresult: int = inner()"
+        refs = extract_code_load_references(code)
+        assert "x" in refs
+        assert "inner" in refs
+
+    def test_load_references_malformed_code_returns_empty(self):
+        assert extract_code_load_references("x: dict =") == set()
+
+    def test_get_outer_type_name_unwraps_forward_ref(self):
+        """Forward-ref annotations (`x: "list"`) come through as `"'list'"` via ast.unparse.
+
+        Without unwrap, validate-time silently skips — hiding real type mismatches.
+        """
+        assert _get_outer_type_name("'list'") == "array"
+        assert _get_outer_type_name('"dict"') == "object"
+        assert _get_outer_type_name("'list[dict]'") == "array"
+        # Still returns None for unknown types inside quotes.
+        assert _get_outer_type_name("'DataFrame'") is None
+
+    def test_get_outer_type_unwraps_forward_ref(self):
+        """Runtime isinstance check must also see through forward-ref quotes.
+
+        Pre-fix: `x: "dict" = [1,2,3]` silently accepted the list.
+        Post-fix: runtime raises TypeError, matching the bare-annotation behavior.
+        """
+        assert _get_outer_type("'list'") is list
+        assert _get_outer_type('"dict"') is dict
+        assert _get_outer_type("'list[dict]'") is list
 
     def test_literal_in_annotation_rejected_with_import_hint(self):
         """Literal (no modern alternative) should be rejected at prep with an import hint."""

--- a/tests/test_runtime/test_template_validation/test_type_checker.py
+++ b/tests/test_runtime/test_template_validation/test_type_checker.py
@@ -299,3 +299,47 @@ class TestParameterTypeLookup:
 
         param_type = get_parameter_type("no-type-node", "value", mock_registry)
         assert param_type == "any"
+
+
+class TestInferTemplateTypeBatchIndexedAccess:
+    """Verify infer_template_type descends into batch item structure on indexed paths.
+
+    Pre-fix behavior: ``${node.results[0].field}`` returned ``None`` — Pass 6/9
+    silently skipped type checking through batch outputs. Post-fix: traversal
+    mirrors path_validation.py::_validate_array_access, using
+    ``output_info["items"]`` as the structure source for indexed base parts.
+    """
+
+    @pytest.fixture
+    def batch_node_outputs(self):
+        """Build node_outputs with a batch output carrying a typed inner result."""
+        return {
+            "batch_node.results": {
+                "type": "array",
+                "node_id": "batch_node",
+                "node_type": "code",
+                "is_batch_output": True,
+                "items": {
+                    "type": "dict",
+                    "structure": {
+                        "item": {"type": "any", "description": "Original batch input"},
+                        "result": {"type": "array", "structure": {}},
+                        "stdout": {"type": "str", "structure": {}},
+                    },
+                },
+            },
+        }
+
+    def test_indexed_access_returns_inner_type(self, batch_node_outputs):
+        workflow_ir = {"nodes": [{"id": "batch_node", "type": "code"}], "enable_namespacing": True}
+        assert infer_template_type("batch_node.results[0].result", workflow_ir, batch_node_outputs) == "array"
+        assert infer_template_type("batch_node.results[0].stdout", workflow_ir, batch_node_outputs) == "str"
+
+    def test_indexed_access_unknown_field_returns_none(self, batch_node_outputs):
+        workflow_ir = {"nodes": [{"id": "batch_node", "type": "code"}], "enable_namespacing": True}
+        assert infer_template_type("batch_node.results[0].nonexistent", workflow_ir, batch_node_outputs) is None
+
+    def test_non_indexed_access_still_returns_array_type(self, batch_node_outputs):
+        """Access to the `.results` array itself (no index) returns the top-level `array` type."""
+        workflow_ir = {"nodes": [{"id": "batch_node", "type": "code"}], "enable_namespacing": True}
+        assert infer_template_type("batch_node.results", workflow_ir, batch_node_outputs) == "array"

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -98,6 +98,22 @@ def test_registry(tmp_path):
                 ],
             },
         },
+        "code": {
+            "class_name": "PythonCodeNode",
+            "module": "pflow.nodes.python.python_code",
+            "interface": {
+                "outputs": [
+                    {"key": "result", "type": "any", "description": "Value of result variable after execution"},
+                    {"key": "stdout", "type": "str", "description": "Captured print output"},
+                    {"key": "stderr", "type": "str", "description": "Captured stderr output"},
+                ],
+                "params": [
+                    {"key": "code", "type": "str", "description": "Python code to execute"},
+                    {"key": "inputs", "type": "dict", "description": "Variable name to value mapping"},
+                    {"key": "timeout", "type": "int", "description": "Execution timeout in seconds"},
+                ],
+            },
+        },
         "list-producer": {
             "class_name": "ListProducer",
             "module": "test",
@@ -1264,3 +1280,607 @@ def test_shell_blocks_multiple_structured_templates_preserves_structure(test_reg
     assert len(diagnostic.suggestions) == 4
     assert any("stdin" in suggestion for suggestion in diagnostic.suggestions)
     assert any("temp files" in suggestion for suggestion in diagnostic.suggestions)
+
+
+class TestCodeNodeInputAnnotationValidation:
+    """Pass 9 validates code-node inputs against code-block annotations."""
+
+    def test_dict_annotation_rejects_list_upstream(self, test_registry):
+        """Annotation `x: dict` with upstream `list` fires a type-mismatch error."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict\nresult: str = str(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "expects dict" in d.message]
+        assert len(annotation_errors) == 1, [d.message for d in errors]
+
+        diagnostic = annotation_errors[0]
+        assert diagnostic.node_id == "consumer"
+        assert diagnostic.context["path"] == "nodes[id=consumer].params.inputs.x"
+        assert diagnostic.context["annotation"] == "dict"
+        # Both inferred and expected types are Python vocabulary for consistency:
+        # agents consuming JSON can compare them directly without crossing the
+        # S1/Python bridge.
+        assert diagnostic.context["inferred_type"] == "list"
+        assert diagnostic.context["expected_type"] == "dict"
+        assert diagnostic.context["template"] == "${producer.items}"
+        assert diagnostic.suggestions is not None
+        assert len(diagnostic.suggestions) == 3
+        # Locality hints tell the agent which file/section each fix applies to.
+        assert any("params.code" in s and "x: list" in s for s in diagnostic.suggestions), diagnostic.suggestions
+        assert any("${producer.items}" in s for s in diagnostic.suggestions), diagnostic.suggestions
+        assert any("params.code" in s and "x: Any" in s for s in diagnostic.suggestions), diagnostic.suggestions
+
+    def test_compatible_types_pass(self, test_registry):
+        """Matching annotation and upstream type produces no diagnostic."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: list\nresult: int = len(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "expects" in d.message and "receives" in d.message]
+        assert annotation_errors == []
+
+    def test_missing_annotation_fires_and_infers_type(self, test_registry):
+        """Input bound but no annotation — suggestion includes the inferred upstream type."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "result: str = 'hi'",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "missing a type annotation" in d.message]
+        assert len(annotation_errors) == 1
+        diagnostic = annotation_errors[0]
+        assert diagnostic.context["input_key"] == "x"
+        # The upstream is a typed list — suggestion should offer the concrete
+        # annotation instead of a `<type>` placeholder so agents can copy-paste.
+        assert diagnostic.context["inferred_type"] == "list"
+        assert diagnostic.suggestions is not None
+        assert any("x: list" in s and "inferred from" in s for s in diagnostic.suggestions), diagnostic.suggestions
+        assert not any("<type>" in s for s in diagnostic.suggestions)
+
+    def test_missing_annotation_falls_back_when_type_unknown(self, test_registry):
+        """When upstream type can't be inferred (literal value), suggestion keeps <type> placeholder."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "result: str = 'hi'",
+                        "inputs": {"x": "literal-value"},  # no template, no source to infer from
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "missing a type annotation" in d.message]
+        assert len(annotation_errors) == 1
+        diagnostic = annotation_errors[0]
+        assert "inferred_type" not in diagnostic.context
+        assert any("<type>" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+
+    def test_missing_annotation_complex_template_infers_str(self, test_registry):
+        """Complex template (text + ref) coerces to str at runtime — infer str, not the source type.
+
+        Runtime concatenates ``"prefix ${source}"`` into a string regardless of
+        what ``source`` declares. The suggestion must reflect the runtime
+        contract: ``x: str``, not ``x: list``.
+        """
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "result: str = x",
+                        "inputs": {"x": "prefix ${producer.items}"},  # complex — coerces to str
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "missing a type annotation" in d.message]
+        assert len(annotation_errors) == 1
+        diagnostic = annotation_errors[0]
+        assert diagnostic.context["inferred_type"] == "str"
+        assert any("x: str" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+        # Must NOT suggest the source type (list) — that's wrong for complex templates.
+        assert not any("x: list" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+
+    def test_orphan_annotation_unused_suggests_removal(self, test_registry):
+        """Orphan annotation with no Load reference is dead code — canonical fix is remove."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        # y is annotated but never read in the body — pure dead code.
+                        "code": "x: dict\ny: list\nresult: str = 'hi'",
+                        "inputs": {"x": "literal_value"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
+        assert len(annotation_errors) == 1
+        diagnostic = annotation_errors[0]
+        assert diagnostic.context["annotation_key"] == "y"
+        assert diagnostic.suggestions is not None
+        # Opinionated one-fix-per-case — "Remove" is the canonical answer here.
+        assert any("Remove" in s and "never read" in s for s in diagnostic.suggestions), diagnostic.suggestions
+        assert not any("Add" in s for s in diagnostic.suggestions), diagnostic.suggestions
+
+    def test_orphan_annotation_used_suggests_adding_to_inputs(self, test_registry):
+        """Orphan annotation read in the body signals missing binding — canonical fix is add."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        # y has annotation AND is read later — author expected it bound.
+                        "code": "x: dict\ny: list\nresult: int = len(y)",
+                        "inputs": {"x": "literal_value"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
+        assert len(annotation_errors) == 1
+        diagnostic = annotation_errors[0]
+        assert any("Add 'y' to the inputs dict" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+        assert not any("Remove" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+
+    def test_orphan_annotation_typo_surfaces_fuzzy_match(self, test_registry):
+        """Typo'd orphan (read in body) surfaces fuzzy-matched input key via similar_names."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        # Annotation is `item` (typo); input binding is `items`.
+                        # Body reads `item` so it's a used-orphan; fuzzy match finds `items`.
+                        "code": "items: list\nitem: dict\nresult: int = len(item)",
+                        "inputs": {"items": "literal_value"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
+        assert len(annotation_errors) == 1
+        diagnostic = annotation_errors[0]
+        assert diagnostic.context.get("similar_names") == ["items"]
+        assert any("Rename" in s and "items" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+
+    def test_result_and_next_are_not_flagged_as_orphan(self, test_registry):
+        """`result` and `next` are routing/output annotations, not input orphans."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "router",
+                    "type": "code",
+                    "params": {
+                        "code": "next: str = 'target'\nresult: str = 'done'",
+                        "inputs": {},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("no corresponding entry" in d.message for d in errors)
+
+    def test_any_annotation_skips_check(self, test_registry):
+        """`x: Any` accepts any upstream type."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: Any\nresult: str = str(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("expects" in d.message and "receives" in d.message for d in errors)
+
+    def test_optional_annotation_decomposes_correctly(self, test_registry):
+        """`x: list | None` is compatible with upstream `list`."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: list | None\nresult: str = str(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("expects" in d.message and "receives" in d.message for d in errors)
+
+    def test_user_defined_class_skips_check(self, test_registry):
+        """Unknown/user-defined annotations skip validate-time type checking."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: DataFrame\nresult: str = str(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("expects DataFrame" in d.message for d in errors)
+
+    def test_code_to_code_chain_catches_mismatch(self, test_registry):
+        """Code -> code mismatch is visible once upstream result typing is enriched."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "upstream",
+                    "type": "code",
+                    "params": {"code": "result: list = [1, 2, 3]"},
+                },
+                {
+                    "id": "downstream",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict\nresult: str = str(x)",
+                        "inputs": {"x": "${upstream.result}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "upstream", "to": "downstream"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "Input 'x' expects dict" in d.message]
+        assert len(annotation_errors) == 1, [d.message for d in errors]
+
+        # Code-block annotations are Python — display must speak Python too.
+        # "x: array" is invalid Python; a user copy-pasting it gets a NameError.
+        diagnostic = annotation_errors[0]
+        assert "receives list" in diagnostic.message, diagnostic.message
+        assert "array" not in diagnostic.message
+        assert diagnostic.context["inferred_type"] == "list"
+        assert diagnostic.suggestions is not None
+        assert any("x: list" in s for s in diagnostic.suggestions), diagnostic.suggestions
+        assert not any("x: array" in s for s in diagnostic.suggestions)
+
+    def test_malformed_code_skips_pass(self, test_registry):
+        """SyntaxError in code skips Pass 9 entirely — runtime surfaces the error.
+
+        Pass 9 must not crash or emit spurious Class 1/2/3 errors on unparseable
+        code; the SyntaxError is the user's primary concern and runtime will
+        report it with a clean line number. Validate-time emitting additional
+        diagnostics here would obscure the real issue.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict =",  # SyntaxError — no RHS
+                        "inputs": {"x": "literal"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        # Pass 9 must not emit its three error classes on unparseable code.
+        pass_9_markers = (
+            "expects",
+            "missing a type annotation",
+            "has no corresponding entry",
+        )
+        pass_9_errors = [d for d in errors if any(marker in d.message for marker in pass_9_markers)]
+        assert pass_9_errors == [], [d.message for d in pass_9_errors]
+
+    def test_literal_values_skipped(self, test_registry):
+        """Literal string values stay out of Pass 9 scope."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict\nresult: str = str(x)",
+                        "inputs": {"x": "hello"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("expects dict" in d.message and "receives" in d.message for d in errors)
+
+    def test_batch_code_node_result_enrichment_catches_downstream_mismatch(self, test_registry):
+        """Batch code-node `result:` annotation enriches inner output type.
+
+        Exercises `_register_batch_outputs`'s enrichment path: a batch code node
+        with `result: list` should produce `results[*].result` with enriched type
+        `array`, so a downstream consumer declaring `x: dict` bound to the
+        indexed path fails validation with the correct type mismatch.
+
+        The batch producer uses the canonical pattern ``inputs: {item: ${item}}``
+        — the engine only injects the batch alias into template resolution,
+        not into code exec, so the binding is required for the `item` load
+        reference inside the code body.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batch_producer",
+                    "type": "code",
+                    "params": {
+                        "code": "item: any\nresult: list = [item]",
+                        "inputs": {"item": "${item}"},
+                    },
+                    "batch": {"items": ["a", "b"], "error_handling": "fail_fast"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict\nresult: str = str(x)",
+                        "inputs": {"x": "${batch_producer.results[0].result}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "batch_producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [d for d in errors if "Input 'x' expects dict" in d.message]
+        assert len(annotation_errors) == 1, [d.message for d in errors]
+        diagnostic = annotation_errors[0]
+        # Batch enrichment produces S1 `array` internally → displayed as `list`.
+        assert "receives list" in diagnostic.message, diagnostic.message
+        assert any("x: list" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
+
+    def test_workflow_input_source_suggestion_wording(self, test_registry):
+        """Workflow-input templates shouldn't suggest 'change X to return Y' — X isn't returned by anything.
+
+        Points the agent at the declared input's type instead.
+        """
+        workflow_ir = {
+            "inputs": {
+                "data": {"type": "array", "required": True},
+            },
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict\nresult: str = str(x)",
+                        "inputs": {"x": "${data}"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Input 'x' expects dict" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        suggestions = ann_errors[0].suggestions or []
+        # Must reference the workflow input declaration, not "change to return".
+        assert any("workflow input declaration for 'data'" in s and "- type: dict" in s for s in suggestions), (
+            suggestions
+        )
+        assert not any("return dict" in s for s in suggestions), suggestions
+
+    def test_optional_annotation_preserved_in_suggestion(self, test_registry):
+        """`x: dict | None` mismatch must suggest `x: list | None`, not strip the `| None`."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict | None\nresult: str = str(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Input 'x'" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        suggestions = ann_errors[0].suggestions or []
+        # Preserves the user's Optional semantics.
+        assert any("x: list | None" in s for s in suggestions), suggestions
+        # Must NOT suggest bare `x: list` (would silently drop None-tolerance).
+        assert not any(s.endswith("x: list") or s.endswith("x: list\n") for s in suggestions), suggestions
+
+    def test_optional_typing_form_also_preserved(self, test_registry):
+        """`x: Optional[dict]` mismatch suggests `x: list | None` (modernized)."""
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "x: Optional[dict]\nresult: str = str(x)",
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Input 'x'" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        suggestions = ann_errors[0].suggestions or []
+        assert any("x: list | None" in s for s in suggestions), suggestions
+
+    def test_batch_orphan_suggests_alias_not_placeholder(self, test_registry):
+        """Missing-inputs.item binding for a batch code node suggests `${item}` literally, not `${<source>}`."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batched",
+                    "type": "code",
+                    "params": {"code": "item: int\nresult: int = item * 2"},
+                    "batch": {"items": [1, 2, 3]},
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "no corresponding entry" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        suggestions = ann_errors[0].suggestions or []
+        # Tells the agent the exact binding, not `${<source>}`.
+        assert any("item: ${item}" in s for s in suggestions), suggestions
+        assert not any("${<source>}" in s for s in suggestions), suggestions
+
+    def test_batch_orphan_with_custom_alias_uses_that_alias(self, test_registry):
+        """Custom batch.as='row' produces 'row: ${row}' in the suggestion."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batched",
+                    "type": "code",
+                    "params": {"code": "row: int\nresult: int = row * 2"},
+                    "batch": {"items": [1, 2, 3], "as": "row"},
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "no corresponding entry" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        suggestions = ann_errors[0].suggestions or []
+        assert any("row: ${row}" in s for s in suggestions), suggestions
+
+    def test_forward_reference_annotation_type_checked(self, test_registry):
+        """Forward-ref `x: "dict"` must be unwrapped so Pass 9 sees the inner type.
+
+        Pre-fix: ast.unparse preserves quotes, the lookup missed, and the
+        mismatch silently passed validation AND runtime. Both layers now see
+        through the quotes.
+        """
+        workflow_ir = {
+            "nodes": [
+                {"id": "producer", "type": "list-producer", "params": {}},
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": 'x: "dict"\nresult: str = str(x)',
+                        "inputs": {"x": "${producer.items}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "producer", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Input 'x' expects" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+
+    def test_batch_code_without_item_input_flags_orphan(self, test_registry):
+        """Batch code node referencing `item` without `inputs.item` is a real runtime bug.
+
+        Runtime doesn't auto-inject the batch alias into code exec — only
+        template resolution. Pass 9 must flag the missing binding as an orphan
+        annotation so the user gets the fix at validate-time rather than
+        "Undefined variable 'item'" at runtime.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batched",
+                    "type": "code",
+                    "params": {"code": "item: int\nresult: int = item * 2"},
+                    "batch": {"items": [1, 2, 3]},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        orphan_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
+        assert len(orphan_errors) == 1, [d.message for d in errors]
+        diagnostic = orphan_errors[0]
+        assert diagnostic.context["annotation_key"] == "item"
+        # `item` is read in the body → canonical fix is "Add to the inputs dict".
+        assert any("Add 'item' to the inputs dict" in s for s in diagnostic.suggestions or []), diagnostic.suggestions

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1686,8 +1686,13 @@ class TestCodeNodeInputAnnotationValidation:
                 {
                     "id": "batch_producer",
                     "type": "code",
+                    # `item: Any` (capitalized) — pflow auto-injects typing.Any.
+                    # Lowercase `any` is the builtin function, not a type; it
+                    # passes validation here only because _get_outer_type_name
+                    # returns None for unknown names, which is a readability
+                    # footgun for future readers.
                     "params": {
-                        "code": "item: any\nresult: list = [item]",
+                        "code": "item: Any\nresult: list = [item]",
                         "inputs": {"item": "${item}"},
                     },
                     "batch": {"items": ["a", "b"], "error_handling": "fail_fast"},
@@ -1830,6 +1835,40 @@ class TestCodeNodeInputAnnotationValidation:
         assert len(ann_errors) == 1, [d.message for d in errors]
         suggestions = ann_errors[0].suggestions or []
         assert any("row: ${row}" in s for s in suggestions), suggestions
+
+    def test_batch_alias_wins_over_fuzzy_match(self, test_registry):
+        """When the orphan key matches batch.as AND fuzzy-matches an input, alias wins.
+
+        Fuzzy match of `item` against `['items']` passes with difflib ratio ~0.89,
+        producing "Rename to 'items'" — which would break valid code that reads
+        the per-iteration `item`. The batch-alias branch is deterministic metadata
+        and must take precedence over the heuristic.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batched",
+                    "type": "code",
+                    "params": {
+                        # Code uses `item` (the batch iteration variable).
+                        # `items` is separately bound as a list-typed input.
+                        "code": "items: list\nitem: int\nresult: int = item * 2",
+                        "inputs": {"items": "${items}"},
+                    },
+                    "batch": {"items": [1, 2, 3]},  # default alias = "item"
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Annotation 'item: int'" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        suggestions = ann_errors[0].suggestions or []
+        # Must suggest binding `item: ${item}`, NOT renaming to `items`.
+        assert any("item: ${item}" in s for s in suggestions), suggestions
+        assert not any("Rename" in s for s in suggestions), suggestions
+        # similar_names context key must be absent (fuzzy path was skipped).
+        assert "similar_names" not in ann_errors[0].context
 
     def test_complex_template_bypass_caught(self, test_registry):
         """Complex templates coerce to str at runtime — Pass 9 must enforce the str contract.

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1831,6 +1831,114 @@ class TestCodeNodeInputAnnotationValidation:
         suggestions = ann_errors[0].suggestions or []
         assert any("row: ${row}" in s for s in suggestions), suggestions
 
+    def test_complex_template_bypass_caught(self, test_registry):
+        """Complex templates coerce to str at runtime — Pass 9 must enforce the str contract.
+
+        Pre-fix: Class 3 validated each embedded ``${ref}`` source type
+        independently. When an embedded source type happened to match the
+        target (e.g. upstream dict → annotation dict), Pass 9 accepted
+        ``"prefix ${x}"`` even though runtime would coerce the whole value
+        to str and TypeError on the isinstance check.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "produce",
+                    "type": "code",
+                    "params": {"code": "result: dict = {'a': 1}"},
+                },
+                {
+                    "id": "consume",
+                    "type": "code",
+                    "params": {
+                        "code": "x: dict\nresult: str = str(x)",
+                        # Complex template: prefix + ${produce.result}. Embedded
+                        # source type is dict (matches annotation), but runtime
+                        # coerces the whole string → str.
+                        "inputs": {"x": "prefix ${produce.result}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "produce", "to": "consume"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Input 'x'" in d.message and "complex templates" in d.message]
+        assert len(ann_errors) == 1, [d.message for d in errors]
+        diagnostic = ann_errors[0]
+        # Exactly one diagnostic — not one-per-embedded-ref.
+        assert "receives str" in diagnostic.message
+        # References the full value, not the embedded ref alone.
+        assert diagnostic.context["inferred_type"] == "str"
+        assert diagnostic.context["expected_type"] == "dict"
+        assert diagnostic.suggestions is not None
+        assert any("x: str" in s for s in diagnostic.suggestions), diagnostic.suggestions
+
+    def test_complex_template_with_compatible_str_target_passes(self, test_registry):
+        """Complex template + `x: str` annotation is valid — no error."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "produce",
+                    "type": "code",
+                    "params": {"code": "result: dict = {'a': 1}"},
+                },
+                {
+                    "id": "consume",
+                    "type": "code",
+                    "params": {
+                        "code": "x: str\nresult: str = x",
+                        "inputs": {"x": "prefix ${produce.result}"},
+                    },
+                },
+            ],
+            "edges": [{"from": "produce", "to": "consume"}],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann_errors = [d for d in errors if "Input 'x' expects" in d.message]
+        assert ann_errors == [], [d.message for d in ann_errors]
+
+    def test_function_local_annotation_not_flagged_as_orphan(self, test_registry):
+        """Function-local `y: int` inside `def helper()` must not trip Pass 9's orphan check."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "node",
+                    "type": "code",
+                    "params": {
+                        "code": ("def helper():\n    y: int = 1\n    return y\n\nx: dict\nresult: int = helper()"),
+                        "inputs": {"x": "literal_dict_binding"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        orphan_errors = [d for d in errors if "no corresponding entry" in d.message]
+        # `y` must NOT be flagged — it's a function-local, not a code-node input.
+        assert not any("'y:" in d.message for d in orphan_errors), [d.message for d in orphan_errors]
+
+    def test_class_body_annotation_not_flagged_as_orphan(self, test_registry):
+        """Class body annotations (`class Config: timeout: int`) must not be orphans."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "node",
+                    "type": "code",
+                    "params": {
+                        "code": ("class Config:\n    timeout: int\n    name: str\n\nx: dict\nresult: int = 1"),
+                        "inputs": {"x": "literal_dict_binding"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        orphan_errors = [d for d in errors if "no corresponding entry" in d.message]
+        assert not any("timeout" in d.message or "name" in d.message for d in orphan_errors), [
+            d.message for d in orphan_errors
+        ]
+
     def test_forward_reference_annotation_type_checked(self, test_registry):
         """Forward-ref `x: "dict"` must be unwrapped so Pass 9 sees the inner type.
 


### PR DESCRIPTION
## Summary

Adds Pass 9 to the template-validation pipeline: code-node input annotations are now checked against upstream output types at validate time. Closes the parent-child boundary with three symmetric error classes, each with opinionated single-fix suggestions. Closes a second pre-existing correctness gap where forward-reference annotations silently skipped type enforcement at both runtime and validate-time.

Fixes #309 (primary task) and #316 (forward-ref unwrap, bundled after adversarial verification surfaced the gap).

## Changes

### Pass 9 — the new validator

New `validate_code_node_input_annotations` producer in `type_validation.py` emits diagnostics for three error classes:

1. **Input bound, annotation missing** — when the upstream template's type is inferrable, the suggestion names the concrete Python annotation (`Add an annotation (in params.code): x: list  (inferred from ${producer.items})`) instead of a `<type>` placeholder.
2. **Annotation declared, no input bound** — AST Load-reference analysis picks the canonical fix per orphan. Unused annotation → "Remove". Used annotation → "Add to the inputs dict". Typo → fuzzy match ("Rename annotation to 'items' to match existing input"). Batch alias → "Add 'item' to the inputs dict: `item: ${item}`" (specific binding, not a placeholder).
3. **Annotation type incompatible with inferred source** — wording mirrors the runtime `_check_input_types` error so validate-time and run-time text read identically. Includes locality hints (`in params.code` vs `in params.inputs`) so agents know which section to edit. Preserves `| None` in suggestions for Optional annotations. Suggestion text tailored to source type: workflow inputs get "update the input declaration" rather than the nonsensical "change ${data} to return X".

### Upstream type enrichment

`extract_node_outputs` in `validator.py` now enriches a code node's `result` output type from its code-block annotation (canonicalized to S1 vocabulary). Plumbed through both the non-batch path (`_register_node_outputs_from_registry`) and the batch path (`_register_batch_outputs`) via a shared `_enrich_code_result_output_type` helper. This makes code→code type-chains visible to every downstream pass.

### Orthogonal fixes unlocked by the work

- **Forward-reference annotation unwrap (#316)** — both `_get_outer_type` (runtime isinstance) and `_get_outer_type_name` (validate-time) now unwrap `"'list'"` forward-refs via shared `_annotation_outer_base` helper, mirroring `_check_annotation_vocabulary`'s existing pattern. Previously: `x: "dict"` silently accepted any type at both layers.
- **Batch-aware type inference** in `type_checker.py::infer_template_type` — when a template indexes into a batch output (`${node.results[0].field}`), traversal descends into `output_info["items"]` instead of `output_info["structure"]`, matching `path_validation.py::_validate_array_access`. Closes a pre-existing Pass 6 gap where batch results couldn't be type-checked at all.

### Tooling and fixtures

- `examples/invalid/code-annotation-type-mismatch.pflow.md` — committed fixture of the T1 scenario from #309; auto-discovered by `test_docs/test_example_validation.py`.
- `tests/test_docs/test_example_validation.py` — tightened to run full `WorkflowValidator.validate()` on invalid fixtures so Pass 9 errors are caught.
- `tests/test_integration/test_code_annotation_validation.py` — end-to-end: validate-only catches, valid workflow passes both layers, runtime defends when validation is bypassed.
- `examples/file-references/` — fixed pre-existing latent bug (`text: str = "${input}"` pattern without inputs binding was relying on code-string template resolution; converted to canonical `inputs:` binding).
- `src/pflow/guide/nodes/code.md` — documents the new validate-time checks with actual error output.

## Explanation

pflow's "fail at validate, not at run" philosophy was surfaced at every boundary except code-node input annotations. A code node with `x: dict` bound to `${upstream.result}` where `upstream` returned `list` would pass `--validate-only` cleanly and fail 30 seconds into execution (potentially after real LLM calls). The information needed to catch this was already computed — code annotations were parsed by the compiler for `optional_input_keys`, the type-compatibility matrix already handled S1/Python aliases, and `infer_template_type` already walked template paths. The gap was that none of these streams met.

Pass 9 threads them together: extracts annotations via the existing `_extract_annotations` helper, feeds them through a new `extract_code_annotation_type` that returns S1 canonical names via the shared `_get_outer_type_name` (which reuses `_get_inner_optional_type` for Optional decomposition), then compares to `infer_template_type` output via `is_type_compatible`. The matrix's existing S1↔Python aliasing (Task 154) handles the vocabulary bridge without new bridge logic.

Adversarial CLI verification (18 probes) surfaced two issues that informed the final shape: (a) my initial batch-alias exclusion was hiding a real runtime bug — code nodes using batch must explicitly bind `inputs: {item: ${item}}` because the engine only injects the alias into template resolution, not code exec. The exclusion was reverted; Pass 9 now correctly flags the missing binding. (b) Forward-reference annotations were silently skipping type checks at both layers — fixed as #316 and bundled into this PR.

External code review (3 specialist agents — validation-consistency, impact-completeness, agent-ux) identified context-field vocabulary asymmetry, Class 1 type-inference opportunity, Class 2 menu-vs-opinionated-fix gap, and Class 3 path/suggestion-locality mismatch. All addressed.

## Testing

- **5000 tests passing** (was 4986 before #316 fix and final agent-UX polish)
- `make check` clean (ruff, ruff-format, mypy, deptry)
- 18 adversarial CLI probes verified manually
- `examples/invalid/code-annotation-type-mismatch.pflow.md` fails validation correctly via auto-discovery

Run `make test` to verify.

## Follow-up issues filed

- #314 — `save_service` does not resolve file references before validation (pre-existing asymmetry surfaced during adversarial probing)
- #315 — Coalesce-operand diagnostics produce conflicting per-operand suggestions (codebase-wide pattern; Pass 6 + Pass 9)