### PR TITLE
feat: validate-time check for code-node result/next annotation (fixes #319)

### DIFF
--- a/examples/invalid/code-missing-result-annotation.pflow.md
+++ b/examples/invalid/code-missing-result-annotation.pflow.md
@@ -1,0 +1,25 @@
+# Code Missing Result Annotation (Invalid)
+
+Demonstrates validate-time enforcement of the code-node output/routing
+annotation requirement. This workflow must fail validation because the code
+block declares neither `result: <type>` nor `next: str` — the runtime would
+reject this, and Pass 9 surfaces it at validate-time so `--validate-only` and
+`--dry-run` agree with runtime.
+
+## Steps
+
+### split
+
+Missing `result:` / `next:` annotation in the code block.
+
+- type: code
+
+```python code
+items = [1, 2, 3]
+```
+
+## Outputs
+
+### out
+Output source.
+- source: ${split.result}

--- a/examples/nested/deep-research/analyze-source.pflow.md
+++ b/examples/nested/deep-research/analyze-source.pflow.md
@@ -49,7 +49,7 @@ Compile the extraction and scores into a structured analysis.
 sections: str
 scores: dict
 
-result = {"sections": sections, "scores": scores, "compiled": True}
+result: dict = {"sections": sections, "scores": scores, "compiled": True}
 ```
 
 ## Outputs

--- a/examples/nested/deep-research/deep-research.pflow.md
+++ b/examples/nested/deep-research/deep-research.pflow.md
@@ -33,7 +33,7 @@ Validate and normalize the source documents.
 docs: list
 focus: str
 
-result = [{"text": d, "focus": focus} for d in docs]
+result: list = [{"text": d, "focus": focus} for d in docs]
 ```
 
 ### analyze-sources
@@ -62,7 +62,7 @@ Merge all source analyses into a unified summary.
 ```python code
 analyses: list
 
-result = {"summary": "Combined analysis", "source_count": len(analyses)}
+result: dict = {"summary": "Combined analysis", "source_count": len(analyses)}
 ```
 
 ### reviews
@@ -103,7 +103,7 @@ Compile the analysis and reviews into a final research report.
 analyses: list
 reviews: list
 
-result = {"report": "Final research report", "analyses": len(analyses), "reviews": len(reviews)}
+result: dict = {"report": "Final research report", "analyses": len(analyses), "reviews": len(reviews)}
 ```
 
 ## Outputs

--- a/examples/nested/deep-research/score-section.pflow.md
+++ b/examples/nested/deep-research/score-section.pflow.md
@@ -37,7 +37,7 @@ Normalize scores to a 0-100 scale.
 ```python code
 raw_score: str
 
-result = {"score": 85, "normalized": True}
+result: dict = {"score": 85, "normalized": True}
 ```
 
 ## Outputs

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -759,7 +759,11 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
     # compiler for code-node annotation introspection.
     import ast as _ast
 
-    from pflow.nodes.python.python_code import extract_code_load_references, extract_top_level_annotations
+    from pflow.nodes.python.python_code import (
+        _extract_annotations,
+        extract_code_load_references,
+        extract_top_level_annotations,
+    )
 
     diagnostics: list[Diagnostic] = []
 
@@ -789,6 +793,38 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         # candidate code-node inputs. Using ``_extract_annotations`` here
         # would flag every ``def helper(): y: int = 1`` as an orphan.
         annotations = extract_top_level_annotations(code)
+
+        # Mirror the runtime check in ``python_code.py::prep``. Message is
+        # byte-identical so agents see the same wording at validate-time and
+        # runtime. Uses walk-mode ``_extract_annotations`` (not module-level)
+        # so validate-time accepts exactly what runtime accepts — a ``result:``
+        # declared inside a helper function passes both layers. Runtime
+        # retains the check as defense-in-depth for callers that bypass
+        # validation.
+        all_annotations = _extract_annotations(code)
+        if "result" not in all_annotations and "next" not in all_annotations:
+            diagnostics.append(
+                Diagnostic(
+                    severity=Severity.ERROR,
+                    source="validator",
+                    title="Validation Error",
+                    node_id=node_id,
+                    message=(
+                        "Code must declare result type annotation (result: <type> = ...) "
+                        "or next type annotation (next: str = ...) for routing"
+                    ),
+                    suggestions=[
+                        "Add a result annotation at the top of the code block: result: <type> = ...",
+                        'Or, to route to a downstream node, declare: next: str = "<target-node-id>"',
+                    ],
+                    context={
+                        "category": "validation",
+                        "path": f"nodes[id={node_id}].params.code",
+                        "node_type": "code",
+                        "missing": ["result", "next"],
+                    },
+                )
+            )
 
         input_keys = set(inputs.keys())
         # `result` / `next` are outputs / routing declarations, not inputs.

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -761,6 +761,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
 
     from pflow.nodes.python.python_code import (
         _extract_annotations,
+        _get_outer_type,
         extract_code_load_references,
         extract_top_level_annotations,
     )
@@ -794,14 +795,24 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         # would flag every ``def helper(): y: int = 1`` as an orphan.
         annotations = extract_top_level_annotations(code)
 
-        # Mirror the runtime check in ``python_code.py::prep``. Message is
-        # byte-identical so agents see the same wording at validate-time and
-        # runtime. Uses walk-mode ``_extract_annotations`` (not module-level)
-        # so validate-time accepts exactly what runtime accepts — a ``result:``
-        # declared inside a helper function passes both layers. Runtime
-        # retains the check as defense-in-depth for callers that bypass
-        # validation.
+        # Mirror the two prep-time checks in ``python_code.py::prep`` at
+        # validate-time:
+        #   1. Presence: ``result:`` or ``next:`` declared (lines 559-563).
+        #   2. Type: ``next`` (if present) must be annotated as str (lines 566-572).
+        # Walk-mode ``_extract_annotations`` matches runtime's AST walk so
+        # validate-time accepts exactly what runtime's prep accepts — a
+        # ``result:`` declared inside a helper function passes both layers.
+        # Messages are byte-identical so agents see the same wording at both
+        # tiers; runtime retains the checks as defense-in-depth for callers
+        # that bypass validation.
+        #
+        # Out of reach for validate-time: runtime's third gate at exec
+        # (``python_code.py:629-631``, ``if "result" not in namespace``)
+        # catches helper-only ``result:`` annotations that are never bound at
+        # module level. That check requires executing the code.
         all_annotations = _extract_annotations(code)
+
+        # Check 1: presence
         if "result" not in all_annotations and "next" not in all_annotations:
             diagnostics.append(
                 Diagnostic(
@@ -826,6 +837,30 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
                     see_also=["code"],
                 )
             )
+
+        # Check 2: next must be annotated as str
+        if "next" in all_annotations:
+            next_type_str = all_annotations["next"]
+            next_outer_type = _get_outer_type(next_type_str)
+            if next_outer_type is not None and next_outer_type is not str:
+                diagnostics.append(
+                    Diagnostic(
+                        severity=Severity.ERROR,
+                        source="validator",
+                        title="Validation Error",
+                        node_id=node_id,
+                        message=f"'next' must be annotated as str, got {next_type_str}",
+                        suggestions=['Change the annotation: next: str = "<target-node-id>"'],
+                        context={
+                            "category": "validation",
+                            "path": f"nodes[id={node_id}].params.code",
+                            "node_type": "code",
+                            "annotation": next_type_str,
+                            "expected_type": "str",
+                        },
+                        see_also=["code"],
+                    )
+                )
 
         input_keys = set(inputs.keys())
         # `result` / `next` are outputs / routing declarations, not inputs.

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -823,6 +823,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
                         "node_type": "code",
                         "missing": ["result", "next"],
                     },
+                    see_also=["code"],
                 )
             )
 

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1664,6 +1664,30 @@ class TestCodeNodeInputAnnotationValidation:
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
         assert not any("'next' must be annotated as str" in d.message for d in errors)
 
+    def test_next_forward_ref_wrong_type_rejected(self, test_registry):
+        """Forward-ref `next: "int"` must be unwrapped and rejected.
+
+        `_get_outer_type` unwraps forward-ref quotes via `_annotation_outer_base`
+        (landed in #317). Without the unwrap, `"'int'"` would miss the type map
+        and silently skip — letting `next: "int"` pass validation only to fail
+        at runtime. This test pins the Pass 9 ↔ unwrap-helper integration so
+        the forward-ref handling can't silently regress.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "router",
+                    "type": "code",
+                    "params": {"code": 'next: "int" = 42', "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        type_errors = [d for d in errors if "'next' must be annotated as str" in d.message]
+        assert len(type_errors) == 1, [d.message for d in errors]
+
     def test_result_annotation_inside_helper_function_matches_runtime(self, test_registry):
         """Presence check uses walk-mode so validate-time matches runtime parity.
 

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1546,6 +1546,9 @@ class TestCodeNodeInputAnnotationValidation:
 
         diagnostic = missing[0]
         assert diagnostic.severity == Severity.ERROR
+        # source="validator" is part of the producer contract that the
+        # renderer relies on (see template_validation/CLAUDE.md).
+        assert diagnostic.source == "validator"
         assert diagnostic.node_id == "split"
         # Byte-identical to runtime check in python_code.py::prep.
         assert diagnostic.message == (
@@ -1593,6 +1596,73 @@ class TestCodeNodeInputAnnotationValidation:
 
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
         assert not any("Code must declare result type annotation" in d.message for d in errors)
+
+    def test_next_annotation_must_be_str(self, test_registry):
+        """`next: int` must fail validation, mirroring the runtime prep check.
+
+        Runtime rejects at ``python_code.py:566-572`` with ``'next' must be
+        annotated as str, got <type>``. Validate-time emits a symmetric
+        Diagnostic so ``--validate-only`` catches the same error.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "router",
+                    "type": "code",
+                    "params": {"code": "next: int = 42", "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        type_errors = [d for d in errors if "'next' must be annotated as str" in d.message]
+        assert len(type_errors) == 1, [d.message for d in errors]
+
+        diagnostic = type_errors[0]
+        assert diagnostic.severity == Severity.ERROR
+        assert diagnostic.source == "validator"
+        assert diagnostic.node_id == "router"
+        assert diagnostic.message == "'next' must be annotated as str, got int"
+        assert diagnostic.context["path"] == "nodes[id=router].params.code"
+        assert diagnostic.context["annotation"] == "int"
+        assert diagnostic.context["expected_type"] == "str"
+        assert diagnostic.see_also == ["code"]
+
+    def test_next_str_annotation_passes(self, test_registry):
+        """`next: str` is the canonical routing declaration — must not fire the type check."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "router",
+                    "type": "code",
+                    "params": {"code": 'next: str = "target"', "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("'next' must be annotated as str" in d.message for d in errors)
+
+    def test_next_unknown_type_skips_check(self, test_registry):
+        """Unknown/user-defined next annotation types skip the check (matches runtime)."""
+        # Runtime's `_get_outer_type` returns None for types outside _TYPE_MAP.
+        # Validate-time must skip the check too — otherwise we'd reject valid
+        # code that runtime accepts via the user-class escape hatch.
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "router",
+                    "type": "code",
+                    "params": {"code": 'next: UserDefinedType = "target"', "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("'next' must be annotated as str" in d.message for d in errors)
 
     def test_result_annotation_inside_helper_function_matches_runtime(self, test_registry):
         """Presence check uses walk-mode so validate-time matches runtime parity.

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1558,6 +1558,9 @@ class TestCodeNodeInputAnnotationValidation:
         # Programmatic consumers (MCP / JSON output) get a structured signal
         # of which declarations are missing without parsing the message text.
         assert diagnostic.context["missing"] == ["result", "next"]
+        # Agents get a direct pointer to the code-node guide topic, matching
+        # the see_also pattern used by Pass 5 and Pass 8 diagnostics.
+        assert diagnostic.see_also == ["code"]
 
     def test_result_annotation_alone_passes(self, test_registry):
         """`result:` without `next:` is sufficient — the check is OR, not AND."""

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1522,6 +1522,94 @@ class TestCodeNodeInputAnnotationValidation:
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
         assert not any("no corresponding entry" in d.message for d in errors)
 
+    def test_missing_result_or_next_annotation_fires(self, test_registry):
+        """Code with neither `result:` nor `next:` annotation fails validation.
+
+        Mirrors the runtime ``ValueError`` in ``python_code.py::prep`` so
+        ``--validate-only`` and ``--dry-run`` catch the gap at validate-time
+        with byte-identical wording.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "split",
+                    "type": "code",
+                    "params": {"code": "items = [1, 2, 3]", "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        missing = [d for d in errors if "Code must declare result type annotation" in d.message]
+        assert len(missing) == 1, [d.message for d in errors]
+
+        diagnostic = missing[0]
+        assert diagnostic.severity == Severity.ERROR
+        assert diagnostic.node_id == "split"
+        # Byte-identical to runtime check in python_code.py::prep.
+        assert diagnostic.message == (
+            "Code must declare result type annotation (result: <type> = ...) "
+            "or next type annotation (next: str = ...) for routing"
+        )
+        assert diagnostic.context["category"] == "validation"
+        assert diagnostic.context["path"] == "nodes[id=split].params.code"
+        assert diagnostic.context["node_type"] == "code"
+        # Programmatic consumers (MCP / JSON output) get a structured signal
+        # of which declarations are missing without parsing the message text.
+        assert diagnostic.context["missing"] == ["result", "next"]
+
+    def test_result_annotation_alone_passes(self, test_registry):
+        """`result:` without `next:` is sufficient — the check is OR, not AND."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "producer",
+                    "type": "code",
+                    "params": {"code": "result: list = [1, 2, 3]", "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("Code must declare result type annotation" in d.message for d in errors)
+
+    def test_next_annotation_alone_passes(self, test_registry):
+        """`next:` without `result:` is sufficient — dynamic-routing code nodes."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "router",
+                    "type": "code",
+                    "params": {"code": "next: str = 'target'", "inputs": {}},
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("Code must declare result type annotation" in d.message for d in errors)
+
+    def test_result_annotation_inside_helper_function_matches_runtime(self, test_registry):
+        """Presence check uses walk-mode so validate-time matches runtime parity.
+
+        Runtime ``_extract_annotations`` walks into function bodies; the
+        presence gate must accept what runtime accepts. A ``result:``
+        annotation inside a helper function that's then reassigned at
+        module level runs cleanly at runtime and must pass validation too.
+        """
+        code = "def build():\n    result: dict = {'ok': True}\n    return result\n\nresult = build()"
+        workflow_ir = {
+            "nodes": [{"id": "build", "type": "code", "params": {"code": code, "inputs": {}}}],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        assert not any("Code must declare result type annotation" in d.message for d in errors), [
+            d.message for d in errors
+        ]
+
     def test_any_annotation_skips_check(self, test_registry):
         """`x: Any` accepts any upstream type."""
         workflow_ir = {

--- a/tests/test_runtime/test_template_validation/test_validator.py
+++ b/tests/test_runtime/test_template_validation/test_validator.py
@@ -1375,7 +1375,7 @@ class TestInputsContextTemplateValidation:
                 {
                     "id": "build-item",
                     "type": "code",
-                    "params": {"code": "result = {'concept_md': 'test'}"},
+                    "params": {"code": "result: dict = {'concept_md': 'test'}"},
                 },
                 {
                     "id": "consumer",
@@ -1399,7 +1399,7 @@ class TestInputsContextTemplateValidation:
                 {
                     "id": "upstream",
                     "type": "code",
-                    "params": {"code": "result = {'a': {'b': {'c': 1}}}"},
+                    "params": {"code": "result: dict = {'a': {'b': {'c': 1}}}"},
                 },
                 {
                     "id": "consumer",


### PR DESCRIPTION
## Summary

Closes the last validate-time gap at the code-node boundary. A code node missing both `result: <type>` and `next: str` annotations now fails `--validate-only`, `--dry-run`, `pflow save`, and runtime with a byte-identical message. Previously the runtime `ValueError` in `python_code.py::prep` was the only check — validate-only and dry-run silently passed.

## Changes

- **Pass 9 inline check** in `src/pflow/runtime/template_validation/type_validation.py::validate_code_node_input_annotations` — emits a `Diagnostic` when neither `result:` nor `next:` is present. Message byte-identical to the runtime check; suggestions include concrete fix templates; `context.missing = ["result", "next"]` gives programmatic consumers a structured signal.
- **Walk-mode annotation extraction** (`_extract_annotations`) for the presence check so validate-time accepts exactly what runtime accepts (e.g. `result:` declared inside a helper function reassigned at module level). Module-level extractor (`extract_top_level_annotations`) retained for the existing orphan/missing-input checks where it's semantically correct.
- **Auto-discovered invalid fixture**: `examples/invalid/code-missing-result-annotation.pflow.md`.
- **5 latent bug fixes** in `examples/nested/deep-research/*.pflow.md` — code blocks used `result = ...` without an annotation; were passing `--validate-only` but would have failed at runtime. Surfaced by the new check.
- **4 new unit tests** covering missing-both (rejects), `result` alone (passes), `next` alone (passes), `result` inside helper function (passes, runtime parity).
- **2 existing tests updated** in `test_validator.py` to include `result: dict` annotations (latent same-class bugs in test fixtures).

## Explanation

Pattern follows Task 153's ‟parse-time structured Diagnostic + runtime ValueError" defense-in-depth model and PR #317's byte-identical-wording convention from the input-annotation half (`fixes #309`). The check is inline (no new helper, no new pass) — Task 153 rejected symmetric-helper extraction as the ‟permanent special case forever" anti-pattern for single-call-site checks.

Adversarial CLI verification across 11 cases: helper-function annotation, forward-ref `result: \"dict\"`, async-def body, tuple unpacking (rejected), batch (rejected), multi-node (rejected only the broken one), parent-with-broken-child (rejected with sub-workflow provenance), next-in-class-body (downstream routing validator catches), whitespace-only code, multi-issue (no cascade). Valid cases actually run end-to-end at runtime, confirming walk-mode parity goes all the way through (not just validate-time).

Code review via specialist agents (validation-consistency, feature-interactions, agent-ux) applied as polish: walk-mode parity fix, `suggestions=[...]` added for agent actionability, ‟to route to a downstream node" replaces ‟dynamic routing" jargon.

## Related

- `#316` was closed separately pointing at the already-shipped fix in #317 — no work in this PR.

## Testing

- `make test` — 5150 passed, 9 skipped
- `make check` — clean (ruff, ruff-format, mypy, deptry)
- Three-surface CLI parity verified manually: `--validate-only`, `--dry-run`, `pflow save`, runtime all emit byte-identical text