### PR TITLE
feat: MCP exception boundary via FastMCP subclass (fixes #325)

### DIFF
--- a/src/pflow/mcp_server/CLAUDE.md
+++ b/src/pflow/mcp_server/CLAUDE.md
@@ -11,7 +11,7 @@ Exposes pflow's workflow building and execution capabilities as MCP tools for AI
 │         MCP Tools (12 enabled)          │  ← FastMCP decorators, async wrappers
 │         asyncio.to_thread bridge        │
 ├─────────────────────────────────────────┤
-│      Services Layer (7 services)        │  ← Business logic, stateless pattern
+│      Services Layer (6 services)        │  ← Business logic, stateless pattern
 │      Fresh instances per request        │
 ├─────────────────────────────────────────┤
 │   Core pflow (sync components)          │  ← Registry, WorkflowManager, WorkflowRunner
@@ -31,9 +31,7 @@ src/pflow/mcp_server/
 │   ├── discovery_tools.py   - workflow_discover, registry_discover
 │   ├── execution_tools.py   - workflow_execute, validate, plan, save, registry_run, read_fields
 │   ├── registry_tools.py    - registry_describe, registry_list
-│   ├── workflow_tools.py    - workflow_list, workflow_describe
-│   ├── settings_tools.py    - DISABLED (4 tools, code kept for future use)
-│   └── test_tools.py        - DISABLED (3 tools, development only)
+│   └── workflow_tools.py    - workflow_list, workflow_describe
 ├── resources/
 │   ├── __init__.py
 │   ├── instruction_resources.py  - 2 MCP resources (regular + sandbox agent instructions)
@@ -45,8 +43,7 @@ src/pflow/mcp_server/
 │   ├── execution_service.py - Execute, validate, save workflows + test nodes
 │   ├── field_service.py     - Read cached fields from previous registry_run executions
 │   ├── registry_service.py  - Node describe, list, search
-│   ├── workflow_service.py  - Workflow list, describe
-│   └── settings_service.py  - Environment variable management (DISABLED tools use this)
+│   └── workflow_service.py  - Workflow list, describe
 └── utils/
     ├── __init__.py
     ├── errors.py            - sanitize_parameters() for sensitive data redaction
@@ -67,7 +64,7 @@ src/pflow/mcp_server/
 
 Tool/resource registration happens at import time via decorators. `register_tools()` imports the modules to trigger this.
 
-## Tools (11 Enabled)
+## Tools (12 Enabled)
 
 All tools use async/sync bridge: `await asyncio.to_thread(_sync_operation)` — pflow is sync, MCP is async.
 
@@ -91,8 +88,6 @@ All tools use async/sync bridge: `await asyncio.to_thread(_sync_operation)` — 
 - `workflow_list(filter_pattern)` — List saved workflows with keyword filtering
 - `workflow_describe(name)` — Show workflow interface (inputs/outputs/example usage)
 
-**Disabled** (code kept): settings_tools (4 tools), test_tools (3 tools).
-
 ## Resources (2)
 
 - `pflow://instructions` — Complete workflow building guide for agents with **full system access** (CLI, settings.json, traces, library)
@@ -105,7 +100,7 @@ All tools use async/sync bridge: `await asyncio.to_thread(_sync_operation)` — 
 
 If none found, returns a fallback message with tool reference and troubleshooting steps.
 
-## Services (7)
+## Services (6)
 
 All inherit from `BaseService`. All methods are `@classmethod` with `@ensure_stateless` decorator. Every request creates fresh instances of Registry, WorkflowManager, etc.
 
@@ -115,7 +110,6 @@ All inherit from `BaseService`. All methods are `@classmethod` with `@ensure_sta
 - **FieldService** — Reads cached fields from previous `registry_run` via ExecutionCache + TemplateResolver. Supports `result[0].title` path syntax. **Not exported from services/__init__.py** — imported directly in execution_tools.py.
 - **RegistryService** — `describe_nodes()` uses `build_component_context()`, `list_all_nodes()` supports filter via Registry.search()
 - **WorkflowService** — List/describe with shared formatters, raises ValueError with "did you mean" suggestions
-- **SettingsService** — Environment variable CRUD via SettingsManager (used by disabled settings_tools)
 
 ## Utilities
 
@@ -153,7 +147,7 @@ MCP execution differs from CLI:
 - Traces always saved to `~/.pflow/debug/workflow-trace-{timestamp}.json`
 - Text output format (LLMs parse text better than nested JSON)
 - Auto-normalization of workflow IR (`ir_version`, `edges`)
-- Services **raise exceptions** (ValueError, RuntimeError, FileExistsError) — tools layer lets MCP handle conversion
+- Services **raise exceptions** (ValueError, RuntimeError, FileExistsError, and pflow types like WorkflowValidationError / MarkdownParseError) with pre-rendered rich text. The `PflowMCP.call_tool` and `PflowMCP.read_resource` overrides (`server.py`) catch unhandled producer bugs and any self-describing exception (anything with `to_diagnostics()` — includes all `PflowError` subclasses plus `MaxNodeVisitsError`) and convert them to structured `CallToolResult(isError=True)` / rendered resource text via `exception_to_diagnostics()` + `format_diagnostic()`, matching the CLI's outer error boundary. Bare pre-formatted `ValueError` / `TypeError` / `RuntimeError` / `FileExistsError` pass through so their hand-rolled rich text survives unchanged.
 
 ## Critical Behaviors
 

--- a/src/pflow/mcp_server/server.py
+++ b/src/pflow/mcp_server/server.py
@@ -1,15 +1,183 @@
 """FastMCP server instance for pflow.
 
 This module creates the central FastMCP server instance that all tools
-register with via decorators. This follows the FastMCP best practice
-of having a single server instance that tools import and use.
+register with via decorators. The :class:`PflowMCP` subclass installs a
+unified exception boundary on both ``call_tool`` and ``read_resource`` so
+unhandled exceptions reach agents as structured ``Diagnostic`` output,
+matching the CLI's outer ``except Exception`` in ``cli/commands/run.py``.
 """
 
-from mcp.server.fastmcp import FastMCP
+from __future__ import annotations
 
-# Create the FastMCP server instance with instructions for agents
-# All tools and resources will register with this instance via decorators
-mcp = FastMCP(
+import logging
+from typing import Any
+
+from mcp import types
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ResourceError, ToolError
+from mcp.server.lowlevel.helper_types import ReadResourceContents
+
+from pflow.core.diagnostic import Diagnostic, Severity, exception_to_diagnostics
+from pflow.core.diagnostic_render import format_diagnostic
+from pflow.core.suggestion_utils import find_similar_items
+
+logger = logging.getLogger(__name__)
+
+
+# Hand-rolled rich-text service exceptions pass through to preserve today's
+# pre-formatted output. This list shrinks once services migrate to typed
+# pflow exceptions (out-of-scope follow-up to issue #325).
+# pydantic_core.ValidationError (v2) is a ValueError subclass, so argument-
+# validation errors pass through without special-casing.
+_PASS_THROUGH_TYPES: tuple[type[BaseException], ...] = (
+    ValueError,
+    TypeError,
+    RuntimeError,
+    FileExistsError,
+)
+
+
+def _should_render(original: Exception) -> bool:
+    """Return True if ``original`` should go through the Diagnostic renderer.
+
+    Self-describing exceptions (``hasattr(..., 'to_diagnostics')``) always
+    render — covers every ``PflowError`` subclass plus ``MaxNodeVisitsError``
+    (which is a ``RuntimeError`` subclass by design).  Producer bugs without
+    ``to_diagnostics()`` (``AttributeError``, ``KeyError``, ``IndexError`` …)
+    also render.  Bare pre-formatted ``ValueError`` / ``TypeError`` /
+    ``RuntimeError`` / ``FileExistsError`` pass through so FastMCP's default
+    handling surfaces their rendered text unchanged.
+    """
+    if hasattr(original, "to_diagnostics"):
+        return True
+    return not isinstance(original, _PASS_THROUGH_TYPES)
+
+
+_MCP_WRAPPER_TYPES: tuple[type[Exception], ...] = (ToolError, ResourceError)
+
+
+def _is_function_resource_wrapper(exc: Exception) -> bool:
+    """FunctionResource.read wraps any exception it sees as
+    ``ValueError(f"Error reading resource {uri}: {e}")``.  Recognize the
+    shape so the unwrap walks past it to the original producer exception.
+    """
+    return isinstance(exc, ValueError) and str(exc).startswith("Error reading resource ")
+
+
+def _unwrap_cause(wrapper: Exception) -> Exception:
+    """Walk __cause__/__context__ past MCP wrapper layers to the original exception.
+
+    Known wrapping patterns (mcp 1.26.0):
+    - ``Tool.run`` uses ``raise ToolError(...) from e`` → original in ``__cause__``
+    - ``FastMCP.read_resource`` uses ``raise ResourceError(str(e))`` inside
+      ``except`` → original in implicit ``__context__``
+    - ``FunctionResource.read`` uses ``raise ValueError(f"Error reading ...")``
+      inside ``except`` → original in implicit ``__context__``
+
+    We deliberately do NOT walk past non-wrapper exceptions, so service code
+    like ``raise ValueError(hint) from e`` preserves the ValueError as the
+    outer type (today's pass-through behavior).
+    """
+    seen = {id(wrapper)}
+    current: Exception = wrapper
+    while isinstance(current, _MCP_WRAPPER_TYPES) or _is_function_resource_wrapper(current):
+        nxt = current.__cause__ or current.__context__
+        if nxt is None or id(nxt) in seen or not isinstance(nxt, Exception):
+            break
+        seen.add(id(nxt))
+        current = nxt
+    return current
+
+
+def _render_exception(original: Exception) -> str:
+    """Render ``original`` via the shared pipeline, iterating ALL diagnostics.
+
+    Matches ``cli/error_output.py::display_exception_text`` so CLI and MCP
+    produce byte-identical text for the same exception.
+    """
+    diagnostics = exception_to_diagnostics(original)
+    if not diagnostics:
+        return f"Error: {original}"
+    return "\n".join(format_diagnostic(d) for d in diagnostics)
+
+
+def _build_unknown_tool_diagnostic(name: str, available_tools: list[str]) -> Diagnostic:
+    """Construct a ``Tool Not Found`` diagnostic with similar-names suggestions."""
+    similar = find_similar_items(name, available_tools, max_results=3, method="fuzzy")
+    suggestions: list[str] = []
+    if similar:
+        suggestions.append(f"Did you mean: {', '.join(similar)}")
+    suggestions.append("Run `workflow_discover` or `registry_discover` to find the right tool.")
+    return Diagnostic(
+        severity=Severity.ERROR,
+        source="mcp",
+        title="Tool Not Found",
+        message=f"Unknown tool: {name}",
+        suggestions=suggestions,
+        context={"category": "not_found", "similar_names": similar or None},
+    )
+
+
+class PflowMCP(FastMCP):
+    """FastMCP subclass with a unified exception boundary.
+
+    Overrides ``call_tool`` and ``read_resource`` to catch producer bugs
+    escaping the tool / resource layer and convert them to structured
+    ``CallToolResult(isError=True)`` / rendered resource text using the
+    shared ``Diagnostic`` pipeline. Matches the CLI's outer
+    ``except Exception`` in ``cli/commands/run.py``.
+    """
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> Any:
+        try:
+            return await super().call_tool(name, arguments)
+        except ToolError as te:
+            # Unknown-tool errors are raised at tool_manager.py:91 without
+            # `from e` and outside any except block — both __cause__ and
+            # __context__ are None. Render with similar-name suggestions.
+            if te.__cause__ is None and te.__context__ is None and str(te).startswith("Unknown tool:"):
+                available = [t.name for t in await self.list_tools()]
+                diagnostic = _build_unknown_tool_diagnostic(name, available)
+                return types.CallToolResult(
+                    content=[types.TextContent(type="text", text=format_diagnostic(diagnostic))],
+                    isError=True,
+                )
+
+            original = _unwrap_cause(te)
+            if not _should_render(original):
+                raise
+            # logger.exception uses sys.exc_info(), which surfaces the full
+            # wrapper → original chain via __cause__/__context__ — strictly
+            # more useful than logging the unwrapped original alone.
+            logger.exception("Unhandled exception in MCP tool %s", name)
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text=_render_exception(original))],
+                isError=True,
+            )
+
+    async def read_resource(self, uri: Any) -> Any:
+        try:
+            return await super().read_resource(uri)
+        except ResourceError as re_:
+            original = _unwrap_cause(re_)
+            if not _should_render(original):
+                raise
+            logger.exception("Unhandled exception reading MCP resource %s", uri)
+            # MCP resource responses have no isError channel — surface the
+            # rendered diagnostic as readable text content. Agents reading
+            # resources typically render the content directly, so the
+            # diagnostic is visible even though the protocol layer doesn't
+            # flag it as an error.
+            return [ReadResourceContents(content=_render_exception(original), mime_type="text/plain")]
+
+
+# Create the FastMCP server instance with instructions for agents.
+# All tools and resources register with this instance via decorators.
+mcp = PflowMCP(
     "pflow",
     instructions="""🚨 MANDATORY WORKFLOW PROTOCOL 🚨
 
@@ -65,4 +233,4 @@ def register_tools() -> None:
     )
 
 
-__all__ = ["mcp", "register_tools"]
+__all__ = ["PflowMCP", "mcp", "register_tools"]

--- a/src/pflow/mcp_server/server.py
+++ b/src/pflow/mcp_server/server.py
@@ -59,6 +59,10 @@ def _is_function_resource_wrapper(exc: Exception) -> bool:
     """FunctionResource.read wraps any exception it sees as
     ``ValueError(f"Error reading resource {uri}: {e}")``.  Recognize the
     shape so the unwrap walks past it to the original producer exception.
+
+    Drift guard: ``test_resource_producer_bug_raises_with_rendered_diagnostic``
+    asserts the 3-layer unwrap walks through this wrapper — a mcp-SDK minor
+    release that reworded the prefix would fail that test.
     """
     return isinstance(exc, ValueError) and str(exc).startswith("Error reading resource ")
 
@@ -135,9 +139,10 @@ def _build_unknown_resource_diagnostic(uri: Any, available_uris: list[str]) -> D
     suggestions: list[str] = []
     if similar:
         suggestions.append(f"Did you mean: {', '.join(similar)}")
-    suggestions.append(
-        "Check the resource URI. Known pflow resources: pflow://instructions, pflow://instructions/sandbox."
-    )
+    # Derive the "known resources" list from the live registry so the hint
+    # stays correct when resources are added or removed.
+    known = ", ".join(available_uris) if available_uris else "(none registered)"
+    suggestions.append(f"Check the resource URI. Known pflow resources: {known}.")
     return Diagnostic(
         severity=Severity.ERROR,
         source="mcp",
@@ -169,6 +174,8 @@ class PflowMCP(FastMCP):
             # Unknown-tool errors are raised at tool_manager.py:91 without
             # `from e` and outside any except block — both __cause__ and
             # __context__ are None. Render with similar-name suggestions.
+            # Drift guard: test_typo_returns_did_you_mean_suggestion pins
+            # this prefix; a mcp-SDK rewording would fail that test.
             if te.__cause__ is None and te.__context__ is None and str(te).startswith("Unknown tool:"):
                 available = [t.name for t in await self.list_tools()]
                 diagnostic = _build_unknown_tool_diagnostic(name, available)
@@ -207,6 +214,8 @@ class PflowMCP(FastMCP):
             # with similar-URI suggestions, symmetric with the unknown-tool
             # path. Must re-raise (not return contents) because the MCP
             # resource protocol signals failure via a JSON-RPC error.
+            # Drift guard: test_unknown_resource_renders_rich_diagnostic pins
+            # this prefix; a mcp-SDK rewording would fail that test.
             if exc.__cause__ is None and exc.__context__ is None and str(exc).startswith("Unknown resource:"):
                 available = [str(r.uri) for r in await self.list_resources()]
                 diagnostic = _build_unknown_resource_diagnostic(uri, available)

--- a/src/pflow/mcp_server/server.py
+++ b/src/pflow/mcp_server/server.py
@@ -15,7 +15,6 @@ from typing import Any
 from mcp import types
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ResourceError, ToolError
-from mcp.server.lowlevel.helper_types import ReadResourceContents
 
 from pflow.core.diagnostic import Diagnostic, Severity, exception_to_diagnostics
 from pflow.core.diagnostic_render import format_diagnostic
@@ -94,8 +93,20 @@ def _render_exception(original: Exception) -> str:
 
     Matches ``cli/error_output.py::display_exception_text`` so CLI and MCP
     produce byte-identical text for the same exception.
+
+    Defensive: if a misbehaving ``to_diagnostics()`` method raises (e.g. a
+    third-party exception that happens to have the attribute but fails when
+    called), fall through to the bare string form rather than letting the
+    secondary exception escape the entire boundary.
     """
-    diagnostics = exception_to_diagnostics(original)
+    try:
+        diagnostics = exception_to_diagnostics(original)
+    except Exception:
+        # Defensive: any failure in the rendering pipeline (e.g. a misbehaving
+        # third-party to_diagnostics() method) falls back to bare-string output
+        # rather than letting a secondary exception escape the boundary.
+        logger.exception("exception_to_diagnostics raised while rendering %r", original)
+        return f"Error: {original}"
     if not diagnostics:
         return f"Error: {original}"
     return "\n".join(format_diagnostic(d) for d in diagnostics)
@@ -113,6 +124,25 @@ def _build_unknown_tool_diagnostic(name: str, available_tools: list[str]) -> Dia
         source="mcp",
         title="Tool Not Found",
         message=f"Unknown tool: {name}",
+        suggestions=suggestions,
+        context={"category": "not_found", "similar_names": similar or None},
+    )
+
+
+def _build_unknown_resource_diagnostic(uri: Any, available_uris: list[str]) -> Diagnostic:
+    """Construct a ``Resource Not Found`` diagnostic with similar-URI suggestions."""
+    similar = find_similar_items(str(uri), available_uris, max_results=3, method="fuzzy")
+    suggestions: list[str] = []
+    if similar:
+        suggestions.append(f"Did you mean: {', '.join(similar)}")
+    suggestions.append(
+        "Check the resource URI. Known pflow resources: pflow://instructions, pflow://instructions/sandbox."
+    )
+    return Diagnostic(
+        severity=Severity.ERROR,
+        source="mcp",
+        title="Resource Not Found",
+        message=f"Unknown resource: {uri}",
         suggestions=suggestions,
         context={"category": "not_found", "similar_names": similar or None},
     )
@@ -149,6 +179,14 @@ class PflowMCP(FastMCP):
 
             original = _unwrap_cause(te)
             if not _should_render(original):
+                # Debug-log the pass-through so a producer bug misclassified
+                # into the pass-through list still leaves an audit trail.
+                logger.debug(
+                    "Passing through %s in MCP tool %s: %s",
+                    type(original).__name__,
+                    name,
+                    original,
+                )
                 raise
             # logger.exception uses sys.exc_info(), which surfaces the full
             # wrapper → original chain via __cause__/__context__ — strictly
@@ -162,17 +200,41 @@ class PflowMCP(FastMCP):
     async def read_resource(self, uri: Any) -> Any:
         try:
             return await super().read_resource(uri)
-        except ResourceError as re_:
-            original = _unwrap_cause(re_)
+        except (ResourceError, ValueError) as exc:
+            # Unknown-resource URIs raise `ValueError("Unknown resource: ...")`
+            # from resource_manager.py:105 (concrete resources) or
+            # `ResourceError("Unknown resource: ...")` from FastMCP. Render
+            # with similar-URI suggestions, symmetric with the unknown-tool
+            # path. Must re-raise (not return contents) because the MCP
+            # resource protocol signals failure via a JSON-RPC error.
+            if exc.__cause__ is None and exc.__context__ is None and str(exc).startswith("Unknown resource:"):
+                available = [str(r.uri) for r in await self.list_resources()]
+                diagnostic = _build_unknown_resource_diagnostic(uri, available)
+                raise ResourceError(format_diagnostic(diagnostic)) from exc
+
+            # For anything else, only intercept ResourceError — FastMCP's
+            # wrapping for exceptions raised INSIDE resource handlers. A
+            # bare ValueError that isn't an unknown-resource marker is not
+            # something we can classify, so let it propagate.
+            if not isinstance(exc, ResourceError):
+                raise
+
+            original = _unwrap_cause(exc)
             if not _should_render(original):
+                logger.debug(
+                    "Passing through %s reading MCP resource %s: %s",
+                    type(original).__name__,
+                    uri,
+                    original,
+                )
                 raise
             logger.exception("Unhandled exception reading MCP resource %s", uri)
-            # MCP resource responses have no isError channel — surface the
-            # rendered diagnostic as readable text content. Agents reading
-            # resources typically render the content directly, so the
-            # diagnostic is visible even though the protocol layer doesn't
-            # flag it as an error.
-            return [ReadResourceContents(content=_render_exception(original), mime_type="text/plain")]
+            # MCP resource protocol has no isError channel; re-raise as
+            # ResourceError so the lowlevel handler produces a proper
+            # JSON-RPC error response. Matches FastMCP's default pass-through
+            # behavior — programmatic agents see the error at the protocol
+            # level, not as successful-looking content.
+            raise ResourceError(_render_exception(original)) from original
 
 
 # Create the FastMCP server instance with instructions for agents.

--- a/src/pflow/mcp_server/services/CLAUDE.md
+++ b/src/pflow/mcp_server/services/CLAUDE.md
@@ -17,7 +17,7 @@ Stateless business logic layer that bridges async MCP tools with synchronous pfl
 
 See `mcp_server/CLAUDE.md` for detailed explanation of why this matters.
 
-## Services (7)
+## Services (6)
 
 - **BaseService** — Pattern enforcement via `@ensure_stateless` decorator
 - **DiscoveryService** — Wraps `find_workflow()` and `find_components()` plain functions
@@ -25,7 +25,6 @@ See `mcp_server/CLAUDE.md` for detailed explanation of why this matters.
 - **FieldService** — Read cached fields from previous `registry_run` via ExecutionCache + TemplateResolver. **Not exported from `__init__.py`** — imported directly in execution_tools.py.
 - **RegistryService** — Node describe, list/search via `build_component_context()` and `Registry.search()`
 - **WorkflowService** — Workflow list/describe with shared formatters, "did you mean" suggestions
-- **SettingsService** — Environment variable CRUD via SettingsManager (used by disabled settings_tools)
 
 ## Discovery Integration (DiscoveryService)
 
@@ -41,7 +40,7 @@ Model defaults to `get_model_for_feature("discovery")`.
 
 ## Error Handling
 
-Services raise exceptions — tools layer lets MCP handle conversion automatically.
+Services raise exceptions. Self-describing exceptions (anything with `to_diagnostics()` — all `PflowError` subclasses plus `MaxNodeVisitsError`) are rendered by the `PflowMCP.call_tool` override (`server.py`) via the shared `exception_to_diagnostics()` + `format_diagnostic()` pipeline, producing structured `CallToolResult(isError=True)` output. Bare `ValueError` / `RuntimeError` / `TypeError` / `FileExistsError` with pre-formatted message text pass through FastMCP's default handling to preserve existing rich output. Producer bugs (`AttributeError`, `KeyError`, etc.) are always rendered.
 
 **Exception types used:**
 - `ValueError` — Invalid input, not found, validation failures
@@ -102,4 +101,4 @@ Mock at service layer (service methods return predictable results). Integration 
 3. Local formatter imports: `from pflow.execution.formatters.X import format_Y`
 4. Validate inputs: check existence, include "did you mean" suggestions via `format_did_you_mean()`
 5. Use shared formatters for output: `return format_Y(result)`
-6. Let exceptions propagate — tool layer handles conversion to MCP errors
+6. Let exceptions propagate — `PflowMCP.call_tool` renders self-describing exceptions via the shared Diagnostic pipeline and passes hand-rolled rich-text exceptions through unchanged.

--- a/src/pflow/mcp_server/tools/workflow_tools.py
+++ b/src/pflow/mcp_server/tools/workflow_tools.py
@@ -109,12 +109,6 @@ async def workflow_describe(
         result: str = WorkflowService.describe_workflow(name)
         return result
 
-    try:
-        # Run in thread pool
-        result = await asyncio.to_thread(_sync_describe)
-        logger.info(f"Described workflow: {name}")
-        return result
-    except ValueError:
-        # Workflow not found - error includes suggestions
-        logger.warning(f"Workflow not found: {name}")
-        raise
+    result = await asyncio.to_thread(_sync_describe)
+    logger.info(f"Described workflow: {name}")
+    return result

--- a/tests/test_mcp_server/test_exception_boundary.py
+++ b/tests/test_mcp_server/test_exception_boundary.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 from mcp import types
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.fastmcp.exceptions import ResourceError, ToolError
 
 from pflow.core.exceptions import MaxNodeVisitsError
 from pflow.mcp_server.server import mcp, register_tools
@@ -106,14 +106,15 @@ class TestPassThrough:
     def test_bare_value_error_passes_through(self):
         # Pass-through re-raises ToolError. In production flow the lowlevel
         # handler converts it to CallToolResult(isError=True) via
-        # _make_error_result(str(e)). Here we assert the override did NOT
-        # swallow it.
+        # _make_error_result(str(e)). `match=` pins the ORIGINAL service
+        # message through the re-raise — without it, a regression that
+        # wrapped as ToolError("internal error") would silently pass.
         with (
             patch(
                 "pflow.mcp_server.services.execution_service.ExecutionService.validate_workflow",
                 side_effect=ValueError("pre-formatted rich text from service"),
             ),
-            pytest.raises(ToolError),
+            pytest.raises(ToolError, match=r"pre-formatted rich text from service"),
         ):
             _run(mcp.call_tool("workflow_validate", {"workflow": _MINIMAL_WORKFLOW}))
 
@@ -142,6 +143,34 @@ class TestCliMcpParity:
 
         assert cli_text == mcp_text, f"CLI/MCP output diverged:\nCLI:\n{cli_text!r}\n\nMCP:\n{mcp_text!r}"
 
+    def test_max_node_visits_matches_cli(self, capsys):
+        """Self-describing exceptions produce byte-identical CLI/MCP text.
+
+        Pins the `hasattr to_diagnostics` branch structurally — a divergence
+        in how self-describing exceptions flow through the renderer between
+        the two surfaces would fail here.
+        """
+        from pflow.cli.error_output import display_exception_text
+
+        exc = MaxNodeVisitsError("node-x", 100, 50)
+
+        display_exception_text(exc)
+        cli_text = capsys.readouterr().err.rstrip("\n")
+
+        with patch(
+            "pflow.mcp_server.services.execution_service.ExecutionService.execute_workflow",
+            side_effect=MaxNodeVisitsError("node-x", 100, 50),
+        ):
+            result = _run(
+                mcp.call_tool(
+                    "workflow_execute",
+                    {"workflow": _MINIMAL_WORKFLOW, "parameters": {}},
+                )
+            )
+        mcp_text = result.content[0].text.rstrip("\n")
+
+        assert cli_text == mcp_text, f"CLI/MCP output diverged:\nCLI:\n{cli_text!r}\n\nMCP:\n{mcp_text!r}"
+
 
 class TestUnknownTool:
     """Calling an unregistered tool renders a rich 'Tool Not Found' diagnostic."""
@@ -161,20 +190,48 @@ class TestUnknownTool:
 
 class TestResourceBoundary:
     """Resources go through a separate FastMCP code path (read_resource →
-    ResourceError). The override covers them symmetrically."""
+    ResourceError). The override covers them symmetrically and raises
+    ResourceError (instead of returning success content) so the protocol
+    layer produces a proper JSON-RPC error response."""
 
-    def test_resource_producer_bug_renders_diagnostic(self):
+    def test_resource_producer_bug_raises_with_rendered_diagnostic(self):
         async def run_with_failing_resource():
             # Patch the underlying function on the Resource object so
             # FastMCP.read_resource → resource.read() → resource.fn()
-            # raises our sentinel.
+            # raises our sentinel. The chain is:
+            #   AttributeError → ValueError("Error reading resource ...")
+            #                  → ResourceError (from FastMCP)
+            # _unwrap_cause must walk past the ValueError wrapper to the
+            # original AttributeError for proper rendering.
             resource = await mcp._resource_manager.get_resource("pflow://instructions")
             assert resource is not None
             with patch.object(resource, "fn", side_effect=AttributeError("resource producer bug sentinel")):
                 return await mcp.read_resource("pflow://instructions")
 
-        contents = list(_run(run_with_failing_resource()))
-        assert len(contents) >= 1
-        first = contents[0]
-        text = first.content if isinstance(first.content, str) else first.content.decode()
-        assert "resource producer bug sentinel" in text
+        with pytest.raises(ResourceError) as exc_info:
+            _run(run_with_failing_resource())
+
+        rendered = str(exc_info.value)
+        # Original AttributeError message must survive the 3-layer unwrap.
+        assert "resource producer bug sentinel" in rendered
+        # Proves the unwrap walked PAST the FunctionResource wrapper — the
+        # outer wrapper's message is "Error reading resource ..."; if the
+        # unwrap stopped there we'd render a ValueError diagnostic, not
+        # the AttributeError's.
+        assert "Error reading resource" not in rendered
+        # Proves we rendered through _builtin_exception_diagnostic's
+        # AttributeError path (title="Execution Failed") rather than
+        # ValueError's validation branch (title="Validation Error").
+        assert "Execution Failed" in rendered
+
+    def test_unknown_resource_renders_rich_diagnostic(self):
+        """Unknown-resource URI gets a 'Resource Not Found' diagnostic with
+        similar-URI suggestions, symmetric with the unknown-tool path."""
+        with pytest.raises(ResourceError) as exc_info:
+            _run(mcp.read_resource("pflow://instructons"))  # typo
+
+        rendered = str(exc_info.value)
+        assert "Resource Not Found" in rendered
+        assert "Unknown resource" in rendered
+        # Similar real URI should appear in the Did you mean: suggestions.
+        assert "pflow://instructions" in rendered

--- a/tests/test_mcp_server/test_exception_boundary.py
+++ b/tests/test_mcp_server/test_exception_boundary.py
@@ -1,0 +1,180 @@
+"""Tests for the PflowMCP exception boundary (issue spinje/pflow#325).
+
+Verifies that unhandled exceptions escaping MCP tool/resource handlers are
+routed through the shared Diagnostic pipeline — same structural behavior as
+the CLI's outer ``except Exception`` in ``cli/commands/run.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from mcp import types
+from mcp.server.fastmcp.exceptions import ToolError
+
+from pflow.core.exceptions import MaxNodeVisitsError
+from pflow.mcp_server.server import mcp, register_tools
+
+# Register all tools / resources once for the module. Idempotent.
+register_tools()
+
+
+# Minimal valid workflow for tools that declare `workflow` as a required
+# parameter. The patched service methods raise before the content matters,
+# but the parameter must satisfy pydantic's required-field check first.
+_MINIMAL_WORKFLOW = (
+    "# Test\n\n"
+    "A description with enough length to pass validation.\n\n"
+    "## Steps\n\n"
+    "### echo-step\n\n"
+    "Step description.\n\n"
+    "- type: echo\n"
+    "- params:\n"
+    "  - message: hi\n"
+)
+
+
+def _run(coro):
+    """Synchronous wrapper around asyncio.run for test readability."""
+    return asyncio.run(coro)
+
+
+class TestUnhandledProducerBugs:
+    """Producer bugs without ``to_diagnostics()`` render via the shared pipeline."""
+
+    def test_str_returning_tool_renders_structured_output(self):
+        with patch(
+            "pflow.mcp_server.services.execution_service.ExecutionService.validate_workflow",
+            side_effect=AttributeError("'str' object has no attribute 'get'"),
+        ):
+            result = _run(mcp.call_tool("workflow_validate", {"workflow": _MINIMAL_WORKFLOW}))
+
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        assert len(result.content) == 1
+        text = result.content[0].text
+        assert "'str' object has no attribute 'get'" in text
+        # Proves we bypassed FastMCP's default rendering, which would
+        # prefix every message with "Error executing tool X:".
+        assert "Error executing tool" not in text
+
+    def test_dict_returning_tool_renders_structured_output(self):
+        with patch(
+            "pflow.mcp_server.services.execution_service.ExecutionService.plan_workflow",
+            side_effect=KeyError("__producer_bug_sentinel__"),
+        ):
+            result = _run(mcp.call_tool("plan_workflow", {"workflow": _MINIMAL_WORKFLOW}))
+
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        assert result.structuredContent is None
+        assert "__producer_bug_sentinel__" in result.content[0].text
+
+
+class TestSelfDescribingExceptions:
+    """Exceptions with ``to_diagnostics()`` render via their own rich output,
+    even when they subclass a pass-through type. Pins the inversion-predicate
+    decision — reverting to an isinstance-only pass-through would fail here."""
+
+    def test_max_node_visits_renders_as_infinite_loop(self):
+        with patch(
+            "pflow.mcp_server.services.execution_service.ExecutionService.execute_workflow",
+            side_effect=MaxNodeVisitsError("node-x", 100, 50),
+        ):
+            result = _run(
+                mcp.call_tool(
+                    "workflow_execute",
+                    {"workflow": _MINIMAL_WORKFLOW, "parameters": {}},
+                )
+            )
+
+        assert result.isError is True
+        text = result.content[0].text
+        # Title from MaxNodeVisitsError.to_diagnostics() — would be lost if
+        # MaxNodeVisitsError were passed through as a plain RuntimeError.
+        assert "Infinite Loop Detected" in text
+        assert "node-x" in text
+
+
+class TestPassThrough:
+    """Hand-rolled rich-text service exceptions pass through unchanged so
+    today's pre-formatted output is preserved.  Follow-up: migrate services
+    to typed pflow exceptions and shrink the pass-through list."""
+
+    def test_bare_value_error_passes_through(self):
+        # Pass-through re-raises ToolError. In production flow the lowlevel
+        # handler converts it to CallToolResult(isError=True) via
+        # _make_error_result(str(e)). Here we assert the override did NOT
+        # swallow it.
+        with (
+            patch(
+                "pflow.mcp_server.services.execution_service.ExecutionService.validate_workflow",
+                side_effect=ValueError("pre-formatted rich text from service"),
+            ),
+            pytest.raises(ToolError),
+        ):
+            _run(mcp.call_tool("workflow_validate", {"workflow": _MINIMAL_WORKFLOW}))
+
+
+class TestCliMcpParity:
+    """MCP boundary produces byte-identical rendered text to the CLI boundary
+    for the same unhandled exception (issue #325 contract)."""
+
+    def test_attribute_error_text_matches_cli(self, capsys):
+        from pflow.cli.error_output import display_exception_text
+
+        exc_message = "'str' object has no attribute 'get'"
+
+        # CLI path writes one diagnostic per line to stderr via click.echo.
+        display_exception_text(AttributeError(exc_message))
+        cli_text = capsys.readouterr().err.rstrip("\n")
+
+        # MCP path: patch a service to raise the same exception and call
+        # through the boundary.
+        with patch(
+            "pflow.mcp_server.services.execution_service.ExecutionService.validate_workflow",
+            side_effect=AttributeError(exc_message),
+        ):
+            result = _run(mcp.call_tool("workflow_validate", {"workflow": _MINIMAL_WORKFLOW}))
+        mcp_text = result.content[0].text.rstrip("\n")
+
+        assert cli_text == mcp_text, f"CLI/MCP output diverged:\nCLI:\n{cli_text!r}\n\nMCP:\n{mcp_text!r}"
+
+
+class TestUnknownTool:
+    """Calling an unregistered tool renders a rich 'Tool Not Found' diagnostic."""
+
+    def test_typo_returns_did_you_mean_suggestion(self):
+        # Deliberate typo close to a real tool name.
+        result = _run(mcp.call_tool("workflow_validat", {"workflow": _MINIMAL_WORKFLOW}))
+
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        text = result.content[0].text
+        assert "Tool Not Found" in text
+        assert "Unknown tool: workflow_validat" in text
+        # The real tool name should appear in the Did you mean: suggestions.
+        assert "workflow_validate" in text
+
+
+class TestResourceBoundary:
+    """Resources go through a separate FastMCP code path (read_resource →
+    ResourceError). The override covers them symmetrically."""
+
+    def test_resource_producer_bug_renders_diagnostic(self):
+        async def run_with_failing_resource():
+            # Patch the underlying function on the Resource object so
+            # FastMCP.read_resource → resource.read() → resource.fn()
+            # raises our sentinel.
+            resource = await mcp._resource_manager.get_resource("pflow://instructions")
+            assert resource is not None
+            with patch.object(resource, "fn", side_effect=AttributeError("resource producer bug sentinel")):
+                return await mcp.read_resource("pflow://instructions")
+
+        contents = list(_run(run_with_failing_resource()))
+        assert len(contents) >= 1
+        first = contents[0]
+        text = first.content if isinstance(first.content, str) else first.content.decode()
+        assert "resource producer bug sentinel" in text


### PR DESCRIPTION
## Summary

Unhandled exceptions in MCP tool/resource handlers now route through the shared `Diagnostic` pipeline, matching the CLI's outer `except Exception` in `cli/commands/run.py`. One site (`PflowMCP.call_tool` + `read_resource` overrides) covers all 12 tools + 2 resources — no per-tool decorators.

Agents previously saw `"Error executing tool workflow_validate: 'str' object has no attribute 'get'"` for a producer bug. Now they see the same structured diagnostic the CLI produces. Closes the MCP/CLI parity gap called out by #325.

## Changes

- **`src/pflow/mcp_server/server.py`** — New `PflowMCP(FastMCP)` subclass. Overrides `call_tool` and `read_resource` to catch producer bugs (AttributeError, KeyError, etc.) and self-describing exceptions (anything with `to_diagnostics()`, which includes all `PflowError` subclasses plus `MaxNodeVisitsError`), rendering them through `exception_to_diagnostics()` + `format_diagnostic()` into `CallToolResult(isError=True)` / `ResourceError` with the rendered text. Bare `ValueError` / `TypeError` / `RuntimeError` / `FileExistsError` with pre-formatted service text pass through FastMCP's default path unchanged.
- **Unknown-tool / unknown-resource** rendered as rich `Tool Not Found` / `Resource Not Found` diagnostics with fuzzy did-you-mean suggestions via `find_similar_items`.
- **`src/pflow/mcp_server/tools/workflow_tools.py`** — removed dead `except ValueError: raise` in `workflow_describe`.
- **`src/pflow/mcp_server/CLAUDE.md`** / **`src/pflow/mcp_server/services/CLAUDE.md`** — updated error-handling sections to describe the boundary; fixed stale references (tool count 11→12, removed non-existent `settings_tools.py` / `test_tools.py` / `settings_service.py` file-tree entries, service count 7→6).
- **`tests/test_mcp_server/test_exception_boundary.py`** — 9 new tests covering unhandled producer bugs (str + dict tool return types), self-describing exception rendering (MaxNodeVisitsError), pass-through of hand-rolled rich-text ValueError (with `match=` to pin the original message through re-raise), CLI/MCP byte-identical parity (AttributeError + MaxNodeVisitsError), unknown-tool did-you-mean, resource boundary producer-bug rendering (with `not in` check proving the 3-layer unwrap walks past the FunctionResource wrapper to the original exception), and unknown-resource rich diagnostic.

## Explanation

**Why the subclass shape over a per-tool decorator:** the CLI has exactly one `except Exception` at its entry point — `cli/commands/run.py:263` and `:882`. Twelve decorated tools would scatter the same responsibility across four files with a foot-gun (a 13th tool added tomorrow without the decorator silently leaks raw exceptions). Subclassing `FastMCP` and overriding `call_tool` captures all 12 tools + both resources at one site, leveraging Python MRO which `FastMCP._setup_handlers` honors at construction time.

**Why the inversion predicate (`hasattr(x, "to_diagnostics")`) over an isinstance tuple:** `MaxNodeVisitsError` is a `RuntimeError` subclass by design (loop-guard use case) but implements `to_diagnostics()` for rich output. An isinstance-based pass-through tuple including `RuntimeError` would silently discard its structured diagnostic. The `hasattr` check mirrors the shared pipeline's own dispatch at `diagnostic.py:181` and automatically covers every future `PflowError` subclass.

**Why pass-through for bare `ValueError` / `RuntimeError` / `TypeError` / `FileExistsError`:** today's services deliberately raise these with pre-formatted rich text (see `execution_service.py:259, 264, 342, 411, 467`). Rendering them through the boundary would double-format — wrap pre-rendered text in a new diagnostic banner. Pass-through preserves today's UX exactly. This list shrinks to empty once services migrate to typed pflow exceptions (natural sequel to this PR).

**Why re-raise ResourceError instead of returning success content:** the MCP resource protocol has no `isError` channel — resource reads either succeed or fail at the JSON-RPC level. Returning rendered diagnostic text as successful content would make programmatic agents see SUCCESS and treat the diagnostic as legitimate resource content. Re-raising matches FastMCP's default pass-through behavior: agents see the error at the protocol level.

**FastMCP middleware investigation:** `mcp==1.26.0` (pinned at `mcp[cli]>=1.17.0`) has no middleware / tool-call hook. Confirmed by inspecting `FastMCP.call_tool` → `ToolManager.call_tool` → `Tool.run` at `.venv/lib/python3.13/site-packages/mcp/server/fastmcp/`. Subclass override is the cleanest interception point and uses only public (non-underscore) methods.

**Out of scope (natural follow-up):** migrate services to raise typed `PflowError` subclasses instead of hand-rolled rich-text `ValueError` / `RuntimeError`, shrinking `_PASS_THROUGH_TYPES` to empty. The boundary would then only activate for genuine producer bugs.

## Testing

- `make test` — 5155 tests pass (9 new in `test_exception_boundary.py`)
- `make check` — clean (ruff, ruff-format, mypy, deptry)
- Manual REPL reproduction: patched real `WorkflowValidator.validate` to raise `AttributeError`, verified MCP output is byte-identical to CLI's `display_exception_text` output
- End-to-end JSON-RPC stdio verification: spawned `pflow mcp serve` subprocess, sent real `tools/call` request, confirmed wire-level `CallToolResult(isError=true, content=[TextContent(...)])` with rendered diagnostic — no `"Error executing tool"` prefix

## Test plan

- [ ] `make test` passes
- [ ] `make check` clean
- [ ] Inject `raise AttributeError("boom")` into a `WorkflowValidator` method, run via MCP client, verify structured output (remove injection before merge)
- [ ] Verify `pflow mcp serve` still starts cleanly and serves all 12 tools