### PR TITLE
fix: dry-run batch sub-workflow recursion (fixes #318, #323)

### DIFF
--- a/.taskmaster/tasks/task_157/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_157/implementation/implementation-plan.md
@@ -1,0 +1,511 @@
+# Fix: Dry-Run Batch Sub-Workflow Recursion
+
+## Context
+
+`--dry-run` fails for batch sub-workflow nodes (GH #318, #323). Three symptoms from one root cause:
+1. **Missing cost/duration** — reports `$0 (no history)` for batch sub-workflows even when child cache exists
+2. **"Nothing cached" cascade** — first batch sub-workflow fails to populate parent shared → all downstream templates fail → entire plan shows "0 cached · 47 would execute" when everything is cached
+3. **False validation error** — emits "Workflow requires input 'source'" at the end of an otherwise-correct plan
+
+**Root cause**: The planner's dispatch has a hole — batch WorkflowExecutor nodes get no per-item planning. `plan_node()` (plan_node.py:50) skips template resolution when `config.batch_config` is set, so `inputs: {source: ${item}}` never resolves. The child compile fails with "missing required input." Even if it compiled, the planner has no per-item loop for cache checking or cost aggregation.
+
+**Fix**: Add `_plan_batch_sub_workflow` — plans the child per-item with full recursion for correct cache status, cost aggregation, and downstream template resolution.
+
+## Architecture Context (for cold-start agents)
+
+**Read these files first (in order):**
+1. `src/pflow/execution/plan.py` — top-of-file docstring (4 load-bearing invariants)
+2. `src/pflow/execution/CLAUDE.md` → "Dry-Run Planner" section (state machine, entry builders, sub-workflow recursion)
+3. `src/pflow/runtime/engine/plan_node.py` — the shared decision primitive (specifically line 50: batch_config skip)
+4. `src/pflow/runtime/engine/batch_executor.py:249-290` — per-item context setup pattern to mirror
+5. `.taskmaster/tasks/task_156/task-review.md` → "Patterns Established" (shared primitives, state machine)
+
+**Key existing functions (reuse, don't duplicate):**
+- `_plan_sub_workflow` (plan.py:909) — non-batch sub-workflow planning (our dispatch target)
+- `_build_plan_with_shared` (plan.py:206) — creates child scratch shared, walks child graph, returns (Plan, shared)
+- `_compile_child` (plan.py:1253) — compiles child IR with inputs, raises `_ChildCompileFailed` on error
+- `_populate_sub_workflow_outputs` → `_resolve_declared_outputs` + `_mirror_child_shared` (plan.py:1022-1101) — extracts clean child outputs for parent shared
+- `resolve_batch_items` (batch_executor.py:32) — resolves items template against shared store
+- `resolve_sub_workflow` (sub_workflow_resolver.py) — resolves child workflow file path
+- `_raw_workflow_ref` (plan.py:1198), `_opaque_sub_workflow_entry` (plan.py:1224), `_sub_workflow_error_entry` (plan.py:1234) — shared helpers
+
+**How the engine handles batch sub-workflows at runtime:**
+1. `_execute_node` detects `config.batch_config` → calls `execute_batch`
+2. `execute_batch` resolves items, then per item: `item_shared = dict(shared); item_shared[alias] = item; item_shared["__index__"] = idx`
+3. Calls `_execute_single_node(node, config, item_shared)` which resolves templates per-item (NOT `plan_node` — the engine skips top-level resolution for batch, delegates per-item to the callback)
+4. `WorkflowExecutor._run()` compiles child, runs child engine, exposes outputs
+5. `_aggregate_batch_results` writes `{results: [...], count: N, ...}` to `shared[node_id]`
+
+**Our planner mirrors this:** resolve items → per-item context setup → per-item template resolution → per-item child planning → aggregate → populate parent shared with batch shape.
+
+## Expected CLI Output
+
+**Fresh run (no cache), batch of 2 items:**
+```
+Dry-run for parent.pflow.md: 1 node
+
+  ─── nothing cached — full run ───
+  ▸ fanout  [workflow './child.pflow.md' × 2 items]
+      ▸ echo  [shell]
+
+Summary (including nested): 0 cached · 2 would execute (2 shell)
+  (2 nodes without duration history)
+```
+
+**After a full run (all cached):**
+```
+Dry-run for parent.pflow.md: 1 node
+
+  ↻ fanout  [workflow './child.pflow.md' × 2 items]
+      ↻ echo  (5s ago)
+
+Summary (including nested): 2 cached · 0 would execute
+```
+
+**Edit one item (a stays cached, b→c is new):**
+```
+Dry-run for parent.pflow.md: 1 node
+
+  ▸ fanout  [workflow './child.pflow.md' × 2 items]
+      ▸ echo  [shell]  1/2 would execute  ≈ $0.01 · ~2.3s
+
+Summary (including nested): 1 cached · 1 would execute (1 shell)
+  Estimated cost: ≈ $0.01
+  Estimated duration: ~2.3s
+```
+
+**Display rules:**
+- Parent line: `▸ node  [workflow 'path' × N items, parallel]` (include path from `sub_plan.workflow`)
+- Child nodes all-cached: normal `↻ node (age)` — no M/N annotation (redundant)
+- Child nodes all-execute: normal `▸ node [type]` — no M/N annotation (redundant)
+- Child nodes PARTIAL: `▸ node [type]  M/N would execute  ≈ $avg · ~avg_time`
+  - M = items that would execute, N = total items
+  - Cost and duration are per-execution AVERAGES (what one call costs/takes)
+- Parent node symbol: `↻` if ALL items fully cached, `▸` if ANY item has ANY work
+- Summary: real aggregated totals (sum of actual per-item costs, parallel-aware duration)
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/pflow/execution/result.py` | Add 4 optional fields to `PlanEntry` |
+| `src/pflow/execution/plan.py` | Add batch dispatch (3 lines) + `_plan_batch_sub_workflow` (~110 LOC) + `_aggregate_batch_child_plans` (~50 LOC) + `_build_batch_output_shape` (~15 LOC) |
+| `src/pflow/execution/formatters/plan_formatter.py` | Batch-aware rendering (~35 LOC) |
+| `src/pflow/execution/CLAUDE.md` | Document batch sub-workflow planning path |
+| `tests/test_execution/test_plan_batch_sub_workflow.py` | NEW — unit tests (~200 LOC) |
+| `tests/test_execution/test_plan_drift.py` | Add batch sub-workflow drift test (~80 LOC) |
+| `tests/test_execution/formatters/test_plan_formatter.py` | Batch display tests (~50 LOC) |
+
+## Implementation Steps
+
+### Step 1: Extend PlanEntry (`result.py:82-104`)
+
+Add after `diagnostic` field (line 103):
+```python
+batch_count: int | None = None
+batch_parallel: bool = False
+batch_items_cached: int | None = None
+batch_items_total: int | None = None
+```
+
+- `batch_count` / `batch_parallel`: set on the PARENT batch entry (for "× N items" header)
+- `batch_items_cached` / `batch_items_total`: set on CHILD entries inside the batch sub_plan (for "M/N would execute" per-node display)
+
+### Step 2: Add batch dispatch in `_plan_sub_workflow` (plan.py:~934)
+
+Insert after `downstream = cause == "downstream"` (line 934):
+```python
+if config.batch_config and not downstream:
+    return _plan_batch_sub_workflow(
+        curr, config, shared, cache, registry,
+        visited_paths=visited_paths, depth=depth,
+    )
+```
+
+The `not downstream` guard is critical: in BFS post-first-miss mode, the existing downstream path with `_force_downstream=True` is correct (plans entire child as downstream). Per-item planning only fires in the state-machine path where upstream shared state is reliable for item resolution.
+
+### Step 3: Implement `_plan_batch_sub_workflow` (plan.py)
+
+New function, ~110 LOC.
+
+```
+_plan_batch_sub_workflow(curr, config, shared, cache, registry, *, visited_paths, depth) -> PlanEntry:
+
+    node_id = config.node_id
+    node_type = config.node_type_name
+    batch_config = config.batch_config
+
+    PROLOGUE:
+    1. Depth check (same as non-batch):
+       if depth >= WorkflowExecutor.MAX_DEPTH_DEFAULT → _sub_workflow_error_entry
+
+    2. Opaque pre-check on workflow ref (same):
+       workflow_ref = _raw_workflow_ref(curr, config)
+       if isinstance(workflow_ref, str) and "${" in workflow_ref → _opaque_sub_workflow_entry
+
+    3. Resolve batch items:
+       items = resolve_batch_items(batch_config.items_template, shared)
+       - if items is None → return _opaque_sub_workflow_entry (items unresolvable)
+       - if not isinstance(items, list) → return _sub_workflow_error_entry with diagnostic
+       - if len(items) == 0 → return PlanEntry(status="sub_workflow", batch_count=0, sub_plan=empty_plan)
+
+    4. Template resolution for workflow ref + inputs (try/finally for cleanup):
+       NOTE: We call resolve_templates directly (NOT plan_node) because we only need
+       resolved params. plan_node with stripped batch_config would compute a meaningless
+       config_hash for WorkflowExecutor (memo_cache_lookup skips WE nodes anyway).
+
+       alias = batch_config.item_alias
+       try:
+           shared[alias] = items[0]
+           shared["__index__"] = 0
+           if config.template_config:
+               resolved_params, _, _ = resolve_templates(config.template_config, shared, node_id)
+               merged = dict(getattr(curr, "params", {}) or {})
+               if config.template_config:
+                   merged.update(config.template_config.static_params or {})
+               merged.update(resolved_params)
+           else:
+               merged = dict(getattr(curr, "params", {}) or {})
+       finally:
+           shared.pop(alias, None)
+           shared.pop("__index__", None)
+
+       child_inputs = dict(merged.get("inputs") or {})
+
+    5. Resolve child workflow (same as non-batch):
+       parent_file = shared.get("_pflow_workflow_file")
+       base_path = Path(parent_file).parent if parent_file else Path.cwd()
+       resolved = resolve_sub_workflow(merged, base_path=base_path)
+       Handle errors same as _plan_sub_workflow
+
+    6. Cycle check (same):
+       resolved_path_str = str(resolved.path.resolve()) if resolved.path else None
+       if resolved_path_str in visited_paths → _sub_workflow_error_entry
+
+    7. Compile child ONCE with items[0]'s inputs:
+       compiled_child = _compile_child(resolved.ir, resolved_path_str, child_inputs, registry, node_id, node_type)
+
+    PER-ITEM LOOP:
+    child_plans: list[Plan] = []
+    item_outputs: list[dict[str, Any]] = []
+    raw_inputs_template = config.template_config.template_params.get("inputs") if config.template_config else None
+
+    for idx, item in enumerate(items):
+        # Build per-item inputs (mirrors batch_executor.py:279-287)
+        if raw_inputs_template is not None:
+            # Context: shared first, then per-item overrides (NOT the reverse!)
+            context = {**shared, alias: item, "__index__": idx}
+            per_item_inputs = TemplateResolver.resolve_nested(raw_inputs_template, context)
+            if not isinstance(per_item_inputs, dict):
+                per_item_inputs = child_inputs  # fallback to items[0]'s resolved inputs
+        else:
+            per_item_inputs = child_inputs  # static inputs, same for all items
+
+        # Plan this item's child execution
+        child_plan, child_shared = _build_plan_with_shared(
+            compiled_child, per_item_inputs, cache, registry,
+            workflow_name=str(merged.get("workflow") or "<sub-workflow>"),
+            _visited_paths=[*visited_paths, resolved_path_str] if resolved_path_str else visited_paths,
+            _depth=depth + 1,
+            _parent_workflow_file=resolved_path_str,
+        )
+        child_plans.append(child_plan)
+
+        # Capture CLEAN child outputs (use declared-output/mirror-child logic, not raw child_shared)
+        declared = getattr(compiled_child, "outputs", None)
+        if isinstance(declared, dict) and declared:
+            item_outputs.append(_resolve_declared_outputs(declared, child_shared))
+        else:
+            item_outputs.append(_mirror_child_shared(child_shared, per_item_inputs))
+
+    AGGREGATION:
+    aggregated_plan = _aggregate_batch_child_plans(
+        child_plans, batch_parallel=batch_config.parallel, batch_count=len(items)
+    )
+
+    OUTPUT POPULATION (for downstream template resolution):
+    shared[node_id] = _build_batch_output_shape(item_outputs, batch_config)
+
+    RETURN:
+    return PlanEntry(
+        node_id=node_id, node_type=node_type,
+        status="sub_workflow", cause="no_cache_match",
+        sub_plan=aggregated_plan,
+        batch_count=len(items), batch_parallel=batch_config.parallel,
+    )
+```
+
+**New imports needed in plan.py:**
+- `from pflow.runtime.engine.batch_executor import resolve_batch_items`
+- `from pflow.runtime.template_resolver import TemplateResolver`
+- `from pflow.runtime.engine.template_resolution import resolve_templates` (already used by plan_node; check if re-export needed)
+
+### Step 4: Implement `_aggregate_batch_child_plans` (plan.py)
+
+New function, ~50 LOC. Aggregates N per-item child plans into one synthetic Plan.
+
+**Key design choice**: Aggregate by `node_id` (NOT position). Branching children may produce different entry sequences per item. Grouping by node_id is safe regardless of child topology.
+
+```
+_aggregate_batch_child_plans(child_plans: list[Plan], *, batch_parallel: bool, batch_count: int) -> Plan:
+
+    1. Build node_id → list[PlanEntry] across all child plans:
+       entries_by_node: dict[str, list[PlanEntry]] = defaultdict(list)
+       for plan in child_plans:
+           for entry in plan.entries:
+               entries_by_node[entry.node_id].append(entry)
+
+    2. Build synthetic entries (preserve order from child_plans[0]):
+       seen_node_ids: list[str] = []  # preserve first-seen order
+       for entry in child_plans[0].entries:
+           if entry.node_id not in seen_node_ids:
+               seen_node_ids.append(entry.node_id)
+
+       synthetic_entries = []
+       for nid in seen_node_ids:
+           entries_for_node = entries_by_node.get(nid, [])
+           cached_count = sum(1 for e in entries_for_node if e.status == "cached")
+           cost_values = [e.last_cost_usd for e in entries_for_node if e.last_cost_usd is not None]
+           duration_values = [e.last_duration_ms for e in entries_for_node if e.last_duration_ms is not None]
+           # None-safe averaging (never produces 0 when no data exists)
+           avg_cost = sum(cost_values) / len(cost_values) if cost_values else None
+           avg_duration = sum(duration_values) / len(duration_values) if duration_values else None
+           # Use first entry for metadata (node_type, sub_plan for nested)
+           template_entry = entries_for_node[0] if entries_for_node else child_plans[0].entries[0]
+
+           synthetic_entries.append(PlanEntry(
+               node_id=nid,
+               node_type=template_entry.node_type,
+               status="cached" if cached_count == batch_count else "execute",
+               cause="hash_match" if cached_count == batch_count else "no_cache_match",
+               last_cost_usd=avg_cost,
+               last_duration_ms=avg_duration,
+               batch_items_cached=cached_count,
+               batch_items_total=batch_count,
+               sub_plan=template_entry.sub_plan,  # preserve nested sub-workflows from items[0]
+           ))
+
+    3. Build aggregated PlanSummary:
+       # Read *_including_nested (fall back to per-level) from each child plan
+       per_item_totals = [p.summary.total_including_nested or p.summary.total for p in child_plans]
+       per_item_cached = [p.summary.cached_including_nested or p.summary.cached_count for p in child_plans]
+       per_item_execute = [p.summary.execute_including_nested or p.summary.execute_count for p in child_plans]
+       per_item_cost = [p.summary.estimated_cost_usd_including_nested if p.summary.estimated_cost_usd_including_nested is not None else p.summary.estimated_cost_usd for p in child_plans]
+       per_item_duration = [p.summary.estimated_duration_ms_including_nested if p.summary.estimated_duration_ms_including_nested is not None else p.summary.estimated_duration_ms for p in child_plans]
+       per_item_no_history = [p.summary.nodes_without_history_including_nested if p.summary.nodes_without_history_including_nested is not None else p.summary.nodes_without_history for p in child_plans]
+       per_item_no_duration = [p.summary.nodes_without_duration_history_including_nested if p.summary.nodes_without_duration_history_including_nested is not None else p.summary.nodes_without_duration_history for p in child_plans]
+
+       total_duration = max(per_item_duration) if batch_parallel else sum(per_item_duration)
+
+       # Merge execute_by_type across all child plans
+       merged_by_type: dict[str, int] = {}
+       for p in child_plans:
+           src = p.summary.execute_by_type_including_nested or p.summary.execute_by_type
+           for k, v in src.items():
+               merged_by_type[k] = merged_by_type.get(k, 0) + v
+
+       # cost_basis: upper_bound if ANY child has upper_bound
+       effective_basis = "exact"
+       for p in child_plans:
+           if p.summary.cost_basis == "upper_bound":
+               effective_basis = "upper_bound"
+               break
+
+       # Build summary with BOTH per-level AND *_including_nested populated
+       # (set equal — batch plan is already fully aggregated)
+       agg_total = sum(per_item_totals)
+       agg_cached = sum(per_item_cached)
+       agg_execute = sum(per_item_execute)
+       agg_cost = sum(c for c in per_item_cost if c)
+       agg_no_history = sum(per_item_no_history)
+       agg_no_duration = sum(per_item_no_duration)
+
+       summary = PlanSummary(
+           total=agg_total, cached_count=agg_cached, execute_count=agg_execute,
+           cache_boundary=None, execute_by_type=merged_by_type,
+           estimated_cost_usd=agg_cost, nodes_without_history=agg_no_history,
+           estimated_duration_ms=total_duration, nodes_without_duration_history=agg_no_duration,
+           cost_basis=effective_basis,
+           # *_including_nested = same values (fully aggregated already)
+           total_including_nested=agg_total, cached_including_nested=agg_cached,
+           execute_including_nested=agg_execute,
+           execute_by_type_including_nested=merged_by_type,
+           estimated_cost_usd_including_nested=agg_cost,
+           nodes_without_history_including_nested=agg_no_history,
+           estimated_duration_ms_including_nested=total_duration,
+           nodes_without_duration_history_including_nested=agg_no_duration,
+       )
+
+    4. Return Plan(workflow=child_plans[0].workflow, entries=synthetic_entries, summary=summary)
+```
+
+### Step 5: Implement `_build_batch_output_shape` (plan.py)
+
+New function, ~15 LOC. Constructs batch output for `parent_shared[node_id]` so downstream parent nodes can resolve templates like `${batch_node.results}`.
+
+```python
+def _build_batch_output_shape(
+    item_outputs: list[dict[str, Any]],
+    batch_config: BatchConfig,
+) -> dict[str, Any]:
+    results = []
+    for idx, output in enumerate(item_outputs):
+        result = dict(output) if output else {}
+        result["original_index"] = idx
+        results.append(result)
+    return {
+        "results": results,
+        "count": len(item_outputs),
+        "success_count": len(item_outputs),
+        "error_count": 0,
+        "errors": None,
+        "batch_metadata": {
+            "parallel": batch_config.parallel,
+            "execution_mode": "parallel" if batch_config.parallel else "sequential",
+        },
+    }
+```
+
+### Step 6: Update formatter (`plan_formatter.py`)
+
+**6a. Batch parent line** — modify `_render_entry_line` (around line 207-211):
+
+Add BEFORE the existing `sub_workflow` rendering:
+```python
+if entry.status == "sub_workflow" and entry.batch_count is not None:
+    ref = entry.sub_plan.workflow if entry.sub_plan else "<unknown>"
+    parallel_tag = ", parallel" if entry.batch_parallel else ""
+    return f"{indent}▸ {entry.node_id}  [workflow '{ref}' × {entry.batch_count} items{parallel_tag}]"
+```
+
+When all items cached (parent shows ↻): check the aggregated plan — if `sub_plan.summary.execute_count == 0`, use `↻` instead of `▸`.
+
+**6b. Batch child entries** — add check BEFORE default execute/cached rendering in `_render_entry_line`:
+
+```python
+if entry.batch_items_total is not None:
+    if entry.batch_items_cached == entry.batch_items_total:
+        # All cached — render as normal cached (no M/N, it's redundant)
+        age_str = _format_age(entry.age_sec) if entry.age_sec else ""
+        return f"{indent}↻ {entry.node_id}  {age_str}".rstrip()
+    else:
+        # Partial or all-execute
+        execute_count = entry.batch_items_total - (entry.batch_items_cached or 0)
+        tag = _NODE_TYPE_TAGS.get(entry.node_type, entry.node_type)
+        # Only show M/N when partial (not when all would execute — that's also redundant)
+        if entry.batch_items_cached and entry.batch_items_cached > 0:
+            stats = _format_batch_node_stats(entry)
+            return f"{indent}▸ {entry.node_id}  [{tag}]  {execute_count}/{entry.batch_items_total} would execute{stats}"
+        else:
+            # All execute — normal format with stats
+            stats = _format_stats_annotation(entry)
+            suffix = f"   {stats}" if stats else ""
+            return f"{indent}▸ {entry.node_id}  [{tag}]{suffix}"
+```
+
+**6c. New helper `_format_batch_node_stats`**: Format `≈ $X · ~Ys` from average cost/duration (same thresholds as `_format_stats_annotation`).
+
+**6d. JSON serialization** — add to `_entry_to_dict`:
+```python
+if entry.batch_count is not None:
+    d["batch_count"] = entry.batch_count
+    d["batch_parallel"] = entry.batch_parallel
+if entry.batch_items_total is not None:
+    d["batch_items_cached"] = entry.batch_items_cached
+    d["batch_items_total"] = entry.batch_items_total
+```
+
+**6e. `_has_any_cached_recursive`** — add batch partial-cache detection:
+```python
+if entry.batch_items_cached is not None and entry.batch_items_cached > 0:
+    return True
+```
+Prevents "nothing cached — full run" divider when some batch items are cached.
+
+### Step 7: Tests
+
+**7a. Drift-catcher** (`test_plan_drift.py`):
+- Create parent.pflow.md with batch sub-workflow (shell/LLM child) + child.pflow.md
+- Run end-to-end via WorkflowRunner to populate cache
+- Plan via build_plan → assert per-item cache status matches execution
+- Change one item → plan → assert partial cache detected (N-1/N cached)
+- Verify cost aggregation is sum of actual per-item costs (not average × N)
+- Verify parallel batch duration uses max (not sum)
+- Mutation-test: temporarily break dispatch → verify drift test fails
+
+**7b. Unit tests** (new file `test_plan_batch_sub_workflow.py`):
+- All cached, partial cache, no cache scenarios
+- Opaque fallback (items unresolvable — template depends on would-execute upstream)
+- Empty items (batch_count=0)
+- Parallel vs sequential duration in summary (max vs sum)
+- Error: items resolves to non-list
+- Per-node aggregation by node_id (not position-dependent)
+- Nested sub-workflows within batch child (grandchild cost rollup)
+- `error_handling: continue` doesn't affect plan (planner assumes all succeed — runtime handles failures)
+
+**7c. Formatter tests** (`test_plan_formatter.py`):
+- "× N items, parallel" header includes workflow path
+- "M/N would execute" display for partial cache
+- Normal `↻` for all-cached batch nodes (no M/N annotation)
+- Normal `▸` for all-execute batch nodes (no M/N annotation)
+- "nothing cached" divider NOT shown when batch items partially cached
+- JSON includes batch fields when present, omits when None
+
+### Step 8: Update CLAUDE.md
+
+Update `src/pflow/execution/CLAUDE.md` "Dry-Run Planner" section:
+- Add "Batch sub-workflow planning" subsection
+- Document: dispatch condition (`config.batch_config and not downstream`)
+- Document: compile-once + plan-N-times pattern
+- Document: aggregation by node_id (not position) and why
+- Document: batch output shape for downstream resolution
+- Document: per-execution averages for display, real sums for totals
+- Document: `batch_count`/`batch_parallel` on parent entry, `batch_items_cached`/`batch_items_total` on child entries
+
+## Review-Identified Fixes (incorporated in steps above)
+
+Issues found by 4 specialized review agents and addressed in the implementation:
+
+1. **Dict unpacking order** (silent-failures): Per-item context MUST be `{**shared, alias: item, "__index__": idx}` — shared first, per-item overrides AFTER. The reverse silently uses stale shared values when shared contains a key matching the alias.
+
+2. **try/finally for prologue cleanup** (silent-failures, impact-completeness): Injection of `item`/`__index__` into parent shared is wrapped in try/finally. Exception between injection and cleanup would leak stale batch context.
+
+3. **Aggregate by node_id, not position** (silent-failures, feature-interactions): Branching children may produce different entry sequences per item. Positional aggregation would mix nodes. Group by `node_id` for safety.
+
+4. **None-safe averaging** (silent-failures): `avg = sum(values) / len(values) if values else None`. Never produces 0 when no data exists. 0 would suppress "no history" warnings.
+
+5. **Per-item output via declared-output/mirror-child logic** (silent-failures): Use `_resolve_declared_outputs` or `_mirror_child_shared` per item (same logic `_populate_sub_workflow_outputs` uses). Raw `child_shared` includes internal keys (`__execution__`, etc.) that would pollute the batch output and cause downstream templates to resolve against keys absent at runtime.
+
+6. **`*_including_nested` fields explicitly computed** (impact-completeness): Sum `child_plans[i].summary.*_including_nested ?? per-level` across all items. Duration uses max (parallel) or sum (sequential). Without these, `_summarize` falls back to per-level values and parent rollup silently under-reports.
+
+7. **`_has_any_cached_recursive` extended** (feature-interactions): Check `entry.batch_items_cached > 0` to detect partial batch cache. Without this, the "nothing cached — full run" divider appears incorrectly when some items are cached.
+
+8. **Call `resolve_templates` directly** (validation-consistency): Instead of calling `plan_node` with a stripped `batch_config` (which computes a meaningless config hash for WorkflowExecutor nodes), call `resolve_templates` directly. Cleaner intent, no dead computation.
+
+## Design Decisions
+
+- **`_summarize` needs NO changes**: The aggregated sub_plan carries correct `*_including_nested` values in its summary. `_summarize` reads these and rolls up naturally. Verified by review agents.
+- **`_classify` / `_represents_work` need NO changes**: Batch entry has `status="sub_workflow"` with `sub_plan` — existing dispatch handles it.
+- **`_compute_totals` handles it correctly**: Parent batch entry counts as 1 WorkflowExecutor in per-level totals (same as non-batch sub-workflows). Nested costs come from `_summarize`'s rollup loop.
+- **`error_handling: continue`**: Doesn't affect the planner. The planner assumes all items succeed (it's predicting cache status and cost, not simulating error handling). Runtime handles failures. The `success_count` in `_build_batch_output_shape` is set to N (optimistic for plan time).
+- **No circular imports**: `plan.py` → `batch_executor.py` (for `resolve_batch_items`). `batch_executor.py` never imports from `execution/`. Verified.
+- **Existing batch drift tests unaffected**: `test_plan_batch_items_cache_matches` and `test_plan_batch_llm_cost_aggregates_across_results` test standard batch nodes (ShellNode/LLMNode), not WorkflowExecutor. Our dispatch only fires for `node_type_name == "WorkflowExecutor"`. Standard batch nodes route through `_plan_standard_node` unchanged.
+
+## Known Limitations (deferred)
+
+1. **Downstream batch**: In BFS post-first-miss mode, batch sub-workflows are planned as single iterations (items template usually depends on would-execute upstream, so `resolve_batch_items` returns None → opaque). When items ARE resolvable downstream, cost underestimates by factor N. Acceptable for v1 — the summary displays no specific cost for opaque entries.
+
+2. **Compile-once**: Compiles child once with items[0]'s inputs. Structural compilation doesn't depend on input VALUES (only presence). This matches runtime behavior (`_compiled_workflow_cache` reuses first compilation).
+
+3. **Heterogeneous workflow refs**: `workflow: ${item.ref}` is caught by the opaque pre-check (`${` in workflow ref → opaque entry). Batch dispatch never fires for these.
+
+4. **Nested batch sub-workflows**: A batch child that itself contains a batch node works naturally via recursion but is not explicitly tested in v1.
+
+## Verification
+
+1. `make check` — ruff + mypy + deptry clean
+2. `make test` — all pass (currently 5144+)
+3. Manual: Run lyrics-generator pipeline → dry-run → verify no validation error, shows "× N items" with correct cache display
+4. Manual: Run → edit one source → dry-run → verify partial cache detection (N-1/N cached nodes)
+5. Mutation-test the drift-catcher: temporarily break batch dispatch → assert drift test fails
+6. Verify JSON output includes batch fields for MCP agent consumers

--- a/.taskmaster/tasks/task_157/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_157/implementation/progress-log.md
@@ -248,3 +248,45 @@ Verification:
 - `uv run pytest tests/test_execution/` — `419 passed`
 - `uv run make test` — `5206 passed`
 - Manual: re-ran the simple repro (parent.pflow.md + child.pflow.md) — all 3 scenarios (fresh/cached/partial) produce correct output
+
+### Step 6: PR review fixes + end-to-end verification
+
+PR review (#332 comment) identified 3 warnings:
+1. Unused `batch_count` parameter in `_aggregate_batch_child_plans` — became dead after the `len(entries_for_node)` fix. Removed.
+2. Redundant nested `if config.template_config:` check — copy-paste artifact from the 3-way merge fix. Removed.
+3. Broad `except Exception` — reviewer suggested narrowing. Kept intentionally (planner must never crash). Removed the `# noqa: BLE001` comment that ruff auto-stripped anyway.
+
+End-to-end verification on lyrics-generator pipeline:
+- Ran the full pipeline ($2.43, ~7 min) to populate fresh cache entries
+- Dry-run immediately after: `fetch-sources` (batch) and `analyze-sources` (batch) correctly show `↻` cached
+- 12 cached · 33 would execute (vs the old "0 cached · 47 would execute")
+- No validation error
+
+### Step 7: Root-cause investigation of pre-existing cache key drift
+
+The lyrics-generator dry-run showed `assign-diversity` (inside `enforce-diversity`) as a cache miss even though it was just written 6 minutes ago. Investigated to determine if this was our bug or pre-existing.
+
+**Attempted repros (all PASSED — no drift):**
+1. Complex nested Python data (20 items, unicode, floats, nested dicts) — stable
+2. LLM structured output through sub-workflow boundary — stable
+3. Chained LLM sub-workflows (step1 → step2, structured JSON crossing boundary) — stable
+
+**Root cause found by comparing runtime trace vs planner cache data:**
+
+The runtime trace showed `assign-diversity`'s resolved `concepts` input with dict keys in INSERTION ORDER (as the LLM produced them): `['title', 'core_idea', 'angle', 'why_compelling', ...]`. The planner's version (read from cache via `json.loads`) had keys in ALPHABETICAL ORDER: `['angle', 'core_idea', 'emotional_core', ...]`.
+
+**The bug**: `cache.py` stores output blobs with `json.dumps(sort_keys=True)`. This is correct for cache KEY computation (deterministic hashing) but WRONG for cache VALUE storage — it destroys insertion order. When cached structured output is restored and stringified into a downstream prompt template via `str()` or `json.dumps()`, the alphabetical key order produces a different string → different cache key → false miss.
+
+**Filed as GH #333** with full repro steps, diagnostic evidence, and suggested fix (separate `sort_keys=True` for hashing from `sort_keys=False` for storage — one-line change in `cache.py`).
+
+**Confirmed NOT caused by our batch fix** — affects non-batch sub-workflows identically. The batch sub-workflow nodes (`fetch-sources`, `analyze-sources`) correctly show as cached. Only `assign-diversity` (a non-batch node downstream of a non-batch sub-workflow) drifts.
+
+### Final state
+
+- PR #332 open with all review fixes
+- 5206 tests pass, `make check` clean
+- GH #333 filed for the pre-existing cache key drift (separate fix)
+- All three original symptoms fixed for the documented scope:
+  - ✅ No false validation error
+  - ✅ Batch sub-workflow nodes show per-item cache status
+  - ✅ Downstream nodes resolve templates (no "nothing cached" cascade)

--- a/.taskmaster/tasks/task_157/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_157/implementation/progress-log.md
@@ -153,3 +153,98 @@ Ran a dedicated searcher to verify our approach doesn't conflict with GH #321 (e
 - 8 review findings incorporated
 - 3 rejected alternatives documented
 - 6 open questions resolved empirically (not by assumption)
+
+## 2026-04-20 — Implementation
+
+### Step 1: Planner core + result model
+
+Implemented the planner-side batch sub-workflow path:
+- Extended `PlanEntry` with batch metadata fields used by parent headers and per-node partial-cache rendering.
+- Added the `_plan_sub_workflow()` batch dispatch and implemented `_plan_batch_sub_workflow()`.
+- Added `_aggregate_batch_child_plans()` and `_build_batch_output_shape()`.
+
+Verified the edited Python files compile with:
+- `python3 -m py_compile src/pflow/execution/plan.py src/pflow/execution/result.py`
+
+Critical implementation notes:
+- **Batch output shape intentionally mirrors runtime more closely than the written plan**. The design doc's minimal `{results, count, ...}` sketch omitted runtime-populated keys that downstream templates may already rely on. The planner now writes `item`, `original_index`, and the same `batch_metadata` keys runtime exposes (`parallel`, `max_concurrent`, `max_retries`, `retry_wait`, `execution_mode`, `timing=None`). This keeps plan-time downstream resolution aligned with runtime shape instead of only solving `${node.results}`.
+- **Synthetic entry ordering is first-seen across ALL item plans, not only item[0]**. The written pseudocode preserved order from `child_plans[0]`, but that drops branch-only nodes that appear in later items. The implementation preserves first-seen order while still aggregating by `node_id`.
+- **Synthetic cached-count logic treats fully-cached nested sub-workflows as cached items**. Counting only `entry.status == "cached"` would incorrectly mark nested `sub_workflow` entries as misses even when their child plans are fully cached.
+- **Opaque counts are aggregated explicitly** in the synthetic `PlanSummary`. The implementation plan called out `*_including_nested` rollups but did not mention `opaque_count`; omitting it would silently under-report unresolved nested work in parent summaries.
+
+Known limitation introduced by the current aggregation:
+- For child nodes that appear only on some per-item branches, the per-node `batch_items_total` currently remains the full outer batch size because that is the task's display contract (`M/N` over total items). This is conservative, but it means branch-specific nodes are displayed against the full batch, not only the items that traverse that branch.
+
+### Step 2: Formatter + tests
+
+Implemented the display layer and pinned the new behavior with tests:
+- Updated `plan_formatter.py` for batch parent headers, partial-cache child lines, JSON batch fields, and the recursive cached-divider guard.
+- Added `tests/test_execution/test_plan_batch_sub_workflow.py` for the new planner path.
+- Added a drift-catcher to `tests/test_execution/test_plan_drift.py` that compares partial batch-sub-workflow planning against a real second execution.
+- Extended formatter tests with the new batch-specific rendering/JSON expectations.
+
+Verification:
+- `.venv/bin/python -m pytest tests/test_execution/test_plan_batch_sub_workflow.py tests/test_execution/formatters/test_plan_formatter.py tests/test_execution/test_plan_drift.py -q`
+- Result: `51 passed`
+
+Critical notes from this step:
+- **The opaque-items unit test must bypass `WorkflowRunner.plan()`**. The validator correctly rejects `${missing.items}` before the planner runs, so the opaque fallback is only reachable when testing `build_plan()` directly on compiled IR. This is a test-shape constraint, not a planner bug.
+- **Cached formatter assertions need to account for ANSI styling**. Cached icons are rendered through `click.style(...)`, so tests should assert on the semantic payload (`(5s ago)`, absence/presence of `M/N would execute`) rather than a raw unstyled line match.
+
+### Step 3: Documentation + broader verification
+
+Completed the docs pass and ran broader execution-surface verification:
+- Updated `src/pflow/execution/CLAUDE.md` with a dedicated "Batch sub-workflow planning" subsection covering the new dispatch, compile-once/plan-N-times pattern, aggregation by `node_id`, output-shape parity, and formatter fields.
+- Kept the display string source ASCII-safe by using `\u00d7` in code/tests while preserving the required rendered output (`×`).
+- Refactored the two planner functions into smaller helper primitives instead of suppressing `C901`.
+
+Verification:
+- `.venv/bin/ruff check --target-version py310 src/pflow/execution/plan.py src/pflow/execution/result.py src/pflow/execution/formatters/plan_formatter.py tests/test_execution/test_plan_batch_sub_workflow.py tests/test_execution/test_plan_drift.py tests/test_execution/formatters/test_plan_formatter.py`
+- `.venv/bin/mypy src/pflow/execution/plan.py src/pflow/execution/result.py src/pflow/execution/formatters/plan_formatter.py`
+- `.venv/bin/python -m pytest tests/test_execution -q`
+- Result: `ruff` clean, `mypy` clean, `417 passed`
+
+Environment note for future agents:
+- `uv run ...` was not usable in this sandbox because `uv` attempted to access a cache path outside the writable roots (`~/.cache/uv/...`) and failed with `Operation not permitted`. Local verification was run through the repo's `.venv/bin/*` tools instead.
+
+### Step 4: Remove `C901` suppressions
+
+User explicitly rejected the temporary `# noqa: C901` markers. Removed them by further decomposing `src/pflow/execution/plan.py`:
+- Added `_precheck_sub_workflow()`, `_prepare_sub_workflow()`, `_prepare_batch_sub_workflow_params()`, `_plan_batch_sub_workflow_items()`, and a few smaller support helpers.
+- Moved the downstream placeholder-input substitution into `_prepare_sub_workflow()` so the standard sub-workflow path keeps the old behavior without carrying the branching in `_plan_sub_workflow()` itself.
+- Restored full inherited `visited_paths` propagation in the per-item batch child loop after the extraction. This was the only subtle regression risk introduced by the refactor.
+
+Verification:
+- `python3 -m py_compile src/pflow/execution/plan.py`
+- `.venv/bin/ruff check --target-version py310 src/pflow/execution/plan.py`
+- `.venv/bin/mypy src/pflow/execution/plan.py`
+- `rg -n "# noqa: C901" src/pflow/execution/plan.py`
+- `.venv/bin/python -m pytest tests/test_execution -q`
+- Result: no `# noqa: C901` remain in the planner file; `417 passed`
+
+### Step 5: Code review fixes + regression tests
+
+Two code reviews (8 agents total) found 6 actionable issues in the staged implementation. All fixed in this step:
+
+**Critical fixes:**
+1. **Branching denominator**: `batch_items_total` was hardcoded to `batch_count` (total items). For conditional child workflows, branch-local nodes appeared as partial misses even when fully cached for their respective items. Fix: use `len(entries_for_node)` (items that actually traversed this node) as the denominator.
+2. **Silent fallback on non-dict per-item inputs**: When `TemplateResolver.resolve_nested` returned a non-dict for one item's inputs, the planner silently fell back to item[0]'s inputs. Runtime would raise `ValueError`. Fix: still fall back (so other items can proceed) but emit a WARNING diagnostic surfacing the likely runtime failure.
+3. **Duplicated resolver warnings**: Child workflow warnings were attached per item (N copies). Fix: attach once to `child_plans[0]` only — warnings describe the child workflow, not individual items.
+
+**Defensive improvements:**
+4. **`except ValueError` → `except Exception`**: The planner should never crash on malformed templates. Broadened catch with type-specific dispatch: `ValueError` → `_template_error_entry`, others → `_sub_workflow_error_entry` with log.
+5. **Missing `age_sec`**: All-cached synthetic entries had no cache age. Fix: aggregate `max(age_values)` from per-item entries (shows stalest cache — conservative).
+6. **3-way merge parity**: Batch path skipped `curr.params` seed that the non-batch path uses. Fix: mirror the 3-way merge pattern (`curr.params` → `static_params` → `resolved_params`).
+
+**Structural improvement (also resolves C901 on `_aggregate_batch_child_plans`):**
+- Extracted `_nested_or_level` helper and `_aggregate_batch_summary` function. Eliminates seven near-identical list comprehensions and keeps the aggregation function under complexity budget.
+
+**Regression tests added:**
+- `test_plan_batch_sub_workflow_branching_child_reports_correct_per_node_status`: Conditional child with 2 branches, verifies branch-local nodes show correct `batch_items_total` and `status="cached"`.
+- `test_plan_batch_sub_workflow_non_dict_per_item_inputs_emits_warning`: One item resolves inputs to non-dict, verifies WARNING diagnostic surfaces.
+
+Verification:
+- `uv run make check` — clean (ruff + format + mypy + deptry)
+- `uv run pytest tests/test_execution/` — `419 passed`
+- `uv run make test` — `5206 passed`
+- Manual: re-ran the simple repro (parent.pflow.md + child.pflow.md) — all 3 scenarios (fresh/cached/partial) produce correct output

--- a/.taskmaster/tasks/task_157/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_157/implementation/progress-log.md
@@ -1,0 +1,155 @@
+# Task 157 Progress Log — Design Journey
+
+## 2026-04-20 — Design session
+
+### Phase 1: Problem space mapping
+
+Read all four related issues (#318, #323, #321, #297) plus the detailed investigation comment on #318. The investigation comment (from the music-generation pipeline) was the most valuable artifact — it included:
+- Minimal repro workflows proving the exact boundary (batch sub-workflow, nothing else)
+- A results matrix showing which combinations work vs break
+- Evidence that #323 is a downstream consequence of #318, not a separate bug
+- A partial finding about cache key stability through sub-workflow re-entry (separate issue, not blocking)
+
+Read task reviews for 156 (dry-run implementation), 96 (batch processing), 131 (batch error handling), 153 (undeclared inputs), and 147 (validator diagnostics). Key takeaways:
+- Task 156 review: the `plan_node()` shared primitive, state machine architecture, `_execute_entry` chokepoint, "Option E" pattern. The review explicitly documents the batch-of-sub-workflow gap as TD2 with two candidate approaches.
+- Task 96 review: wrapper chain position (batch OUTSIDE namespace), per-item shallow copy pattern, `item_alias` injection at ROOT level
+- Task 153 review: `inputs:` is the single canonical form, `ALLOWED_PARAMS` closed schema, heterogeneous batch IR cache
+- Task 147 review: "prioritize simplicity of final code, not how easy it is to get there" — Option D (full conversion) over phased approaches. This principle directly applied to our design decisions.
+
+### Phase 2: Initial approach (wrong framing)
+
+First proposed three options:
+- **A**: Full per-item recursion (~450 LOC)
+- **B**: Representative-item recursion (~200 LOC)
+- **C**: Opaque with aggregate stats (~80 LOC)
+
+Recommended **Option B** based on: smaller delta, reuses existing machinery, honest approximation, overestimates (safe for cost-gating).
+
+**This framing was wrong.** It treated the problem as "which approximation strategy for batch sub-workflows" — a patch to bolt onto the existing code. The user's pushback ("prioritize simplicity of final code") forced a reframe.
+
+### Phase 3: Architectural reframe (the real insight)
+
+The actual problem is structural: the planner's dispatch has a hole in a 2×2 matrix.
+
+```
+                    non-batch           batch
+                    ─────────           ─────
+standard node       _plan_standard      _plan_standard (plan_node handles batch keys)
+WorkflowExecutor    _plan_sub_workflow   ??? ← hole
+```
+
+The engine solves this cleanly: batch is an OUTER concern that wraps per-item execution. `_execute_node` dispatches on batch at the top level; `_execute_single_node` is batch-unaware. This orthogonality is the engine's architecture.
+
+The planner should mirror it: batch dispatch at `_plan_sub_workflow` entry, with per-item planning reusing `_plan_sub_workflow`'s infrastructure.
+
+**Key decision**: The dispatch belongs inside `_plan_sub_workflow` (3-line check at the top) rather than at `_plan_one_node`, because only WorkflowExecutor nodes reach `_plan_sub_workflow`. Standard batch nodes are already handled by `plan_node`'s batch cache key computation.
+
+### Phase 4: Representative vs full per-item (the elderberry argument)
+
+Initially classified full per-item as "overengineering." User challenged: "is it really overengineering if it's correct?"
+
+The decisive example: You run a batch of 5 items, then change "elderberry" to "strawberry" and run `--dry-run`. Representative-item plans with items[0] ("apple") → cached → reports "all cached." But "strawberry" has never been seen — it would execute. The agent proceeds thinking it's free.
+
+**This is not an edge case — it's THE use case for `--dry-run`**: "I changed something, what would re-execute?"
+
+The LOC delta between representative and full per-item is ~50 lines, not 300 as initially estimated. The architecture (dispatch, PlanEntry fields, formatter, aggregation) is the same either way. The inner loop is the only difference.
+
+**Decision**: Full per-item recursion. The ~50 LOC delta buys correctness for the primary use case. And with it, we don't need multiplier heuristics — the aggregated plan reflects real per-item data.
+
+### Phase 5: Display format iteration
+
+Checked actual current output by running `--dry-run` on the lyrics-generator workflow. Discoveries:
+- Current cached format: `↻ node  (5s ago)` — recycle symbol + age, NO `✓`
+- Current execute format: `▸ node  [type]  ≈ $X · ~Ys (last run Xm ago)`
+- Sub-workflow header: `▸ node  [sub-workflow './path' (N nodes)]`
+- Batch sub-workflows in BFS mode DO get sub-plans (via `_make_downstream_entry` → `_plan_sub_workflow(cause="downstream")`), but as single iterations
+- The pre-boundary batch sub-workflow (`fetch-sources`) shows NO recursion — just flat `[workflow]`
+
+User pointed out: if we show "× 10 items", each child node should show its per-item breakdown. With full per-item data available, the natural display is `M/N would execute` per node.
+
+**Key display decisions:**
+- All-cached nodes: normal `↻` format (M/N is redundant when M=N)
+- All-execute nodes: normal `▸` format (M/N is redundant when M=0)
+- Partial: `▸ node [type]  M/N would execute  ≈ $avg · ~avg_time`
+- Only show M/N when it adds information (the partial case)
+
+### Phase 6: Cost and duration semantics
+
+User asked: "if one of the parallel sub-workflows costs differently, we ignore that?"
+
+No — with full per-item recursion we have each item's actual cost from its own cache entry. The per-node cost shown is the average (representative of "what one call costs"), and the summary shows the real sum.
+
+**Cost**: Always additive (parallel doesn't reduce cost). Per-node line shows per-execution average. Summary shows real total.
+
+**Duration**: Depends on execution mode. Per-node line shows per-execution average (how long one call takes — unambiguous). Summary shows parallel-aware total (max for parallel, sum for sequential). This avoids the ambiguity of "does this per-node number represent wall-clock for the batch?"
+
+Decision: Per-execution averages on per-node lines (consistent with non-batch format). Summary handles the batch-level math. The reader understands "2/4 would execute ≈ $0.28 · ~30.6s" as "each execution costs $0.28 and takes 30.6s, and 2 items need it."
+
+### Phase 7: Plan review findings
+
+Deployed 4 review agents (silent-failures, feature-interactions, validation-consistency, impact-completeness). Key findings that changed the implementation:
+
+**1. Dict unpacking order** (silent-failures) — Would have silently used wrong per-item values. `{alias: item, **shared}` puts item first, then shared overwrites it. Must be `{**shared, alias: item}`.
+
+**2. Aggregate by node_id, not position** (silent-failures + feature-interactions) — Branching children produce different entry sequences per item. Positional aggregation would silently mix nodes.
+
+**3. `resolve_templates` directly instead of `plan_node`** (validation-consistency) — Using `plan_node` with stripped `batch_config` computes a meaningless config hash (WorkflowExecutor is never memoized anyway). Calling `resolve_templates` directly is honest about intent and avoids dead computation.
+
+**4. `*_including_nested` must be explicitly computed** (impact-completeness) — Without these, `_summarize` falls back to per-level values and the parent rollup silently under-reports. This was the most complex piece of the aggregation and the plan was hand-waving it.
+
+**5. `_has_any_cached_recursive` needs extending** (feature-interactions) — Without checking `batch_items_cached > 0`, the "nothing cached" divider appears when batch items are partially cached. Cosmetic but directly undermines fix #2 (the cascade symptom).
+
+**6. Per-item output extraction must use declared-output logic** (silent-failures) — Raw `child_shared` includes internal keys that would pollute the batch output shape and cause downstream templates to resolve against keys absent at runtime.
+
+### Phase 8: #321 compatibility verification
+
+Ran a dedicated searcher to verify our approach doesn't conflict with GH #321 (extending shared-primitive pattern to sub-workflow output population + cycle detection).
+
+**Finding**: Our batch wrapper operates ABOVE the abstraction boundary #321 targets. It reads `parent_shared[node_id]` AFTER `_populate_sub_workflow_outputs` writes it. If #321 replaces that function with a shared `compute_child_exposure()` helper, our wrapper is unaffected. **Neutral to #321's goals.**
+
+### Critical insights for the implementer
+
+1. **The `plan_node` batch_config skip is CORRECT for standard batch nodes** — the engine also skips top-level resolution for batch. The fix is NOT "remove the skip" — it's "add a dispatch that handles WE batch nodes before reaching the skip."
+
+2. **`_build_plan_with_shared` creates its own scratch shared** — each per-item call is isolated. No cross-contamination between items. The parent shared is only modified for output population (once, after the loop).
+
+3. **Compile once is safe** because `compile_workflow` validates input PRESENCE, not VALUES. All items use the same child topology — only the input values (and thus cache keys) differ.
+
+4. **The downstream path (`cause="downstream"`) is intentionally left unchanged** — items templates in downstream mode usually depend on would-execute upstream → `resolve_batch_items` returns None → opaque. The fix targets the pre-boundary state-machine path where upstream cached data makes item resolution possible.
+
+5. **Task 147's principle applies directly**: "Task 143 took the pragmatic shortcut and Task 144 had to fix it. The lesson is in the codebase history." We chose full per-item over representative because the "shortcut" (representative) gives wrong answers for the primary use case and would need fixing later.
+
+6. **The `_summarize` NO-CHANGES claim is verified** but depends on the aggregated plan having correct `*_including_nested` fields. If those are wrong or missing, `_summarize` silently under-reports. This is why the review agents flagged it as the most critical piece to get right.
+
+### Rejected alternatives (and why)
+
+| Alternative | Why rejected |
+|---|---|
+| Representative-item (items[0] × N) | Wrong for "edit one item" scenario — THE primary use case for dry-run |
+| `plan_node` with stripped `batch_config` | Computes meaningless config hash for WE nodes. `resolve_templates` directly is cleaner |
+| Batch dispatch at `_plan_one_node` level | Only WE nodes need it — standard batch already handled. Dispatch inside `_plan_sub_workflow` is more focused |
+| Aggregate by entry position | Breaks for branching children with different entry sequences per item |
+| Scale child plan summary (mutate Plan) | Less clean than aggregating from real data. Child plan becomes inaccurate as standalone object |
+| `batch_count` multiplier on PlanEntry (without per-item recursion) | Can't detect which specific items are cached/miss. Gives wrong answers |
+| Lifting the `WorkflowExecutor` memo cache skip | Fights a documented invariant ("sub-workflow files may change"). Inner nodes already cached individually |
+| Phased approach (fix validation error first, cost later) | Task 147's lesson: "phased approaches accrue debt the next task has to fix" |
+
+### Open questions resolved during session
+
+| Question | Answer | Evidence |
+|---|---|---|
+| Does `resolve_batch_items` work with planner's scratch shared? | Yes — uses TemplateResolver against shared dict. Upstream cached outputs are in shared via `apply_memo_hit`. | batch_executor.py:32-55, confirmed by searcher |
+| Can we `dataclasses.replace(config, batch_config=None)`? | Yes — NodeConfig is regular `@dataclass`, not frozen | types.py:37 |
+| Does `_summarize` need changes? | No — reads `sub_plan.summary.*_including_nested` which our aggregation correctly populates | Verified by 2 review agents |
+| Does our fix break existing batch drift tests? | No — those test standard batch nodes (ShellNode/LLMNode), our dispatch only fires for WorkflowExecutor | Confirmed by searcher |
+| Circular import risk? | None — `batch_executor.py` never imports from `execution/` | Confirmed by searcher |
+| Is #321 affected? | Neutral — we operate above the level #321 targets | Confirmed by dedicated searcher |
+
+### Session metrics
+
+- ~3 hours of design discussion
+- 4 parallel searcher deployments for verification
+- 4 parallel review agents for plan review
+- 8 review findings incorporated
+- 3 rejected alternatives documented
+- 6 open questions resolved empirically (not by assumption)

--- a/.taskmaster/tasks/task_157/task-157.md
+++ b/.taskmaster/tasks/task_157/task-157.md
@@ -1,0 +1,110 @@
+# Task 157: Fix Dry-Run Batch Sub-Workflow Recursion
+
+## Problem
+
+`pflow <workflow> --dry-run` produces three incorrect behaviors for batch sub-workflow nodes (nodes with both `type: workflow` and a `batch:` config):
+
+1. **Missing cost/duration estimates** (GH #318) — Reports `$0 (no history)` and unknown duration even when per-item cache entries exist with full cost/duration data. Agents cost/time-gating on dry-run output approve runs they should abort.
+
+2. **"Nothing cached" cascade** — After a successful full run, dry-run reports "0 cached · 47 would execute" when all 47 nodes are actually cached. The first batch sub-workflow fails to populate parent shared store → all downstream template resolution fails → no cache keys computed anywhere.
+
+3. **False validation error** (GH #323) — Emits `Workflow requires input 'X'` for child inputs that are correctly satisfied via batch `${item}`. The error fires after a complete plan is printed. The same workflow passes `--validate-only` and runs successfully.
+
+## Why This Matters
+
+`--dry-run` exists so agents can cost/time-gate before expensive runs. When it reports "$0, nothing cached" for a fully-cached $2.43 pipeline, agents either:
+- Trust it and proceed (wasting the dry-run entirely)
+- Learn to distrust it (defeating the feature's purpose)
+
+The batch-of-sub-workflow pattern is used in every non-trivial pipeline (the lyrics-generator uses it for `fetch-sources`, `analyze-sources`, `create-songs`, `curate-briefs`). This isn't an edge case — it's the primary composition pattern that dry-run can't handle.
+
+## Root Cause
+
+The planner's dispatch has a structural gap. It handles:
+- Standard nodes (batch or not) via `_plan_standard_node` + `plan_node`
+- Non-batch sub-workflow nodes via `_plan_sub_workflow`
+
+But NOT batch sub-workflow nodes. When `_plan_sub_workflow` is reached for a batch WorkflowExecutor:
+- `plan_node()` skips template resolution because `config.batch_config` is set (plan_node.py:50)
+- `inputs: {source: ${item}}` never resolves → child compile fails → "missing required input"
+- Even if it compiled, there's no per-item loop → no per-item cache checking → no cost aggregation
+
+## Requirements
+
+### Functional
+
+1. **Per-item cache detection**: For a batch of N items, each item's child nodes must be individually checked against the memo cache. If 4/5 items are cached and 1 is new, the plan must report this accurately (not "all cached" or "nothing cached").
+
+2. **Cost aggregation**: Total cost = sum of actual per-item historical costs from cache (not one item × N). Items may have different costs (different input lengths → different token counts).
+
+3. **Duration estimation**: Sequential batches = sum of per-item durations. Parallel batches = max of per-item durations (wall-clock). Never multiply by N for parallel.
+
+4. **Downstream template resolution**: After planning the batch, `parent_shared[node_id]` must contain the batch output shape (`{results: [...], count: N, ...}`) so downstream parent nodes can resolve templates like `${batch_node.results}`.
+
+5. **No false validation errors**: Batch items provide `${item}` context for child inputs at runtime. The planner must provide the same context at plan time.
+
+6. **Opaque fallback**: When batch items can't be resolved (template depends on would-execute upstream), return an opaque entry honestly (not an error).
+
+### Display
+
+Per-node lines inside a batch sub-plan:
+- **All items cached for a node**: normal `↻ node (age)` — no M/N (redundant)
+- **All items would execute**: normal `▸ node [type]` — no M/N (redundant)
+- **Partial cache**: `▸ node [type]  M/N would execute  ≈ $avg · ~avg_time`
+  - M = items that would execute, N = total items
+  - Cost/duration = per-execution averages
+
+Parent batch node line:
+- `▸ node  [workflow 'path' × N items, parallel]` or `↻` if all items fully cached
+
+Summary: real aggregated totals (sum of actual per-item costs, parallel-aware duration).
+
+### Non-functional
+
+- No changes to `_summarize`, `_classify`, `_represents_work`, `_compute_totals` — the fix must work within existing aggregation infrastructure
+- No circular imports (plan.py may import from batch_executor.py but not vice versa)
+- Existing batch drift tests (`test_plan_batch_items_cache_matches`, `test_plan_batch_llm_cost_aggregates_across_results`) must pass unchanged — they test standard batch nodes, not WorkflowExecutor
+- `make check` and `make test` clean
+
+## Acceptance Criteria
+
+1. **Repro from GH #323 produces correct output**: Parent with `batch: items: ${sources}` + child with required input → `--dry-run` shows no validation error, displays per-item cache status.
+
+2. **"Nothing cached" cascade fixed**: After a full run of the lyrics-generator pipeline, `--dry-run` shows "47 cached · 0 would execute" (not "0 cached · 47 would execute").
+
+3. **Partial cache detected**: Run a batch workflow → change one item → `--dry-run` correctly identifies which items are cached and which would execute.
+
+4. **Cost is sum of actuals**: Drift-catcher test verifies plan cost equals sum of per-item historical costs from cache (not average × N).
+
+5. **Parallel duration is max, not sum**: A parallel batch of 5 items each taking 2s shows ~2s duration (not 10s).
+
+6. **Downstream nodes resolve**: After the batch sub-workflow is planned, downstream parent nodes that template against `${batch_node.results}` resolve correctly (no template_error cascade).
+
+7. **Drift-catcher test exists and is mutation-verified**: Temporarily breaking the batch dispatch causes the test to fail.
+
+## Scope
+
+### In scope
+- Batch sub-workflow planning in the pre-boundary (state-machine) path
+- Per-item full recursion with accurate cache checking
+- Aggregation across N child plans
+- Batch output shape for downstream template resolution
+- Formatter changes for batch display
+- CLAUDE.md documentation
+
+### Out of scope (deferred)
+- Downstream (BFS post-first-miss) batch handling — items usually unresolvable, existing single-iteration path acceptable for v1
+- Heterogeneous workflow refs (`workflow: ${item.ref}`) — already handled by opaque pre-check
+- Nested batch-inside-batch testing — works via recursion, explicit tests later
+- Per-item input validation in planner — validator catches these pre-execution
+
+## Related Issues
+
+- **GH #318**: Cost AND duration estimates missing for batch-of-sub-workflow nodes
+- **GH #323**: False validation error for sub-workflow inputs satisfied via batch `${item}`
+- **GH #321**: Extend shared-primitive pattern to sub-workflow output population (our fix is neutral to this — operates above the level #321 targets)
+- **GH #297**: Aggregation shape in compile_validation (context only, not fixed here)
+
+## Implementation
+
+See `implementation/implementation-plan.md` for the detailed HOW.

--- a/.taskmaster/tasks/task_157/task-review.md
+++ b/.taskmaster/tasks/task_157/task-review.md
@@ -1,0 +1,261 @@
+# Task 157 Review: Fix Dry-Run Batch Sub-Workflow Recursion
+
+## Metadata
+
+- **Implementation window**: 2026-04-20
+- **Branch**: `fix/dry-run-batch-recursion`
+- **GitHub issues**: #318 (cost/duration), #323 (false validation error)
+- **Scope**: ~450 LOC added to production, ~200 LOC tests, 8 files touched
+
+## Executive Summary
+
+Filled the last structural gap in the dry-run planner's dispatch matrix: batch WorkflowExecutor nodes now get full per-item recursive planning. The planner compiles the child once, plans it N times (once per batch item) with per-item template context, aggregates N child plans into one synthetic plan with per-node cache status, and populates the parent shared store with the runtime batch output shape. This fixes three user-visible symptoms: missing cost/duration estimates, "nothing cached" cascade for entire pipelines, and false validation errors on `${item}`-backed child inputs.
+
+## Implementation Overview
+
+### What Was Built
+
+A batch sub-workflow planning path consisting of 6 new/modified functions in `plan.py`:
+
+- `_plan_batch_sub_workflow` — top-level orchestrator (dispatch target)
+- `_prepare_batch_sub_workflow_params` — item[0]-scoped template resolution with try/finally cleanup
+- `_plan_batch_sub_workflow_items` — per-item loop calling `_build_plan_with_shared` N times
+- `_resolve_per_item_sub_workflow_inputs` — per-item input resolution with non-dict fallback + WARNING diagnostic
+- `_aggregate_batch_child_plans` — collapses N plans into one synthetic plan (by node_id)
+- `_aggregate_batch_summary` — builds PlanSummary from N child summaries (extracted for C901)
+- `_build_batch_output_shape` — mirrors runtime's `_aggregate_batch_results` output for downstream template resolution
+
+Plus `_nested_or_level` helper (reads `*_including_nested` with per-level fallback).
+
+### Deviations from Plan
+
+| Plan said | Actually built | Why |
+|-----------|---------------|-----|
+| Representative-item (Option B, ~200 LOC) | Full per-item recursion (~400 LOC) | User demonstrated representative gives WRONG answers for the "edit one item and re-check" scenario — THE primary use case for `--dry-run` |
+| Call `plan_node` with stripped `batch_config` | Call `resolve_templates` directly | Review found `plan_node` computes meaningless config hash for WorkflowExecutor (memo_cache_lookup skips WE anyway). Direct call is honest about intent. |
+| `batch_items_total = batch_count` | `batch_items_total = len(entries_for_node)` | Review found branching children produce contradictory display (per-node says "1/2 would execute" but summary says "0 execute"). Fix: denominator = items that traversed this node. |
+| Silent fallback on non-dict inputs | Fallback + WARNING diagnostic | Review found this masks runtime failures — planner should honestly warn when an item will fail at execution time. |
+| `# noqa: C901` on complex functions | Extracted `_aggregate_batch_summary` and `_nested_or_level` | User rejected suppressions; structural extraction was achievable. |
+
+### Implementation Approach
+
+**Mirrors the engine's outer-batch / inner-single-item split.** The engine handles batch at `_execute_node` level (outer concern), then `_execute_single_node` is batch-unaware (inner). The planner mirrors this: `_plan_sub_workflow` dispatches batch at entry, then `_build_plan_with_shared` is batch-unaware.
+
+**Compile once, plan N times.** Child workflow is compiled once with items[0]'s inputs (structural compilation doesn't depend on input VALUES, only presence). Each per-item call to `_build_plan_with_shared` creates its own scratch shared seeded from per-item inputs — no cross-contamination between items.
+
+**Aggregate by node_id, not position.** Different items may take different branches in a conditional child workflow, producing different entry sequences. Grouping by `node_id` handles this safely. `batch_items_total` = number of items that actually traversed each node.
+
+## Files Modified/Created
+
+### Core Changes
+
+- `src/pflow/execution/result.py` (+4 lines) — `batch_count`, `batch_parallel`, `batch_items_cached`, `batch_items_total` on PlanEntry
+- `src/pflow/execution/plan.py` (+410 lines) — Batch dispatch, 6 new functions, `_nested_or_level` helper
+- `src/pflow/execution/formatters/plan_formatter.py` (+58 lines) — Batch parent header, partial-cache child lines, JSON serialization, `_has_any_cached_recursive` extension
+- `src/pflow/execution/CLAUDE.md` (+26 lines) — "Batch sub-workflow planning" subsection
+
+### Test Files
+
+- `tests/test_execution/test_plan_batch_sub_workflow.py` (NEW, 490 lines, 9 tests) — Unit tests for all batch planning paths
+- `tests/test_execution/test_plan_drift.py` (+74 lines, 1 test) — Drift-catcher: partial-cache prediction matches real execution
+- `tests/test_execution/formatters/test_plan_formatter.py` (+183 lines, 4 tests) — Batch display rendering
+
+**Critical tests** (don't weaken these):
+- `test_plan_batch_sub_workflow_partial_cache_matches_execution` — THE drift-catcher. Runs workflow, edits one item, asserts planner detects partial cache. Mutation: remove batch dispatch → fails.
+- `test_plan_batch_sub_workflow_branching_child_reports_correct_per_node_status` — Pins the `batch_items_total = len(entries_for_node)` fix. Without it, branching children show contradictory display.
+- `test_aggregate_batch_child_plans_parallel_duration_uses_max` — Pins parallel vs sequential duration semantics.
+
+## Integration Points & Dependencies
+
+### Incoming (consumers of the new code)
+
+- `_plan_sub_workflow` → `_plan_batch_sub_workflow` (batch dispatch at line ~936)
+- `plan_formatter._render_entry_line` → reads `batch_count`, `batch_items_cached`, `batch_items_total`
+- `plan_formatter._entry_to_dict` → serializes batch fields to JSON for MCP consumers
+- `plan_formatter._has_any_cached_recursive` → checks `batch_items_cached > 0`
+- `_summarize` → reads aggregated `sub_plan.summary.*_including_nested` (no batch-specific code needed)
+
+### Outgoing (what this code depends on)
+
+- `resolve_batch_items` (batch_executor.py:32) — items resolution from shared store
+- `resolve_templates` (template_resolution.py) — prologue param resolution with item[0] in scope
+- `TemplateResolver.resolve_nested` (template_resolver.py) — per-item input resolution
+- `_build_plan_with_shared` (plan.py:206) — per-item child planning (isolated scratch shared)
+- `_resolve_declared_outputs` / `_mirror_child_shared` (plan.py:1022-1101) — per-item output extraction
+- `_compile_child` (plan.py) — one-shot child compilation
+- `resolve_sub_workflow` (sub_workflow_resolver.py) — child workflow file resolution
+
+### Shared Store Keys
+
+- `shared[node_id]` — batch output shape written after per-item loop: `{results: [...], count: N, success_count: N, error_count: 0, errors: None, batch_metadata: {...}}`. Each result has `item` + `original_index`. Downstream parent nodes template against this.
+- `shared[batch_config.item_alias]` + `shared["__index__"]` — temporarily injected during prologue (try/finally cleanup). Never persists past the function.
+
+## Architectural Decisions & Tradeoffs
+
+### D1. Full per-item recursion over representative-item
+
+**Reasoning**: The "elderberry argument" — representative-item (plan items[0], multiply by N) gives WRONG answers for the primary use case. If you run a batch, edit one item, then `--dry-run`, representative says "all cached" when one item would actually execute. The agent proceeds thinking it's free.
+
+**LOC delta**: ~50 lines more than representative. The architecture (dispatch, PlanEntry fields, formatter, output shape) is identical either way. Only the inner loop differs.
+
+**Alternative rejected**: Representative-item. Wrong for the edit-one-item scenario. Would need fixing later (Task 147's lesson: "phased approaches accrue debt the next task has to fix").
+
+### D2. Aggregate by node_id, not list position
+
+**Reasoning**: Conditional child workflows produce different entry sequences per item. Item "a" might take the `fast` branch, item "b" the `slow` branch. Positional aggregation silently mixes unrelated nodes.
+
+**`batch_items_total`**: Set to `len(entries_for_node)` (items that traversed this node), NOT `batch_count` (total items). This prevents branch-local nodes from appearing as partial misses.
+
+### D3. `resolve_templates` directly (not `plan_node`)
+
+**Reasoning**: `plan_node` computes a config hash and checks memo cache. For WorkflowExecutor nodes, memo cache always returns `(False, None, None)` — the hash is dead computation. Calling `resolve_templates` directly is honest about intent.
+
+### D4. 3-way merge mirroring non-batch path
+
+**Reasoning**: The non-batch path does `curr.params → static_params → resolved_params`. The batch path initially only did `static_params → resolved_params`, missing keys that live solely on `curr.params`. Although not reachable today (compiler routes all keys through template_config), the 3-way merge is defense-in-depth that matches the non-batch path.
+
+### D5. WARNING diagnostic (not error) for non-dict per-item inputs
+
+**Reasoning**: Runtime raises `ValueError` when inputs resolve to non-dict. The planner should be honest about this. But it shouldn't STOP planning other items — `error_handling: continue` means runtime will skip the bad item and proceed. A WARNING surfaces the issue without blocking the plan.
+
+### D6. Downstream batch deferred
+
+**Reasoning**: In BFS post-first-miss mode, batch items templates usually depend on would-execute upstream (`${fetch-sources.results}` where fetch-sources hasn't executed). `resolve_batch_items` returns None → opaque entry. Per-item planning only fires in the state-machine path where upstream shared state is reliable.
+
+## Testing Implementation
+
+### Test Strategy
+
+Three layers, matching the established drift-catcher pattern from Task 156:
+
+1. **Drift-catcher** (`test_plan_drift.py`) — runs workflow end-to-end then plans, asserts prediction matches execution. THE load-bearing parity test. Has explicit mutation recipe in docstring.
+2. **Unit tests** (`test_plan_batch_sub_workflow.py`) — tests each function/path in isolation: all-cached, partial-cache, empty items, opaque fallback, non-list items, parallel duration, cost aggregation, branching children, non-dict input warning.
+3. **Formatter tests** (`test_plan_formatter.py`) — pins display rendering: "× N items" header, "M/N would execute", absence of redundant annotations, JSON batch fields.
+
+### Critical Test Cases
+
+| Test | What it catches |
+|------|-----------------|
+| `test_plan_batch_sub_workflow_partial_cache_matches_execution` | Planner-engine parity for batch sub-workflows. Mutation: remove dispatch → fails |
+| `test_plan_batch_sub_workflow_branching_child_reports_correct_per_node_status` | `batch_items_total` uses traversal count, not batch count |
+| `test_plan_batch_sub_workflow_non_dict_per_item_inputs_emits_warning` | Non-dict inputs produce WARNING, not silent fallback |
+| `test_aggregate_batch_child_plans_parallel_duration_uses_max` | Parallel = max, sequential = sum |
+| `test_aggregate_batch_child_plans_sums_costs_without_average_times_count` | Cost = sum of actuals, not average × N |
+| `test_format_plan_text_nothing_cached_divider_respects_partial_batch_cache` | Partial batch cache prevents "nothing cached" divider |
+
+## Unexpected Discoveries
+
+### Pre-existing cache key drift (NOT our bug)
+
+The lyrics-generator pipeline (the motivating example from #318) still shows "nothing cached" for `fetch-sources` even after the fix. Investigation revealed: cache entries written 3h ago have DIFFERENT cache keys than both the planner AND the engine compute NOW. The runtime and planner agree on the same key (`19e9455...`) but the stored key is `d285e99...`. This is a pre-existing cache key drift issue (prior pflow version wrote entries with different serialization). Running the workflow FRESH and then dry-running correctly shows "all cached."
+
+### The `not downstream` guard is load-bearing
+
+Without it, batch sub-workflows reached via BFS (downstream) crash because items templates depend on would-execute upstream. The guard routes downstream batch sub-workflows through the existing force-downstream path, which uses placeholders and skips per-item planning entirely.
+
+### `ir_to_markdown` doesn't handle routing syntax
+
+The `write_workflow_file` helper from `tests/shared/markdown_utils.py` doesn't emit `- next: end` directives needed for branch targets. Tests with conditional child workflows must write raw markdown instead of using the IR→markdown conversion.
+
+### Formatter uses Click styling for `↻`
+
+Test assertions on cached batch entries must account for ANSI escape codes from `click.style('↻', fg='blue', dim=True)`. Assert on semantic payload (`(5s ago)`, absence of `M/N would execute`) not on exact string equality.
+
+## Patterns Established
+
+### P1. Batch dispatch at sub-workflow entry (outer-batch / inner-single-item)
+
+```python
+# In _plan_sub_workflow, before any existing logic:
+if config.batch_config and not downstream:
+    return _plan_batch_sub_workflow(...)
+```
+
+Mirrors the engine's `if config.batch_config: execute_batch(...)` dispatch. The rest of `_plan_sub_workflow` is batch-unaware.
+
+### P2. `_nested_or_level` for PlanSummary field access
+
+```python
+def _nested_or_level(summary: PlanSummary, *, nested: str, level: str) -> Any:
+    value = getattr(summary, nested)
+    return value if value is not None else getattr(summary, level)
+```
+
+Eliminates 7 near-identical list comprehensions. Use whenever reading `*_including_nested` with per-level fallback across N plans.
+
+### P3. try/finally for shared-store injection in planner
+
+```python
+try:
+    shared[alias] = items[0]
+    shared["__index__"] = 0
+    # ... template resolution ...
+finally:
+    shared.pop(alias, None)
+    shared.pop("__index__", None)
+```
+
+Prevents leaking batch context into parent shared on exception. Matches runtime pattern at `_execute_batch_item`.
+
+### P4. WARNING diagnostic for runtime-would-fail cases
+
+When the planner detects a condition that runtime would reject, emit a WARNING diagnostic and fall back to safe defaults. Don't silently mask the failure. Don't error (that would stop planning other items).
+
+### P5. Dict unpacking order: `{**shared, alias: item}`
+
+NOT `{alias: item, **shared}`. Python evaluates left-to-right; later keys override earlier. The per-item override must come AFTER the shared spread, otherwise shared overwrites it if shared has a key matching the alias.
+
+### Anti-patterns to avoid
+
+- **Don't use `batch_count` (total items) as denominator for branch-local nodes** — use `len(entries_for_node)` (items that traversed this node).
+- **Don't aggregate by list position** — branching children produce different entry sequences. Always group by `node_id`.
+- **Don't call `plan_node` when you only need template resolution** for WorkflowExecutor. It computes a dead config hash. Call `resolve_templates` directly.
+- **Don't attach per-child-workflow warnings inside the per-item loop** — they describe the child workflow (invariant across items), not individual items.
+- **Don't suppress M/N when `batch_items_total == batch_count`** — suppress only when ALL items cached or ALL execute. Partial display is the value add.
+
+## Known Limitations
+
+1. **Downstream batch** — In BFS post-first-miss, batch sub-workflows planned as single iteration. Items usually unresolvable (depends on would-execute upstream). Cost underestimates by factor N for the rare case where items ARE resolvable downstream.
+2. **Nested `sub_plan` on synthetic entries** — Preserves items[0]'s nested sub-workflow view only. Cross-item aggregation of nested sub_plans is not implemented. Aggregated SUMMARY is correct; only the displayed nested tree is approximate.
+3. **Stale cache from prior pflow versions** — Cache entries written by older versions have different keys. Dry-run shows "nothing cached" until the workflow is re-run with the current version.
+
+## AI Agent Guidance
+
+### Quick Start for Related Tasks
+
+**Read first (in order):**
+1. `src/pflow/execution/plan.py` — search for `_plan_batch_sub_workflow` to see the complete implementation
+2. `src/pflow/execution/CLAUDE.md` → "Batch sub-workflow planning" subsection
+3. `tests/test_execution/test_plan_batch_sub_workflow.py` — shows all exercised paths
+4. This review
+
+**For changes to batch sub-workflow planning:**
+- Run `test_plan_batch_sub_workflow_partial_cache_matches_execution` first — it's the parity invariant.
+- The aggregation is in `_aggregate_batch_child_plans` + `_aggregate_batch_summary`.
+- Per-item inputs are resolved in `_resolve_per_item_sub_workflow_inputs`.
+- Output population is in `_build_batch_output_shape`.
+
+**For changes to the formatter:**
+- Batch-specific rendering fires when `entry.batch_count is not None` (parent) or `entry.batch_items_total is not None` (child).
+- Run `test_format_plan_text_batch_*` tests.
+- The `_has_any_cached_recursive` check handles batch partial-cache.
+
+### Common Pitfalls
+
+1. **Forgetting `not downstream` in the batch dispatch** — downstream mode uses force-downstream, which is correct. Per-item planning in downstream mode crashes because items can't resolve.
+2. **Using `batch_count` instead of `len(entries_for_node)`** for denominator — causes contradictory display for branching children.
+3. **Dict unpacking order** — `{alias: item, **shared}` silently uses stale values if shared has the alias key.
+4. **Testing branching children with `write_workflow_file`** — `ir_to_markdown` doesn't emit `- next: end` directives. Use raw markdown for routing tests.
+5. **Expecting lyrics-generator to show "all cached"** with old cache entries — pre-existing key drift issue, not a bug in this implementation. Run the workflow fresh first.
+
+### Test-First Recommendations
+
+When modifying batch sub-workflow planning:
+1. Run `test_plan_batch_sub_workflow_partial_cache_matches_execution` — if this fails, planner-engine parity is broken.
+2. Run `test_plan_batch_sub_workflow_branching_child_reports_correct_per_node_status` — if this fails, denominator logic regressed.
+3. Run the full `tests/test_execution/test_plan_batch_sub_workflow.py` suite (9 tests, <1s).
+4. Run `tests/test_execution/test_plan_drift.py` for full drift-catcher coverage (30+ tests).
+
+---
+
+*Generated from implementation context of Task 157.*

--- a/src/pflow/execution/CLAUDE.md
+++ b/src/pflow/execution/CLAUDE.md
@@ -86,6 +86,31 @@ Per-entry `last_duration_ms` is only rendered in text when ≥ 1s (`_TEXT_DURATI
 
 Both paths share: depth guard, opaque check (`workflow: ${var}`), resolve + compile + recurse + warning attach. `cause` flows through to the returned `PlanEntry`.
 
+### Batch sub-workflow planning (pre-boundary only)
+
+Batch `WorkflowExecutor` nodes are the one place where the planner cannot rely on `plan_node()` alone. `plan_node()` intentionally skips top-level template resolution when `config.batch_config` is set — correct for standard batch nodes because runtime resolves the batch item context inside the batch loop. For sub-workflows, the planner must mirror that same outer-batch / inner-single-item split explicitly.
+
+`_plan_sub_workflow()` therefore has an early dispatch:
+
+```python
+if config.batch_config and not downstream:
+    return _plan_batch_sub_workflow(...)
+```
+
+Load-bearing details:
+- **Only pre-boundary uses per-item recursion.** Post-boundary (`cause="downstream"`) keeps the existing force-downstream behavior because upstream state is dirty and batch item templates are usually not resolvable there.
+- **Compile once, plan N times.** `_plan_batch_sub_workflow()` resolves the child workflow path + item[0] inputs once, compiles the child once, then calls `_build_plan_with_shared()` once per item with per-item inputs. This mirrors runtime's compiled sub-workflow cache reuse.
+- **Per-item inputs use item context only where needed.** The prologue resolves the parent workflow node with `item[0]` injected into shared so `${item}`-backed child inputs don't false-fail validation. The per-item loop then re-resolves only the raw `inputs` template with `{**shared, alias: item, "__index__": idx}`.
+- **Aggregation is by `node_id`, not list position.** Different items can take different child branches, so positional zipping silently mixes unrelated nodes. `_aggregate_batch_child_plans()` groups entries by `node_id` and preserves first-seen order across all item plans. `batch_items_total` on each synthetic entry is `len(entries_for_node)` (items that traversed this node), NOT `batch_count` — branch-local nodes correctly show as fully cached when all their traversing items hit cache.
+- **Nested `sub_plan` on synthetic entries is item[0]'s view only.** When a child node is itself a sub-workflow, the synthetic entry preserves that sub_plan from the first item's plan. Cross-item aggregation of nested sub-plans is a known limitation — the aggregated summary IS correct (sums across all items), but the displayed nested tree under a synthetic entry shows only one item's structure.
+- **Synthetic plan summary is already fully aggregated.** The returned child `PlanSummary` sets both per-level fields and `*_including_nested` fields to the same aggregated values. This is why `_summarize()` needs no batch-specific branch.
+- **Parent shared output must match runtime batch shape.** `_build_batch_output_shape()` writes `results[]`, `count`, `success_count`, `error_count`, `errors`, and `batch_metadata` to `shared[node_id]`, and each result carries `item` + `original_index`. Downstream parent nodes templating `${fanout.results}` or `${fanout.count}` resolve against the same shape runtime exposes.
+
+Current display contract:
+- Parent batch entry uses `PlanEntry.batch_count` / `batch_parallel` and renders as `[workflow 'path' × N items[, parallel]]`.
+- Synthetic child entries use `batch_items_cached` / `batch_items_total`.
+- Partial cache lines show `M/N would execute` plus per-execution average cost/duration; all-cached and all-execute cases intentionally fall back to the normal cached/execute rendering to avoid redundant labels.
+
 ### Force-downstream mode — `_build_plan_with_shared(_force_downstream=True)`
 
 When `_plan_sub_workflow(cause="downstream")` recurses into a child, it passes `_force_downstream=True`. The child then:
@@ -119,7 +144,7 @@ Text-only rendering decisions, all pinned by `tests/test_execution/formatters/te
 - **Header**: `Dry-run for {Path(plan.workflow).name}: N nodes, M sub-workflow(s)`. Base name only — the absolute path is already in the command the user ran. JSON `plan.workflow` keeps the full value.
 - **Type translation in summary**: class names → `_NODE_TYPE_TAGS` map (same one per-entry labels use).
 - **Nested-aware counts**: when `*_including_nested` fields exist on `PlanSummary`, the summary displays those numbers under the label `Summary (including nested):`. Agents cost- or time-gating must read `*_including_nested` when present — the formatter mirrors.
-- **"Nothing cached" divider**: `_has_any_cached_recursive(entries)` checks sub_plans too. A plan whose top-level entries are all `sub_workflow` with fully-cached children must NOT render "nothing cached" — something IS cached, just one level down.
+- **"Nothing cached" divider**: `_has_any_cached_recursive(entries)` checks sub_plans AND `batch_items_cached > 0`. A plan whose top-level entries are all `sub_workflow` with fully-cached children (or partially-cached batch items) must NOT render "nothing cached."
 - **No redundant "No side effects performed." trailer.** The `--dry-run` flag is the contract; restating it on every plan is noise.
 
 ## WorkflowRunner — Primary Entry Point
@@ -201,7 +226,7 @@ class ExecutionResult:
     def warnings(self) -> list[Diagnostic]: ...
 
 @dataclass(frozen=True)
-class PlanEntry: ...
+class PlanEntry: ...  # Includes batch_count / batch_parallel / batch_items_* for batch sub-workflows
 
 @dataclass(frozen=True)
 class PlanSummary: ...

--- a/src/pflow/execution/formatters/plan_formatter.py
+++ b/src/pflow/execution/formatters/plan_formatter.py
@@ -192,6 +192,8 @@ def _has_any_cached_recursive(entries: list[PlanEntry]) -> bool:
     for entry in entries:
         if entry.status == "cached":
             return True
+        if entry.batch_items_cached is not None and entry.batch_items_cached > 0:
+            return True
         if entry.sub_plan is not None and _has_any_cached_recursive(entry.sub_plan.entries):
             return True
     return False
@@ -199,6 +201,33 @@ def _has_any_cached_recursive(entries: list[PlanEntry]) -> bool:
 
 def _render_entry_line(entry: PlanEntry, indent: str) -> str:
     """Render one plan entry."""
+    if entry.status == "sub_workflow" and entry.batch_count is not None:
+        ref = entry.sub_plan.workflow if entry.sub_plan else "<unknown>"
+        has_work = True
+        if entry.sub_plan is not None:
+            child = entry.sub_plan.summary
+            has_work = child.execute_count > 0 or (child.execute_including_nested or 0) > 0
+        symbol = "▸" if has_work else click.style("↻", fg="blue", dim=True)
+        parallel_tag = ", parallel" if entry.batch_parallel else ""
+        return f"{indent}{symbol} {entry.node_id}  [workflow '{ref}' \u00d7 {entry.batch_count} items{parallel_tag}]"
+
+    if entry.batch_items_total is not None:
+        cached = entry.batch_items_cached or 0
+        total = entry.batch_items_total
+        if cached == total:
+            age = f"  ({_format_age(entry.age_sec)} ago)" if entry.age_sec is not None else ""
+            return f"{indent}{click.style('↻', fg='blue', dim=True)} {entry.node_id}{age}"
+
+        tag = f"  [{_tag_from_entry(entry)}]"
+        execute_count = total - cached
+        if cached > 0:
+            stats = _format_batch_node_stats(entry)
+            return f"{indent}▸ {entry.node_id}{tag}  {execute_count}/{total} would execute{stats}"
+
+        annotation = _format_stats_annotation(entry)
+        suffix = f"   {annotation}" if annotation else ""
+        return f"{indent}▸ {entry.node_id}{tag}{suffix}"
+
     if entry.status == "cached":
         age = f"  ({_format_age(entry.age_sec)} ago)" if entry.age_sec is not None else ""
         return f"{indent}{click.style('↻', fg='blue', dim=True)} {entry.node_id}{age}"
@@ -219,6 +248,29 @@ def _render_entry_line(entry: PlanEntry, indent: str) -> str:
     annotation = _format_stats_annotation(entry)
     suffix = f"   {annotation}" if annotation else ""
     return f"{indent}▸ {entry.node_id}{tag}{suffix}"
+
+
+def _format_batch_node_stats(entry: PlanEntry) -> str:
+    """Build the average-cost / average-duration suffix for partial batch nodes."""
+    is_llm = _is_llm_entry(entry)
+    has_cost = entry.last_cost_usd is not None
+    duration_ms = entry.last_duration_ms
+    show_duration = duration_ms is not None and duration_ms >= _TEXT_DURATION_THRESHOLD_MS
+
+    if not has_cost and not show_duration:
+        return "  ≈ $? (no history)" if is_llm else ""
+
+    parts: list[str] = []
+    if is_llm:
+        if has_cost and entry.last_cost_usd is not None:
+            parts.append(f"≈ {_format_cost(entry.last_cost_usd)}")
+        else:
+            parts.append("≈ $?")
+    if show_duration and duration_ms is not None:
+        parts.append(f"~{format_duration(duration_ms)}")
+    if not parts:
+        return ""
+    return f"  {' · '.join(parts)}"
 
 
 def _format_stats_annotation(entry: PlanEntry) -> str | None:
@@ -307,6 +359,12 @@ def _entry_to_dict(entry: PlanEntry) -> dict[str, Any]:
         result["last_duration_ms"] = entry.last_duration_ms
     if entry.last_run_age_sec is not None:
         result["last_run_age_sec"] = entry.last_run_age_sec
+    if entry.batch_count is not None:
+        result["batch_count"] = entry.batch_count
+        result["batch_parallel"] = entry.batch_parallel
+    if entry.batch_items_total is not None:
+        result["batch_items_cached"] = entry.batch_items_cached
+        result["batch_items_total"] = entry.batch_items_total
     if entry.sub_plan is not None:
         result["sub_plan"] = format_plan_json(entry.sub_plan)
     if entry.diagnostic is not None:

--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -1089,7 +1089,6 @@ def _plan_batch_sub_workflow(
     aggregated_plan = _aggregate_batch_child_plans(
         child_plans,
         batch_parallel=batch_config.parallel,
-        batch_count=len(items),
         extra_diagnostics=per_item_diagnostics,
     )
     shared[node_id] = _build_batch_output_shape(item_outputs, items, batch_config)
@@ -1264,8 +1263,7 @@ def _prepare_batch_sub_workflow_params(
         if config.template_config:
             resolved_params, _, _ = resolve_templates(config.template_config, shared, config.node_id)
             merged = dict(getattr(curr, "params", {}) or {})
-            if config.template_config:
-                merged.update(config.template_config.static_params or {})
+            merged.update(config.template_config.static_params or {})
             merged.update(resolved_params)
         else:
             merged = dict(getattr(curr, "params", {}) or {})
@@ -1484,7 +1482,6 @@ def _aggregate_batch_child_plans(
     child_plans: list[Plan],
     *,
     batch_parallel: bool,
-    batch_count: int,
     extra_diagnostics: list[Diagnostic] | None = None,
 ) -> Plan:
     """Collapse N per-item child plans into one display/rollup plan."""

--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 import math
-from collections import deque
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
@@ -43,10 +43,13 @@ from pflow.core.workflow.sub_workflow_resolver import resolve_sub_workflow
 from pflow.execution.result import Plan, PlanEntry, PlanSummary
 from pflow.registry import Registry
 from pflow.runtime.cache import MemoizationCache
+from pflow.runtime.engine.batch_executor import resolve_batch_items
 from pflow.runtime.engine.engine import is_clean_termination
 from pflow.runtime.engine.instrumentation import apply_memo_hit, enforce_loop_guard
 from pflow.runtime.engine.plan_node import NodePlan, plan_node
-from pflow.runtime.engine.types import CompiledWorkflow, NodeConfig
+from pflow.runtime.engine.template_resolution import resolve_templates
+from pflow.runtime.engine.types import BatchConfig, CompiledWorkflow, NodeConfig
+from pflow.runtime.template_resolver import TemplateResolver
 from pflow.runtime.workflow_executor import WorkflowExecutor
 
 logger = logging.getLogger(__name__)
@@ -94,6 +97,26 @@ class _ChildCompileFailed(Exception):
     def __init__(self, entry: PlanEntry) -> None:
         super().__init__()
         self.entry = entry
+
+
+@dataclass(frozen=True)
+class _PreparedSubWorkflow:
+    """Resolved sub-workflow target ready for recursive planning."""
+
+    merged: dict[str, Any]
+    child_inputs: dict[str, Any]
+    resolved: Any
+    resolved_path_str: str | None
+    compiled_child: CompiledWorkflow
+
+
+@dataclass(frozen=True)
+class _PreparedBatchSubWorkflowParams:
+    """Item[0]-resolved params needed to plan a batch sub-workflow."""
+
+    merged: dict[str, Any]
+    child_inputs: dict[str, Any]
+    raw_inputs_template: Any
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -933,71 +956,51 @@ def _plan_sub_workflow(
     node_type = config.node_type_name
     downstream = cause == "downstream"
 
-    if depth >= WorkflowExecutor.MAX_DEPTH_DEFAULT:
-        return _sub_workflow_error_entry(
-            node_id,
-            node_type,
-            f"Max sub-workflow depth {WorkflowExecutor.MAX_DEPTH_DEFAULT} exceeded at '{node_id}'",
+    if config.batch_config and not downstream:
+        return _plan_batch_sub_workflow(
+            curr,
+            config,
+            shared,
+            cache,
+            registry,
+            visited_paths=visited_paths,
+            depth=depth,
         )
 
-    # Opaque pre-check: `workflow: ${...}` can't be planned; don't run plan_node.
-    workflow_ref = _raw_workflow_ref(curr, config)
-    if isinstance(workflow_ref, str) and "${" in workflow_ref:
-        return _opaque_sub_workflow_entry(node_id, node_type)
+    guard_entry = _precheck_sub_workflow(curr, config, depth=depth)
+    if guard_entry is not None:
+        return guard_entry
 
     params_or_entry = _resolve_sub_workflow_params(curr, config, shared, downstream=downstream)
     if isinstance(params_or_entry, PlanEntry):
         return params_or_entry
     merged, child_inputs = params_or_entry
-
-    # Resolve relative child refs against the parent's dir, or CWD for inline
-    # (non-file) workflows. Mirrors `WorkflowExecutor._load_workflow` exactly:
-    # `shared["_pflow_workflow_file"]` is the parent's absolute path for file
-    # runs, the synthetic `"ir-hash:..."` identifier for inline runs (whose
-    # `Path(...).parent` is `Path(".")` → CWD-relative), or absent.
-    parent_file = shared.get("_pflow_workflow_file")
-    base_path = Path(parent_file).parent if parent_file else Path.cwd()
-    try:
-        resolved = resolve_sub_workflow(merged, base_path=base_path)
-    except _SUB_WORKFLOW_RESOLVE_EXCEPTIONS as exc:
-        return _sub_workflow_error_entry(node_id, node_type, f"Sub-workflow resolve failed: {exc}")
-    if resolved is None:
-        return _opaque_sub_workflow_entry(node_id, node_type)
-
-    resolved_path_str = str(resolved.path.resolve()) if resolved.path else None
-
-    if resolved_path_str is not None and resolved_path_str in visited_paths:
-        return _sub_workflow_error_entry(
-            node_id,
-            node_type,
-            f"Circular sub-workflow reference: {resolved_path_str}",
-        )
-
-    child_inputs = _effective_child_inputs(resolved.ir, child_inputs, downstream=downstream)
-
-    try:
-        compiled_child = _compile_child(resolved.ir, resolved_path_str, child_inputs, registry, node_id, node_type)
-    except _ChildCompileFailed as failure:
-        return failure.entry
+    target_or_entry = _prepare_sub_workflow(
+        merged=merged,
+        child_inputs=child_inputs,
+        shared=shared,
+        registry=registry,
+        visited_paths=visited_paths,
+        node_id=node_id,
+        node_type=node_type,
+        downstream=downstream,
+    )
+    if isinstance(target_or_entry, PlanEntry):
+        return target_or_entry
+    prepared = target_or_entry
 
     child_plan, child_shared = _build_plan_with_shared(
-        compiled_child,
-        child_inputs,
+        prepared.compiled_child,
+        prepared.child_inputs,
         cache,
         registry,
-        workflow_name=str(merged.get("workflow") or "<sub-workflow>"),
-        _visited_paths=[*visited_paths, resolved_path_str] if resolved_path_str else visited_paths,
+        workflow_name=str(prepared.merged.get("workflow") or "<sub-workflow>"),
+        _visited_paths=[*visited_paths, prepared.resolved_path_str] if prepared.resolved_path_str else visited_paths,
         _depth=depth + 1,
-        _parent_workflow_file=resolved_path_str,
+        _parent_workflow_file=prepared.resolved_path_str,
         _force_downstream=downstream,
     )
-    if resolved.warnings:
-        child_plan = Plan(
-            workflow=child_plan.workflow,
-            entries=child_plan.entries,
-            summary=child_plan.summary,
-            diagnostics=[*child_plan.diagnostics, *resolved.warnings],
-        )
+    child_plan = _attach_sub_workflow_warnings(child_plan, prepared.resolved.warnings)
 
     # Populate parent's shared[node_id] with the child's outputs so downstream
     # nodes that template against ${<node_id>.<key>} can resolve at plan time.
@@ -1008,7 +1011,13 @@ def _plan_sub_workflow(
     # to resolve from. Parent's downstream successors won't template against
     # this sub_plan anyway (they're all downstream too).
     if not downstream:
-        _populate_sub_workflow_outputs(shared, node_id, compiled_child, child_shared, child_inputs)
+        _populate_sub_workflow_outputs(
+            shared,
+            node_id,
+            prepared.compiled_child,
+            child_shared,
+            prepared.child_inputs,
+        )
 
     return PlanEntry(
         node_id=node_id,
@@ -1017,6 +1026,577 @@ def _plan_sub_workflow(
         cause=cause,
         sub_plan=child_plan,
     )
+
+
+def _plan_batch_sub_workflow(
+    curr: Any,
+    config: NodeConfig,
+    shared: dict[str, Any],
+    cache: MemoizationCache,
+    registry: Registry,
+    *,
+    visited_paths: list[str],
+    depth: int,
+) -> PlanEntry:
+    """Plan a batch WorkflowExecutor by recursively planning one child per item."""
+    node_id = config.node_id
+    node_type = config.node_type_name
+    batch_config = config.batch_config
+    if batch_config is None:
+        return _sub_workflow_error_entry(node_id, node_type, "Batch sub-workflow planning requires batch config")
+
+    guard_entry = _precheck_sub_workflow(curr, config, depth=depth)
+    if guard_entry is not None:
+        return guard_entry
+
+    items_or_entry = _resolve_batch_sub_workflow_items(config, shared, batch_config)
+    if isinstance(items_or_entry, PlanEntry):
+        return items_or_entry
+    items = items_or_entry
+
+    if not items:
+        return _empty_batch_sub_workflow_entry(curr, config, shared, batch_config)
+
+    params_or_entry = _prepare_batch_sub_workflow_params(curr, config, shared, items, batch_config)
+    if isinstance(params_or_entry, PlanEntry):
+        return params_or_entry
+    batch_params = params_or_entry
+    target_or_entry = _prepare_sub_workflow(
+        merged=batch_params.merged,
+        child_inputs=batch_params.child_inputs,
+        shared=shared,
+        registry=registry,
+        visited_paths=visited_paths,
+        node_id=node_id,
+        node_type=node_type,
+    )
+    if isinstance(target_or_entry, PlanEntry):
+        return target_or_entry
+    prepared = target_or_entry
+    child_plans, item_outputs, per_item_diagnostics = _plan_batch_sub_workflow_items(
+        items=items,
+        shared=shared,
+        cache=cache,
+        registry=registry,
+        batch_config=batch_config,
+        raw_inputs_template=batch_params.raw_inputs_template,
+        prepared=prepared,
+        depth=depth,
+        visited_paths=visited_paths,
+        node_id=node_id,
+    )
+
+    aggregated_plan = _aggregate_batch_child_plans(
+        child_plans,
+        batch_parallel=batch_config.parallel,
+        batch_count=len(items),
+        extra_diagnostics=per_item_diagnostics,
+    )
+    shared[node_id] = _build_batch_output_shape(item_outputs, items, batch_config)
+
+    return PlanEntry(
+        node_id=node_id,
+        node_type=node_type,
+        status="sub_workflow",
+        cause="no_cache_match",
+        sub_plan=aggregated_plan,
+        batch_count=len(items),
+        batch_parallel=batch_config.parallel,
+    )
+
+
+def _precheck_sub_workflow(curr: Any, config: NodeConfig, *, depth: int) -> PlanEntry | None:
+    """Return an early guard entry for depth / dynamic-ref failures."""
+    node_id = config.node_id
+    node_type = config.node_type_name
+    if depth >= WorkflowExecutor.MAX_DEPTH_DEFAULT:
+        return _sub_workflow_error_entry(
+            node_id,
+            node_type,
+            f"Max sub-workflow depth {WorkflowExecutor.MAX_DEPTH_DEFAULT} exceeded at '{node_id}'",
+        )
+
+    workflow_ref = _raw_workflow_ref(curr, config)
+    if isinstance(workflow_ref, str) and "${" in workflow_ref:
+        return _opaque_sub_workflow_entry(node_id, node_type)
+    return None
+
+
+def _resolve_sub_workflow_base_path(shared: dict[str, Any]) -> Path:
+    """Resolve child workflow refs against the same base runtime uses."""
+    parent_file = shared.get("_pflow_workflow_file")
+    return Path(parent_file).parent if parent_file else Path.cwd()
+
+
+def _prepare_sub_workflow(
+    *,
+    merged: dict[str, Any],
+    child_inputs: dict[str, Any],
+    shared: dict[str, Any],
+    registry: Registry,
+    visited_paths: list[str],
+    node_id: str,
+    node_type: str,
+    downstream: bool = False,
+) -> _PreparedSubWorkflow | PlanEntry:
+    """Resolve, cycle-check, and compile a child workflow target."""
+    try:
+        resolved = resolve_sub_workflow(merged, base_path=_resolve_sub_workflow_base_path(shared))
+    except _SUB_WORKFLOW_RESOLVE_EXCEPTIONS as exc:
+        return _sub_workflow_error_entry(node_id, node_type, f"Sub-workflow resolve failed: {exc}")
+    if resolved is None:
+        return _opaque_sub_workflow_entry(node_id, node_type)
+
+    resolved_path_str = str(resolved.path.resolve()) if resolved.path else None
+    if resolved_path_str is not None and resolved_path_str in visited_paths:
+        return _sub_workflow_error_entry(
+            node_id,
+            node_type,
+            f"Circular sub-workflow reference: {resolved_path_str}",
+        )
+
+    effective_inputs = _effective_child_inputs(resolved.ir, child_inputs, downstream=downstream)
+    try:
+        compiled_child = _compile_child(resolved.ir, resolved_path_str, effective_inputs, registry, node_id, node_type)
+    except _ChildCompileFailed as failure:
+        return failure.entry
+
+    return _PreparedSubWorkflow(
+        merged=merged,
+        child_inputs=effective_inputs,
+        resolved=resolved,
+        resolved_path_str=resolved_path_str,
+        compiled_child=compiled_child,
+    )
+
+
+def _attach_sub_workflow_warnings(plan: Plan, warnings: list[Diagnostic] | tuple[Diagnostic, ...]) -> Plan:
+    """Append resolver warnings to a child plan when present."""
+    if not warnings:
+        return plan
+    return Plan(
+        workflow=plan.workflow,
+        entries=plan.entries,
+        summary=plan.summary,
+        diagnostics=[*plan.diagnostics, *warnings],
+    )
+
+
+def _resolve_batch_sub_workflow_items(
+    config: NodeConfig,
+    shared: dict[str, Any],
+    batch_config: BatchConfig,
+) -> list[Any] | PlanEntry:
+    """Resolve batch items for a WorkflowExecutor or surface an honest entry."""
+    items = resolve_batch_items(batch_config.items_template, shared)
+    if items is None:
+        return _opaque_sub_workflow_entry(config.node_id, config.node_type_name)
+    if not isinstance(items, list):
+        return _sub_workflow_error_entry(
+            config.node_id,
+            config.node_type_name,
+            f"Workflow batch items resolved to {type(items).__name__}, expected list",
+        )
+    return items
+
+
+def _empty_plan(workflow: str) -> Plan:
+    """Create an empty nested plan with fully-populated zero summary fields."""
+    return Plan(
+        workflow=workflow,
+        entries=[],
+        summary=PlanSummary(
+            total=0,
+            cached_count=0,
+            execute_count=0,
+            cache_boundary=None,
+            execute_by_type={},
+            estimated_cost_usd=0.0,
+            nodes_without_history=0,
+            estimated_duration_ms=0.0,
+            nodes_without_duration_history=0,
+            opaque_count=0,
+            cost_basis="exact",
+            total_including_nested=0,
+            cached_including_nested=0,
+            execute_including_nested=0,
+            execute_by_type_including_nested={},
+            estimated_cost_usd_including_nested=0.0,
+            nodes_without_history_including_nested=0,
+            estimated_duration_ms_including_nested=0.0,
+            nodes_without_duration_history_including_nested=0,
+            opaque_count_including_nested=0,
+        ),
+    )
+
+
+def _empty_batch_sub_workflow_entry(
+    curr: Any,
+    config: NodeConfig,
+    shared: dict[str, Any],
+    batch_config: BatchConfig,
+) -> PlanEntry:
+    """Return the empty-batch plan entry and runtime-shaped shared output."""
+    workflow_ref = _raw_workflow_ref(curr, config)
+    shared[config.node_id] = _build_batch_output_shape([], [], batch_config)
+    return PlanEntry(
+        node_id=config.node_id,
+        node_type=config.node_type_name,
+        status="sub_workflow",
+        cause="no_cache_match",
+        sub_plan=_empty_plan(str(workflow_ref or "<sub-workflow>")),
+        batch_count=0,
+        batch_parallel=batch_config.parallel,
+    )
+
+
+def _prepare_batch_sub_workflow_params(
+    curr: Any,
+    config: NodeConfig,
+    shared: dict[str, Any],
+    items: list[Any],
+    batch_config: BatchConfig,
+) -> _PreparedBatchSubWorkflowParams | PlanEntry:
+    """Resolve item[0]-scoped params for a batch sub-workflow."""
+    try:
+        shared[batch_config.item_alias] = items[0]
+        shared["__index__"] = 0
+        if config.template_config:
+            resolved_params, _, _ = resolve_templates(config.template_config, shared, config.node_id)
+            merged = dict(getattr(curr, "params", {}) or {})
+            if config.template_config:
+                merged.update(config.template_config.static_params or {})
+            merged.update(resolved_params)
+        else:
+            merged = dict(getattr(curr, "params", {}) or {})
+    except Exception as exc:
+        if isinstance(exc, ValueError):
+            return _template_error_entry(config, exc)
+        logger.warning("Batch sub-workflow template resolution failed: %s", exc)
+        return _sub_workflow_error_entry(config.node_id, config.node_type_name, f"Template resolution failed: {exc}")
+    finally:
+        shared.pop(batch_config.item_alias, None)
+        shared.pop("__index__", None)
+
+    raw_inputs = merged.get("inputs")
+    if raw_inputs is not None and not isinstance(raw_inputs, dict):
+        return _sub_workflow_error_entry(
+            config.node_id,
+            config.node_type_name,
+            f"Workflow node 'inputs:' resolved to {type(raw_inputs).__name__}, expected dict",
+        )
+
+    raw_inputs_template = None
+    if config.template_config:
+        raw_inputs_template = config.template_config.template_params.get("inputs")
+
+    return _PreparedBatchSubWorkflowParams(
+        merged=merged,
+        child_inputs=dict(raw_inputs) if raw_inputs else {},
+        raw_inputs_template=raw_inputs_template,
+    )
+
+
+def _resolve_per_item_sub_workflow_inputs(
+    *,
+    shared: dict[str, Any],
+    batch_config: BatchConfig,
+    item: Any,
+    idx: int,
+    raw_inputs_template: Any,
+    default_inputs: dict[str, Any],
+    node_id: str,
+) -> tuple[dict[str, Any], Diagnostic | None]:
+    """Resolve child inputs for one batch item, falling back to item[0] shape.
+
+    Returns (inputs, diagnostic). Diagnostic is non-None when resolution
+    produced a non-dict — runtime would raise ValueError in that case, so
+    we surface a WARNING to make the plan honest about a likely runtime failure.
+    """
+    if raw_inputs_template is None:
+        return default_inputs, None
+    per_item_context = {**shared, batch_config.item_alias: item, "__index__": idx}
+    resolved_inputs = TemplateResolver.resolve_nested(raw_inputs_template, per_item_context)
+    if isinstance(resolved_inputs, dict):
+        return resolved_inputs, None
+    diag = Diagnostic(
+        severity=Severity.WARNING,
+        source="planner",
+        node_id=node_id,
+        message=(
+            f"Batch item {idx}: 'inputs:' resolved to {type(resolved_inputs).__name__}, "
+            f"expected dict. Runtime will reject this item."
+        ),
+        context={"category": "validation", "batch_item_index": idx},
+    )
+    return default_inputs, diag
+
+
+def _extract_child_outputs(
+    compiled_child: CompiledWorkflow,
+    child_shared: dict[str, Any],
+    child_inputs: dict[str, Any],
+) -> dict[str, Any]:
+    """Mirror runtime child-output exposure for one per-item child plan."""
+    declared = getattr(compiled_child, "outputs", None)
+    if isinstance(declared, dict) and declared:
+        return _resolve_declared_outputs(declared, child_shared)
+    return _mirror_child_shared(child_shared, child_inputs)
+
+
+def _plan_batch_sub_workflow_items(
+    *,
+    items: list[Any],
+    shared: dict[str, Any],
+    cache: MemoizationCache,
+    registry: Registry,
+    batch_config: BatchConfig,
+    raw_inputs_template: Any,
+    prepared: _PreparedSubWorkflow,
+    depth: int,
+    visited_paths: list[str],
+    node_id: str,
+) -> tuple[list[Plan], list[dict[str, Any]], list[Diagnostic]]:
+    """Plan each batch item's child workflow and collect exposed outputs."""
+    child_plans: list[Plan] = []
+    item_outputs: list[dict[str, Any]] = []
+    child_workflow_name = str(prepared.merged.get("workflow") or "<sub-workflow>")
+    child_visited_paths = [*visited_paths, prepared.resolved_path_str] if prepared.resolved_path_str else visited_paths
+
+    per_item_diagnostics: list[Diagnostic] = []
+
+    for idx, item in enumerate(items):
+        per_item_inputs, input_diag = _resolve_per_item_sub_workflow_inputs(
+            shared=shared,
+            batch_config=batch_config,
+            item=item,
+            idx=idx,
+            raw_inputs_template=raw_inputs_template,
+            default_inputs=prepared.child_inputs,
+            node_id=node_id,
+        )
+        if input_diag is not None:
+            per_item_diagnostics.append(input_diag)
+        child_plan, child_shared = _build_plan_with_shared(
+            prepared.compiled_child,
+            per_item_inputs,
+            cache,
+            registry,
+            workflow_name=child_workflow_name,
+            _visited_paths=child_visited_paths,
+            _depth=depth + 1,
+            _parent_workflow_file=prepared.resolved_path_str,
+        )
+        child_plans.append(child_plan)
+        item_outputs.append(_extract_child_outputs(prepared.compiled_child, child_shared, per_item_inputs))
+
+    if prepared.resolved.warnings:
+        child_plans[0] = _attach_sub_workflow_warnings(child_plans[0], prepared.resolved.warnings)
+
+    return child_plans, item_outputs, per_item_diagnostics
+
+
+def _nested_or_level(summary: PlanSummary, *, nested: str, level: str) -> Any:
+    """Read the *_including_nested variant of a summary field, falling back to per-level."""
+    value = getattr(summary, nested)
+    return value if value is not None else getattr(summary, level)
+
+
+def _aggregate_batch_summary(child_plans: list[Plan], *, batch_parallel: bool) -> PlanSummary:
+    """Build a single PlanSummary aggregating N per-item child plan summaries."""
+    per_item_totals = [_nested_or_level(p.summary, nested="total_including_nested", level="total") for p in child_plans]
+    per_item_cached = [
+        _nested_or_level(p.summary, nested="cached_including_nested", level="cached_count") for p in child_plans
+    ]
+    per_item_execute = [
+        _nested_or_level(p.summary, nested="execute_including_nested", level="execute_count") for p in child_plans
+    ]
+    per_item_cost = [
+        _nested_or_level(p.summary, nested="estimated_cost_usd_including_nested", level="estimated_cost_usd")
+        for p in child_plans
+    ]
+    per_item_duration = [
+        _nested_or_level(p.summary, nested="estimated_duration_ms_including_nested", level="estimated_duration_ms")
+        for p in child_plans
+    ]
+    per_item_no_history = [
+        _nested_or_level(p.summary, nested="nodes_without_history_including_nested", level="nodes_without_history")
+        for p in child_plans
+    ]
+    per_item_no_duration = [
+        _nested_or_level(
+            p.summary, nested="nodes_without_duration_history_including_nested", level="nodes_without_duration_history"
+        )
+        for p in child_plans
+    ]
+    per_item_opaque = [
+        _nested_or_level(p.summary, nested="opaque_count_including_nested", level="opaque_count") for p in child_plans
+    ]
+
+    execute_by_type: dict[str, int] = {}
+    for p in child_plans:
+        child_types = (
+            p.summary.execute_by_type_including_nested
+            if p.summary.execute_by_type_including_nested is not None
+            else p.summary.execute_by_type
+        )
+        for node_type, count in child_types.items():
+            execute_by_type[node_type] = execute_by_type.get(node_type, 0) + count
+
+    cost_basis: _CostBasis = "exact"
+    if any(p.summary.cost_basis == "upper_bound" for p in child_plans):
+        cost_basis = "upper_bound"
+
+    total_duration = max(per_item_duration) if batch_parallel else sum(per_item_duration)
+    agg_total = sum(per_item_totals)
+    agg_cached = sum(per_item_cached)
+    agg_execute = sum(per_item_execute)
+    agg_cost = sum(cost for cost in per_item_cost if cost is not None)
+    agg_no_history = sum(per_item_no_history)
+    agg_no_duration = sum(per_item_no_duration)
+    agg_opaque = sum(per_item_opaque)
+
+    return PlanSummary(
+        total=agg_total,
+        cached_count=agg_cached,
+        execute_count=agg_execute,
+        cache_boundary=None,
+        execute_by_type=execute_by_type,
+        estimated_cost_usd=agg_cost,
+        nodes_without_history=agg_no_history,
+        estimated_duration_ms=total_duration,
+        nodes_without_duration_history=agg_no_duration,
+        opaque_count=agg_opaque,
+        cost_basis=cost_basis,
+        total_including_nested=agg_total,
+        cached_including_nested=agg_cached,
+        execute_including_nested=agg_execute,
+        execute_by_type_including_nested=execute_by_type,
+        estimated_cost_usd_including_nested=agg_cost,
+        nodes_without_history_including_nested=agg_no_history,
+        estimated_duration_ms_including_nested=total_duration,
+        nodes_without_duration_history_including_nested=agg_no_duration,
+        opaque_count_including_nested=agg_opaque,
+    )
+
+
+def _aggregate_batch_child_plans(
+    child_plans: list[Plan],
+    *,
+    batch_parallel: bool,
+    batch_count: int,
+    extra_diagnostics: list[Diagnostic] | None = None,
+) -> Plan:
+    """Collapse N per-item child plans into one display/rollup plan."""
+    if not child_plans:
+        return Plan(
+            workflow="<sub-workflow>",
+            entries=[],
+            summary=PlanSummary(
+                total=0,
+                cached_count=0,
+                execute_count=0,
+                cache_boundary=None,
+                execute_by_type={},
+                estimated_cost_usd=0.0,
+                nodes_without_history=0,
+                estimated_duration_ms=0.0,
+                nodes_without_duration_history=0,
+                opaque_count=0,
+                cost_basis="exact",
+                total_including_nested=0,
+                cached_including_nested=0,
+                execute_including_nested=0,
+                execute_by_type_including_nested={},
+                estimated_cost_usd_including_nested=0.0,
+                nodes_without_history_including_nested=0,
+                estimated_duration_ms_including_nested=0.0,
+                nodes_without_duration_history_including_nested=0,
+                opaque_count_including_nested=0,
+            ),
+        )
+
+    entries_by_node: dict[str, list[PlanEntry]] = defaultdict(list)
+    seen_node_ids: list[str] = []
+    seen_lookup: set[str] = set()
+    for plan in child_plans:
+        for entry in plan.entries:
+            entries_by_node[entry.node_id].append(entry)
+            if entry.node_id not in seen_lookup:
+                seen_lookup.add(entry.node_id)
+                seen_node_ids.append(entry.node_id)
+
+    synthetic_entries: list[PlanEntry] = []
+    for node_id in seen_node_ids:
+        entries_for_node = entries_by_node.get(node_id, [])
+        if not entries_for_node:
+            continue
+
+        items_traversed = len(entries_for_node)
+        cached_count = sum(
+            1
+            for entry in entries_for_node
+            if entry.status == "cached" or (entry.status == "sub_workflow" and not _represents_work(entry))
+        )
+        cost_values = [entry.last_cost_usd for entry in entries_for_node if entry.last_cost_usd is not None]
+        duration_values = [entry.last_duration_ms for entry in entries_for_node if entry.last_duration_ms is not None]
+        age_values = [entry.age_sec for entry in entries_for_node if entry.age_sec is not None]
+        template_entry = entries_for_node[0]
+
+        synthetic_entries.append(
+            PlanEntry(
+                node_id=node_id,
+                node_type=template_entry.node_type,
+                status="cached" if cached_count == items_traversed else "execute",
+                cause="hash_match" if cached_count == items_traversed else "no_cache_match",
+                last_cost_usd=sum(cost_values) / len(cost_values) if cost_values else None,
+                last_duration_ms=sum(duration_values) / len(duration_values) if duration_values else None,
+                age_sec=max(age_values) if age_values else None,
+                batch_items_cached=cached_count,
+                batch_items_total=items_traversed,
+                sub_plan=template_entry.sub_plan,
+            )
+        )
+
+    summary = _aggregate_batch_summary(child_plans, batch_parallel=batch_parallel)
+    all_diagnostics = [diagnostic for child_plan in child_plans for diagnostic in child_plan.diagnostics]
+    if extra_diagnostics:
+        all_diagnostics.extend(extra_diagnostics)
+    return Plan(
+        workflow=child_plans[0].workflow,
+        entries=synthetic_entries,
+        summary=summary,
+        diagnostics=all_diagnostics,
+    )
+
+
+def _build_batch_output_shape(
+    item_outputs: list[dict[str, Any]],
+    items: list[Any],
+    batch_config: BatchConfig,
+) -> dict[str, Any]:
+    """Mirror the runtime batch result shape for downstream template resolution."""
+    results: list[dict[str, Any]] = []
+    for idx, (item, output) in enumerate(zip(items, item_outputs, strict=True)):
+        result = dict(output) if output else {}
+        result["item"] = item
+        result["original_index"] = idx
+        results.append(result)
+    return {
+        "results": results,
+        "count": len(items),
+        "success_count": len(item_outputs),
+        "error_count": 0,
+        "errors": None,
+        "batch_metadata": {
+            "parallel": batch_config.parallel,
+            "max_concurrent": batch_config.max_concurrent if batch_config.parallel else None,
+            "max_retries": batch_config.max_retries,
+            "retry_wait": batch_config.retry_wait if batch_config.retry_wait > 0 else None,
+            "execution_mode": "parallel" if batch_config.parallel else "sequential",
+            "timing": None,
+        },
+    }
 
 
 def _populate_sub_workflow_outputs(

--- a/src/pflow/execution/result.py
+++ b/src/pflow/execution/result.py
@@ -102,6 +102,10 @@ class PlanEntry:
     last_run_age_sec: float | None = None
     sub_plan: Plan | None = None
     diagnostic: Diagnostic | None = None
+    batch_count: int | None = None
+    batch_parallel: bool = False
+    batch_items_cached: int | None = None
+    batch_items_total: int | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_execution/formatters/test_plan_formatter.py
+++ b/tests/test_execution/formatters/test_plan_formatter.py
@@ -181,6 +181,162 @@ def test_format_plan_text_nothing_cached_divider_shows_when_truly_empty() -> Non
     assert "─── nothing cached — full run ───" in format_plan_text(plan)
 
 
+def test_format_plan_text_batch_parent_header_includes_items_and_parallel() -> None:
+    """Batch sub-workflow parents render the item count and parallel flag."""
+    child_plan = Plan(
+        workflow="./child.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="echo",
+                node_type="ShellNode",
+                status="execute",
+                cause="no_cache_match",
+                batch_items_cached=1,
+                batch_items_total=2,
+                last_duration_ms=2300.0,
+            )
+        ],
+        summary=_summary(
+            total=2,
+            cached_count=1,
+            execute_count=1,
+            execute_by_type={"ShellNode": 1},
+            total_including_nested=2,
+            cached_including_nested=1,
+            execute_including_nested=1,
+            execute_by_type_including_nested={"ShellNode": 1},
+            estimated_duration_ms_including_nested=2300.0,
+        ),
+    )
+    plan = Plan(
+        workflow="parent.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="fanout",
+                node_type="WorkflowExecutor",
+                status="sub_workflow",
+                cause="no_cache_match",
+                sub_plan=child_plan,
+                batch_count=2,
+                batch_parallel=True,
+            )
+        ],
+        summary=_summary(
+            total=1,
+            execute_count=1,
+            execute_by_type={"WorkflowExecutor": 1},
+            total_including_nested=3,
+            cached_including_nested=1,
+            execute_including_nested=2,
+            execute_by_type_including_nested={"WorkflowExecutor": 1, "ShellNode": 1},
+        ),
+    )
+
+    out = format_plan_text(plan)
+
+    assert "[workflow './child.pflow.md' \u00d7 2 items, parallel]" in out
+
+
+def test_format_plan_text_batch_partial_child_shows_fraction_and_stats() -> None:
+    """Partial batch cache lines show `M/N would execute` with average stats."""
+    plan = Plan(
+        workflow="child.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="echo",
+                node_type="ShellNode",
+                status="execute",
+                cause="no_cache_match",
+                batch_items_cached=1,
+                batch_items_total=2,
+                last_duration_ms=2300.0,
+            )
+        ],
+        summary=_summary(total=2, cached_count=1, execute_count=1, execute_by_type={"ShellNode": 1}),
+    )
+
+    out = format_plan_text(plan)
+
+    assert "1/2 would execute" in out
+    assert "~2.3s" in out
+
+
+def test_format_plan_text_batch_all_cached_child_omits_fraction() -> None:
+    """All-cached synthetic batch child entries render as normal cached lines."""
+    plan = Plan(
+        workflow="child.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="echo",
+                node_type="ShellNode",
+                status="cached",
+                cause="hash_match",
+                age_sec=5.0,
+                batch_items_cached=2,
+                batch_items_total=2,
+            )
+        ],
+        summary=_summary(total=2, cached_count=2, execute_count=0),
+    )
+
+    out = format_plan_text(plan)
+
+    assert "(5s ago)" in out
+    assert "1/2 would execute" not in out
+
+
+def test_format_plan_text_nothing_cached_divider_respects_partial_batch_cache() -> None:
+    """Partial batch cache counts as cached for the top-level divider guard."""
+    child_plan = Plan(
+        workflow="child.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="echo",
+                node_type="ShellNode",
+                status="execute",
+                cause="no_cache_match",
+                batch_items_cached=1,
+                batch_items_total=2,
+                last_duration_ms=2300.0,
+            )
+        ],
+        summary=_summary(
+            total=2,
+            cached_count=1,
+            execute_count=1,
+            execute_by_type={"ShellNode": 1},
+            total_including_nested=2,
+            cached_including_nested=1,
+            execute_including_nested=1,
+            execute_by_type_including_nested={"ShellNode": 1},
+        ),
+    )
+    plan = Plan(
+        workflow="parent.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="fanout",
+                node_type="WorkflowExecutor",
+                status="sub_workflow",
+                cause="no_cache_match",
+                sub_plan=child_plan,
+                batch_count=2,
+            )
+        ],
+        summary=_summary(
+            total=1,
+            execute_count=1,
+            execute_by_type={"WorkflowExecutor": 1},
+            total_including_nested=3,
+            cached_including_nested=1,
+            execute_including_nested=2,
+            execute_by_type_including_nested={"WorkflowExecutor": 1, "ShellNode": 1},
+        ),
+    )
+
+    assert "nothing cached" not in format_plan_text(plan)
+
+
 def test_format_plan_json_exposes_execute_by_type_including_nested() -> None:
     """JSON must expose the nested-type breakdown as a stable agent field."""
     plan = Plan(
@@ -202,6 +358,33 @@ def test_format_plan_json_exposes_execute_by_type_including_nested() -> None:
     # JSON keeps raw class names (stable agent contract, not pretty tags).
     assert payload["summary"]["execute_by_type"] == {"LLMNode": 1}
     assert payload["summary"]["execute_by_type_including_nested"] == {"LLMNode": 2, "ShellNode": 1}
+
+
+def test_format_plan_json_exposes_batch_fields() -> None:
+    """JSON includes batch-specific entry fields when they are present."""
+    plan = Plan(
+        workflow="wf.pflow.md",
+        entries=[
+            PlanEntry(
+                node_id="fanout",
+                node_type="WorkflowExecutor",
+                status="sub_workflow",
+                cause="no_cache_match",
+                batch_count=3,
+                batch_parallel=True,
+                batch_items_cached=2,
+                batch_items_total=3,
+            )
+        ],
+        summary=_summary(total=1, execute_count=1, execute_by_type={"WorkflowExecutor": 1}),
+    )
+
+    payload = format_plan_json(plan)
+
+    assert payload["plan"][0]["batch_count"] == 3
+    assert payload["plan"][0]["batch_parallel"] is True
+    assert payload["plan"][0]["batch_items_cached"] == 2
+    assert payload["plan"][0]["batch_items_total"] == 3
 
 
 def test_format_plan_json_preserves_full_workflow_path() -> None:

--- a/tests/test_execution/test_plan_batch_sub_workflow.py
+++ b/tests/test_execution/test_plan_batch_sub_workflow.py
@@ -317,8 +317,8 @@ def test_aggregate_batch_child_plans_parallel_duration_uses_max() -> None:
         ),
     ]
 
-    parallel = _aggregate_batch_child_plans(child_plans, batch_parallel=True, batch_count=2)
-    sequential = _aggregate_batch_child_plans(child_plans, batch_parallel=False, batch_count=2)
+    parallel = _aggregate_batch_child_plans(child_plans, batch_parallel=True)
+    sequential = _aggregate_batch_child_plans(child_plans, batch_parallel=False)
 
     assert parallel.summary.estimated_duration_ms == 5000.0
     assert parallel.summary.estimated_duration_ms_including_nested == 5000.0
@@ -375,7 +375,7 @@ def test_aggregate_batch_child_plans_sums_costs_without_average_times_count() ->
         ),
     ]
 
-    aggregated = _aggregate_batch_child_plans(child_plans, batch_parallel=False, batch_count=2)
+    aggregated = _aggregate_batch_child_plans(child_plans, batch_parallel=False)
 
     assert aggregated.summary.estimated_cost_usd == 0.40
     assert aggregated.summary.estimated_cost_usd_including_nested == 0.40

--- a/tests/test_execution/test_plan_batch_sub_workflow.py
+++ b/tests/test_execution/test_plan_batch_sub_workflow.py
@@ -1,0 +1,544 @@
+"""Targeted tests for batch sub-workflow dry-run planning."""
+
+from __future__ import annotations
+
+from pflow.execution.plan import _aggregate_batch_child_plans, build_plan
+from pflow.execution.result import Plan, PlanEntry, PlanSummary, RunnerConfig
+from pflow.execution.runner import WorkflowRunner
+from pflow.registry import Registry
+from pflow.runtime import compile_workflow
+from pflow.runtime.cache import MemoizationCache
+from tests.shared.markdown_utils import write_workflow_file
+
+
+def _summary(**overrides) -> PlanSummary:
+    base = {
+        "total": 0,
+        "cached_count": 0,
+        "execute_count": 0,
+        "cache_boundary": None,
+        "execute_by_type": {},
+        "estimated_cost_usd": 0.0,
+        "nodes_without_history": 0,
+    }
+    base.update(overrides)
+    return PlanSummary(**base)
+
+
+def _plan_workflow_file(path, params: dict | None = None):
+    return WorkflowRunner().plan(str(path), params or {}, RunnerConfig())
+
+
+def _run_workflow_file(path, params: dict | None = None):
+    return WorkflowRunner().run(str(path), params or {}, RunnerConfig())
+
+
+def test_plan_batch_sub_workflow_populates_outputs_for_downstream_resolution(tmp_path) -> None:
+    """Batch sub-workflow planning must populate parent shared outputs for downstream nodes."""
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": "printf ${value}"},
+                }
+            ],
+            "edges": [],
+            "outputs": {"out": {"source": "${echo.stdout}", "description": "Echoed value"}},
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"value": "${item}"},
+                    },
+                    "batch": {"items": "${items}"},
+                },
+                {
+                    "id": "post",
+                    "type": "shell",
+                    "params": {"command": "printf '${fanout.results[0].out}-${fanout.count}'"},
+                },
+            ],
+            "edges": [{"from": "fanout", "to": "post"}],
+        },
+        parent_path,
+    )
+
+    run_result = _run_workflow_file(parent_path, {"items": ["a", "b"]})
+    assert run_result.success
+
+    plan = _plan_workflow_file(parent_path, {"items": ["a", "b"]})
+
+    assert [entry.status for entry in plan.entries] == ["sub_workflow", "cached"]
+    fanout = plan.entries[0]
+    assert fanout.batch_count == 2
+    assert fanout.sub_plan is not None
+    assert len(fanout.sub_plan.entries) == 1
+    child_entry = fanout.sub_plan.entries[0]
+    assert child_entry.status == "cached"
+    assert child_entry.batch_items_cached == 2
+    assert child_entry.batch_items_total == 2
+
+
+def test_plan_batch_sub_workflow_detects_partial_cache_per_item(tmp_path) -> None:
+    """Changing one batch item should produce partial child cache counts."""
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": "printf ${value}"},
+                }
+            ],
+            "edges": [],
+            "outputs": {"out": {"source": "${echo.stdout}", "description": "Echoed value"}},
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"value": "${item}"},
+                    },
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    run_result = _run_workflow_file(parent_path, {"items": ["a", "b"]})
+    assert run_result.success
+
+    plan = _plan_workflow_file(parent_path, {"items": ["a", "c"]})
+
+    fanout = plan.entries[0]
+    assert fanout.status == "sub_workflow"
+    assert fanout.batch_count == 2
+    assert fanout.sub_plan is not None
+
+    child_entry = fanout.sub_plan.entries[0]
+    assert child_entry.status == "execute"
+    assert child_entry.batch_items_cached == 1
+    assert child_entry.batch_items_total == 2
+    assert fanout.sub_plan.summary.cached_count == 1
+    assert fanout.sub_plan.summary.execute_count == 1
+
+
+def test_plan_batch_sub_workflow_empty_items_produces_empty_sub_plan(tmp_path) -> None:
+    """An empty batch should plan as zero child work instead of failing item resolution."""
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": "printf ${value}"},
+                }
+            ],
+            "edges": [],
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"value": "${item}"},
+                    },
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    plan = _plan_workflow_file(parent_path, {"items": []})
+
+    fanout = plan.entries[0]
+    assert fanout.status == "sub_workflow"
+    assert fanout.batch_count == 0
+    assert fanout.sub_plan is not None
+    assert fanout.sub_plan.entries == []
+    assert fanout.sub_plan.summary.execute_count == 0
+
+
+def test_plan_batch_sub_workflow_non_list_items_surfaces_error(tmp_path) -> None:
+    """A batch items template that resolves to a non-list must produce a diagnostic."""
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": "printf ${value}"},
+                }
+            ],
+            "edges": [],
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"value": "${item}"},
+                    },
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    plan = _plan_workflow_file(parent_path, {"items": "not-a-list"})
+
+    assert plan.entries[0].status == "execute"
+    assert plan.entries[0].diagnostic is not None
+    assert "expected list" in plan.entries[0].diagnostic.message
+
+
+def test_plan_batch_sub_workflow_unresolvable_items_is_opaque(tmp_path) -> None:
+    """Unresolvable batch items should produce an opaque entry instead of a false error."""
+    child_path = tmp_path / "child.pflow.md"
+    write_workflow_file(
+        {
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": "printf child"},
+                }
+            ],
+            "edges": [],
+        },
+        child_path,
+    )
+    ir = {
+        "nodes": [
+            {
+                "id": "fanout",
+                "type": "workflow",
+                "params": {
+                    "workflow": str(child_path),
+                    "inputs": {"value": "${item}"},
+                },
+                "batch": {"items": "${missing.items}"},
+            }
+        ],
+        "edges": [],
+    }
+    registry = Registry()
+    compiled = compile_workflow(ir, registry=registry, initial_params={})
+    cache = MemoizationCache(db_path=tmp_path / "cache.db")
+
+    plan = build_plan(compiled, {}, cache, registry, workflow_name="opaque-batch")
+
+    assert plan.entries[0].status == "opaque"
+    assert plan.entries[0].cause == "dynamic"
+    assert plan.summary.opaque_count == 1
+
+
+def test_aggregate_batch_child_plans_parallel_duration_uses_max() -> None:
+    """Parallel batch duration must use max(item), while sequential uses sum(item)."""
+    child_plans = [
+        Plan(
+            workflow="child.pflow.md",
+            entries=[PlanEntry(node_id="echo", node_type="ShellNode", status="execute", cause="no_cache_match")],
+            summary=_summary(
+                total=1,
+                execute_count=1,
+                execute_by_type={"ShellNode": 1},
+                estimated_duration_ms=2000.0,
+                total_including_nested=1,
+                execute_including_nested=1,
+                execute_by_type_including_nested={"ShellNode": 1},
+                estimated_duration_ms_including_nested=2000.0,
+            ),
+        ),
+        Plan(
+            workflow="child.pflow.md",
+            entries=[PlanEntry(node_id="echo", node_type="ShellNode", status="execute", cause="no_cache_match")],
+            summary=_summary(
+                total=1,
+                execute_count=1,
+                execute_by_type={"ShellNode": 1},
+                estimated_duration_ms=5000.0,
+                total_including_nested=1,
+                execute_including_nested=1,
+                execute_by_type_including_nested={"ShellNode": 1},
+                estimated_duration_ms_including_nested=5000.0,
+            ),
+        ),
+    ]
+
+    parallel = _aggregate_batch_child_plans(child_plans, batch_parallel=True, batch_count=2)
+    sequential = _aggregate_batch_child_plans(child_plans, batch_parallel=False, batch_count=2)
+
+    assert parallel.summary.estimated_duration_ms == 5000.0
+    assert parallel.summary.estimated_duration_ms_including_nested == 5000.0
+    assert sequential.summary.estimated_duration_ms == 7000.0
+    assert sequential.summary.estimated_duration_ms_including_nested == 7000.0
+
+
+def test_aggregate_batch_child_plans_sums_costs_without_average_times_count() -> None:
+    """Synthetic batch summary cost must sum per-item costs, not average and multiply."""
+    child_plans = [
+        Plan(
+            workflow="child.pflow.md",
+            entries=[
+                PlanEntry(
+                    node_id="answer",
+                    node_type="LLMNode",
+                    status="execute",
+                    cause="no_cache_match",
+                    last_cost_usd=0.10,
+                )
+            ],
+            summary=_summary(
+                total=1,
+                execute_count=1,
+                execute_by_type={"LLMNode": 1},
+                estimated_cost_usd=0.10,
+                total_including_nested=1,
+                execute_including_nested=1,
+                execute_by_type_including_nested={"LLMNode": 1},
+                estimated_cost_usd_including_nested=0.10,
+            ),
+        ),
+        Plan(
+            workflow="child.pflow.md",
+            entries=[
+                PlanEntry(
+                    node_id="answer",
+                    node_type="LLMNode",
+                    status="execute",
+                    cause="no_cache_match",
+                    last_cost_usd=0.30,
+                )
+            ],
+            summary=_summary(
+                total=1,
+                execute_count=1,
+                execute_by_type={"LLMNode": 1},
+                estimated_cost_usd=0.30,
+                total_including_nested=1,
+                execute_including_nested=1,
+                execute_by_type_including_nested={"LLMNode": 1},
+                estimated_cost_usd_including_nested=0.30,
+            ),
+        ),
+    ]
+
+    aggregated = _aggregate_batch_child_plans(child_plans, batch_parallel=False, batch_count=2)
+
+    assert aggregated.summary.estimated_cost_usd == 0.40
+    assert aggregated.summary.estimated_cost_usd_including_nested == 0.40
+    assert aggregated.entries[0].last_cost_usd == 0.20
+
+
+def test_plan_batch_sub_workflow_branching_child_reports_correct_per_node_status(tmp_path) -> None:
+    """Branch-local nodes show fully cached when all items traversing them hit cache.
+
+    Regression guard for the batch_items_total fix: using len(entries_for_node)
+    instead of batch_count prevents branch-local nodes from appearing as partial
+    misses when they were actually cached for every item that took that branch.
+    """
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    child_path.write_text(
+        """\
+# Branching Child
+Routes items to different branches.
+
+## Inputs
+
+### value
+The routing value.
+- type: string
+- required: true
+
+## Steps
+
+### route
+Route based on value.
+- type: code
+- inputs:
+    value: ${value}
+
+```python code
+value: str
+
+result: str = value
+if value == "a":
+    next: str = "fast"
+else:
+    next: str = "slow"
+```
+
+### fast
+Fast branch target.
+- type: shell
+- next: end
+
+```shell command
+printf 'fast-${value}'
+```
+
+### slow
+Slow branch target.
+- type: shell
+- next: end
+
+```shell command
+printf 'slow-${value}'
+```
+""",
+        encoding="utf-8",
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"value": "${item}"},
+                    },
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    run_result = _run_workflow_file(parent_path, {"items": ["a", "b"]})
+    assert run_result.success
+
+    plan = _plan_workflow_file(parent_path, {"items": ["a", "b"]})
+
+    fanout = plan.entries[0]
+    assert fanout.status == "sub_workflow"
+    assert fanout.batch_count == 2
+    assert fanout.sub_plan is not None
+
+    entries_by_id = {e.node_id: e for e in fanout.sub_plan.entries}
+    route_entry = entries_by_id["route"]
+    assert route_entry.status == "cached"
+    assert route_entry.batch_items_cached == 2
+    assert route_entry.batch_items_total == 2
+
+    fast_entry = entries_by_id["fast"]
+    assert fast_entry.status == "cached"
+    assert fast_entry.batch_items_cached == 1
+    assert fast_entry.batch_items_total == 1
+
+    slow_entry = entries_by_id["slow"]
+    assert slow_entry.status == "cached"
+    assert slow_entry.batch_items_cached == 1
+    assert slow_entry.batch_items_total == 1
+
+    assert fanout.sub_plan.summary.execute_count == 0
+
+
+def test_plan_batch_sub_workflow_non_dict_per_item_inputs_emits_warning(tmp_path) -> None:
+    """When one batch item's inputs resolve to non-dict, a WARNING diagnostic surfaces.
+
+    Runtime would raise ValueError; the planner falls back to item[0]'s inputs
+    but honestly warns that this item will fail at execution time.
+    """
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": "printf ${value}"},
+                }
+            ],
+            "edges": [],
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": "${item}",
+                    },
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    plan = _plan_workflow_file(parent_path, {"items": [{"value": "ok"}, "broken-string"]})
+
+    fanout = plan.entries[0]
+    assert fanout.status == "sub_workflow"
+    assert fanout.sub_plan is not None
+
+    warnings = [d for d in fanout.sub_plan.diagnostics if d.severity.name == "WARNING"]
+    assert len(warnings) == 1
+    assert "item 1" in warnings[0].message.lower() or "Batch item 1" in warnings[0].message
+    assert "str" in warnings[0].message

--- a/tests/test_execution/test_plan_drift.py
+++ b/tests/test_execution/test_plan_drift.py
@@ -282,6 +282,74 @@ def test_plan_batch_items_cache_matches(tmp_path) -> None:
     assert _log_lines(log_file) == first_lines
 
 
+def test_plan_batch_sub_workflow_partial_cache_matches_execution(tmp_path) -> None:
+    """Batch sub-workflow partial-cache prediction must match the next real run.
+
+    Regression target for task 157's missing dispatch. Without the batch
+    WorkflowExecutor planning path, `--dry-run` either reported the whole
+    sub-workflow as uncached or failed to resolve `${item}` for the child
+    input, while the real execution reused cached items correctly.
+
+    Mutation: remove the `config.batch_config and not downstream` dispatch in
+    `_plan_sub_workflow` → this assertion fails because the child sub-plan no
+    longer reports `1/2` cache reuse.
+    """
+    log_file = tmp_path / "batch-sub.log"
+    child_path = tmp_path / "child.pflow.md"
+    parent_path = tmp_path / "parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "params": {"command": f"echo ${{value}} >> {log_file}; printf '${{value}}'"},
+                }
+            ],
+            "edges": [],
+            "outputs": {"out": {"source": "${echo.stdout}", "description": "Echoed value"}},
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"value": "${item}"},
+                    },
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    first_result = _runner_run(parent_path, {"items": ["a", "b"]})
+    assert first_result.success
+
+    plan = _runner_plan(parent_path, {"items": ["a", "c"]})
+    second_result = _runner_run(parent_path, {"items": ["a", "c"]})
+    assert second_result.success
+
+    assert [entry.status for entry in plan.entries] == ["sub_workflow"]
+    fanout = plan.entries[0]
+    assert fanout.sub_plan is not None
+    assert len(fanout.sub_plan.entries) == 1
+    child_entry = fanout.sub_plan.entries[0]
+    assert child_entry.status == "execute"
+    assert child_entry.batch_items_cached == 1
+    assert child_entry.batch_items_total == 2
+    assert _log_lines(log_file) == ["a", "b", "c"]
+
+
 def test_plan_cache_false_always_executes(tmp_path) -> None:
     """Nodes with cache:false must re-execute regardless of previous runs."""
     log_file = tmp_path / "cache-false.log"
@@ -798,7 +866,7 @@ def test_plan_batch_llm_cost_aggregates_across_results(tmp_path) -> None:
 
     # Directly seed the cache with a batch entry shape matching what the
     # engine would write — no real LLM call needed.
-    compiled, registry = _compile(ir, params={"items": ["a", "b", "c"]})
+    compiled, _registry = _compile(ir, params={"items": ["a", "b", "c"]})
     cache = MemoizationCache(db_path=tmp_path / "cache.db")
     batch_output = {
         "results": [
@@ -856,7 +924,7 @@ def test_plan_workflow_path_scoped_lookup_no_pollution(tmp_path) -> None:
         "edges": [],
     }
     compiled_a, registry_a = _compile(ir_a)
-    compiled_b, registry_b = _compile(ir_b)
+    compiled_b, _registry_b = _compile(ir_b)
     cache = MemoizationCache(db_path=tmp_path / "cache.db")
 
     # Write each entry with its own workflow_path, different durations.
@@ -1204,7 +1272,7 @@ def test_plan_direct_ir_null_workflow_path_historical_stats(tmp_path) -> None:
         "nodes": [{"id": "work", "type": "shell", "params": {"command": "printf result"}}],
         "edges": [],
     }
-    compiled, registry = _compile(ir)
+    compiled, _registry = _compile(ir)
     cache = MemoizationCache(db_path=tmp_path / "cache.db")
 
     # Seed a cache entry with NULL workflow_path (matches what the engine


### PR DESCRIPTION
## Summary

`--dry-run` now correctly handles batch sub-workflow nodes — the one structural gap in the planner's dispatch matrix. Fixes three symptoms from one root cause:
- Missing cost/duration estimates for batch sub-workflows
- "Nothing cached" cascade (entire pipelines showing 0 cached when everything is cached)
- False `Workflow requires input 'X'` validation error for `${item}`-backed child inputs

## Task

157

## Changes

- **`src/pflow/execution/plan.py`** — Add batch dispatch in `_plan_sub_workflow` + 6 new functions for per-item planning, aggregation, and output population (+676 LOC)
- **`src/pflow/execution/result.py`** — Add `batch_count`, `batch_parallel`, `batch_items_cached`, `batch_items_total` to `PlanEntry`
- **`src/pflow/execution/formatters/plan_formatter.py`** — Batch-aware rendering: `× N items` headers, `M/N would execute` partial-cache display, JSON serialization
- **`src/pflow/execution/CLAUDE.md`** — Document batch sub-workflow planning architecture

## Explanation

The planner had a 2×2 dispatch gap: it handled standard nodes (batch or not) and non-batch sub-workflows, but NOT batch sub-workflow nodes. When `_plan_sub_workflow` was reached for a batched WorkflowExecutor, `plan_node()` skipped template resolution (correct for standard batch nodes, wrong for sub-workflows), so `inputs: {source: ${item}}` never resolved.

The fix mirrors the engine's outer-batch / inner-single-item architecture:
1. Resolve batch items from shared store
2. Compile child workflow ONCE (structural compilation doesn't depend on input values)
3. Plan child N times — once per item with per-item template context
4. Aggregate N child plans by `node_id` (not position — handles branching children)
5. Populate parent `shared[node_id]` with runtime batch output shape for downstream resolution

Key design decisions: full per-item recursion (not representative-item approximation), aggregate by node_id (not list position), parallel duration = max (not sum), WARNING diagnostic for non-dict per-item inputs (not silent fallback).

## Created Docs

- `.taskmaster/tasks/task_157/task-157.md` — Task spec (what/why)
- `.taskmaster/tasks/task_157/task-review.md` — Implementation review (patterns, decisions, pitfalls)
- `.taskmaster/tasks/task_157/implementation/implementation-plan.md` — Approved implementation plan
- `.taskmaster/tasks/task_157/implementation/progress-log.md` — Design journey and implementation notes

## Testing

- `make test` — 5206 passed
- `make check` — clean (ruff + mypy + deptry)
- New drift-catcher test: runs batch sub-workflow end-to-end, edits one item, asserts planner detects partial cache
- 9 unit tests covering: all-cached, partial-cache, empty items, opaque fallback, branching children, non-dict inputs, parallel/sequential duration, cost aggregation
- 4 formatter tests for batch display rendering
- Manual verification: simple repro (fresh → cached → edit-one-item) all produce correct output

## Note: Pre-existing cache key drift (#333)

During end-to-end verification on the `lyrics-generator` pipeline, we observed that some downstream nodes still show as cache misses after a fresh run. Investigation traced this to a **separate pre-existing bug** (now filed as #333): the memo cache stores output blobs with `json.dumps(sort_keys=True)`, which reorders dict keys alphabetically. When cached structured output (e.g., LLM JSON with insertion-ordered keys) is restored and stringified into a downstream prompt template, the alphabetical key order produces a different cache key than the original.

This is NOT caused by the batch sub-workflow fix in this PR — it affects non-batch sub-workflows identically and was documented in the #318 investigation comment as a "partial finding" without a root cause. This PR identified the root cause during verification.