### PR TITLE
fix: memo cache sort_keys + heterogeneous batch dry-run (fixes #333, #336)

### DIFF
--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -1045,9 +1045,10 @@ def _plan_batch_sub_workflow(
     if batch_config is None:
         return _sub_workflow_error_entry(node_id, node_type, "Batch sub-workflow planning requires batch config")
 
-    guard_entry = _precheck_sub_workflow(curr, config, depth=depth)
-    if guard_entry is not None:
-        return guard_entry
+    if depth >= WorkflowExecutor.MAX_DEPTH_DEFAULT:
+        return _sub_workflow_error_entry(
+            node_id, node_type, f"Max sub-workflow depth {WorkflowExecutor.MAX_DEPTH_DEFAULT} exceeded at '{node_id}'"
+        )
 
     items_or_entry = _resolve_batch_sub_workflow_items(config, shared, batch_config)
     if isinstance(items_or_entry, PlanEntry):
@@ -1057,34 +1058,50 @@ def _plan_batch_sub_workflow(
     if not items:
         return _empty_batch_sub_workflow_entry(curr, config, shared, batch_config)
 
-    params_or_entry = _prepare_batch_sub_workflow_params(curr, config, shared, items, batch_config)
-    if isinstance(params_or_entry, PlanEntry):
-        return params_or_entry
-    batch_params = params_or_entry
-    target_or_entry = _prepare_sub_workflow(
-        merged=batch_params.merged,
-        child_inputs=batch_params.child_inputs,
-        shared=shared,
-        registry=registry,
-        visited_paths=visited_paths,
-        node_id=node_id,
-        node_type=node_type,
-    )
-    if isinstance(target_or_entry, PlanEntry):
-        return target_or_entry
-    prepared = target_or_entry
-    child_plans, item_outputs, per_item_diagnostics = _plan_batch_sub_workflow_items(
-        items=items,
-        shared=shared,
-        cache=cache,
-        registry=registry,
-        batch_config=batch_config,
-        raw_inputs_template=batch_params.raw_inputs_template,
-        prepared=prepared,
-        depth=depth,
-        visited_paths=visited_paths,
-        node_id=node_id,
-    )
+    workflow_ref = _raw_workflow_ref(curr, config)
+    is_per_item_workflow = isinstance(workflow_ref, str) and "${" in workflow_ref
+
+    if is_per_item_workflow:
+        child_plans, item_outputs, per_item_diagnostics = _plan_heterogeneous_batch_items(
+            curr=curr,
+            config=config,
+            shared=shared,
+            cache=cache,
+            registry=registry,
+            items=items,
+            batch_config=batch_config,
+            visited_paths=visited_paths,
+            depth=depth,
+        )
+    else:
+        params_or_entry = _prepare_batch_sub_workflow_params(curr, config, shared, items, batch_config)
+        if isinstance(params_or_entry, PlanEntry):
+            return params_or_entry
+        batch_params = params_or_entry
+        target_or_entry = _prepare_sub_workflow(
+            merged=batch_params.merged,
+            child_inputs=batch_params.child_inputs,
+            shared=shared,
+            registry=registry,
+            visited_paths=visited_paths,
+            node_id=node_id,
+            node_type=node_type,
+        )
+        if isinstance(target_or_entry, PlanEntry):
+            return target_or_entry
+        prepared = target_or_entry
+        child_plans, item_outputs, per_item_diagnostics = _plan_batch_sub_workflow_items(
+            items=items,
+            shared=shared,
+            cache=cache,
+            registry=registry,
+            batch_config=batch_config,
+            raw_inputs_template=batch_params.raw_inputs_template,
+            prepared=prepared,
+            depth=depth,
+            visited_paths=visited_paths,
+            node_id=node_id,
+        )
 
     aggregated_plan = _aggregate_batch_child_plans(
         child_plans,
@@ -1394,6 +1411,110 @@ def _plan_batch_sub_workflow_items(
     return child_plans, item_outputs, per_item_diagnostics
 
 
+def _plan_heterogeneous_batch_items(
+    *,
+    curr: Any,
+    config: NodeConfig,
+    shared: dict[str, Any],
+    cache: MemoizationCache,
+    registry: Registry,
+    items: list[Any],
+    batch_config: BatchConfig,
+    visited_paths: list[str],
+    depth: int,
+) -> tuple[list[Plan], list[dict[str, Any]], list[Diagnostic]]:
+    """Plan a batch where each item may reference a different child workflow.
+
+    Mirrors runtime's per-item compile-once cache: resolve the workflow path
+    per item, compile each unique path once, plan each item against its own
+    compiled child. Tracked as intentional duplication in GH #334.
+    """
+    node_id = config.node_id
+    node_type = config.node_type_name
+    compile_cache: dict[str, _PreparedSubWorkflow] = {}
+    child_plans: list[Plan] = []
+    item_outputs: list[dict[str, Any]] = []
+    per_item_diagnostics: list[Diagnostic] = []
+
+    raw_inputs_template = config.template_config.template_params.get("inputs") if config.template_config else None
+
+    for idx, item in enumerate(items):
+        try:
+            shared[batch_config.item_alias] = item
+            shared["__index__"] = idx
+            if config.template_config:
+                resolved_params, _, _ = resolve_templates(config.template_config, shared, node_id)
+                merged: dict[str, Any] = dict(getattr(curr, "params", {}) or {})
+                merged.update(config.template_config.static_params or {})
+                merged.update(resolved_params)
+            else:
+                merged = dict(getattr(curr, "params", {}) or {})
+        except Exception as exc:
+            if isinstance(exc, ValueError):
+                per_item_diagnostics.append(
+                    Diagnostic(
+                        severity=Severity.WARNING,
+                        source="planner",
+                        node_id=node_id,
+                        message=f"Batch item {idx}: template resolution failed: {exc}",
+                        context={"category": "template_error", "batch_item_index": idx},
+                    )
+                )
+            else:
+                logger.warning("Batch item %d template resolution failed: %s", idx, exc)
+            continue
+        finally:
+            shared.pop(batch_config.item_alias, None)
+            shared.pop("__index__", None)
+
+        child_inputs = dict(merged.get("inputs", {})) if isinstance(merged.get("inputs"), dict) else {}
+        resolved_path_key = str(merged.get("workflow", ""))
+
+        if resolved_path_key not in compile_cache:
+            prepared_or_entry = _prepare_sub_workflow(
+                merged=merged,
+                child_inputs=child_inputs,
+                shared=shared,
+                registry=registry,
+                visited_paths=visited_paths,
+                node_id=node_id,
+                node_type=node_type,
+            )
+            if isinstance(prepared_or_entry, PlanEntry):
+                continue
+            compile_cache[resolved_path_key] = prepared_or_entry
+
+        prepared = compile_cache[resolved_path_key]
+
+        per_item_inputs, input_diag = _resolve_per_item_sub_workflow_inputs(
+            shared=shared,
+            batch_config=batch_config,
+            item=item,
+            idx=idx,
+            raw_inputs_template=raw_inputs_template,
+            default_inputs=child_inputs,
+            node_id=node_id,
+        )
+        if input_diag is not None:
+            per_item_diagnostics.append(input_diag)
+
+        child_visited = [*visited_paths, prepared.resolved_path_str] if prepared.resolved_path_str else visited_paths
+        child_plan, child_shared = _build_plan_with_shared(
+            prepared.compiled_child,
+            per_item_inputs,
+            cache,
+            registry,
+            workflow_name=str(prepared.merged.get("workflow") or "<sub-workflow>"),
+            _visited_paths=child_visited,
+            _depth=depth + 1,
+            _parent_workflow_file=prepared.resolved_path_str,
+        )
+        child_plans.append(child_plan)
+        item_outputs.append(_extract_child_outputs(prepared.compiled_child, child_shared, per_item_inputs))
+
+    return child_plans, item_outputs, per_item_diagnostics
+
+
 def _nested_or_level(summary: PlanSummary, *, nested: str, level: str) -> Any:
     """Read the *_including_nested variant of a summary field, falling back to per-level."""
     value = getattr(summary, nested)
@@ -1478,6 +1599,35 @@ def _aggregate_batch_summary(child_plans: list[Plan], *, batch_parallel: bool) -
     )
 
 
+def _collect_entry_stats(entries: list[PlanEntry]) -> tuple[list[float], list[float]]:
+    """Collect cost and duration values from plan entries.
+
+    For sub-workflow entries without direct stats, reads from the sub_plan summary.
+    """
+    cost_values: list[float] = []
+    duration_values: list[float] = []
+    for entry in entries:
+        if entry.last_cost_usd is not None:
+            cost_values.append(entry.last_cost_usd)
+        elif entry.sub_plan is not None:
+            sub_cost = _nested_or_level(
+                entry.sub_plan.summary, nested="estimated_cost_usd_including_nested", level="estimated_cost_usd"
+            )
+            if sub_cost is not None and sub_cost > 0:
+                cost_values.append(sub_cost)
+        if entry.last_duration_ms is not None:
+            duration_values.append(entry.last_duration_ms)
+        elif entry.sub_plan is not None:
+            sub_dur = _nested_or_level(
+                entry.sub_plan.summary,
+                nested="estimated_duration_ms_including_nested",
+                level="estimated_duration_ms",
+            )
+            if sub_dur is not None and sub_dur > 0:
+                duration_values.append(sub_dur)
+    return cost_values, duration_values
+
+
 def _aggregate_batch_child_plans(
     child_plans: list[Plan],
     *,
@@ -1535,8 +1685,7 @@ def _aggregate_batch_child_plans(
             for entry in entries_for_node
             if entry.status == "cached" or (entry.status == "sub_workflow" and not _represents_work(entry))
         )
-        cost_values = [entry.last_cost_usd for entry in entries_for_node if entry.last_cost_usd is not None]
-        duration_values = [entry.last_duration_ms for entry in entries_for_node if entry.last_duration_ms is not None]
+        cost_values, duration_values = _collect_entry_stats(entries_for_node)
         age_values = [entry.age_sec for entry in entries_for_node if entry.age_sec is not None]
         template_entry = entries_for_node[0]
 

--- a/src/pflow/runtime/cache.py
+++ b/src/pflow/runtime/cache.py
@@ -339,7 +339,7 @@ class MemoizationCache:
         try:
             # Serialize and compress output (use default=str for non-JSON types,
             # NOT _make_serializable which mangles __dunder__ key values)
-            output_json = json.dumps(output, sort_keys=True, default=str)
+            output_json = json.dumps(output, default=str)
             output_blob = zlib.compress(output_json.encode())
             output_hash = hashlib.md5(output_json.encode()).hexdigest()  # noqa: S324
 

--- a/tests/test_execution/test_plan_drift.py
+++ b/tests/test_execution/test_plan_drift.py
@@ -1939,3 +1939,142 @@ def test_plan_cached_end_action_terminates_cleanly(tmp_path) -> None:
     causes = [entry.cause for entry in plan.entries]
     assert statuses == ["cached", "cached"]
     assert "routing_error" not in causes
+
+
+def test_plan_heterogeneous_batch_sub_workflow_per_item_cache(tmp_path) -> None:
+    """Batch sub-workflows with per-item workflow paths resolve per-item cache status.
+
+    Regression target for GH #336. Without the heterogeneous batch planning
+    path, `workflow: ${item.workflow}` returns opaque — no per-item cache
+    checking, no cost/duration, and everything downstream cascades to
+    "would execute."
+
+    Mutation: revert _plan_batch_sub_workflow to call _precheck_sub_workflow
+    unconditionally → this test fails because the batch entry becomes opaque.
+    """
+    log_file = tmp_path / "hetero.log"
+
+    child_a = tmp_path / "child-a.pflow.md"
+    child_a.write_text(
+        f"""\
+# Child A
+
+Test child workflow A.
+
+## Inputs
+
+### value
+
+Input value.
+
+- type: string
+- required: true
+
+## Steps
+
+### do-a
+
+Echoes the value.
+
+- type: shell
+- command: echo a:${{value}} >> {log_file}; printf a:${{value}}
+
+## Outputs
+
+### out
+
+Output from do-a.
+
+- source: ${{do-a.stdout}}
+""",
+        encoding="utf-8",
+    )
+
+    child_b = tmp_path / "child-b.pflow.md"
+    child_b.write_text(
+        f"""\
+# Child B
+
+Test child workflow B.
+
+## Inputs
+
+### value
+
+Input value.
+
+- type: string
+- required: true
+
+## Steps
+
+### do-b
+
+Echoes the value.
+
+- type: shell
+- command: echo b:${{value}} >> {log_file}; printf b:${{value}}
+
+## Outputs
+
+### out
+
+Output from do-b.
+
+- source: ${{do-b.stdout}}
+""",
+        encoding="utf-8",
+    )
+
+    parent = tmp_path / "parent.pflow.md"
+    parent.write_text(
+        f"""\
+# Heterogeneous Batch Parent
+
+Dispatches to different child workflows per item.
+
+## Steps
+
+### fanout
+
+Runs different child workflows per batch item.
+
+- type: workflow
+- workflow: ${{item.workflow}}
+- inputs: ${{item.inputs}}
+
+```yaml batch
+items:
+  - workflow: {child_a}
+    inputs:
+      value: hello
+  - workflow: {child_b}
+    inputs:
+      value: world
+parallel: false
+```
+""",
+        encoding="utf-8",
+    )
+
+    first_result = _runner_run(parent)
+    assert first_result.success, first_result.diagnostics
+
+    plan = _runner_plan(parent)
+    second_result = _runner_run(parent)
+    assert second_result.success
+
+    assert len(plan.entries) == 1
+    fanout = plan.entries[0]
+    assert fanout.status == "sub_workflow"
+    assert fanout.batch_count == 2
+    assert fanout.sub_plan is not None
+
+    child_entries = fanout.sub_plan.entries
+    assert len(child_entries) == 2
+    statuses = {e.node_id: e.status for e in child_entries}
+    assert statuses.get("do-a") == "cached"
+    assert statuses.get("do-b") == "cached"
+
+    # Second run did no extra work
+    assert _log_lines(log_file) == ["a:hello", "b:world"]

--- a/tests/test_runtime/test_cache.py
+++ b/tests/test_runtime/test_cache.py
@@ -410,3 +410,69 @@ def test_concurrent_access(tmp_path):
     count = cursor.fetchone()[0]
     conn.close()
     assert count == num_threads * ops_per_thread
+
+
+# ---------------------------------------------------------------------------
+# Key order preservation (GH #333)
+# ---------------------------------------------------------------------------
+
+
+def test_put_get_preserves_dict_key_order(tmp_path):
+    """Cache round-trip preserves dict insertion order (not alphabetical).
+
+    Regression guard for GH #333: sort_keys=True in the storage path
+    reordered keys, causing downstream cache misses when dicts were
+    stringified in templates.
+    """
+    db_path = tmp_path / "cache.db"
+    cache = MemoizationCache(db_path=db_path)
+
+    output = {
+        "zebra": 1,
+        "apple": 2,
+        "mango": {"nested_z": True, "nested_a": False},
+        "banana": [{"z_key": 1, "a_key": 2}],
+    }
+    cache.put("k", "n", "/wf.pflow.md", "default", output)
+    _, restored = cache.get("k")
+
+    assert list(restored.keys()) == ["zebra", "apple", "mango", "banana"]
+    assert list(restored["mango"].keys()) == ["nested_z", "nested_a"]
+    assert list(restored["banana"][0].keys()) == ["z_key", "a_key"]
+
+
+def test_cached_output_produces_same_downstream_cache_key(tmp_path):
+    """Downstream cache key is identical whether upstream output comes from live run or cache.
+
+    Regression guard for GH #333: sort_keys=True in storage reordered dict keys.
+    When a downstream node embeds the upstream dict in a complex template
+    (str() stringification), different key order → different prompt string →
+    different cache key → false cache miss.
+
+    Mutation: add sort_keys=True to MemoizationCache.put() → this test fails.
+    """
+    db_path = tmp_path / "cache.db"
+    cache = MemoizationCache(db_path=db_path)
+
+    upstream_output = {
+        "zebra": 1,
+        "apple": 2,
+        "mango": {"nested_z": True, "nested_a": False},
+    }
+
+    cache.put("upstream-key", "upstream-node", "/wf.pflow.md", "default", upstream_output)
+    _, restored_output = cache.get("upstream-key")
+
+    # Simulate downstream template resolution: dict embedded in a complex
+    # template gets stringified via str(), becoming part of resolved_params.
+    live_resolved = {"prompt": f"Analyze: {upstream_output}"}
+    cached_resolved = {"prompt": f"Analyze: {restored_output}"}
+
+    live_key = compute_node_cache_key("config-hash", live_resolved)
+    cached_key = compute_node_cache_key("config-hash", cached_resolved)
+
+    assert live_key == cached_key, (
+        f"Cache key diverged: live={live_key}, cached={cached_key}. "
+        f"Live keys: {list(upstream_output.keys())}, "
+        f"Cached keys: {list(restored_output.keys())}"
+    )


### PR DESCRIPTION
## Summary

Two fixes improving `--dry-run` accuracy: a one-line cache bug fix and per-item planning for heterogeneous batch sub-workflows.

**Lyrics-generator dry-run improvement:**
- Before: `12 cached · 33 would execute, ≈ $0.44, 2 opaque`
- After: `106 cached · 19 would execute, ≈ $0.13, 1 opaque`

## Changes

### 1. Cache storage key ordering (GH #333)

Removed `sort_keys=True` from `MemoizationCache.put()` — the storage serialization path. This kwarg reordered dict keys alphabetically, so when cached output was restored and stringified into downstream prompt templates via `str()`, the different key order produced different cache keys → false cache misses.

The hashing path (`_deterministic_json`, used by `compute_node_cache_key`) correctly uses `sort_keys=True` and is unchanged.

**One kwarg deleted.**

### 2. Heterogeneous batch sub-workflow planning (GH #336)

Batch sub-workflows with per-item workflow paths (`workflow: ${item.workflow}`) were marked opaque — the planner saw `${` in the raw ref and bailed before resolving items. In a batch context, each item has a concrete workflow path that's resolvable.

Added `_plan_heterogeneous_batch_items` — resolves each item's workflow path, compiles each unique path once (local cache), and plans each item against its own compiled child. This mirrors the runtime's `WorkflowExecutor` compile-once cache pattern (duplication tracked in #334).

Also extracted `_collect_entry_stats` to read cost/duration from sub_plan summaries for sub-workflow batch entries that lack direct stats.

## Explanation

The sort_keys bug was discovered during the Task 157 investigation (PR #332). The root cause: `json.dumps(output, sort_keys=True)` in `put()` was cargo-culted from the hashing mindset ("deterministic serialization = good") without distinguishing hashing from storage. Storage should be transparent — `put(X)` → `get()` returns `X`.

The heterogeneous batch fix was motivated by the lyrics-generator pipeline, where `emotional-reviews` and `craft-reviews` each dispatch to 3-4 different review workflow files per batch item. Without per-item resolution, these showed as opaque in `--dry-run`, cascading "would execute" to everything downstream and overreporting cost by ~3x.

The remaining gap (GH #335): downstream dynamic batch sub-workflows (after a cache boundary) still show no cost — the downstream BFS path can't resolve items because upstream state is dirty. Tracked separately.

## Testing

- `test_cached_output_produces_same_downstream_cache_key` — mutation-verified: reintroducing `sort_keys=True` fails this test
- `test_put_get_preserves_dict_key_order` — cache round-trip preserves key order at all nesting levels
- `test_plan_heterogeneous_batch_sub_workflow_per_item_cache` — drift-catcher: runs a workflow with two different child workflows per batch item, verifies per-item cache status
- 5211 tests pass, `make check` clean
- Manual verification on lyrics-generator pipeline (run + dry-run)

Run `make test` to verify all tests pass.

## File Changes

```
src/pflow/runtime/cache.py              |   2 +-   (removed sort_keys=True)
src/pflow/execution/plan.py             | 215 ++++ (heterogeneous batch path + stats extraction)
tests/test_runtime/test_cache.py        |  66 ++   (2 regression tests)
tests/test_execution/test_plan_drift.py | 139 ++   (1 drift-catcher)
```