### PR TITLE
feat: support dotted paths in --only for sub-workflow targeting (#338)

### DIFF
--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -165,10 +165,14 @@ def _save_trace_and_report(ctx: click.Context, workflow_trace: Any | None) -> No
 def _echo_target_node_path(ctx: click.Context, report_dir: Path, events: list[dict[str, Any]], only_node: str) -> None:
     """Display the --only target node's report file path."""
     from pflow.core.trace_report import _safe_name
+    from pflow.runtime.engine.engine import parse_only_path
 
+    this_only, _ = parse_only_path(only_node)
+    if this_only is None:
+        return
     for i, event in enumerate(events, 1):
-        if event.get("node_id") == only_node:
-            safe_id = _safe_name(only_node)
+        if event.get("node_id") == this_only:
+            safe_id = _safe_name(this_only)
             prefix = f"{i:02d}"
             is_container = event.get("batch_items") or event.get("sub_workflow_events")
             target = (
@@ -816,7 +820,10 @@ def _handle_invalid_workflow_input(workflow: tuple[str, ...]) -> None:
 @click.option("--dry-run", "dry_run", is_flag=True, help="Build execution plan without invoking side effects")
 @click.option("--cache/--no-cache", default=True, help="Enable/disable memoization cache (default: enabled)")
 @click.option(
-    "--only", "only_node", default=None, help="Run workflow through this node then stop (caching still applies)"
+    "--only",
+    "only_node",
+    default=None,
+    help="Run through this node then stop. Use dotted paths for sub-workflows: --only sub-wf.inner-node",
 )
 @click.argument("workflow", nargs=-1, type=click.UNPROCESSED)
 def run(

--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -44,7 +44,7 @@ from pflow.execution.result import Plan, PlanEntry, PlanSummary
 from pflow.registry import Registry
 from pflow.runtime.cache import MemoizationCache
 from pflow.runtime.engine.batch_executor import resolve_batch_items
-from pflow.runtime.engine.engine import is_clean_termination
+from pflow.runtime.engine.engine import is_clean_termination, parse_only_path
 from pflow.runtime.engine.instrumentation import apply_memo_hit, enforce_loop_guard
 from pflow.runtime.engine.plan_node import NodePlan, plan_node
 from pflow.runtime.engine.template_resolution import resolve_templates
@@ -78,6 +78,7 @@ class _WalkerState:
     diagnostics: list[Diagnostic]
     visited_edges: set[tuple[str, str]]
     only_node: str | None
+    child_only_node: str | None
     shared: dict[str, Any]
     registry: Registry
     visited_paths: list[str]
@@ -254,7 +255,9 @@ def _build_plan_with_shared(
     historical cost/duration estimates scoped to the child's workflow_path.
     Cost basis is always `upper_bound` — conservative for cost-gating.
     """
-    _validate_only_target(compiled, only_node, _depth)
+    _validate_only_target(compiled, only_node)
+
+    this_only, child_only = parse_only_path(only_node)
 
     shared = _create_planner_shared(compiled, params, cache, _parent_workflow_file)
     visited_paths = list(_visited_paths) if _visited_paths else []
@@ -270,7 +273,8 @@ def _build_plan_with_shared(
             visited_paths=visited_paths,
             depth=_depth,
             workflow_path=workflow_path,
-            only_node=only_node,
+            only_node=this_only,
+            child_only_node=child_only,
         )
         diagnostics: list[Diagnostic] = []
         for entry in entries:
@@ -294,7 +298,8 @@ def _build_plan_with_shared(
         entries=[],
         diagnostics=[],
         visited_edges=set(),
-        only_node=only_node,
+        only_node=this_only,
+        child_only_node=child_only,
         workflow_path=workflow_path,
         shared=shared,
         registry=registry,
@@ -312,6 +317,7 @@ def _build_plan_with_shared(
 
         enforce_loop_guard(node_id, shared)
 
+        target_child_only = child_only if (this_only is not None and node_id == this_only) else None
         entry = _plan_one_node(
             curr,
             config,
@@ -320,6 +326,7 @@ def _build_plan_with_shared(
             registry,
             visited_paths=visited_paths,
             depth=_depth,
+            child_only_node=target_child_only,
         )
         state.entries.append(entry)
         if entry.sub_plan is not None:
@@ -396,6 +403,7 @@ def _apply_boundary(
         visited_nodes={e.node_id for e in state.entries if e.sub_plan is None},
         visited_edges=state.visited_edges,
         only_node=state.only_node,
+        child_only_node=state.child_only_node,
         workflow_path=state.workflow_path,
         shared=state.shared,
         registry=state.registry,
@@ -428,17 +436,29 @@ def _apply_follow(
     return curr.successors.get(action)
 
 
-def _validate_only_target(compiled: CompiledWorkflow, only_node: str | None, depth: int) -> None:
-    """Hard-error when --only names a node that doesn't exist (top level only)."""
-    if only_node is None or depth != 0 or only_node in compiled.node_configs:
+def _validate_only_target(compiled: CompiledWorkflow, only_node: str | None) -> None:
+    """Hard-error when --only names a node that doesn't exist or dotted path targets a non-workflow."""
+    this_only, child_only = parse_only_path(only_node)
+    if this_only is None:
         return
-    available = sorted(compiled.node_configs.keys())
-    raise CompilationError(
-        f"Node '{only_node}' not found",
-        phase="only_node_resolution",
-        details={"available_nodes": available},
-        suggestion=f"Available nodes: {', '.join(available)}",
-    )
+    if this_only not in compiled.node_configs:
+        available = sorted(compiled.node_configs.keys())
+        raise CompilationError(
+            f"Node '{this_only}' not found",
+            phase="only_node_resolution",
+            details={"available_nodes": available},
+            suggestion=f"Available nodes: {', '.join(available)}",
+        )
+    if child_only:
+        target_config = compiled.node_configs[this_only]
+        if target_config.node_type_name != "WorkflowExecutor":
+            raise CompilationError(
+                f"Node '{this_only}' is not a sub-workflow",
+                phase="only_node_resolution",
+                details={"node_type": target_config.node_type_name},
+                suggestion=f"Cannot use dotted path '{only_node}' — "
+                f"'{this_only}' is a {target_config.node_type_name}, not a sub-workflow.",
+            )
 
 
 def _create_planner_shared(
@@ -510,6 +530,7 @@ def _bfs_downstream(
     visited_nodes: set[str],
     visited_edges: set[tuple[str, str]],
     only_node: str | None,
+    child_only_node: str | None = None,
     workflow_path: str | None = None,
     shared: dict[str, Any],
     registry: Registry,
@@ -536,6 +557,7 @@ def _bfs_downstream(
         visited_nodes=visited_nodes,
         visited_edges=visited_edges,
         only_node=only_node,
+        child_only_node=child_only_node,
         workflow_path=workflow_path,
         shared=shared,
         registry=registry,
@@ -556,6 +578,7 @@ def _bfs_from_start(
     depth: int,
     workflow_path: str | None,
     only_node: str | None,
+    child_only_node: str | None = None,
 ) -> tuple[list[PlanEntry], bool]:
     """BFS over the entire graph from the start node, every entry downstream.
 
@@ -573,6 +596,7 @@ def _bfs_from_start(
         visited_nodes=set(),
         visited_edges=set(),
         only_node=only_node,
+        child_only_node=child_only_node,
         workflow_path=workflow_path,
         shared=shared,
         registry=registry,
@@ -589,6 +613,7 @@ def _bfs_walk(
     visited_nodes: set[str],
     visited_edges: set[tuple[str, str]],
     only_node: str | None,
+    child_only_node: str | None = None,
     workflow_path: str | None,
     shared: dict[str, Any],
     registry: Registry,
@@ -613,6 +638,8 @@ def _bfs_walk(
 
     while queue:
         node = queue.popleft()
+        node_id = getattr(node, "node_id", None)
+        target_child = child_only_node if (only_node and node_id == only_node) else None
         entry = _make_downstream_entry(
             node,
             compiled,
@@ -623,6 +650,7 @@ def _bfs_walk(
             registry=registry,
             visited_paths=visited_paths,
             depth=depth,
+            child_only_node=target_child,
         )
         if entry is None:
             continue
@@ -664,6 +692,7 @@ def _make_downstream_entry(
     registry: Registry,
     visited_paths: list[str],
     depth: int,
+    child_only_node: str | None = None,
 ) -> PlanEntry | None:
     """Build a downstream PlanEntry for a BFS-discovered node, or None to skip it.
 
@@ -696,6 +725,7 @@ def _make_downstream_entry(
             visited_paths=visited_paths,
             depth=depth,
             cause="downstream",
+            child_only_node=child_only_node,
         )
 
     return _execute_entry(config, cache, cause="downstream", workflow_path=workflow_path)
@@ -739,6 +769,7 @@ def _plan_one_node(
     *,
     visited_paths: list[str],
     depth: int,
+    child_only_node: str | None = None,
 ) -> PlanEntry:
     """Plan a single node, dispatching on WorkflowExecutor vs standard."""
     if config.node_type_name == "WorkflowExecutor":
@@ -750,6 +781,7 @@ def _plan_one_node(
             registry,
             visited_paths=visited_paths,
             depth=depth,
+            child_only_node=child_only_node,
         )
     return _plan_standard_node(curr, config, shared, cache)
 
@@ -939,6 +971,7 @@ def _plan_sub_workflow(
     visited_paths: list[str],
     depth: int,
     cause: Literal["no_cache_match", "downstream"] = "no_cache_match",
+    child_only_node: str | None = None,
 ) -> PlanEntry:
     """Compile and recursively plan a nested workflow.
 
@@ -965,6 +998,7 @@ def _plan_sub_workflow(
             registry,
             visited_paths=visited_paths,
             depth=depth,
+            child_only_node=child_only_node,
         )
 
     guard_entry = _precheck_sub_workflow(curr, config, depth=depth)
@@ -995,6 +1029,7 @@ def _plan_sub_workflow(
         cache,
         registry,
         workflow_name=str(prepared.merged.get("workflow") or "<sub-workflow>"),
+        only_node=child_only_node,
         _visited_paths=[*visited_paths, prepared.resolved_path_str] if prepared.resolved_path_str else visited_paths,
         _depth=depth + 1,
         _parent_workflow_file=prepared.resolved_path_str,
@@ -1037,6 +1072,7 @@ def _plan_batch_sub_workflow(
     *,
     visited_paths: list[str],
     depth: int,
+    child_only_node: str | None = None,
 ) -> PlanEntry:
     """Plan a batch WorkflowExecutor by recursively planning one child per item."""
     node_id = config.node_id
@@ -1072,6 +1108,7 @@ def _plan_batch_sub_workflow(
             batch_config=batch_config,
             visited_paths=visited_paths,
             depth=depth,
+            child_only_node=child_only_node,
         )
     else:
         params_or_entry = _prepare_batch_sub_workflow_params(curr, config, shared, items, batch_config)
@@ -1101,6 +1138,7 @@ def _plan_batch_sub_workflow(
             depth=depth,
             visited_paths=visited_paths,
             node_id=node_id,
+            child_only_node=child_only_node,
         )
 
     aggregated_plan = _aggregate_batch_child_plans(
@@ -1371,6 +1409,7 @@ def _plan_batch_sub_workflow_items(
     depth: int,
     visited_paths: list[str],
     node_id: str,
+    child_only_node: str | None = None,
 ) -> tuple[list[Plan], list[dict[str, Any]], list[Diagnostic]]:
     """Plan each batch item's child workflow and collect exposed outputs."""
     child_plans: list[Plan] = []
@@ -1398,6 +1437,7 @@ def _plan_batch_sub_workflow_items(
             cache,
             registry,
             workflow_name=child_workflow_name,
+            only_node=child_only_node,
             _visited_paths=child_visited_paths,
             _depth=depth + 1,
             _parent_workflow_file=prepared.resolved_path_str,
@@ -1422,6 +1462,7 @@ def _plan_heterogeneous_batch_items(
     batch_config: BatchConfig,
     visited_paths: list[str],
     depth: int,
+    child_only_node: str | None = None,
 ) -> tuple[list[Plan], list[dict[str, Any]], list[Diagnostic]]:
     """Plan a batch where each item may reference a different child workflow.
 
@@ -1505,6 +1546,7 @@ def _plan_heterogeneous_batch_items(
             cache,
             registry,
             workflow_name=str(prepared.merged.get("workflow") or "<sub-workflow>"),
+            only_node=child_only_node,
             _visited_paths=child_visited,
             _depth=depth + 1,
             _parent_workflow_file=prepared.resolved_path_str,

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -150,7 +150,7 @@ shared["__execution__"] = {
     "node_hashes": {},         # MD5 config hashes for cache validation
     "failed_node": None,       # Node that caused workflow failure
     "node_visit_counts": {},   # Per-node visit counter (loop guard)
-    "only_node": None,         # --only target node ID (set by engine)
+    "only_node": None,         # --only target (full dotted path if nested, set by engine)
 }
 
 # Failure archive (managed by runtime/node_state.py::mark_node_failed)
@@ -177,6 +177,9 @@ shared["__index__"] = int                 # 0-based batch item index
 shared["_pflow_depth"] = int
 shared["_pflow_stack"] = list[str]
 shared["_pflow_workflow_file"] = str
+shared["_pflow_child_only_node"] = str   # Transient: remaining dotted --only path for child engine.
+                                         # Written by engine before target sub-workflow, read+consumed
+                                         # by WorkflowExecutor.exec(), cleaned up by engine after.
 ```
 
 ## Critical Behaviors

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -7,7 +7,7 @@ Orchestration engine that handles graph traversal and all runtime concerns: temp
 ```
 src/pflow/runtime/engine/
 ├── __init__.py              # Exports: CompiledWorkflow, WorkflowEngine, type classes
-├── engine.py                # WorkflowEngine — graph walker + per-node orchestration
+├── engine.py                # WorkflowEngine, parse_only_path — graph walker + per-node orchestration
 ├── types.py                 # CompiledWorkflow, NodeConfig, TemplateConfig, BatchConfig
 ├── template_resolution.py   # Standalone template resolution functions
 ├── batch_executor.py        # Standalone batch execution functions
@@ -70,11 +70,11 @@ Stateless executor. No per-node instance state.
 
 ### `run(workflow, shared) → str`
 
-1. Validates `--only` target exists (raises `CompilationError` if not)
+1. Parses `--only` via `parse_only_path` into `(this_only, child_only)`. Validates first segment exists; if dotted, validates it's a `WorkflowExecutor`.
 2. Resets `node_visit_counts`
 3. Walks graph: `_execute_node` per node, follows `curr.successors.get(action or "default")`
 4. On unmatched action: `_handle_no_successor` checks if step 17.5 already archived the node; if so, preserves the existing failure record and only writes a routing hint to `__warnings__`. Otherwise rolls back success bookkeeping, archives as `routing_error` via `mark_node_failed`, AND calls `self.trace.mark_last_event_failed(node_id, error=...)` to flip the already-recorded trace event so trace state agrees with `__failures__` (GH #250). The trace-flip call happens only in the non-error-action branch — the error-action branch is already correct because `is_error_action=True` caused step 16 to record `success=False`.
-5. On `--only`: stops after target node, sets `__execution__["only_node"]`
+5. On `--only`: writes `shared["_pflow_child_only_node"] = child_only` before target sub-workflow execution (cleaned up after). Stops after target, sets `__execution__["only_node"]` to the full dotted path.
 6. On success: calls `populate_declared_outputs` (skipped on error or `--only`)
 
 ### `_execute_node(node, config, shared) → str`

--- a/src/pflow/runtime/engine/__init__.py
+++ b/src/pflow/runtime/engine/__init__.py
@@ -5,7 +5,7 @@ with direct orchestration. The engine walks the node graph and handles all
 runtime concerns sequentially per node.
 """
 
-from .engine import WorkflowEngine
+from .engine import WorkflowEngine, parse_only_path
 from .plan_node import NodePlan, plan_node
 from .types import BatchConfig, CompiledWorkflow, NodeConfig, TemplateConfig
 
@@ -16,5 +16,6 @@ __all__ = [
     "NodePlan",
     "TemplateConfig",
     "WorkflowEngine",
+    "parse_only_path",
     "plan_node",
 ]

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -60,6 +60,27 @@ _NODE_TYPE_FAILURE_CATEGORY: dict[str, str] = {
 }
 
 
+def parse_only_path(only_node: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Split a dotted ``--only`` path into (this_level, child_level).
+
+    ``'a.b.c'`` → ``('a', 'b.c')``.  No dots → ``(value, None)``.
+    ``None`` → ``(None, None)``.
+
+    Raises ``CompilationError`` on malformed paths (empty segments from
+    leading/trailing dots like ``'.b'`` or ``'a.'``).
+    """
+    if only_node is None or "." not in only_node:
+        return only_node, None
+    first, remaining = only_node.split(".", 1)
+    if not first or not remaining:
+        raise CompilationError(
+            f"Invalid --only path: '{only_node}' contains an empty segment",
+            phase="only_node_resolution",
+            suggestion="Use 'parent-node.child-node' format, e.g. '--only my-workflow.target-step'.",
+        )
+    return first, remaining
+
+
 def is_clean_termination(action: Optional[str], successors: dict[str, Any]) -> bool:
     """Whether the graph walk should clean-terminate after a node returns `action`.
 
@@ -92,17 +113,34 @@ class WorkflowEngine:
         self.trace = trace_collector
         self.only_node = only_node
 
-    def run(self, workflow: CompiledWorkflow, shared: dict[str, Any]) -> str:
-        """Execute a compiled workflow. Returns action string."""
-        # 0. Validate --only target exists
-        if self.only_node and self.only_node not in workflow.node_configs:
+    def _validate_only_target(self, workflow: CompiledWorkflow, this_only: str, child_only: str | None) -> None:
+        """Validate ``--only`` target: must exist, dotted paths must target a sub-workflow."""
+        if this_only not in workflow.node_configs:
             available = sorted(workflow.node_configs.keys())
             raise CompilationError(
-                f"Node '{self.only_node}' not found",
+                f"Node '{this_only}' not found",
                 phase="only_node_resolution",
                 details={"available_nodes": available},
                 suggestion=f"Available nodes: {', '.join(available)}",
             )
+        if child_only:
+            target_config = workflow.node_configs[this_only]
+            if target_config.node_type_name != "WorkflowExecutor":
+                raise CompilationError(
+                    f"Node '{this_only}' is not a sub-workflow",
+                    phase="only_node_resolution",
+                    details={"node_type": target_config.node_type_name},
+                    suggestion=f"Cannot use dotted path '{self.only_node}' — "
+                    f"'{this_only}' is a {target_config.node_type_name}, not a sub-workflow.",
+                )
+
+    def run(self, workflow: CompiledWorkflow, shared: dict[str, Any]) -> str:
+        """Execute a compiled workflow. Returns action string."""
+        this_only, child_only = parse_only_path(self.only_node)
+
+        # 0. Validate --only target
+        if this_only:
+            self._validate_only_target(workflow, this_only, child_only)
 
         # 1. Reset visit counts
         if "__execution__" in shared and "node_visit_counts" in shared["__execution__"]:
@@ -121,10 +159,15 @@ class WorkflowEngine:
                 )
 
             config = workflow.node_configs[node_id]
+
+            if child_only and node_id == this_only:
+                shared["_pflow_child_only_node"] = child_only
+
             last_action = self._execute_node(curr, config, shared)
 
             # --only: stop after target node
-            if self.only_node and node_id == self.only_node:
+            if this_only and node_id == this_only:
+                shared.pop("_pflow_child_only_node", None)
                 if "__execution__" in shared:
                     shared["__execution__"]["only_node"] = self.only_node
                 break

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -60,17 +60,23 @@ _NODE_TYPE_FAILURE_CATEGORY: dict[str, str] = {
 }
 
 
-def parse_only_path(only_node: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+def parse_only_path(only_node: str | None) -> tuple[str | None, str | None]:
     """Split a dotted ``--only`` path into (this_level, child_level).
 
     ``'a.b.c'`` → ``('a', 'b.c')``.  No dots → ``(value, None)``.
     ``None`` → ``(None, None)``.
 
     Raises ``CompilationError`` on malformed paths (empty segments from
-    leading/trailing dots like ``'.b'`` or ``'a.'``).
+    leading/trailing dots like ``'.b'``, ``'a.'``, or ``'a..b'``).
     """
     if only_node is None or "." not in only_node:
         return only_node, None
+    if ".." in only_node:
+        raise CompilationError(
+            f"Invalid --only path: '{only_node}' contains an empty segment",
+            phase="only_node_resolution",
+            suggestion="Use 'parent-node.child-node' format, e.g. '--only my-workflow.target-step'.",
+        )
     first, remaining = only_node.split(".", 1)
     if not first or not remaining:
         raise CompilationError(
@@ -134,6 +140,22 @@ class WorkflowEngine:
                     f"'{this_only}' is a {target_config.node_type_name}, not a sub-workflow.",
                 )
 
+    def _run_node_with_child_only(
+        self, node: Any, config: NodeConfig, shared: dict[str, Any], child_only: str | None
+    ) -> str:
+        """Execute a node, injecting ``_pflow_child_only_node`` for sub-workflow targeting.
+
+        The key is written before and cleaned up after execution (including on
+        exception) so it never leaks into ``shared_after``.
+        """
+        if child_only:
+            shared["_pflow_child_only_node"] = child_only
+        try:
+            return self._execute_node(node, config, shared)
+        finally:
+            if child_only:
+                shared.pop("_pflow_child_only_node", None)
+
     def run(self, workflow: CompiledWorkflow, shared: dict[str, Any]) -> str:
         """Execute a compiled workflow. Returns action string."""
         this_only, child_only = parse_only_path(self.only_node)
@@ -159,15 +181,12 @@ class WorkflowEngine:
                 )
 
             config = workflow.node_configs[node_id]
+            is_only_target = this_only is not None and node_id == this_only
 
-            if child_only and node_id == this_only:
-                shared["_pflow_child_only_node"] = child_only
-
-            last_action = self._execute_node(curr, config, shared)
+            last_action = self._run_node_with_child_only(curr, config, shared, child_only if is_only_target else None)
 
             # --only: stop after target node
-            if this_only and node_id == this_only:
-                shared.pop("_pflow_child_only_node", None)
+            if is_only_target:
                 if "__execution__" in shared:
                     shared["__execution__"]["only_node"] = self.only_node
                 break

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -364,7 +364,8 @@ class WorkflowExecutor(BaseNode):
                 child_storage[k] = v
         child_storage.update(child_params)
 
-        engine = WorkflowEngine(trace_collector=child_trace)
+        child_only = parent_shared.get("_pflow_child_only_node")
+        engine = WorkflowEngine(trace_collector=child_trace, only_node=child_only)
 
         try:
             result = engine.run(compiled, child_storage)

--- a/tests/test_runtime/test_dotted_only_path.py
+++ b/tests/test_runtime/test_dotted_only_path.py
@@ -87,6 +87,11 @@ class TestParseOnlyPath:
         with pytest.raises(CompilationError, match="empty segment"):
             parse_only_path(".")
 
+    def test_consecutive_dots_raises(self) -> None:
+        """``a..b`` is caught early with the full original path in the error."""
+        with pytest.raises(CompilationError, match="a\\.\\.b"):
+            parse_only_path("a..b")
+
 
 # ---------------------------------------------------------------------------
 # 2. Engine validation tests
@@ -233,6 +238,28 @@ class TestDottedOnlyIntegration:
         config = RunnerConfig(only_node="step-b.child-first")
         result = runner.run(str(parent_path), {}, config)
 
+        assert "_pflow_child_only_node" not in result.shared_after
+
+    def test_dotted_only_cleans_up_key_on_child_failure(self, tmp_path: Path) -> None:
+        """``_pflow_child_only_node`` must not leak into shared_after when the child fails."""
+        broken_child = tmp_path / "broken-child.pflow.md"
+        broken_child.write_text(
+            "# Broken Child\n\nA child that fails.\n\n## Steps\n\n"
+            "### child-first\n\nFails immediately.\n\n- type: shell\n- command: exit 1\n\n"
+            "### child-second\n\nNever reached.\n\n- type: shell\n- command: echo unreachable\n"
+        )
+        parent = tmp_path / "parent.pflow.md"
+        parent.write_text(
+            "# Parent\n\nParent workflow.\n\n## Steps\n\n"
+            "### step-a\n\nFirst step.\n\n- type: shell\n- command: echo ok\n\n"
+            f"### step-b\n\nSub-workflow.\n\n- type: workflow\n- workflow: {broken_child}\n\n"
+            "### step-c\n\nLast step.\n\n- type: shell\n- command: echo done\n"
+        )
+
+        runner = WorkflowRunner()
+        result = runner.run(str(parent), {}, RunnerConfig(only_node="step-b.child-first"))
+
+        assert not result.success
         assert "_pflow_child_only_node" not in result.shared_after
 
 

--- a/tests/test_runtime/test_dotted_only_path.py
+++ b/tests/test_runtime/test_dotted_only_path.py
@@ -1,0 +1,312 @@
+"""Tests for dotted-path --only feature (GH #338).
+
+``--only step-b.child-first`` targets a node inside a sub-workflow:
+the engine executes the parent up to ``step-b``, and the child workflow
+inside ``step-b`` runs only up to ``child-first``.
+
+Covers:
+  1. ``parse_only_path`` pure-function unit tests
+  2. Engine validation (node not found, not a sub-workflow)
+  3. Engine + WorkflowExecutor integration (child-level targeting)
+  4. Planner integration (``build_plan`` with dotted paths)
+  5. Cleanup of ``_pflow_child_only_node`` key
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pflow.core.exceptions import CompilationError
+from pflow.core.node import BaseNode
+from pflow.execution.result import RunnerConfig
+from pflow.execution.runner import WorkflowRunner
+from pflow.runtime.engine.engine import WorkflowEngine, parse_only_path
+from pflow.runtime.engine.types import CompiledWorkflow, NodeConfig
+from tests.shared.markdown_utils import write_workflow_file
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubNode(BaseNode):
+    """Minimal node that writes its node_id to shared for execution tracking."""
+
+    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+        shared.setdefault("_executed", []).append(self.node_id)
+        shared["stdout"] = f"output-from-{self.node_id}"
+        return "default"
+
+
+def _make_config(node_id: str, type_name: str = "StubNode") -> NodeConfig:
+    return NodeConfig(
+        node_id=node_id,
+        node_type_name=type_name,
+        template_config=None,
+        batch_config=None,
+        namespaced=False,
+        interface_metadata=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. parse_only_path unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseOnlyPath:
+    """Pure-function tests for the path parser."""
+
+    def test_none_returns_none_pair(self) -> None:
+        assert parse_only_path(None) == (None, None)
+
+    def test_simple_name_no_dot(self) -> None:
+        assert parse_only_path("step-a") == ("step-a", None)
+
+    def test_two_segments(self) -> None:
+        assert parse_only_path("step-a.child-first") == ("step-a", "child-first")
+
+    def test_multi_level_preserves_remaining(self) -> None:
+        """``a.b.c`` splits as ``('a', 'b.c')`` — remaining is still dotted."""
+        assert parse_only_path("a.b.c") == ("a", "b.c")
+
+    def test_empty_string_no_dot(self) -> None:
+        """Edge case: empty string has no dot, so it returns as-is."""
+        assert parse_only_path("") == ("", None)
+
+    def test_trailing_dot_raises(self) -> None:
+        with pytest.raises(CompilationError, match="empty segment"):
+            parse_only_path("step-a.")
+
+    def test_leading_dot_raises(self) -> None:
+        with pytest.raises(CompilationError, match="empty segment"):
+            parse_only_path(".child-first")
+
+    def test_single_dot_raises(self) -> None:
+        with pytest.raises(CompilationError, match="empty segment"):
+            parse_only_path(".")
+
+
+# ---------------------------------------------------------------------------
+# 2. Engine validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestEngineOnlyValidation:
+    """Engine.run() validates --only targets before execution starts."""
+
+    def test_dotted_path_nonexistent_first_segment_raises(self) -> None:
+        """Dotted path where the first segment doesn't exist in the workflow."""
+        node = _StubNode()
+        node.node_id = "step-a"
+
+        workflow = CompiledWorkflow(
+            start_node=node,
+            node_configs={"step-a": _make_config("step-a")},
+        )
+        shared: dict[str, Any] = {}
+        engine = WorkflowEngine(only_node="nonexistent.child")
+
+        with pytest.raises(CompilationError, match="not found"):
+            engine.run(workflow, shared)
+
+    def test_dotted_path_on_non_workflow_node_raises(self) -> None:
+        """Dotted path where first segment is a shell node, not a sub-workflow."""
+        node = _StubNode()
+        node.node_id = "step-a"
+
+        workflow = CompiledWorkflow(
+            start_node=node,
+            node_configs={"step-a": _make_config("step-a", type_name="ShellNode")},
+        )
+        shared: dict[str, Any] = {}
+        engine = WorkflowEngine(only_node="step-a.child")
+
+        with pytest.raises(CompilationError, match="not a sub-workflow"):
+            engine.run(workflow, shared)
+
+    def test_flat_only_still_works_regression(self) -> None:
+        """Flat --only (no dots) still stops after the target node."""
+        node_a = _StubNode()
+        node_a.node_id = "first"
+
+        node_b = _StubNode()
+        node_b.node_id = "second"
+
+        node_a >> node_b
+
+        workflow = CompiledWorkflow(
+            start_node=node_a,
+            node_configs={
+                "first": _make_config("first"),
+                "second": _make_config("second"),
+            },
+        )
+        shared: dict[str, Any] = {}
+        engine = WorkflowEngine(only_node="first")
+        engine.run(workflow, shared)
+
+        assert shared["_executed"] == ["first"]
+        assert shared["__execution__"]["only_node"] == "first"
+
+
+# ---------------------------------------------------------------------------
+# 3. Engine + WorkflowExecutor integration tests
+# ---------------------------------------------------------------------------
+
+
+def _write_child_workflow(tmp_path: Path) -> Path:
+    """Write a 2-step child workflow (child-first -> child-second)."""
+    child_ir = {
+        "nodes": [
+            {"id": "child-first", "type": "shell", "params": {"command": "printf child-one"}},
+            {"id": "child-second", "type": "shell", "params": {"command": "printf child-two"}},
+        ],
+        "edges": [{"from": "child-first", "to": "child-second"}],
+    }
+    child_path = tmp_path / "child.pflow.md"
+    write_workflow_file(child_ir, child_path)
+    return child_path
+
+
+def _write_parent_workflow(tmp_path: Path, child_path: Path) -> Path:
+    """Write a 3-step parent: step-a(shell) -> step-b(workflow) -> step-c(shell)."""
+    parent_ir = {
+        "nodes": [
+            {"id": "step-a", "type": "shell", "params": {"command": "printf parent-a"}},
+            {
+                "id": "step-b",
+                "type": "workflow",
+                "params": {"workflow": str(child_path)},
+            },
+            {"id": "step-c", "type": "shell", "params": {"command": "printf parent-c"}},
+        ],
+        "edges": [
+            {"from": "step-a", "to": "step-b"},
+            {"from": "step-b", "to": "step-c"},
+        ],
+    }
+    parent_path = tmp_path / "parent.pflow.md"
+    write_workflow_file(parent_ir, parent_path)
+    return parent_path
+
+
+class TestDottedOnlyIntegration:
+    """Full integration: parent workflow with a sub-workflow, using dotted --only."""
+
+    def test_dotted_only_targets_child_node(self, tmp_path: Path) -> None:
+        """``--only step-b.child-first`` executes step-a, step-b (child runs
+        only child-first), and stops before step-c."""
+        child_path = _write_child_workflow(tmp_path)
+        parent_path = _write_parent_workflow(tmp_path, child_path)
+
+        runner = WorkflowRunner()
+        config = RunnerConfig(only_node="step-b.child-first")
+        result = runner.run(str(parent_path), {}, config)
+
+        shared = result.shared_after
+
+        # step-a executed
+        assert "step-a" in shared, "step-a should have executed"
+
+        # step-b executed (sub-workflow node)
+        assert "step-b" in shared, "step-b should have executed"
+
+        # Inside child: child-first executed, child-second did NOT
+        child_data = shared.get("step-b", {})
+        assert "child-first" in child_data, "child-first inside step-b should have executed"
+        assert "child-second" not in child_data, "child-second should NOT have executed (dotted --only)"
+
+        # step-c did NOT execute
+        assert "step-c" not in shared, "step-c should NOT have executed"
+
+        # The full dotted path is recorded
+        assert shared["__execution__"]["only_node"] == "step-b.child-first"
+
+    def test_dotted_only_cleans_up_child_only_key(self, tmp_path: Path) -> None:
+        """After engine stops, ``_pflow_child_only_node`` must NOT be in shared."""
+        child_path = _write_child_workflow(tmp_path)
+        parent_path = _write_parent_workflow(tmp_path, child_path)
+
+        runner = WorkflowRunner()
+        config = RunnerConfig(only_node="step-b.child-first")
+        result = runner.run(str(parent_path), {}, config)
+
+        assert "_pflow_child_only_node" not in result.shared_after
+
+
+# ---------------------------------------------------------------------------
+# 4. Planner integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDottedOnlyPlanner:
+    """Planner (build_plan) respects dotted --only paths."""
+
+    def test_plan_dotted_only_limits_child_entries_cached_parent(self, tmp_path: Path) -> None:
+        """When the parent prefix is cached, ``build_plan(only_node='step-b.child-first')``
+        produces a child sub-plan that stops at child-first.
+
+        The planner threads ``child_only`` through the state-machine path
+        (FOLLOW transitions for cached nodes).  We prime the cache first
+        so step-a is cached and the walker reaches step-b via FOLLOW, not
+        BFS downstream.
+        """
+        child_path = _write_child_workflow(tmp_path)
+        parent_path = _write_parent_workflow(tmp_path, child_path)
+
+        # Prime the memo cache so step-a is cached on the next plan
+        WorkflowRunner().run(str(parent_path), {}, RunnerConfig())
+
+        plan = WorkflowRunner().plan(str(parent_path), {}, RunnerConfig(only_node="step-b.child-first"))
+
+        # Parent plan should have entries for step-a and step-b only
+        parent_ids = [e.node_id for e in plan.entries]
+        assert "step-a" in parent_ids
+        assert "step-b" in parent_ids
+        assert "step-c" not in parent_ids
+
+        # step-b should have a sub_plan
+        step_b_entry = next(e for e in plan.entries if e.node_id == "step-b")
+        assert step_b_entry.sub_plan is not None
+
+        # Child sub-plan should only include child-first, not child-second
+        child_ids = [e.node_id for e in step_b_entry.sub_plan.entries]
+        assert "child-first" in child_ids
+        assert "child-second" not in child_ids
+
+    def test_plan_dotted_only_bfs_path_limits_child_entries(self, tmp_path: Path) -> None:
+        """When upstream is a cache miss, BFS fires — child sub-plan must still
+        respect the dotted ``--only`` constraint.
+
+        Uses ``MemoizationCache(read_enabled=False)`` so ALL nodes are misses.
+        The first miss triggers BOUNDARY → BFS reaches step-b → must thread
+        ``child_only_node`` to the child plan. Without the fix, BFS would show
+        the full child workflow (child-first AND child-second).
+        """
+        child_path = _write_child_workflow(tmp_path)
+        parent_path = _write_parent_workflow(tmp_path, child_path)
+
+        plan = WorkflowRunner().plan(
+            str(parent_path), {}, RunnerConfig(only_node="step-b.child-first", cache_enabled=False)
+        )
+
+        step_b_entry = next((e for e in plan.entries if e.node_id == "step-b"), None)
+        assert step_b_entry is not None, "step-b should appear in plan"
+        assert step_b_entry.sub_plan is not None, "step-b should have a sub_plan"
+
+        child_ids = [e.node_id for e in step_b_entry.sub_plan.entries]
+        assert "child-first" in child_ids
+        assert "child-second" not in child_ids, (
+            "BFS downstream must thread child_only_node — child-second should be excluded"
+        )
+
+    def test_plan_dotted_only_on_shell_node_raises(self, tmp_path: Path) -> None:
+        """``build_plan(only_node='step-a.foo')`` where step-a is a shell node
+        should raise CompilationError."""
+        child_path = _write_child_workflow(tmp_path)
+        parent_path = _write_parent_workflow(tmp_path, child_path)
+
+        with pytest.raises(CompilationError, match="not a sub-workflow"):
+            WorkflowRunner().plan(str(parent_path), {}, RunnerConfig(only_node="step-a.foo"))


### PR DESCRIPTION
## Summary

`--only step-b.child-first` targets a node inside a sub-workflow. The engine executes through `step-b`, the child workflow runs only through `child-first`, everything downstream is skipped. Works at any nesting depth (`a.b.c`), with batch sub-workflows, and with `--dry-run`.

Fixes #338

## Changes

- `parse_only_path()` utility in `engine.py` — splits dotted path per engine level
- Engine `run()` validates first segment, writes `_pflow_child_only_node` to shared before target, cleans up after
- `WorkflowExecutor.exec()` reads `_pflow_child_only_node` and passes to child engine
- Planner threads `child_only_node` through walker state-machine path AND BFS downstream path (5 functions)
- `_validate_only_target` in both engine and planner rejects dotted paths on non-WorkflowExecutor nodes
- `_echo_target_node_path` uses first segment for trace event matching (was comparing full dotted path)
- Empty-segment validation (`--only a.` / `--only .b` → clear error)
- CLI `--only` help text updated to mention dotted path syntax
- 16 tests covering parsing, validation, engine integration, planner (FOLLOW + BFS paths), cleanup

6 files changed, +431 / -25 lines (production: ~50 LOC across 5 files; tests: 312 LOC)

## Explanation

The core mechanism: `only_node` is a path through the workflow tree. Each engine level peels off one segment via `parse_only_path(only_node).split(".", 1)` and passes the rest to the child engine via the shared store — the same channel used for `_pflow_depth`, `_pflow_stack`, and `_pflow_workflow_file`. Recursive by construction: `a.b.c` at level 0 → target `a`, pass `b.c` down; at level 1 → target `b`, pass `c` down; at level 2 → flat target `c`.

For the planner, the BFS downstream path (triggered when upstream nodes are cache misses) needed explicit `child_only_node` threading through `_apply_boundary` → `_bfs_downstream` → `_bfs_walk` → `_make_downstream_entry` → `_plan_sub_workflow`. Without this, `--dry-run --only X.Y` with uncached upstream would show the full child workflow — found and fixed during adversarial verification.

`storage_mode: shared` creates a key-leak surface for this mechanism (the shared-store key is visible to grandchild WorkflowExecutors via NamespacedSharedStore root fallback). Filed as #339 — `storage_mode: shared` is unused, already broken (pre-existing `NamespacedSharedStore.pop` crash), and should be removed.

## Testing

**Automated (16 tests in `tests/test_runtime/test_dotted_only_path.py`):**
- `TestParseOnlyPath` (8) — None, flat, two-segment, multi-level, empty string, trailing/leading/single dot errors
- `TestEngineOnlyValidation` (3) — nonexistent first segment, non-WorkflowExecutor target, flat `--only` regression
- `TestDottedOnlyIntegration` (2) — end-to-end via WorkflowRunner: child-first executes / child-second skipped / key cleaned up
- `TestDottedOnlyPlanner` (3) — cached upstream (FOLLOW path), **uncached upstream (BFS path)**, non-workflow error

**The BFS planner test is the high-value one** — `test_plan_dotted_only_bfs_path_limits_child_entries` uses `cache_enabled=False` to force the BFS downstream path, directly pinning the fix that prevents planner/engine divergence.

**Manual CLI verification (9 scenarios):**
- `--only step-b.child-first` (cached, uncached, `--no-cache`)
- `--only step-b.child-inner.gc-first` (three-level nesting)
- `--only fanout.bc-first` (batch × 3 items)
- `--dry-run --only` (cached upstream, uncached upstream)
- Error cases: non-workflow target, nonexistent first segment, nonexistent child node

**Full suite**: 5227 passed, 9 skipped, `make check` clean (ruff, mypy, deptry)