### PR TITLE
fix: --only populates resolvable declared outputs (#341, #342)

### DIFF
--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -158,23 +158,47 @@ def _handle_text_output(
     elif workflow_ir and "outputs" in workflow_ir and workflow_ir["outputs"]:
         if _try_declared_outputs(shared_storage, workflow_ir, verbose and not print_flag, print_flag):
             output_found = True
+        elif shared_storage.get("__execution__", {}).get("only_node"):
+            # --only left every declared output unresolved (the target is
+            # upstream of all output sources). Fall through to auto-detection
+            # so the user sees output from the node they actually targeted,
+            # rather than silent empty stdout.
+            output_found = _emit_auto_detected_output(
+                shared_storage,
+                print_flag,
+                "cli: Declared outputs unresolvable under --only. Showing auto-detected key '{key}'.",
+            )
 
     # Fall back to auto-detect from common keys (using unified function)
     else:
-        from pflow.execution.formatters.output_utils import find_auto_output
-
-        key_found, value = find_auto_output(shared_storage)
-        if key_found:
-            if not print_flag:
-                msg = (
-                    f"cli: No outputs declared — showing auto-detected key '{key_found}'."
-                    " Declare outputs for reliable results."
-                )
-                click.echo(msg, err=True)
-            _output_with_header(value, print_flag)
-            output_found = True
+        output_found = _emit_auto_detected_output(
+            shared_storage,
+            print_flag,
+            "cli: No outputs declared — showing auto-detected key '{key}'. Declare outputs for reliable results.",
+        )
 
     return output_found
+
+
+def _emit_auto_detected_output(
+    shared_storage: dict[str, Any],
+    print_flag: bool,
+    message_template: str,
+) -> bool:
+    """Auto-detect output from shared storage and emit it with a stderr note.
+
+    ``message_template`` must contain ``{key}`` for the detected key name.
+    Returns True if output was emitted.
+    """
+    from pflow.execution.formatters.output_utils import find_auto_output
+
+    key_found, value = find_auto_output(shared_storage)
+    if not key_found:
+        return False
+    if not print_flag:
+        click.echo(message_template.format(key=key_found), err=True)
+    _output_with_header(value, print_flag)
+    return True
 
 
 def _emit_declared_output(
@@ -286,7 +310,13 @@ def _try_declared_outputs(
 
 
 def _populate_declared_outputs_best_effort(shared_storage: dict[str, Any], workflow_ir: dict[str, Any]) -> None:
-    """Best-effort population of declared outputs from source expressions."""
+    """Best-effort population of declared outputs from source expressions.
+
+    Redundant with ``engine._populate_outputs`` for normal CLI runs (engine
+    populates first), but kept as a safety net for callers that bypass the
+    engine path. The second call is idempotent — resolvable outputs already
+    in ``shared_storage`` are overwritten with the same values.
+    """
     from pflow.core.user_errors import OutputResolutionError
     from pflow.runtime.output_resolver import populate_declared_outputs
 

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -153,14 +153,9 @@ def _handle_text_output(
             if not print_flag:
                 click.echo(f"cli: Warning - output key '{output_key}' not found in shared store", err=True)
 
-    # Check workflow-declared outputs (skip when --only is active — declared outputs
-    # reference downstream nodes that didn't execute; use auto-detection instead)
-    elif (
-        workflow_ir
-        and "outputs" in workflow_ir
-        and workflow_ir["outputs"]
-        and not shared_storage.get("__execution__", {}).get("only_node")
-    ):
+    # Check workflow-declared outputs (resolvable outputs are populated by the
+    # engine even under --only; _try_declared_outputs handles partial availability)
+    elif workflow_ir and "outputs" in workflow_ir and workflow_ir["outputs"]:
         if _try_declared_outputs(shared_storage, workflow_ir, verbose and not print_flag, print_flag):
             output_found = True
 
@@ -171,15 +166,10 @@ def _handle_text_output(
         key_found, value = find_auto_output(shared_storage)
         if key_found:
             if not print_flag:
-                only_node = shared_storage.get("__execution__", {}).get("only_node")
-                has_declared_outputs = workflow_ir and workflow_ir.get("outputs")
-                if only_node and has_declared_outputs:
-                    msg = f"cli: Declared outputs skipped (--only). Showing auto-detected key '{key_found}'."
-                else:
-                    msg = (
-                        f"cli: No outputs declared — showing auto-detected key '{key_found}'."
-                        " Declare outputs for reliable results."
-                    )
+                msg = (
+                    f"cli: No outputs declared — showing auto-detected key '{key_found}'."
+                    " Declare outputs for reliable results."
+                )
                 click.echo(msg, err=True)
             _output_with_header(value, print_flag)
             output_found = True
@@ -303,10 +293,12 @@ def _populate_declared_outputs_best_effort(shared_storage: dict[str, Any], workf
     try:
         populate_declared_outputs(shared_storage, workflow_ir)
     except OutputResolutionError as e:
-        from pflow.core.diagnostic import exception_to_diagnostics
+        only_node = shared_storage.get("__execution__", {}).get("only_node")
+        if not only_node:
+            from pflow.core.diagnostic import exception_to_diagnostics
 
-        for d in exception_to_diagnostics(e):
-            click.echo(format_diagnostic(d), err=True)
+            for d in exception_to_diagnostics(e):
+                click.echo(format_diagnostic(d), err=True)
     except Exception:  # noqa: S110
         pass  # Best-effort: non-diagnostic errors silently ignored
 

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -786,8 +786,13 @@ def _push_batch_warnings(
     """Push warnings for DEGRADED status when batch had issues."""
     empty_indices = _detect_empty_output_items(exec_res, errors)
 
-    # Under --only, empty output is expected — child declared outputs may not
-    # resolve when the targeted node is upstream of the output source.
+    # Under --only, suppress empty-output warnings workflow-wide. The common
+    # case is that the target sub-workflow batch has empty items because the
+    # child's declared outputs couldn't resolve against skipped nodes. A rare
+    # false negative: an upstream batch (not the target) with legitimately
+    # empty items would also have its warning suppressed here. Scoping to the
+    # target subtree requires threading the target node id into the batch
+    # executor; the complexity isn't worth it for a debugging-mode flag.
     only_node = shared.get("__execution__", {}).get("only_node")
     if only_node:
         empty_indices = []

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -786,6 +786,12 @@ def _push_batch_warnings(
     """Push warnings for DEGRADED status when batch had issues."""
     empty_indices = _detect_empty_output_items(exec_res, errors)
 
+    # Under --only, empty output is expected — child declared outputs may not
+    # resolve when the targeted node is upstream of the output source.
+    only_node = shared.get("__execution__", {}).get("only_node")
+    if only_node:
+        empty_indices = []
+
     warning_parts: list[str] = []
     if not exec_res:
         warning_parts.append("0 items to process (input list was empty)")

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -186,9 +186,9 @@ class WorkflowEngine:
             last_action = self._run_node_with_child_only(curr, config, shared, child_only if is_only_target else None)
 
             # --only: stop after target node
+            # (__execution__["only_node"] was already written by _execute_node
+            # step 2 for this same node)
             if is_only_target:
-                if "__execution__" in shared:
-                    shared["__execution__"]["only_node"] = self.only_node
                 break
 
             # Follow successor edge
@@ -207,10 +207,11 @@ class WorkflowEngine:
         """Resolve declared workflow outputs into the shared store.
 
         Under ``--only``, outputs whose source templates cannot resolve (because
-        the source node was skipped) are silently ignored — the resolver writes
-        each successful resolution to ``shared`` during iteration before raising
-        ``OutputResolutionError`` for failures.  Non-``--only`` runs re-raise
-        so the user sees the full error.
+        the source node was skipped) are skipped without error — the resolver
+        writes each successful resolution to ``shared`` during iteration before
+        raising ``OutputResolutionError`` for failures, so resolvable outputs
+        are still populated. Non-``--only`` runs re-raise so the user sees the
+        full error.
         """
         is_error = last_action and isinstance(last_action, str) and str(last_action).startswith("error")
         if not workflow.outputs or is_error:

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -199,13 +199,31 @@ class WorkflowEngine:
             curr = nxt
 
         # 3. Populate declared outputs
-        is_error = last_action and isinstance(last_action, str) and str(last_action).startswith("error")
-        if workflow.outputs and not is_error and not self.only_node:
-            from pflow.runtime.output_resolver import populate_declared_outputs
-
-            populate_declared_outputs(shared, {"outputs": workflow.outputs})
+        self._populate_outputs(workflow, shared, last_action)
 
         return str(last_action) if last_action else "default"
+
+    def _populate_outputs(self, workflow: CompiledWorkflow, shared: dict[str, Any], last_action: Optional[str]) -> None:
+        """Resolve declared workflow outputs into the shared store.
+
+        Under ``--only``, outputs whose source templates cannot resolve (because
+        the source node was skipped) are silently ignored — the resolver writes
+        each successful resolution to ``shared`` during iteration before raising
+        ``OutputResolutionError`` for failures.  Non-``--only`` runs re-raise
+        so the user sees the full error.
+        """
+        is_error = last_action and isinstance(last_action, str) and str(last_action).startswith("error")
+        if not workflow.outputs or is_error:
+            return
+
+        from pflow.core.user_errors import OutputResolutionError
+        from pflow.runtime.output_resolver import populate_declared_outputs
+
+        try:
+            populate_declared_outputs(shared, {"outputs": workflow.outputs})
+        except OutputResolutionError:
+            if not self.only_node:
+                raise
 
     def _handle_no_successor(
         self, last_action: Optional[str], node_id: str, curr: Any, shared: dict[str, Any]
@@ -275,6 +293,8 @@ class WorkflowEngine:
 
         # 2. Execution state
         initialize_execution_state(shared)
+        if self.only_node:
+            shared["__execution__"]["only_node"] = self.only_node
 
         # 3. Loop guard
         enforce_loop_guard(config.node_id, shared)

--- a/tests/test_execution/formatters/test_output_utils.py
+++ b/tests/test_execution/formatters/test_output_utils.py
@@ -242,12 +242,7 @@ class TestFindAutoOutput:
 
 
 class TestAutoDetectionWarning:
-    """Tests for the CLI warning messages when auto-detection is used.
-
-    The warning distinguishes between two cases:
-    1. No declared outputs — "No outputs declared"
-    2. --only active — "Declared outputs skipped (--only)"
-    """
+    """Tests for the CLI warning messages when auto-detection is used."""
 
     def test_no_declared_outputs_warning(self, capsys):
         """CORRECTNESS: Warning says 'No outputs declared' when workflow has no outputs."""
@@ -260,29 +255,23 @@ class TestAutoDetectionWarning:
         assert "No outputs declared" in captured.err
         assert "auto-detected key 'result'" in captured.err
 
-    def test_only_node_warning(self, capsys):
-        """CORRECTNESS: Warning says 'Declared outputs skipped' when --only is active."""
+    def test_only_node_tries_declared_outputs(self, capsys):
+        """CORRECTNESS: --only still tries declared outputs (engine populates resolvable ones)."""
         from pflow.cli.workflow_output import _handle_text_output
 
         shared = {
             "__execution__": {"only_node": "fetch"},
-            "result": "some value",
+            "final": "populated value",
         }
-        # workflow_ir has outputs, but --only skips them (condition at line 154)
         workflow_ir = {"outputs": {"final": {"type": "string"}}}
         _handle_text_output(shared, output_key=None, workflow_ir=workflow_ir, verbose=False)
 
         captured = capsys.readouterr()
-        assert "Declared outputs skipped (--only)" in captured.err
-        assert "auto-detected key 'result'" in captured.err
+        assert "populated value" in captured.out
+        assert "Declared outputs skipped" not in captured.err
 
     def test_only_node_without_declared_outputs_shows_no_outputs_warning(self, capsys):
-        """CORRECTNESS: --only on workflow without outputs section says 'No outputs declared'.
-
-        Bug caught in review: the else branch triggers for both 'no declared outputs'
-        and '--only with declared outputs'. Without checking has_declared_outputs,
-        --only on a workflow without outputs: would incorrectly say 'Declared outputs skipped'.
-        """
+        """CORRECTNESS: --only on workflow without outputs falls through to auto-detection."""
         from pflow.cli.workflow_output import _handle_text_output
 
         shared = {

--- a/tests/test_execution/formatters/test_output_utils.py
+++ b/tests/test_execution/formatters/test_output_utils.py
@@ -255,20 +255,31 @@ class TestAutoDetectionWarning:
         assert "No outputs declared" in captured.err
         assert "auto-detected key 'result'" in captured.err
 
-    def test_only_node_tries_declared_outputs(self, capsys):
-        """CORRECTNESS: --only still tries declared outputs (engine populates resolvable ones)."""
+    def test_only_node_falls_through_to_auto_detect_when_declared_outputs_unresolvable(self, capsys):
+        """REGRESSION GUARD: --only on a node whose output isn't referenced by any
+        declared output must still emit *something* to stdout via auto-detection.
+
+        Before the fallback was added, the CLI's ``elif`` declared-output branch
+        returned False silently and the ``else`` auto-detect branch was never
+        reached (elif/else are mutually exclusive), leaving stdout empty.
+        """
         from pflow.cli.workflow_output import _handle_text_output
 
+        # --only targeted "upstream" whose stdout is in shared, but the only
+        # declared output sources from "downstream" which didn't execute.
         shared = {
-            "__execution__": {"only_node": "fetch"},
-            "final": "populated value",
+            "__execution__": {"only_node": "upstream"},
+            "upstream": {"stdout": "target-node-value"},
         }
-        workflow_ir = {"outputs": {"final": {"type": "string"}}}
+        workflow_ir = {"outputs": {"final": {"source": "${downstream.stdout}"}}}
         _handle_text_output(shared, output_key=None, workflow_ir=workflow_ir, verbose=False)
 
         captured = capsys.readouterr()
-        assert "populated value" in captured.out
-        assert "Declared outputs skipped" not in captured.err
+        # Auto-detected value MUST reach stdout — this is the silent regression we fix
+        assert "target-node-value" in captured.out
+        # Stderr explains why we fell back, without falsely claiming no outputs were declared
+        assert "Declared outputs unresolvable under --only" in captured.err
+        assert "No outputs declared" not in captured.err
 
     def test_only_node_without_declared_outputs_shows_no_outputs_warning(self, capsys):
         """CORRECTNESS: --only on workflow without outputs falls through to auto-detection."""

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -2845,3 +2845,25 @@ class TestEmptyOutputWarnings:
 
         assert "test_node" in shared.get("__warnings__", {})
         assert "0 items" in shared["__warnings__"]["test_node"]
+
+    def test_only_node_suppresses_empty_output_warning(self):
+        """Under --only, empty output is expected and should not trigger a warning."""
+
+        class EmptyOutputNode:
+            def __init__(self, node_id: str):
+                self.node_id = node_id
+
+            def _run(self, shared: dict) -> str:
+                shared[self.node_id] = {"item": shared.get("item", "")}
+                return "default"
+
+        inner = EmptyOutputNode("test_node")
+        shared: dict = {
+            "data": ["a", "b"],
+            "__execution__": {"only_node": "parent.child"},
+        }
+
+        _run_batch(inner, shared)
+
+        warnings = shared.get("__warnings__", {})
+        assert "empty output" not in str(warnings)

--- a/tests/test_runtime/test_dotted_only_path.py
+++ b/tests/test_runtime/test_dotted_only_path.py
@@ -337,3 +337,101 @@ class TestDottedOnlyPlanner:
 
         with pytest.raises(CompilationError, match="not a sub-workflow"):
             WorkflowRunner().plan(str(parent_path), {}, RunnerConfig(only_node="step-a.foo"))
+
+
+# ---------------------------------------------------------------------------
+# 5. Dotted --only with batch sub-workflow output population (GH #342)
+# ---------------------------------------------------------------------------
+
+
+class TestDottedOnlyOutputPopulation:
+    """Dotted --only on a batch sub-workflow must populate child declared
+    outputs in batch result items.
+
+    GH #342: before the fix, ``populate_declared_outputs`` was skipped when
+    ``--only`` was active, so child declared outputs never appeared in the
+    batch results — downstream nodes referencing ``${batch-node.results}``
+    would find items without the expected output keys.
+    """
+
+    def test_batch_subworkflow_only_populates_declared_outputs(self, tmp_path: Path) -> None:
+        """``--only process-all.echo`` must produce batch results that include
+        the child's declared output ``result``."""
+        # --- child workflow: echo input text, declare "result" output ---
+        child_path = tmp_path / "child.pflow.md"
+        child_ir = {
+            "inputs": {
+                "text": {"type": "string", "description": "The text to echo"},
+            },
+            "outputs": {
+                "result": {"source": "${echo.stdout}", "description": "The echoed text"},
+            },
+            "nodes": [
+                {
+                    "id": "echo",
+                    "type": "shell",
+                    "purpose": "Echo the input text back",
+                    "params": {"command": 'echo "${text}"'},
+                },
+            ],
+        }
+        write_workflow_file(child_ir, child_path)
+
+        # --- parent workflow: batch over items calling child, plus downstream ---
+        parent_path = tmp_path / "parent.pflow.md"
+        parent_ir = {
+            "inputs": {
+                "messages": {"type": "array", "description": "List of messages to process"},
+            },
+            "nodes": [
+                {
+                    "id": "process-all",
+                    "type": "workflow",
+                    "purpose": "Process each message through child workflow",
+                    "params": {
+                        "workflow": str(child_path),
+                        "inputs": {"text": "${item}"},
+                    },
+                    "batch": {
+                        "items": "${messages}",
+                    },
+                },
+                {
+                    "id": "count",
+                    "type": "shell",
+                    "purpose": "Count processed messages from batch output",
+                    "params": {"command": 'echo "Done: ${process-all.count}"'},
+                },
+            ],
+            "edges": [{"from": "process-all", "to": "count"}],
+        }
+        write_workflow_file(parent_ir, parent_path)
+
+        # --- run with dotted --only targeting child node inside batch ---
+        config = RunnerConfig(only_node="process-all.echo")
+        result = WorkflowRunner().run(
+            str(parent_path),
+            params={"messages": ["hello", "world"]},
+            config=config,
+        )
+
+        assert result.success is True
+        shared = result.shared_after
+
+        # The batch node executed
+        assert "process-all" in shared, "batch node 'process-all' should be in shared"
+
+        # Each batch result item contains the child's declared output
+        batch_output = shared["process-all"]
+        results = batch_output["results"]
+        assert len(results) == 2
+
+        # THIS is the #342 fix verification — "result" comes from
+        # populate_declared_outputs running even under --only
+        for item in results:
+            assert "result" in item, f"Child declared output 'result' missing from batch item: {item}"
+        assert results[0]["result"] == "hello"
+        assert results[1]["result"] == "world"
+
+        # Downstream "count" should NOT have executed (--only stops at process-all)
+        assert "count" not in shared, "downstream 'count' should not execute under --only"

--- a/tests/test_runtime/test_engine_behavior.py
+++ b/tests/test_runtime/test_engine_behavior.py
@@ -20,6 +20,14 @@ class _ActionNode(BaseNode):
         return self.params.get("action", "default")
 
 
+class _OutputNode(BaseNode):
+    """Test node that writes a value to shared and returns a configurable action."""
+
+    def post(self, shared, prep_res, exec_res):
+        shared["result"] = self.params.get("output_value", "hello")
+        return self.params.get("action", "default")
+
+
 class _FlakyLoopNode(BaseNode):
     """Fails on first visit, succeeds on second, writing namespaced output."""
 
@@ -190,13 +198,14 @@ class TestUnmatchedActionWarning:
 
 
 class TestOnlyNodeWithOutputs:
-    """When --only is set, output resolution must be skipped even if
-    the workflow declares outputs. Without this gate, OutputResolutionError
-    would fire for outputs depending on nodes that were skipped.
+    """When --only is set, output resolution attempts to populate all declared
+    outputs but silently skips any that fail to resolve (because the source
+    node was skipped). Outputs whose source templates CAN resolve are populated
+    normally — this is critical for -o and batch sub-workflow results.
     """
 
-    def test_only_node_skips_output_resolution(self):
-        """--only with declared outputs does NOT attempt to resolve them."""
+    def test_only_node_skips_unresolvable_output(self):
+        """--only silently skips outputs whose source depends on a skipped node."""
         node_a = _ActionNode()
         node_a.node_id = "first"
         node_a.set_params({"action": "default"})
@@ -240,8 +249,106 @@ class TestOnlyNodeWithOutputs:
 
         assert result == "default"
         assert shared["__execution__"]["only_node"] == "first"
-        # "result" output should NOT be in shared (resolution was skipped)
+        # "result" output should NOT be in shared (source node was skipped)
         assert "result" not in shared
+
+    def test_only_node_populates_resolvable_outputs(self):
+        """--only populates declared outputs whose source templates can resolve."""
+        node_a = _OutputNode()
+        node_a.node_id = "first"
+        node_a.set_params({"action": "default", "output_value": "hello"})
+
+        node_b = _ActionNode()
+        node_b.node_id = "second"
+        node_b.set_params({"action": "default"})
+
+        node_a >> node_b
+
+        configs = {
+            "first": NodeConfig(
+                node_id="first",
+                node_type_name="OutputNode",
+                template_config=None,
+                batch_config=None,
+                namespaced=True,
+                interface_metadata=None,
+            ),
+            "second": NodeConfig(
+                node_id="second",
+                node_type_name="ActionNode",
+                template_config=None,
+                batch_config=None,
+                namespaced=True,
+                interface_metadata=None,
+            ),
+        }
+
+        workflow = CompiledWorkflow(
+            start_node=node_a,
+            node_configs=configs,
+            # Output from FIRST node — resolvable even with --only=first
+            outputs={"output": {"source": "${first.result}"}},
+        )
+
+        shared: dict = {}
+        engine = WorkflowEngine(only_node="first")
+        result = engine.run(workflow, shared)
+
+        assert result == "default"
+        assert shared["__execution__"]["only_node"] == "first"
+        # Output SHOULD be populated — source resolves from the target node
+        assert "output" in shared
+        assert shared["output"] == "hello"
+
+    def test_only_node_partial_output_resolution(self):
+        """--only populates resolvable outputs, silently skips unresolvable ones."""
+        node_a = _OutputNode()
+        node_a.node_id = "first"
+        node_a.set_params({"action": "default", "output_value": "hello"})
+
+        node_b = _OutputNode()
+        node_b.node_id = "second"
+        node_b.set_params({"action": "default", "output_value": "world"})
+
+        node_a >> node_b
+
+        configs = {
+            "first": NodeConfig(
+                node_id="first",
+                node_type_name="OutputNode",
+                template_config=None,
+                batch_config=None,
+                namespaced=True,
+                interface_metadata=None,
+            ),
+            "second": NodeConfig(
+                node_id="second",
+                node_type_name="OutputNode",
+                template_config=None,
+                batch_config=None,
+                namespaced=True,
+                interface_metadata=None,
+            ),
+        }
+
+        workflow = CompiledWorkflow(
+            start_node=node_a,
+            node_configs=configs,
+            outputs={
+                "from_first": {"source": "${first.result}"},
+                "from_second": {"source": "${second.result}"},
+            },
+        )
+
+        shared: dict = {}
+        engine = WorkflowEngine(only_node="first")
+        result = engine.run(workflow, shared)
+
+        assert result == "default"
+        # Resolvable output IS populated
+        assert shared["from_first"] == "hello"
+        # Unresolvable output is silently skipped (second didn't run)
+        assert "from_second" not in shared
 
 
 class TestCustomErrorAction:


### PR DESCRIPTION
## Summary

`--only` unconditionally skipped `populate_declared_outputs`, breaking `-o <declared-output-name>` and batch sub-workflow results under dotted `--only` paths.

Fixes #341, fixes #342

## Changes

- **`engine.py`**: Extract `_populate_outputs` helper. Always call `populate_declared_outputs`; catch `OutputResolutionError` under `--only`, re-raise otherwise. Set `only_node` in `__execution__` early (after `initialize_execution_state`) so batch executor and CLI can see it during execution.
- **`batch_executor.py`**: Suppress "empty output" warning in `_push_batch_warnings` when `--only` is active — empty batch items are expected when child declared outputs reference skipped nodes.
- **`workflow_output.py`**: Remove stale `--only` guard that skipped declared output display. Silence `_populate_declared_outputs_best_effort` diagnostic rendering under `--only`.

7 files changed: +282 / -48 (3 production, 4 test)

## Explanation

The root cause was `engine.py:203`: `if workflow.outputs and not is_error and not self.only_node` — the `not self.only_node` guard prevented ALL output population when `--only` was active, even when outputs could resolve.

`populate_declared_outputs` writes successful resolutions to `shared_storage` during iteration (line 163), before raising `OutputResolutionError` for failures (line 177). The fix exploits this contract: always call the resolver, and when `--only` is active, catch the error (resolvable outputs are already written). Non-`--only` runs are completely unchanged.

The same guard existed at three coordinated layers (engine, CLI display, CLI best-effort), all added during Task 106 when `--only` was first implemented. All three needed updating because the engine now populates resolvable outputs.

For the batch warning fix: `__execution__["only_node"]` was previously set only after the target node finished executing. But `_push_batch_warnings` runs during execution. Moving the assignment into `_execute_node` (after `initialize_execution_state`) makes it visible to the batch executor.

## Testing

**New automated tests (5):**
- `test_only_node_populates_resolvable_outputs` — `--only` on target node populates declared output sourced from that node
- `test_only_node_partial_output_resolution` — mixed case: resolvable output populated, unresolvable silently skipped
- `test_only_node_tries_declared_outputs` — CLI display path tries declared outputs under `--only` (no longer skips)
- `test_only_node_suppresses_empty_output_warning` — batch empty output warning suppressed when `--only` active
- `test_batch_subworkflow_only_populates_declared_outputs` — **end-to-end through `WorkflowRunner`**: parent batch workflow + dotted `--only` targeting child node, asserts child declared output appears in batch result items. This is the exact #342 bug path with no mocks.

**Updated tests (3):**
- `test_only_node_skips_unresolvable_output` — renamed, updated docstrings (assertions unchanged)
- `TestAutoDetectionWarning` class docstring and companion test docstrings updated

**Manual CLI verification (18 scenarios):**
- `--only` last node + `-o declared-output-name` (core #341 fix)
- Dotted `--only` batch results include child declared output (core #342 fix)
- Partial resolution (resolvable populated, unresolvable skipped)
- Regression: full run with broken output still errors (exit 1)
- Error node + `--only` skips output resolution
- `--dry-run` + `--only` combinations
- Non-batch sub-workflow + dotted `--only` + `-o`
- Coalesce (`??`) outputs with `--only`
- `--output-format json` verification
- Exit code 0 for dotted `--only` on non-last child node (was exit 2)

5233 passed, `make check` clean (ruff, mypy, deptry).