### PR TITLE
fix: auto-detection shadows dotted --only target (#344)

### DIFF
--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -164,11 +164,13 @@ def _handle_text_output(
             # so the user sees output from the node they actually targeted,
             # rather than silent empty stdout. Pass the --only target as
             # preferred_key so the target's namespace wins over unrelated
-            # resolved declared outputs at root (GH #344).
+            # resolved declared outputs at root (GH #344). No stderr note —
+            # the --only indicator line already established context; a second
+            # "declared outputs unresolvable" message is noise.
             output_found = _emit_auto_detected_output(
                 shared_storage,
                 print_flag,
-                "cli: Declared outputs unresolvable under --only. Showing auto-detected key '{key}'.",
+                message_template=None,
                 preferred_key=_only_target_root(shared_storage),
             )
 
@@ -205,12 +207,14 @@ def _only_target_root(shared_storage: dict[str, Any]) -> str | None:
 def _emit_auto_detected_output(
     shared_storage: dict[str, Any],
     print_flag: bool,
-    message_template: str,
+    message_template: str | None,
     preferred_key: str | None = None,
 ) -> bool:
-    """Auto-detect output from shared storage and emit it with a stderr note.
+    """Auto-detect output from shared storage and emit it.
 
-    ``message_template`` must contain ``{key}`` for the detected key name.
+    ``message_template`` (optional) must contain ``{key}`` for the detected
+    key name. Pass ``None`` to suppress the stderr note entirely — used for
+    --only fallback where the --only indicator already establishes context.
     ``preferred_key`` is forwarded to ``find_auto_output`` — when set and valid,
     it wins over priority-key matches elsewhere in shared. Returns True if
     output was emitted.
@@ -220,7 +224,7 @@ def _emit_auto_detected_output(
     key_found, value = find_auto_output(shared_storage, preferred_key=preferred_key)
     if not key_found:
         return False
-    if not print_flag:
+    if message_template and not print_flag:
         click.echo(message_template.format(key=key_found), err=True)
     _output_with_header(value, print_flag)
     return True

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -162,11 +162,14 @@ def _handle_text_output(
             # --only left every declared output unresolved (the target is
             # upstream of all output sources). Fall through to auto-detection
             # so the user sees output from the node they actually targeted,
-            # rather than silent empty stdout.
+            # rather than silent empty stdout. Pass the --only target as
+            # preferred_key so the target's namespace wins over unrelated
+            # resolved declared outputs at root (GH #344).
             output_found = _emit_auto_detected_output(
                 shared_storage,
                 print_flag,
                 "cli: Declared outputs unresolvable under --only. Showing auto-detected key '{key}'.",
+                preferred_key=_only_target_root(shared_storage),
             )
 
     # Fall back to auto-detect from common keys (using unified function)
@@ -175,24 +178,46 @@ def _handle_text_output(
             shared_storage,
             print_flag,
             "cli: No outputs declared — showing auto-detected key '{key}'. Declare outputs for reliable results.",
+            preferred_key=_only_target_root(shared_storage),
         )
 
     return output_found
+
+
+def _only_target_root(shared_storage: dict[str, Any]) -> str | None:
+    """Return the root segment of a DOTTED ``--only`` path, or None.
+
+    ``--only X.Y.Z`` → ``"X"``. Flat ``--only X`` → None (priority-key unwrap
+    via ``find_auto_output`` gives cleaner scalar output for leaf nodes).
+    No ``--only`` → None.
+
+    Dotted ``--only`` targets a node INSIDE a sub-workflow. The parent-level
+    namespace (``X``) holds the batch results or sub-workflow output structure
+    — that's what the user wants to see, even when priority keys at root
+    would otherwise win (GH #344).
+    """
+    only_node = shared_storage.get("__execution__", {}).get("only_node")
+    if not isinstance(only_node, str) or "." not in only_node:
+        return None
+    return only_node.split(".", 1)[0]
 
 
 def _emit_auto_detected_output(
     shared_storage: dict[str, Any],
     print_flag: bool,
     message_template: str,
+    preferred_key: str | None = None,
 ) -> bool:
     """Auto-detect output from shared storage and emit it with a stderr note.
 
     ``message_template`` must contain ``{key}`` for the detected key name.
-    Returns True if output was emitted.
+    ``preferred_key`` is forwarded to ``find_auto_output`` — when set and valid,
+    it wins over priority-key matches elsewhere in shared. Returns True if
+    output was emitted.
     """
     from pflow.execution.formatters.output_utils import find_auto_output
 
-    key_found, value = find_auto_output(shared_storage)
+    key_found, value = find_auto_output(shared_storage, preferred_key=preferred_key)
     if not key_found:
         return False
     if not print_flag:

--- a/src/pflow/execution/formatters/output_utils.py
+++ b/src/pflow/execution/formatters/output_utils.py
@@ -48,23 +48,39 @@ def _find_in_namespaces(shared_storage: dict[str, Any], key: str) -> Any:
     return last_value
 
 
-def find_auto_output(shared_storage: dict[str, Any]) -> tuple[str | None, Any]:
+def find_auto_output(
+    shared_storage: dict[str, Any],
+    preferred_key: str | None = None,
+) -> tuple[str | None, Any]:
     """Find the auto-detectable output with the highest priority.
 
     Unified implementation used by both CLI text and JSON/MCP paths.
 
-    Priority order: result > response > output > text > data > stdout
+    Priority order: ``preferred_key`` (when valid) > result > response > output >
+    text > data > stdout
     Search order: root first, then namespaces (root is where declared outputs live)
     Validity filter: skips None and empty/whitespace strings
     Key filter: skips _ and __ prefixed keys
     Last-key fallback: if no priority key matches, takes the last valid non-internal key
 
+    ``preferred_key`` is an explicit hint from the caller — when the user ran
+    ``--only X.Y`` the caller can pass ``"X"`` so the target node's namespace
+    wins over priority-key matches elsewhere in shared. Without it, a resolved
+    declared output named ``result`` at root shadows the batch namespace the
+    user actually targeted (GH #344).
+
     Args:
         shared_storage: The shared storage dictionary
+        preferred_key: Optional explicit key to return first if present and valid
 
     Returns:
         Tuple of (key_found, value) or (None, None) if no output found
     """
+    if preferred_key and preferred_key in shared_storage:
+        value = shared_storage[preferred_key]
+        if _is_valid_output_value(value):
+            return preferred_key, value
+
     priority_keys = ["result", "response", "output", "text", "data", "stdout"]
 
     for key in priority_keys:

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -158,9 +158,16 @@ def _collect_outputs(
         # Auto-detect output (handles both --only and no-declared-outputs cases).
         # find_auto_output is namespace-aware: looks inside node namespace dicts
         # for common output keys, so it finds the target node's stdout/result/response.
+        # Under --only, pass the target's root segment as preferred_key so the
+        # user's explicit target wins over unrelated resolved declared outputs
+        # at root (GH #344).
         from pflow.execution.formatters.output_utils import find_auto_output
 
-        key_found, value = find_auto_output(shared_storage)
+        # Only dotted --only passes preferred_key — flat --only relies on
+        # priority-key unwrap for clean scalar output from leaf nodes.
+        only_node = shared_storage.get("__execution__", {}).get("only_node")
+        preferred_key = only_node.split(".", 1)[0] if isinstance(only_node, str) and "." in only_node else None
+        key_found, value = find_auto_output(shared_storage, preferred_key=preferred_key)
         if key_found:
             result[key_found] = parse_json_or_original(value)
 

--- a/tests/test_execution/formatters/test_output_utils.py
+++ b/tests/test_execution/formatters/test_output_utils.py
@@ -233,6 +233,60 @@ class TestFindAutoOutput:
         assert key == "result"
         assert value is False
 
+    def test_preferred_key_wins_over_priority_keys_at_root(self):
+        """GH #344 regression guard: preferred_key beats priority-key match at root.
+
+        When the user explicitly targets a node via --only, the engine's
+        resolved declared outputs may land at root with a priority-key name
+        (e.g. 'result') from an UNRELATED upstream node. Without
+        preferred_key, find_auto_output returns that unrelated value;
+        with it, the user's target wins.
+        """
+        shared = {
+            # Unrelated upstream declared output at root — priority search would win this
+            "result": ["unrelated", "upstream", "data"],
+            # User's actual target — batch node's output namespace
+            "process-all": {"results": [{"result": "hello"}, {"result": "world"}], "count": 2},
+        }
+        key, value = find_auto_output(shared, preferred_key="process-all")
+        assert key == "process-all"
+        assert value == {"results": [{"result": "hello"}, {"result": "world"}], "count": 2}
+
+    def test_preferred_key_missing_falls_to_priority_search(self):
+        """preferred_key pointing to a missing key falls through to priority search."""
+        shared = {"result": "priority value"}
+        key, value = find_auto_output(shared, preferred_key="nonexistent")
+        assert key == "result"
+        assert value == "priority value"
+
+    def test_preferred_key_invalid_value_falls_to_priority_search(self):
+        """preferred_key pointing to None/empty falls through to priority search."""
+        shared = {
+            "target": None,
+            "result": "priority value",
+        }
+        key, value = find_auto_output(shared, preferred_key="target")
+        assert key == "result"
+        assert value == "priority value"
+
+    def test_preferred_key_none_preserves_default_behavior(self):
+        """preferred_key=None (default) behaves exactly like no preferred_key."""
+        shared = {"result": "R", "response": "S"}
+        key_no, value_no = find_auto_output(shared)
+        key_none, value_none = find_auto_output(shared, preferred_key=None)
+        assert (key_no, value_no) == (key_none, value_none)
+        assert key_no == "result"
+
+    def test_preferred_key_dict_value_is_returned(self):
+        """preferred_key works for dict values (common case: batch node namespace)."""
+        shared = {
+            "result": "scalar",
+            "batch-node": {"results": [1, 2, 3], "count": 3},
+        }
+        key, value = find_auto_output(shared, preferred_key="batch-node")
+        assert key == "batch-node"
+        assert value == {"results": [1, 2, 3], "count": 3}
+
     def test_dict_value_at_root_is_returned(self):
         """Dict values at root level are valid outputs (not just namespaces)."""
         shared = {"result": {"key": "value"}}
@@ -280,6 +334,51 @@ class TestAutoDetectionWarning:
         # Stderr explains why we fell back, without falsely claiming no outputs were declared
         assert "Declared outputs unresolvable under --only" in captured.err
         assert "No outputs declared" not in captured.err
+
+    def test_dotted_only_prefers_target_namespace_over_shadowing_declared_output(self, capsys):
+        """GH #344 regression guard: dotted --only on a batch sub-workflow must
+        emit the target's namespace, even when a parent-level declared output
+        resolved to a priority-key name at root.
+
+        Setup mirrors the real lyrics-generator case: the parent has two
+        declared outputs. The first (becomes stdout target) references a
+        downstream node and fails to resolve under --only. The second is
+        named 'result' and references an upstream node that DID run, so it
+        resolves at root. Without preferred_key, find_auto_output's priority
+        search returns the unrelated 'result' value instead of the user's
+        actual target (the batch namespace).
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "process-all.echo"},
+            # Unrelated upstream declared output that resolved at root (shadowing)
+            "result": ["upstream", "data", "NOT", "what", "user", "wants"],
+            # Target: the batch node's namespace — what the user actually wants to see
+            "process-all": {
+                "results": [
+                    {"result": "hello", "item": "hello"},
+                    {"result": "world", "item": "world"},
+                ],
+                "count": 2,
+            },
+        }
+        workflow_ir = {
+            "outputs": {
+                # First = stdout target, references downstream → won't resolve
+                "downstream_summary": {"source": "${count.stdout}"},
+                # Second = resolves, shadows batch namespace in priority search
+                "result": {"source": "${upstream.stdout}"},
+            }
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=workflow_ir, verbose=False)
+
+        captured = capsys.readouterr()
+        # Target namespace MUST reach stdout — the batch namespace, not the shadowing value
+        assert "process-all" in captured.err  # message mentions the auto-detected key
+        assert '"count": 2' in captured.out  # batch namespace structure
+        # Critically: the shadowing value MUST NOT reach stdout
+        assert "NOT" not in captured.out
 
     def test_only_node_without_declared_outputs_shows_no_outputs_warning(self, capsys):
         """CORRECTNESS: --only on workflow without outputs falls through to auto-detection."""

--- a/tests/test_execution/formatters/test_output_utils.py
+++ b/tests/test_execution/formatters/test_output_utils.py
@@ -331,8 +331,8 @@ class TestAutoDetectionWarning:
         captured = capsys.readouterr()
         # Auto-detected value MUST reach stdout — this is the silent regression we fix
         assert "target-node-value" in captured.out
-        # Stderr explains why we fell back, without falsely claiming no outputs were declared
-        assert "Declared outputs unresolvable under --only" in captured.err
+        # No noisy stderr note — the --only indicator line already establishes context
+        assert "Declared outputs unresolvable" not in captured.err
         assert "No outputs declared" not in captured.err
 
     def test_dotted_only_prefers_target_namespace_over_shadowing_declared_output(self, capsys):
@@ -375,10 +375,11 @@ class TestAutoDetectionWarning:
 
         captured = capsys.readouterr()
         # Target namespace MUST reach stdout — the batch namespace, not the shadowing value
-        assert "process-all" in captured.err  # message mentions the auto-detected key
         assert '"count": 2' in captured.out  # batch namespace structure
         # Critically: the shadowing value MUST NOT reach stdout
         assert "NOT" not in captured.out
+        # No noisy stderr note under --only — the --only indicator already establishes context
+        assert "Declared outputs unresolvable" not in captured.err
 
     def test_only_node_without_declared_outputs_shows_no_outputs_warning(self, capsys):
         """CORRECTNESS: --only on workflow without outputs falls through to auto-detection."""

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -1086,3 +1086,46 @@ class TestFindAutoOutputNamespaceAware:
 
         assert key == "result"
         assert value == "clean declared output"
+
+    def test_mcp_json_dotted_only_returns_target_namespace(self):
+        """GH #344 regression guard: MCP JSON output for dotted --only on a
+        batch sub-workflow must return the target's namespace, not a shadowing
+        declared output at root.
+
+        The ``_collect_outputs`` path (used by ``format_execution_success`` to
+        build the ``result`` field in JSON/MCP responses) must pass
+        ``preferred_key`` to ``find_auto_output`` when --only is dotted, so the
+        user's explicit target wins over unrelated resolved declared outputs.
+        """
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {
+            "__execution__": {"only_node": "process-all.echo"},
+            # Unrelated upstream declared output that resolved at root
+            "result": ["upstream", "data", "NOT", "what", "user", "wants"],
+            # Target: the batch node's namespace
+            "process-all": {
+                "results": [{"result": "hello", "item": "hello"}],
+                "count": 1,
+            },
+        }
+        workflow_ir = {
+            "outputs": {"result": {"source": "${upstream.stdout}"}},
+        }
+        outputs = _collect_outputs(shared, workflow_ir, output_key=None)
+
+        # The target namespace must be what we return — not the shadowing 'result'
+        assert "process-all" in outputs
+        assert outputs["process-all"] == {
+            "results": [{"result": "hello", "item": "hello"}],
+            "count": 1,
+        }
+        # The shadowing unrelated value must NOT be what we return
+        assert "result" not in outputs or outputs.get("result") != [
+            "upstream",
+            "data",
+            "NOT",
+            "what",
+            "user",
+            "wants",
+        ]


### PR DESCRIPTION
## Summary

Under dotted `--only` (e.g. `--only batch-node.child-step`), parent-level declared outputs that resolve at root can shadow the target's namespace in `find_auto_output`'s priority search. Users see unrelated upstream data instead of the batch results with child declared outputs they actually targeted.

Fixes #344

## Changes

- **`find_auto_output`** — new optional `preferred_key` parameter. When set and valid in shared, it wins over priority-key matches.
- **CLI (`workflow_output.py`)** — passes `_only_target_root` as preferred_key in the `--only` auto-detect fallback. Flat `--only` keeps priority-unwrap for clean scalar output from leaf nodes; only dotted `--only` sets preferred_key.
- **MCP (`success_formatter.py`)** — same preferred_key pass in `_collect_outputs` for JSON consumers.
- **Stderr cleanup** — dropped the noisy "Declared outputs unresolvable under --only" note. The `⤷ Stopped after 'X' (--only)` indicator already establishes context; a second "unresolvable" message implied things went wrong even when we honored exactly what the user asked for. Agents consuming JSON never saw it anyway.

## Explanation

### Why dotted --only needed this

`--only X.Y` means "target node Y inside sub-workflow X". The data the user wants lives at `shared[X]` (X's namespace, containing batch results with child declared outputs). But `find_auto_output` walks priority keys first (`result > response > output > text > data > stdout`), and after #341/#342 declared outputs land at root. If any parent declared output happened to be named `result` (common), it shadowed the target namespace.

`preferred_key` is the user's explicit signal — when they say `--only X.Y`, we pass `X` as preferred_key and it wins over unrelated priority-key matches.

### Why flat --only is NOT affected

For flat `--only shell-node`, the old behavior correctly unwrapped `stdout` from the shell namespace (clean scalar like `"hello world"`). Applying preferred_key uniformly would have returned the full dict (`{"stdout": "...", "exit_code": 0, "command": "...", ...}`) — a pipeline-breaking regression for `pflow workflow --only shell-cmd -p | grep X`.

So `_only_target_root` returns None for flat paths and only fires for dotted.

### Why we missed it in #343

The test for #342 asserted data was in `result.shared_after["process-all"]["results"][i]["result"]` — the data was there. The test never exercised `find_auto_output` which is what CLI/MCP actually show. Our manual reproducers had no parent declared outputs that resolved under `--only`, so priority search fell through to namespace-fallback by accident. The three-way interaction (parent declared outputs + dotted --only + target in namespace) didn't fire until a real workflow hit it.

## Testing

**Primitive (`find_auto_output`):**
- `test_preferred_key_wins_over_priority_keys_at_root` — the #344 fix in isolation
- `test_preferred_key_missing_falls_to_priority_search` — graceful fallback
- `test_preferred_key_invalid_value_falls_to_priority_search` — None/empty handling
- `test_preferred_key_none_preserves_default_behavior` — default parameter safety
- `test_preferred_key_dict_value_is_returned` — batch namespace shape

**CLI integration (`_handle_text_output`):**
- `test_dotted_only_prefers_target_namespace_over_shadowing_declared_output` — full #344 shape with shadowing declared output at root, asserts target namespace reaches stdout
- Updated `test_only_node_falls_through_to_auto_detect_when_declared_outputs_unresolvable` to reflect quiet stderr

**MCP integration (`_collect_outputs`):**
- `test_mcp_json_dotted_only_returns_target_namespace` — same shape, JSON path

**Mutation-tested:** reverting each production file makes the corresponding regression guard fail. Confirmed for `output_utils.py`, `workflow_output.py`, and `success_formatter.py` independently.

**Manual CLI verification:**
- #344 reproducer (parent with unresolvable + shadowing `result` declared outputs): now emits batch namespace ✓
- Flat `--only greet -p`: still emits clean scalar `hello world` ✓
- Primary #341/#342 scenarios: unchanged ✓
- Non-only workflows: "No outputs declared" message preserved where useful ✓

5240 passed, `make check` clean.