### PR TITLE
[codex] Fix prompt ref indirection cache analysis

### DIFF
--- a/scratchpads/prompt-refs-indirection-progress-20260512.md
+++ b/scratchpads/prompt-refs-indirection-progress-20260512.md
@@ -1,0 +1,75 @@
+# Prompt refs indirection implementation progress
+
+## Phase 0 - Plan and trust boundary
+
+- Verified plan source: local Claude plan `yes-lets-write-the-sequential-key.md`.
+- Verified sandbox testing instructions: use `.venv/bin/python -m pytest` with `HOME=/private/tmp/pflow-test-home`; avoid `uv run` and `make test` in this sandbox.
+- Read local guidance for `src/pflow/core`, `src/pflow/nodes`, `src/pflow/runtime`, and `tests`.
+- Assumption: the plan's production scope is correct unless direct code inspection shows drift. No deviations yet.
+
+## Phase 1 - Classifier contract
+
+- Added `src/pflow/core/prompt_refs.py` with one-level `inputs` dealiasing, coalesce support via `TemplateResolver.split_coalesce_operands`, and batch-alias classification.
+- Added focused unit tests in `tests/test_core/test_prompt_refs.py`.
+- Verification blocked by environment: the checkout had no `.venv`; `uv run` reproduced the known sandbox panic; the partial `.venv` has no `pytest`. This is an environment constraint, not a planned shortcut. Focused tests will be rerun if a usable environment becomes available.
+
+## Phase 2 - Runtime prewarm path
+
+- Added `CacheRenderContext.node_inputs` with producer-side `MappingProxyType` wrapping in `_make_cache_render_context`.
+- Replaced the LLM runtime auto-batch-prefix regex with `first_per_item_position`, so runtime marker placement sees through `- inputs:` indirection.
+- No plan deviation. Verification still blocked by missing test dependencies in the sandbox-created `.venv`.
+
+## Phase 3 - Analyzer migration
+
+- Migrated analyzer prompt-ref classification sites A-I to `classify_prompt_refs` / `first_per_item_position`.
+- Deleted `_first_batch_scoped_template_ref` and `_is_batch_scoped_operand`; `rg` shows no remaining references.
+- Adjusted `_literal_spans_after_template` to use `PromptRef.position/end`, keeping suffix slicing tied to the same classifier result.
+- Deviation: the plan requested a `/code-review` skill checkpoint before helper deletion, but no `code-review` skill is installed in this session and subagent use is constrained by the active tool instructions. Substituted local review checks (`rg` and `py_compile`) instead; this is a capability constraint, not deferral for convenience.
+
+## Phase 4 - Regression coverage and docs
+
+- Added a parametrized `_collect_llm_nodes_referencing_path` regression for direct refs, indirected refs, missing `inputs`, and indirected chained refs.
+- Added `tests/fixtures/cache_analysis/inputs_indirection_batch.pflow.md` plus an analyzer regression asserting prewarm recommendation and positive `batch_prefix` evidence.
+- Documented prompt-ref classification as the cache-analysis single source of truth and added the user-guide note that analyzer recommendations see through LLM `inputs:` aliases.
+- Verification remains limited to `py_compile` because project test dependencies are unavailable in the sandbox.
+
+## Phase 5 - Verification and final notes
+
+- Passed: `python3 -m py_compile` over touched production and test Python files.
+- Passed: `git diff --check`.
+- Blocked: pytest, ruff, mypy, CLI smoke, and the Task 159 baseline harness. Root cause is environment/tooling: there was no pre-existing `.venv`, Homebrew `uv run` reproduced the documented sandbox panic, and system Python lacks project dependencies (`pytest`, `jsonschema`, `ruff`, `mypy`). Baseline `command.sh` files invoke `uv run`, so running the harness would hit the same verified failure mode rather than test this patch.
+- Created a partial `.venv` during the failed `uv run`; direct `rm -rf` cleanup was rejected by sandbox policy, so generated `.venv` and `__pycache__` artifacts were removed with a narrow Python cleanup script.
+- Key implementation insight: runtime/analyzer parity depends on carrying `params.inputs` into `CacheRenderContext`; analyzer-only dealiasing would have created recommendations that the runtime could not realize.
+
+## Phase 6 - Self-review fix
+
+- Tightened `_find_batch_static_tail_after_dynamic` after self-review: classification uses dealiased paths, but the diagnostic's `dynamic_ref` should remain the original prompt expression. Showing `item.x` for a prompt that contains `${X}` would be confusing and was not required for the fix.
+
+## Phase 7 - Mypy fix
+
+- Fixed mypy narrowing in `prompt_refs.py`: `bool(batch_alias) and any(...)` did not narrow the alias type inside the generator, so the classifier now branches explicitly before calling `_starts_with_alias`.
+
+## Phase 8 - Greenfield batch-prefix fix
+
+- Fixed the failing `test_inputs_indirection_does_not_suppress_prewarm_recommendation`: `_estimate_batch_prefix_cacheable_tokens` was still gated on observed trace call count only. For greenfield static-list batches, it now uses observed calls when available and falls back to `_estimate_batch_size(batch)`.
+- This aligns row-level `batch_prefix` evidence with `_batch_prewarm_recommendations`, which already uses `row.batch_size_estimated or row.observed_call_count`.
+- Follow-up correction: `_batch_prewarm_recommendations` should only reuse row-level `batch_prefix` evidence when it came from observed calls. Greenfield row evidence can be clamped against per-call input tokens, so recommendations keep using direct prompt-boundary tokenization in that mode.
+
+## Phase 9 - Review follow-up
+
+- Accepted review finding on renderer wording: `batch_prefix` evidence now covers observed dynamic batches and greenfield static-list batches, so the footer says the prefix repeats across the batch rather than across observed calls.
+- Accepted review finding on declared-cache matching: added a regression proving `${data}` with `inputs.data: ${extract.response}` is treated as declared when `prompt_cache` names `extract.response`.
+- Strengthened coalesced `inputs:` behavior instead of documenting the limitation: `${X.name}` with `inputs.X: ${item.primary ?? fallback}` now classifies as `("item.primary.name", "fallback.name")`.
+- Scrubbed the local absolute plan path from this committed progress log.
+
+## Phase 10 - Follow-up review clarity fixes
+
+- Tightened the indirection regression assertion to require `cache.batch-prewarm-recommended`; `cache.prewarm-no-prefix` would indicate the opposite prompt shape.
+- Added `PromptRef.raw_expr` so diagnostics can report the author-written template expression without repeating slice arithmetic.
+- Added doc notes for greenfield batch-prefix call-count fallback, classifier `is_per_item` semantics, and the `CacheRenderContext.node_inputs` immutability requirement.
+
+## Phase 11 - Final follow-up cleanup
+
+- Added `_node_inputs(node)` in `analyze.py` to centralize safe access to `params.inputs` and avoid repeating `node.get("params", {}).get("inputs")`.
+- Tightened the prewarm-reuse comment to explain why the observed-call gate is `>= 2`.
+- Added a classifier comment documenting why non-string/dict-valued `inputs:` entries pass through unchanged.

--- a/src/pflow/core/cache_analysis/CLAUDE.md
+++ b/src/pflow/core/cache_analysis/CLAUDE.md
@@ -64,6 +64,10 @@ Refactor planned to split `analyze.py` into a thin orchestrator plus `stages/` a
 - **Discrepancy detection** (`_emit_discrepancy_diagnostics`, `_predict_cache_keys`): compile workflow + simulate planner + compare to trace.
 - **Summary builders**: aggregation glue scattered between the orchestrator and the per-call cluster.
 
+**Prompt ref classification**: `pflow.core.prompt_refs.classify_prompt_refs` is the canonical helper for "what does this `${X}` point to?" Every cache-analysis detector that walks `${...}` refs in an LLM prompt body should consume it. As of v0.13, production consumers cover prefix detection, prewarm detection, dynamic-before-static, batch static tail, cross-workflow LLM-consumer detection, greenfield shared-context discovery, prompt-cache-incomplete partial-declaration detection, and the runtime auto-batch-prefix path in `nodes/llm/llm.py`.
+
+LLM `- inputs:` mappings are first-class for prompt-cache analysis. A prompt ref `${X}` mapped through `node["params"]["inputs"]` to `${item.Y}` is per-item; mapped to `${some_node.Z}` it is static. The classifier dealiases one level to match the runtime inputs-first resolution contract in `runtime/engine/template_resolution.py`; dict-valued `inputs:` entries are not recursively dealiased and pass through unchanged. Historical references to `_first_batch_scoped_template_ref` or `_is_batch_scoped_operand` should be replaced with `classify_prompt_refs` or `first_per_item_position`.
+
 **`_run_full_validation` is the analyzer's validation seam.** It calls the same `WorkflowValidator.validate()` pipeline as run, validate-only, and save, then enriches root diagnostics with `context["affected_workflow"]` for cross-workflow scoping. Domain focus is preserved after validation: ERRORs surface universally, while advisory actions and headline counts filter to provider prompt-cache findings.
 
 ### context.py

--- a/src/pflow/core/cache_analysis/analyze.py
+++ b/src/pflow/core/cache_analysis/analyze.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import re
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -57,6 +56,7 @@ from pflow.core.llm_capabilities import anthropic_models_at_threshold, get_min_c
 from pflow.core.llm_config import get_default_workflow_model
 from pflow.core.llm_providers import detect_provider, normalize_model_name
 from pflow.core.llm_usage import normalize_litellm_usage_tokens
+from pflow.core.prompt_refs import PromptRef, classify_prompt_refs, first_per_item_position
 from pflow.core.validation_utils import generate_dummy_parameters
 from pflow.core.workflow.validator import WorkflowValidator
 from pflow.core.workflow_id import synthesize_inline_workflow_id
@@ -2160,6 +2160,15 @@ def _extract_unique_refs(prompt: str) -> list[str]:
     return refs
 
 
+def _node_inputs(node: dict[str, Any]) -> Mapping[str, Any] | None:
+    """Return an LLM node's ``params.inputs`` mapping, if present."""
+    params = node.get("params")
+    if not isinstance(params, Mapping):
+        return None
+    inputs = params.get("inputs")
+    return inputs if isinstance(inputs, Mapping) else None
+
+
 def _build_shared_store_for_refs(refs: list[str], ctx: AnalysisContext) -> dict[str, Any]:
     """Build a synthetic shared store keyed by root node ids for ``refs``."""
     shared: dict[str, Any] = {}
@@ -2228,20 +2237,18 @@ def _per_node_warnings(
     # the first batch-scoped reference. Detected by inspecting the unresolved
     # template at position 0.
     #
-    # Boundary regex MUST match the runtime gate at ``nodes/llm/llm.py``
-    # (``re.compile(r"\$\{" + re.escape(alias) + r"(\.|\[)")``) so analyzer
-    # and runtime agree on what counts as batch-scoped — both ``${item.field}``
-    # and ``${item[0].field}`` are batch references. Earlier dot-only matcher
-    # silently missed every ``${alias[N]...}`` workflow (CR-1430 C1).
+    # Boundary classification MUST match the runtime gate at
+    # ``nodes/llm/llm.py`` so analyzer and runtime agree on what counts as
+    # batch-scoped, including refs indirected through ``params.inputs``.
     prewarm = node.get("prewarm")
     batch = node.get("batch")
     if prewarm is True and isinstance(batch, dict):
         alias = str(batch.get("as", "item"))
         prompt = node.get("params", {}).get("prompt", "") or ""
         if isinstance(prompt, str):
-            pattern = re.compile(r"\$\{" + re.escape(alias) + r"(\.|\[)")
-            match = pattern.search(prompt)
-            if match is not None and match.start() == 0:
+            node_inputs = _node_inputs(node)
+            first = first_per_item_position(prompt, alias, node_inputs)
+            if first == 0:
                 diagnostics.append(
                     make_diagnostic(
                         "cache.prewarm-no-prefix",
@@ -2275,17 +2282,23 @@ def _batch_prewarm_recommendations(node: dict[str, Any], row: PerCallRow) -> lis
     uses_existing_prefix_evidence = False
     prefix_tokens: int | None = None
     dynamic_tokens: int | None = None
-    if row.cacheable_data_source == "batch_prefix" and row.cacheable_tokens_estimated:
+    # Row-level greenfield batch-prefix evidence is clamped against per-call
+    # input tokens, so only observed rows can safely be reused here. The
+    # earlier affected_calls gate already rejected 0/1-call rows; >= 2 is the
+    # minimum observed row count that can carry reusable batch-prefix evidence.
+    # Greenfield recommendations compute the prefix directly below.
+    if row.observed_call_count >= 2 and row.cacheable_data_source == "batch_prefix" and row.cacheable_tokens_estimated:
         uses_existing_prefix_evidence = True
         prefix_tokens = round(row.cacheable_tokens_estimated / affected_calls)
         input_tokens_per_call = round(row.input_tokens_estimated / affected_calls)
         dynamic_tokens = max(0, input_tokens_per_call - prefix_tokens)
     else:
-        match = _first_batch_scoped_template_ref(prompt, alias)
-        if match is None or match.start() == 0:
+        node_inputs = _node_inputs(node)
+        first = first_per_item_position(prompt, alias, node_inputs)
+        if first is None or first == 0:
             return []
-        prefix_tokens = estimate_tokens(row.model, prompt[: match.start()])[0]
-        dynamic_tokens = estimate_tokens(row.model, prompt[match.start() :])[0]
+        prefix_tokens = estimate_tokens(row.model, prompt[:first])[0]
+        dynamic_tokens = estimate_tokens(row.model, prompt[first:])[0]
     if not uses_existing_prefix_evidence and prefix_tokens < get_min_cache_tokens(row.model):
         return []
 
@@ -2327,7 +2340,13 @@ def _dynamic_before_static_warnings(
         if affected_calls < 2:
             return []
         alias = str(batch.get("as", "item"))
-        finding = _find_batch_static_tail_after_dynamic(prompt=prompt, model=row.model, batch_alias=alias)
+        node_inputs = _node_inputs(node)
+        finding = _find_batch_static_tail_after_dynamic(
+            prompt=prompt,
+            model=row.model,
+            batch_alias=alias,
+            node_inputs=node_inputs,
+        )
         if finding is None:
             return []
         return [
@@ -2357,25 +2376,25 @@ def _dynamic_before_static_warnings(
         return []
 
     declared = set(declared_chunks)
-    for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
-        var_expr = match.group(1)
-        operands = TemplateResolver.split_coalesce_operands(var_expr)
-        if any(operand in declared for operand in operands):
+    node_inputs = _node_inputs(node)
+    refs = classify_prompt_refs(prompt, batch_alias=None, node_inputs=node_inputs)
+    for index, ref in enumerate(refs):
+        if any(path in declared for path in ref.operand_paths):
             continue
 
-        cacheable_tokens = estimate_tokens(row.model, prompt[match.end() :])[0]
+        cacheable_tokens = estimate_tokens(row.model, prompt[ref.end :])[0]
         if cacheable_tokens < get_min_cache_tokens(row.model):
             break
 
         affected_calls = row.batch_size_estimated if row.is_batch and row.batch_size_estimated else 1
-        tokens_before = estimate_tokens(row.model, prompt[: match.start()])[0]
+        tokens_before = estimate_tokens(row.model, prompt[: ref.position])[0]
         return [
             make_diagnostic(
                 "cache.dynamic-before-static",
                 node_id=row.node_path,
                 affected_workflow=row.workflow_path,
-                dynamic_ref=var_expr,
-                dynamic_line=1 + prompt[: match.start()].count("\n"),
+                dynamic_ref=ref.raw_expr,
+                dynamic_line=1 + prompt[: ref.position].count("\n"),
                 cacheable_tokens=cacheable_tokens,
                 affected_calls=affected_calls,
                 savings_usd=_estimate_token_savings_usd(row.model, cacheable_tokens, affected_calls),
@@ -2384,8 +2403,8 @@ def _dynamic_before_static_warnings(
                 min_cache_tokens=get_min_cache_tokens(row.model),
                 model=row.model,
                 tokens_before_dynamic=tokens_before,
-                template_refs_after_dynamic=len(list(TemplateResolver.TEMPLATE_PATTERN.finditer(prompt, match.end()))),
-                static_tail_excerpt=_static_excerpt(prompt[match.end() :]),
+                template_refs_after_dynamic=len(refs) - index - 1,
+                static_tail_excerpt=_static_excerpt(prompt[ref.end :]),
             )
         ]
     return []
@@ -2396,52 +2415,39 @@ def _find_batch_static_tail_after_dynamic(
     prompt: str,
     model: str,
     batch_alias: str,
+    node_inputs: Mapping[str, Any] | None = None,
 ) -> _PromptStaticTailFinding | None:
     """Find a local-batch dynamic ref followed by enough literal stable text."""
-    matches = list(TemplateResolver.TEMPLATE_PATTERN.finditer(prompt))
-    for index, match in enumerate(matches):
-        var_expr = match.group(1)
-        operands = TemplateResolver.split_coalesce_operands(var_expr)
-        if not any(_is_batch_scoped_operand(operand, batch_alias) for operand in operands):
+    refs = list(classify_prompt_refs(prompt, batch_alias, node_inputs))
+    for index, ref in enumerate(refs):
+        if not ref.is_per_item:
             continue
 
-        literal_tail = _literal_spans_after_template(prompt, matches, index)
+        literal_tail = _literal_spans_after_template(prompt, refs, index)
         stable_tail_tokens = estimate_tokens(model, literal_tail)[0]
         if stable_tail_tokens < get_min_cache_tokens(model):
             return None
         return _PromptStaticTailFinding(
-            dynamic_ref=var_expr,
-            dynamic_line=1 + prompt[: match.start()].count("\n"),
+            dynamic_ref=ref.raw_expr,
+            dynamic_line=1 + prompt[: ref.position].count("\n"),
             stable_tail_tokens=stable_tail_tokens,
-            tokens_before_dynamic=estimate_tokens(model, prompt[: match.start()])[0],
-            template_refs_after_dynamic=len(matches) - index - 1,
+            tokens_before_dynamic=estimate_tokens(model, prompt[: ref.position])[0],
+            template_refs_after_dynamic=len(refs) - index - 1,
             static_tail_excerpt=_static_excerpt(literal_tail),
         )
     return None
 
 
-def _first_batch_scoped_template_ref(prompt: str, batch_alias: str) -> re.Match[str] | None:
-    for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
-        operands = TemplateResolver.split_coalesce_operands(match.group(1))
-        if any(_is_batch_scoped_operand(operand, batch_alias) for operand in operands):
-            return match
-    return None
-
-
-def _is_batch_scoped_operand(operand: str, batch_alias: str) -> bool:
-    return operand == batch_alias or operand.startswith(f"{batch_alias}.") or operand.startswith(f"{batch_alias}[")
-
-
 def _literal_spans_after_template(
     prompt: str,
-    matches: list[re.Match[str]],
+    refs: list[PromptRef],
     dynamic_match_index: int,
 ) -> str:
     spans: list[str] = []
-    cursor = matches[dynamic_match_index].end()
-    for match in matches[dynamic_match_index + 1 :]:
-        spans.append(prompt[cursor : match.start()])
-        cursor = match.end()
+    cursor = refs[dynamic_match_index].end
+    for ref in refs[dynamic_match_index + 1 :]:
+        spans.append(prompt[cursor : ref.position])
+        cursor = ref.end
     spans.append(prompt[cursor:])
     return "".join(spans)
 
@@ -2548,18 +2554,26 @@ def _estimate_batch_prefix_cacheable_tokens(
     declared_subset: list[str] | None,
     observed_call_count: int,
 ) -> int | None:
-    """Estimate repeated static prefix tokens before the first batch-item ref."""
+    """Estimate repeated static prefix tokens before the first batch-item ref.
+
+    Uses observed call count when available, otherwise falls back to static
+    ``batch.items`` length for greenfield static-list batches.
+    """
     batch = node.get("batch")
-    if declared_subset or not isinstance(batch, dict) or observed_call_count < 2:
+    if declared_subset or not isinstance(batch, dict):
+        return None
+    affected_call_count = observed_call_count or (_estimate_batch_size(batch) or 0)
+    if affected_call_count < 2:
         return None
     alias = str(batch.get("as", "item"))
-    match = re.compile(r"\$\{" + re.escape(alias) + r"(\.|\[)").search(resolved_prompt)
-    if match is None or match.start() == 0:
+    node_inputs = _node_inputs(node)
+    boundary = first_per_item_position(resolved_prompt, alias, node_inputs)
+    if boundary is None or boundary == 0:
         return None
-    prefix_tokens = estimate_tokens(model, resolved_prompt[: match.start()])[0]
+    prefix_tokens = estimate_tokens(model, resolved_prompt[:boundary])[0]
     if prefix_tokens <= 0:
         return None
-    return prefix_tokens * observed_call_count
+    return prefix_tokens * affected_call_count
 
 
 def _prefer_batch_prefix_cacheable_tokens(
@@ -2877,8 +2891,9 @@ def _collect_llm_template_references(workflow_ir: dict[str, Any]) -> tuple[dict[
             continue
         batch_aliases = _batch_aliases(node)
         seen_in_node: set[str] = set()
-        for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
-            for ref in TemplateResolver.split_coalesce_operands(match.group(1)):
+        node_inputs = _node_inputs(node)
+        for classified_ref in classify_prompt_refs(prompt, batch_alias=None, node_inputs=node_inputs):
+            for ref in classified_ref.operand_paths:
                 if _is_batch_scoped_ref(ref, batch_aliases) or ref in seen_in_node:
                     continue
                 seen_in_node.add(ref)
@@ -2909,8 +2924,9 @@ def _collect_llm_template_root_references(
             continue
         batch_aliases = _batch_aliases(node)
         seen_names: set[str] = set()
-        for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
-            for operand in TemplateResolver.split_coalesce_operands(match.group(1)):
+        node_inputs = _node_inputs(node)
+        for ref in classify_prompt_refs(prompt, batch_alias=None, node_inputs=node_inputs):
+            for operand in ref.operand_paths:
                 if _is_batch_scoped_ref(operand, batch_aliases):
                     continue
                 matched_var = _longest_var_prefix_match(operand, vars_)
@@ -3641,8 +3657,9 @@ def _node_referenced_cache_names(node: dict[str, Any], var_to_name: dict[str, st
         return set()
     node_refs: set[str] = set()
     batch_aliases = _batch_aliases(node)
-    for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
-        for operand in TemplateResolver.split_coalesce_operands(match.group(1)):
+    node_inputs = _node_inputs(node)
+    for ref in classify_prompt_refs(prompt, batch_alias=None, node_inputs=node_inputs):
+        for operand in ref.operand_paths:
             if _is_batch_scoped_ref(operand, batch_aliases):
                 continue
             matched_var = _longest_var_prefix_match(operand, var_to_name.keys())
@@ -5053,16 +5070,14 @@ def _collect_llm_nodes_referencing_path(ir: dict[str, Any], template_path: str) 
         node_id = node.get("id")
         if not isinstance(node_id, str) or not node_id or node_id in ids:
             continue
-        for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
-            for operand in TemplateResolver.split_coalesce_operands(match.group(1)):
-                # Match exact path OR dotted-prefix (``${creative.direction}``
-                # references the ``creative`` chunk identifier when keyed by root).
-                if operand == template_path or operand.startswith(f"{template_path}."):
-                    ids.append(node_id)
-                    break
-            else:
-                continue
-            break  # each LLM node listed at most once
+        node_inputs = _node_inputs(node)
+        refs = classify_prompt_refs(prompt, batch_alias=None, node_inputs=node_inputs)
+        if any(
+            operand == template_path or operand.startswith(f"{template_path}.")
+            for ref in refs
+            for operand in ref.operand_paths
+        ):
+            ids.append(node_id)
     return ids
 
 

--- a/src/pflow/core/cache_analysis/render_text.py
+++ b/src/pflow/core/cache_analysis/render_text.py
@@ -1826,11 +1826,11 @@ def _per_call_confidence_footer(rows: list[PerCallRow]) -> list[str] | None:
     if batch_prefix_nodes:
         # Distinct from the batch-exemplar case above: this projection scans
         # the prompt's static prefix (bytes before the first per-item ref)
-        # and multiplies by observed call count. No item content participates,
-        # so the message must not claim sampling.
+        # and multiplies by observed call count or static batch size. No item
+        # content participates, so the message must not claim sampling.
         bullets.append(
             f"{_format_node_list(batch_prefix_nodes)}: savings projected from a stable prompt prefix "
-            "repeated across observed calls. Declare prompt_cache to confirm."
+            "repeated across the batch. Declare prompt_cache to confirm."
         )
     if cross_workflow_nodes:
         bullets.append(

--- a/src/pflow/core/cache_render.py
+++ b/src/pflow/core/cache_render.py
@@ -13,6 +13,7 @@ lazy-import runtime symbols inside function bodies.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Final, Union
 
@@ -51,13 +52,16 @@ class CacheRenderContext:
     **Parallel-batch safety is by frozen-attribute construction, NOT by the
     outer MappingProxyType wrap.** ``MappingProxyType`` only blocks mutation
     of the outer ``dict[node_id, CacheRenderContext]`` keys; it does NOT
-    deep-freeze field values. Today every field is immutable by construction:
+    deep-freeze field values. Today every field is immutable by construction
+    (``node_inputs`` is wrapped in ``MappingProxyType`` by the producer):
     ``cache_block: CacheBlockIR`` (frozen, tuple items), ``subset: tuple``,
     ``prewarm: bool``, ``unresolved_batch_prompt: str``, ``batch_alias: str``.
     A future contributor adding a non-immutable field (e.g., a memo dict for
     resolved-chunk reuse) would silently introduce a parallel-batch race.
     Add only immutable fields here, or wrap mutable fields in their own
-    immutable container.
+    immutable container. Producers MUST wrap ``node_inputs`` in
+    ``MappingProxyType``; raw dicts type-check but violate this freeze
+    invariant.
     """
 
     cache_block: CacheBlockIR | None
@@ -65,6 +69,7 @@ class CacheRenderContext:
     prewarm: bool
     unresolved_batch_prompt: str | None
     batch_alias: str | None
+    node_inputs: Mapping[str, Any] | None = None
 
 
 # --- Sentinel for branch-absent chunks -------------------------------------

--- a/src/pflow/core/prompt_refs.py
+++ b/src/pflow/core/prompt_refs.py
@@ -1,0 +1,128 @@
+"""Classify template refs in prompt bodies with optional ``params.inputs`` dealiasing.
+
+The analyzer and runtime both need to answer: given an LLM prompt body, where
+is the first per-item batch reference, and what path does each ``${...}`` ref
+point to after dealiasing through the node's ``- inputs:`` mapping?
+
+This module is the single source of truth for that classification. Dealiasing
+is intentionally one level deep: ``inputs`` values resolve against the runtime
+shared store, not against other ``inputs`` entries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pflow.runtime.template_resolver import TemplateResolver
+
+
+@dataclass(frozen=True)
+class PromptRef:
+    """A single ``${...}`` occurrence in a prompt body, classified.
+
+    ``position`` is the byte offset of the leading ``$`` in the original
+    prompt string. ``end`` is the byte offset immediately after the closing
+    ``}``, matching ``re.Match.end()`` semantics.
+
+    ``raw_expr`` is the original inner expression without the surrounding
+    ``${...}`` delimiters. It is intentionally not dealiased, so diagnostics
+    can report the expression the workflow author actually wrote.
+
+    ``operand_paths`` carries the dealiased path text for each coalesce
+    operand. ``is_per_item`` is true iff any operand path starts with the
+    batch alias. With ``batch_alias`` unset, ``is_per_item`` is always false.
+    """
+
+    position: int
+    end: int
+    raw_expr: str
+    operand_paths: tuple[str, ...]
+    is_per_item: bool
+
+
+def classify_prompt_refs(
+    prompt: str,
+    batch_alias: str | None,
+    node_inputs: Mapping[str, Any] | None,
+) -> tuple[PromptRef, ...]:
+    """Walk every ``${...}`` ref in ``prompt`` and return classified refs.
+
+    ``is_per_item`` is true when any dealiased operand path begins with
+    ``batch_alias.``, ``batch_alias[``, or equals ``batch_alias``. With
+    ``batch_alias`` unset or empty, it is always false.
+    """
+    if not isinstance(prompt, str) or not prompt:
+        return ()
+
+    inputs: Mapping[str, Any] = node_inputs if isinstance(node_inputs, Mapping) else {}
+    refs: list[PromptRef] = []
+    for match in TemplateResolver.TEMPLATE_PATTERN.finditer(prompt):
+        raw_expr = match.group(1)
+        operands = TemplateResolver.split_coalesce_operands(raw_expr)
+        paths = tuple(path for operand in operands for path in _dealias_operand(operand, inputs))
+        per_item = False
+        if batch_alias:
+            per_item = any(_starts_with_alias(path, batch_alias) for path in paths)
+        refs.append(
+            PromptRef(
+                position=match.start(),
+                end=match.end(),
+                raw_expr=raw_expr,
+                operand_paths=paths,
+                is_per_item=per_item,
+            )
+        )
+    return tuple(refs)
+
+
+def first_per_item_position(
+    prompt: str,
+    batch_alias: str | None,
+    node_inputs: Mapping[str, Any] | None,
+) -> int | None:
+    """Return the byte offset of the first per-item ref, or ``None``."""
+    for ref in classify_prompt_refs(prompt, batch_alias, node_inputs):
+        if ref.is_per_item:
+            return ref.position
+    return None
+
+
+def _dealias_operand(operand: str, inputs: Mapping[str, Any]) -> tuple[str, ...]:
+    """Replace an operand head with its single-template ``inputs`` mapping."""
+    head, sep, rest = _split_head(operand)
+    chain = sep + rest if sep else ""
+    mapped = inputs.get(head)
+    if not isinstance(mapped, str):
+        # Dict/list-valued inputs can still resolve at runtime through the
+        # remaining path chain. The classifier only dealiases simple template
+        # strings, so preserve the author-written operand here.
+        return (operand,)
+    inner = _extract_template_inner(mapped)
+    if inner is None:
+        return (operand,)
+    return tuple(inner_operand + chain for inner_operand in TemplateResolver.split_coalesce_operands(inner))
+
+
+def _split_head(operand: str) -> tuple[str, str, str]:
+    """Split an operand path into ``(head, separator, rest)``."""
+    for index, char in enumerate(operand):
+        if char == ".":
+            return operand[:index], char, operand[index + 1 :]
+        if char == "[":
+            return operand[:index], char, operand[index + 1 :]
+    return operand, "", ""
+
+
+def _extract_template_inner(value: str) -> str | None:
+    """Return the inner expression for a single strict ``"${...}"`` value."""
+    stripped = value.strip()
+    match = TemplateResolver.SIMPLE_TEMPLATE_PATTERN.match(stripped)
+    if match is None:
+        return None
+    return match.group(1).strip()
+
+
+def _starts_with_alias(path: str, alias: str) -> bool:
+    return path == alias or path.startswith(f"{alias}.") or path.startswith(f"{alias}[")

--- a/src/pflow/guide/features/prompt-caching.md
+++ b/src/pflow/guide/features/prompt-caching.md
@@ -176,6 +176,13 @@ Without `prewarm`, parallel batch items can all try to write the same provider
 cache prefix at once. With `prewarm`, the first item writes the prefix, then
 the remaining items fan out as reads.
 
+Prompt cache analysis sees through `- inputs:` indirection: a batch LLM node
+that maps batch-item fields onto template variables, such as
+`concept_md: ${item.concept_md}`, is analyzed identically to one using
+`${item.concept_md}` directly. Reusable `.prompt.md` files using indirected
+refs receive accurate prewarm, shared-context, and partial-declaration
+recommendations.
+
 ## Python-Assembled Prompts
 
 Prompt caching works best when stable prompt text is visible in the LLM node's

--- a/src/pflow/nodes/llm/llm.py
+++ b/src/pflow/nodes/llm/llm.py
@@ -34,6 +34,7 @@ from pflow.core.llm_reasoning_map import (
     map_reasoning_options,
 )
 from pflow.core.node import Node
+from pflow.core.prompt_refs import first_per_item_position
 
 logger = logging.getLogger(__name__)
 
@@ -387,8 +388,6 @@ def _build_user_message_blocks(
     the same logical value, so cache hits fire reliably across calls. See
     ``_resolve_static_prefix_for_cache`` docstring + B3.3 plan section.
     """
-    import re
-
     if cache_ctx is None:
         return None
     if not cache_ctx.prewarm:
@@ -425,11 +424,10 @@ def _build_user_message_blocks(
         )
         return None
 
-    pattern = re.compile(r"\$\{" + re.escape(alias) + r"(\.|\[)")
-    match = pattern.search(unresolved)
-    if match is None:
+    boundary = first_per_item_position(unresolved, alias, cache_ctx.node_inputs)
+    if boundary is None:
         return None
-    cut = match.start()
+    cut = boundary
     if cut == 0:
         # No static portion — boundary at position 0.
         return None

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -100,15 +100,23 @@ def _make_cache_render_context(
     """
     unresolved = None
     alias = None
+    node_inputs = None
     if config.batch_config and config.template_config:
         unresolved = config.template_config.template_params.get("prompt")
         alias = config.batch_config.item_alias
+        raw_inputs = config.template_config.template_params.get("inputs")
+        if isinstance(raw_inputs, Mapping):
+            # Snapshot + freeze for parallel-batch safety. CacheRenderContext
+            # is shared by batch workers, so the immutability contract is
+            # explicit even though template_params is compile-time data.
+            node_inputs = MappingProxyType(dict(raw_inputs))
     return CacheRenderContext(
         cache_block=cache_block,
         subset=config.prompt_cache_items,
         prewarm=config.prewarm,
         unresolved_batch_prompt=unresolved,
         batch_alias=alias,
+        node_inputs=node_inputs,
     )
 
 

--- a/tests/fixtures/cache_analysis/inputs_indirection_batch.pflow.md
+++ b/tests/fixtures/cache_analysis/inputs_indirection_batch.pflow.md
@@ -1,0 +1,28 @@
+# Inputs Indirection Batch
+
+Regression fixture for cache analysis seeing through LLM `inputs:` aliases in
+batch prompts.
+
+## Steps
+
+### score
+
+Scores each concept against a stable rubric.
+
+- type: llm
+- model: anthropic/claude-haiku-4-5
+- inputs:
+    concept_md: ${item.concept_md}
+- batch:
+    items:
+      - concept_md: Alpha concept
+      - concept_md: Beta concept
+      - concept_md: Gamma concept
+    as: item
+
+```prompt
+Shared rubric stable criterion one stable criterion two stable criterion three stable criterion four stable criterion five.
+
+Evaluate this concept:
+${concept_md}
+```

--- a/tests/test_core/test_cache_analysis_per_id_emission.py
+++ b/tests/test_core/test_cache_analysis_per_id_emission.py
@@ -20,6 +20,7 @@ from pflow.core.cache_analysis.analyze import CrossWorkflowInputContribution, an
 from pflow.core.cache_analysis.cost_estimation import ModelPricing
 from pflow.core.cache_analysis.render_text import render_text
 from pflow.core.file_resolver import resolve_file_references
+from pflow.core.markdown_parser import parse_markdown
 from pflow.core.workflow.sub_workflow_resolver import SubWorkflowResult
 from pflow.core.workflow.validator import WorkflowValidator
 
@@ -119,6 +120,27 @@ def test_batch_prewarm_recommended_fires_only_when_prewarm_absent() -> None:
     workflow_ir["nodes"][0]["prewarm"] = False
     opted_out = analyze(workflow_ir, workflow_path="x.pflow.md", auto_load_trace=False, memo_cache=None)
     assert "cache.batch-prewarm-recommended" not in {d.id for d in opted_out.warnings}
+
+
+def test_inputs_indirection_does_not_suppress_prewarm_recommendation() -> None:
+    """Mutation contract: removing prompt-ref dealiasing loses batch_prefix evidence."""
+    fixture = Path(__file__).parents[1] / "fixtures" / "cache_analysis" / "inputs_indirection_batch.pflow.md"
+    workflow_ir = parse_markdown(fixture.read_text(encoding="utf-8")).ir
+
+    result = analyze(
+        workflow_ir,
+        parameters={},
+        workflow_path=str(fixture),
+        auto_load_trace=False,
+        memo_cache=None,
+    )
+
+    warning_ids = {warning.id for warning in result.warnings}
+    assert "cache.batch-prewarm-recommended" in warning_ids
+    row = next(row for row in result.per_call if row.node_path == "score")
+    assert row.cacheable_data_source == "batch_prefix"
+    assert row.cacheable_tokens_estimated is not None
+    assert row.cacheable_tokens_estimated > 0
 
 
 def test_batch_static_tail_after_dynamic_emits_recommended_action() -> None:
@@ -272,6 +294,29 @@ def test_dynamic_before_static_treats_coalesce_as_static_when_any_operand_is_dec
         ],
     }
     result = analyze(workflow_ir, workflow_path="x.pflow.md", auto_load_trace=False, memo_cache=None)
+    assert "cache.dynamic-before-static" not in {d.id for d in result.warnings}
+
+
+def test_dynamic_before_static_treats_indirected_declared_chunk_as_static() -> None:
+    """Mutation contract: comparing raw prompt aliases to declared chunks emits a false warning."""
+    workflow_ir = {
+        "cache": {"items": [{"name": "extract.response", "var": "extract.response", "prose_before": "Extract:\n"}]},
+        "nodes": [
+            {
+                "id": "score",
+                "type": "llm",
+                "model": "anthropic/claude-sonnet-4-5",
+                "prompt_cache": ["extract.response"],
+                "params": {
+                    "inputs": {"data": "${extract.response}"},
+                    "prompt": "${data}\n" + ("stable " * 60),
+                },
+            }
+        ],
+    }
+
+    result = analyze(workflow_ir, workflow_path="x.pflow.md", auto_load_trace=False, memo_cache=None)
+
     assert "cache.dynamic-before-static" not in {d.id for d in result.warnings}
 
 

--- a/tests/test_core/test_cache_analysis_renderers.py
+++ b/tests/test_core/test_cache_analysis_renderers.py
@@ -3531,7 +3531,7 @@ def test_per_call_confidence_footer_flags_batch_exemplar_projections() -> None:
 def test_per_call_confidence_footer_uses_distinct_message_for_batch_prefix_projection() -> None:
     """Batch-prefix projection is structurally different from the parameters-tier
     batch exemplar case: no batch item content participates in the projection.
-    The footer message must say "static prefix repeated across observed calls",
+    The footer message must say "static prefix repeated across the batch",
     NOT "first batch item as a representative sample" — the latter would be a
     factual misrepresentation of what the analyzer measured.
 
@@ -3550,7 +3550,7 @@ def test_per_call_confidence_footer_uses_distinct_message_for_batch_prefix_proje
     text = render_text(_make_analysis(rows=[row]))
     assert "Token estimate confidence:" in text
     assert (
-        "score-choruses: savings projected from a stable prompt prefix repeated across observed calls. "
+        "score-choruses: savings projected from a stable prompt prefix repeated across the batch. "
         "Declare prompt_cache to confirm."
     ) in text
     assert "first batch item as a representative sample" not in text
@@ -3581,7 +3581,7 @@ def test_per_call_confidence_footer_uses_distinct_message_for_cross_workflow_pro
     assert "shared inputs declared in parent workflow" not in text
     # Cleanup-first guidance lives in Recommended actions (the bullet routes
     # the agent there); the footer no longer duplicates that prose.
-    assert "static prefix repeated across observed calls" not in text
+    assert "static prefix repeated across the batch" not in text
 
 
 def test_per_call_confidence_footer_aggregates_duplicate_node_names() -> None:

--- a/tests/test_core/test_prompt_refs.py
+++ b/tests/test_core/test_prompt_refs.py
@@ -1,0 +1,106 @@
+"""Unit tests for the prompt-ref classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from pflow.core.prompt_refs import PromptRef, classify_prompt_refs, first_per_item_position
+
+
+@pytest.mark.parametrize("prompt", ["", None, 42])
+def test_classify_empty_prompt_returns_empty_tuple(prompt: object) -> None:
+    assert classify_prompt_refs(prompt, "item", None) == ()  # type: ignore[arg-type]
+
+
+def test_classify_direct_per_item_ref_position_and_end() -> None:
+    assert classify_prompt_refs("prefix ${item.id} suffix", "item", None) == (
+        PromptRef(position=7, end=17, raw_expr="item.id", operand_paths=("item.id",), is_per_item=True),
+    )
+
+
+def test_classify_indirected_per_item_ref_via_inputs() -> None:
+    """Mutation contract: returning operands unchanged fails this test."""
+    refs = classify_prompt_refs("prefix ${item_id} suffix", "item", {"item_id": "${item.id}"})
+
+    assert refs == (PromptRef(position=7, end=17, raw_expr="item_id", operand_paths=("item.id",), is_per_item=True),)
+
+
+def test_classify_indirected_via_node_output_stays_static() -> None:
+    refs = classify_prompt_refs("${shared_x}", "item", {"shared_x": "${some_node.result}"})
+
+    assert refs == (
+        PromptRef(position=0, end=11, raw_expr="shared_x", operand_paths=("some_node.result",), is_per_item=False),
+    )
+
+
+def test_classify_coalesce_operands_per_item_when_any_branch_matches() -> None:
+    """Mutation contract: changing classifier ``any(...)`` to ``all(...)`` fails."""
+    refs = classify_prompt_refs("${a ?? item.x}", "item", None)
+
+    assert refs == (
+        PromptRef(position=0, end=14, raw_expr="a ?? item.x", operand_paths=("a", "item.x"), is_per_item=True),
+    )
+
+
+def test_classify_bracket_chain_dealiased() -> None:
+    refs = classify_prompt_refs("${X[0].name}", "item", {"X": "${item.list}"})
+
+    assert refs == (
+        PromptRef(position=0, end=12, raw_expr="X[0].name", operand_paths=("item.list[0].name",), is_per_item=True),
+    )
+
+
+def test_classify_indirected_coalesce_splits_operand_paths() -> None:
+    refs = classify_prompt_refs("${X.name}", "item", {"X": "${item.primary ?? fallback}"})
+
+    assert refs == (
+        PromptRef(
+            position=0,
+            end=9,
+            raw_expr="X.name",
+            operand_paths=("item.primary.name", "fallback.name"),
+            is_per_item=True,
+        ),
+    )
+
+
+def test_classify_batch_alias_none_never_per_item() -> None:
+    refs = classify_prompt_refs("${item.id}", None, None)
+
+    assert refs == (PromptRef(position=0, end=10, raw_expr="item.id", operand_paths=("item.id",), is_per_item=False),)
+
+
+def test_classify_empty_batch_alias_never_per_item() -> None:
+    refs = classify_prompt_refs("${item.id}", "", None)
+
+    assert refs == (PromptRef(position=0, end=10, raw_expr="item.id", operand_paths=("item.id",), is_per_item=False),)
+
+
+def test_first_per_item_position_returns_none_when_no_per_item_refs() -> None:
+    assert first_per_item_position("static ${other.id}", "item", None) is None
+
+
+def test_first_per_item_position_returns_first_when_multiple() -> None:
+    assert first_per_item_position("static ${item.a} more static ${item.b}", "item", None) == 7
+
+
+def test_classify_ignores_non_string_inputs_values() -> None:
+    refs = classify_prompt_refs("${X} ${Y}", "item", {"X": 42, "Y": "${item.id}"})
+
+    assert refs == (
+        PromptRef(position=0, end=4, raw_expr="X", operand_paths=("X",), is_per_item=False),
+        PromptRef(position=5, end=9, raw_expr="Y", operand_paths=("item.id",), is_per_item=True),
+    )
+
+
+def test_classify_dict_valued_inputs_pass_through_unchanged() -> None:
+    refs = classify_prompt_refs("${X.nested}", "item", {"X": {"nested": "${item.y}"}})
+
+    assert refs == (PromptRef(position=0, end=11, raw_expr="X.nested", operand_paths=("X.nested",), is_per_item=False),)
+
+
+def test_classify_junk_template_value_passes_through() -> None:
+    """Mutation contract: a startswith/endswith parser would wrongly dealias."""
+    refs = classify_prompt_refs("${X}", "item", {"X": "${ unknown stuff }"})
+
+    assert refs == (PromptRef(position=0, end=4, raw_expr="X", operand_paths=("X",), is_per_item=False),)

--- a/tests/test_core/test_sub_workflow_resolver.py
+++ b/tests/test_core/test_sub_workflow_resolver.py
@@ -295,6 +295,41 @@ Calls the LLM with an external prompt file.
     )
 
 
+@pytest.mark.parametrize(
+    ("prompt", "node_inputs", "expected_found"),
+    [
+        ("text ${concept} text", None, True),
+        ("text ${concept_md} text", {"concept_md": "${concept}"}, True),
+        ("text ${concept_md} text", None, False),
+        ("text ${concept_md.title} text", {"concept_md": "${concept}"}, True),
+    ],
+)
+def test_collect_llm_nodes_referencing_path_handles_inputs_indirection(
+    prompt: str,
+    node_inputs: dict[str, str] | None,
+    expected_found: bool,
+) -> None:
+    """Mutation contract: removing classifier dealiasing misses indirect cases."""
+    from pflow.core.cache_analysis.analyze import _collect_llm_nodes_referencing_path
+
+    params: dict[str, object] = {"prompt": prompt}
+    if node_inputs is not None:
+        params["inputs"] = node_inputs
+    child_ir = {
+        "nodes": [
+            {
+                "id": "consume",
+                "type": "llm",
+                "params": params,
+            }
+        ]
+    }
+
+    consumers = _collect_llm_nodes_referencing_path(child_ir, "concept")
+
+    assert consumers == (["consume"] if expected_found else [])
+
+
 def test_resolve_sub_workflow_cross_workflow_walker_sees_resolved_prompts(tmp_path: Path) -> None:
     """End-to-end gate: cross-workflow walker via the primitive sees inlined prompts.
 


### PR DESCRIPTION
## Summary

- Add a shared `prompt_refs` classifier for LLM prompt template refs with one-level `params.inputs` dealiasing, including coalesced input mappings.
- Use the classifier in cache analysis and runtime prewarm boundary detection so indirected `${X}` refs behave like direct `${item.X}` refs.
- Add regression coverage for classifier behavior, cross-workflow input indirection, dynamic-before-static declared-cache matching, and batch-prefix cache analysis evidence.
- Document the classifier contract and prompt-caching behavior.

## Root Cause

Cache analysis and runtime prewarm detection walked prompt templates with local regex logic that only recognized direct batch aliases such as `${item.x}`. When an LLM prompt used `inputs:` to bind `${X}` to `${item.x}`, the analyzer missed recommendations and the runtime did not place cache-control markers consistently.

## Review Follow-Up

- Reworded render-text confidence wording so greenfield `batch_prefix` evidence no longer claims observed calls.
- Added a regression for indirected declared-cache matching in `cache.dynamic-before-static`.
- Split coalesced `inputs:` mappings into separate dealiased operand paths instead of preserving `"a ?? b"` as one path.
- Added `PromptRef.raw_expr` so diagnostics do not repeat raw `${...}` slice arithmetic.
- Centralized analyzer access to `params.inputs` through `_node_inputs()` and documented the observed-call reuse gate.
- Tightened the indirection regression to require `cache.batch-prewarm-recommended` specifically.
- Scrubbed the local absolute plan path from the committed scratchpad log.

## Validation

- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_core/test_cache_analysis_per_id_emission.py tests/test_core/test_cache_analysis_analyze.py tests/test_core/test_cache_analysis_renderers.py -q` → 438 passed
- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_core/test_prompt_refs.py tests/test_core/test_cache_analysis_per_id_emission.py::test_inputs_indirection_does_not_suppress_prewarm_recommendation tests/test_core/test_cache_analysis_per_id_emission.py::test_dynamic_before_static_treats_indirected_declared_chunk_as_static -q` → 18 passed
- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m ruff check src/pflow/core/prompt_refs.py src/pflow/core/cache_analysis/analyze.py src/pflow/core/cache_analysis/render_text.py src/pflow/core/cache_render.py src/pflow/runtime/engine/engine.py src/pflow/nodes/llm/llm.py tests/test_core/test_prompt_refs.py tests/test_core/test_cache_analysis_per_id_emission.py tests/test_core/test_cache_analysis_renderers.py tests/test_core/test_sub_workflow_resolver.py` → passed
- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m mypy src/pflow/core/prompt_refs.py` → passed
- `git diff --check` → passed