### PR TITLE
feat(claude-code): native SDK structured output via JSON Schema

### DIFF
--- a/.taskmaster/tasks/task_126/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_126/implementation/implementation-plan.md
@@ -1,0 +1,928 @@
+# Task 126: Implementation Plan — Structured Output for Claude Code Node
+
+> **Read first**: `.taskmaster/tasks/task_126/task-126.md` (problem, design decisions, requirements). This file is the step-by-step *how*; the task spec is the *what & why*.
+
+## Orientation
+
+`claude_agent_sdk` v0.2.82 (current) has `ClaudeAgentOptions.output_format` and `ResultMessage.structured_output` natively. This plan replaces the current prompt-injection + regex-extraction approach with direct SDK usage, swaps the schema format from custom Python-alias to JSON Schema, and adds a `__warnings__` write so soft-failures surface as DEGRADED workflow status (agent-visible).
+
+**Prework already completed** (before this plan is picked up):
+- SDK pin bumped to `claude-agent-sdk>=0.2.82` in `pyproject.toml`; `uv.lock` resolved
+- Existing Claude Code test suite passed against 0.2.82 (47/47)
+- Phase 0 smoke test executed and findings captured in [`phase-0-findings.md`](./phase-0-findings.md)
+
+**Read [`phase-0-findings.md`](./phase-0-findings.md) BEFORE Phase 1** — it contains plan-altering findings about:
+- Top-level non-object schemas are rejected by the API → must validate in `_validate_schema`
+- Schema typos like `type: intger` are silently accepted by the API (motivates issue #398)
+- `max_turns: 1` is insufficient for structured output → validate to require `max_turns >= 2` when schema is set
+- Subscription auth via the bundled `claude` CLI works zero-config (no `ANTHROPIC_API_KEY` needed)
+
+All line numbers reference the **current pre-modification** file. The file gets shorter as deletions land — make changes in any order within a phase; line numbers don't shift between phases because each phase's anchors are unambiguous (method names, distinctive strings).
+
+**Verification cadence**: `make test && make check` after Phases 1, 2, 3, 5.
+
+## Anchor map — `src/pflow/nodes/claude/claude_code.py` (1033 lines)
+
+| Symbol | Line range |
+|---|---|
+| Module docstring | 1–43 |
+| SDK imports (`try/except ImportError`) | 54–74 |
+| `ClaudeCodeNode` class | 93 |
+| Class docstring | 94–180 |
+| `__init__` | 182–185 |
+| `_validate_schema` | 199–214 |
+| `prep` | 348–407 |
+| `exec` (sync entry) | 409–426 |
+| `_exec_async` | 428–450 |
+| `_build_claude_options` | 452–488 |
+| `_execute_with_timeout` | 490–514 |
+| `_run_claude_session` (SDK loop) | 516–559 |
+| `_process_assistant_message` | 561–605 |
+| `_extract_metadata` | 607–628 |
+| `_create_completion_event` | 630–644 |
+| `_log_session_results` | 646–663 |
+| `post` | 665–679 |
+| `exec_fallback` | 681–738 |
+| `_build_prompt` | 740–766 |
+| `_build_system_prompt` | 768–788 |
+| `_build_schema_prompt` | 790–836 |
+| `_store_results` | 838–939 |
+| `_extract_json` + 3 helpers | 941–1033 |
+
+**Reference patterns to mirror** (read these before implementing the corresponding section):
+- `src/pflow/nodes/llm/llm.py:795` — how nodes retrieve `node_id` from `self`
+- `src/pflow/nodes/llm/llm.py:289-301` — canonical `__warnings__` write shape
+- `src/pflow/nodes/llm/llm.py:296` — guard pattern (`if node_id is not None:`)
+
+---
+
+## Phase 0 — SDK runtime smoke test  ✅ DONE (prework)
+
+**Status**: Completed before plan handoff. Findings: [`phase-0-findings.md`](./phase-0-findings.md).
+
+**Key plan-altering findings** propagated into the phases below:
+1. **Top-level non-object schemas rejected by API** → Phase 1.2 must validate this
+2. **`max_turns: 1` fails for structured output** (needs ≥ 2) → Phase 1.2 / `_validate_max_turns` should reject
+3. **Schema typos silently fall through to soft-fail** → no plan change, but a hint in `_schema_error` is worth adding (see Phase 1.7)
+4. **Subscription auth via bundled CLI works zero-config** → no `ANTHROPIC_API_KEY` needed for Phase 5 verification
+
+**Smoke test artifacts** (delete in Phase 5.6):
+- `scratchpads/task_126/smoke_test.py` — the script
+- `scratchpads/task_126/smoke-output.txt` — raw output
+- `scratchpads/task_126/auth_probe.py` — minimal auth probe (already redundant)
+- (`phase-0-findings.md` is permanent — lives in `implementation/`)
+
+**Original Phase 0 plan** (kept here as a reference for re-running probes if Phase 1 discovers SDK quirks):
+
+<details>
+<summary>Phase 0 plan as originally written (kept for reference)</summary>
+
+The original Phase 0 section called for running an end-to-end smoke test via `scratchpads/task_126/smoke_test.py`. That script and its findings now exist. If implementation surprises emerge (e.g., a SDK behavior the plan didn't anticipate), re-run the smoke test or extend it with new probes.
+</details>
+
+---
+
+## Phase 1 — Modify `src/pflow/nodes/claude/claude_code.py`
+
+### 1.0 SDK field-presence probe at module import
+
+Immediately after the existing `try: from claude_agent_sdk import ...` block (lines 54–74), append a runtime assertion:
+
+```python
+# Guard against SDK field renames that would silently break structured output.
+# If claude_agent_sdk renames `structured_output` → `json_output` (or similar),
+# the soft-fail path would trigger on every call with a misleading "model
+# didn't comply" message. Fail at import time instead.
+if "structured_output" not in getattr(ResultMessage, "__annotations__", {}):
+    raise ImportError(
+        "claude_agent_sdk.types.ResultMessage has no 'structured_output' field. "
+        "pflow's Claude Code node requires claude-agent-sdk>=0.2.82 with native "
+        "structured output support. Got an incompatible SDK version."
+    )
+```
+
+### 1.1 Delete methods entirely
+
+- `_build_schema_prompt` (790–836)
+- `_extract_json` (941–965)
+- `_extract_json_from_code_block` (967–985)
+- `_extract_json_from_raw_object` (987–1005)
+- `_extract_json_from_last_brace` (1007–1033)
+
+### 1.2 Rewrite `_validate_schema` (199–214)
+
+**Scope**: legacy-format detection + top-level-object enforcement (Claude-API-specific limit discovered in Phase 0). JSON Schema syntactic validity is deferred to issue #398.
+
+**Key constraint from Phase 0 findings**: the Anthropic API rejects non-object top-level schemas when wrapped as a tool's `input_schema`. The SDK passes our `output_format` schema through this path, so workflow authors MUST use `type: object` at the top level. This is **specific to the Claude Code node** — the LLM node has no such restriction (LiteLLM/OpenAI accept top-level arrays/primitives in JSON Schema).
+
+Replace the body of `_validate_schema` with:
+
+```python
+def _validate_schema(self, output_schema: Any) -> dict | None:
+    """Validate output_schema parameter.
+
+    - None: no schema requested (returns None)
+    - {} (empty): likely a typo; raises with guidance
+    - Non-dict: TypeError
+    - Legacy Python-alias format: raises with migration guidance
+    - Non-object top-level: raises (Anthropic API tool-use limitation)
+    - Otherwise: returns as-is; SDK/CLI enforces remaining JSON Schema validity
+
+    Note on schema typos (e.g. type: "intger"): the Anthropic API silently accepts
+    them — schema typos will result in a soft-fail at runtime (structured_output is None)
+    with a generic "model did not return structured output" message. Centralized JSON
+    Schema syntactic validation is tracked in issue #398.
+    """
+    if output_schema is None:
+        return None
+    if not isinstance(output_schema, dict):
+        raise TypeError(
+            f"output_schema must be a dict (JSON Schema), got {type(output_schema).__name__}"
+        )
+    if not output_schema:
+        raise ValueError(
+            "output_schema is an empty dict. Did you forget to populate the schema body? "
+            "Use a real JSON Schema (e.g. {\"type\": \"object\", \"properties\": {...}}) "
+            "or remove the output_schema field entirely."
+        )
+    if self._looks_like_legacy_python_alias_format(output_schema):
+        raise ValueError(
+            "output_schema appears to use the legacy Python-alias format "
+            "({\"field\": {\"type\": \"str\", ...}}). "
+            "Use JSON Schema instead: {\"type\": \"object\", \"properties\": {...}, \"required\": [...]}. "
+            "See docs/reference/nodes/claude-code.mdx for an example."
+        )
+    # Claude API limitation (verified in Phase 0 smoke test): the SDK wraps output_format
+    # as a tool's input_schema, and the API rejects non-object top-level schemas with a
+    # 400. Catch this at prep time with a clear error.
+    top_level_type = output_schema.get("type")
+    if top_level_type is not None and top_level_type != "object":
+        raise ValueError(
+            f"output_schema on claude-code nodes must have top-level type: object "
+            f"(got type: {top_level_type!r}). "
+            "The Anthropic API rejects non-object top-level schemas in tool input_schema "
+            "wrappers. For array or primitive outputs, wrap in an object with a single "
+            "property, e.g. {\"type\": \"object\", \"properties\": {\"items\": {\"type\": \"array\", "
+            "\"items\": ...}}, \"required\": [\"items\"]}. "
+            "(The LLM node has no such restriction.)"
+        )
+    return output_schema
+
+
+@staticmethod
+def _looks_like_legacy_python_alias_format(schema: dict) -> bool:
+    """Detect the old custom Python-alias format.
+
+    Heuristic: no top-level JSON Schema markers AND any value is a dict
+    with type in {str, int, bool, list, dict, float} (Python alias).
+    """
+    JSON_SCHEMA_MARKERS = {"type", "$ref", "$schema", "oneOf", "anyOf", "allOf", "enum", "const"}
+    if any(marker in schema for marker in JSON_SCHEMA_MARKERS):
+        return False
+    PYTHON_ALIAS_TYPES = {"str", "int", "bool", "list", "dict", "float"}
+    # Check ALL values, not just the first.
+    return any(
+        isinstance(v, dict) and v.get("type") in PYTHON_ALIAS_TYPES
+        for v in schema.values()
+    )
+```
+
+**Note on `oneOf`/`anyOf`/`allOf` top-level**: the legacy-format detector accepts these as JSON Schema markers and skips the migration error. The top-level-type check above only fires when `type` is explicitly set and != `"object"`. A pure `oneOf` top-level schema (no `type` key) would pass `_validate_schema` but may still be rejected by the API at runtime — surfacing via the existing soft-fail path. If users hit this in practice, tighten the validation (Phase 0 did not probe `oneOf` top-level).
+
+### 1.2b Enforce `max_turns >= 2` when `output_schema` is set
+
+**Phase 0 finding**: with `max_turns=1`, the SDK raises `"Reached maximum number of turns (1)"` even for trivial structured-output prompts. The agent needs at least 2 turns to produce structured output (one to plan, one to emit). Catch this at prep time with a clear error rather than letting it surface as a generic SDK exception.
+
+In `prep` (current line 348–407), after `_validate_schema` and `_validate_max_turns` are both called, add a cross-check:
+
+```python
+# Phase 0 finding: structured output requires the agent to take at least 2 turns
+# (one to plan, one to produce). max_turns=1 fails with "Reached maximum number of turns".
+if output_schema is not None and max_turns < 2:
+    raise ValueError(
+        f"max_turns must be >= 2 when output_schema is set (got {max_turns}). "
+        "Structured output requires the agent to take at least one turn beyond producing "
+        "the final response. Set max_turns to 2 or higher (default is typically sufficient)."
+    )
+```
+
+Place this near the end of `prep`'s validation block, after both `output_schema` and `max_turns` have been individually validated.
+
+### 1.3 Delete `_build_prompt` (740–766) — inline
+
+After removing schema framing, the method becomes `return prep_res["prompt"]`. **Inline at the call site** in `_exec_async` (line 438):
+
+```python
+# Before:
+prompt = self._build_prompt(prep_res)
+# After:
+prompt = prep_res["prompt"]
+```
+
+Delete the method entirely.
+
+### 1.4 Delete `_build_system_prompt` (768–788) — inline
+
+After removing schema-merge logic, the method becomes `return prep_res.get("system_prompt") or ""`. Inline at the call site in `_exec_async` (line 441):
+
+```python
+# Before:
+system_prompt = self._build_system_prompt(prep_res)
+# After:
+system_prompt = prep_res.get("system_prompt") or ""
+```
+
+Delete the method.
+
+### 1.5 Modify `_build_claude_options` (452–488)
+
+After line 482 (the `resume` conditional block) and before line 485 (the `sandbox` conditional), add:
+
+```python
+# Native structured output: SDK translates this to --json-schema CLI flag.
+# subprocess_cli.py:316-325 in the SDK silently ignores any output_format
+# whose type != "json_schema" — the wrapping shape is mandatory.
+if prep_res.get("output_schema"):
+    options_kwargs["output_format"] = {
+        "type": "json_schema",
+        "schema": prep_res["output_schema"],
+    }
+```
+
+### 1.6 Modify `_run_claude_session` (516–559)
+
+**Initialize before the `async for` loop** (alongside `result_text`, `tool_uses`, `progress_events` at lines 529–533):
+
+```python
+structured_output: Any = None       # last-seen ResultMessage.structured_output
+is_error_from_sdk: bool = False     # sticky — once True, stays True
+```
+
+**Modify the `ResultMessage` branch** (currently lines 545–547):
+
+```python
+elif isinstance(message, ResultMessage):
+    metadata = self._extract_metadata(message)
+    progress_events.append(self._create_completion_event(metadata))
+    # Direct attribute access — Phase 1.0's import-time probe guarantees the field exists.
+    structured_output = message.structured_output
+    # Sticky-true: if ANY ResultMessage reports an error, retain that signal
+    # even if a later message claims success. Prevents silent error swallowing
+    # in streamed multi-message responses.
+    is_error_from_sdk = is_error_from_sdk or message.is_error
+```
+
+**Add the two new fields to the return dict** at the end of the method (around lines 555–559):
+
+```python
+return {
+    "result_text": result_text,
+    "tool_uses": tool_uses,
+    "progress_events": progress_events,
+    "metadata": metadata,
+    "structured_output": structured_output,
+    "is_error_from_sdk": is_error_from_sdk,
+    # NOTE: do NOT include output_schema — _store_results reads it from prep_res
+}
+```
+
+### 1.7 Rewrite `_store_results` (838–939)
+
+**New signature**: `_store_results(shared, prep_res, exec_res, node_id)`.
+
+The usage-metrics block (current lines 866–895) stays **inline** — do not extract a helper. Reproduce the exact dict shape from the current implementation.
+
+**Full replacement**:
+
+```python
+def _store_results(
+    self,
+    shared: dict[str, Any],
+    prep_res: dict[str, Any],
+    exec_res: dict[str, Any],
+    node_id: str | None,
+) -> None:
+    """Store execution results in shared store.
+
+    Result placement rules:
+    - No schema: shared["result"] = raw text (str)
+    - Schema + structured_output present: shared["result"] = parsed (dict/list/primitive)
+    - Schema + structured_output missing: soft-fail — raw text in result,
+      _schema_error string set, __warnings__ entry written → DEGRADED status
+    - is_error=True AND structured_output present: prefer structured_output AS RESULT,
+      BUT emit a warning so the SDK error signal isn't silently dropped
+    """
+    result_text = exec_res.get("result_text", "")
+    structured_output = exec_res.get("structured_output")
+    is_error_from_sdk = exec_res.get("is_error_from_sdk", False)
+    has_schema = prep_res.get("output_schema") is not None
+    progress_events = exec_res.get("progress_events", [])
+    tool_uses = exec_res.get("tool_uses", [])
+    metadata = exec_res.get("metadata", {})
+
+    if progress_events:
+        shared["_claude_progress"] = progress_events
+    if tool_uses:
+        shared["_claude_tools"] = tool_uses
+
+    # Usage metrics — reproduce current shape inline (do not extract a helper).
+    # See pre-modification lines 866-895 for the exact dict the current code builds.
+    if metadata:
+        usage = metadata.get("usage") or {}
+        shared["llm_usage"] = {
+            "input_tokens": usage.get("input_tokens"),
+            "output_tokens": usage.get("output_tokens"),
+            # Keep whatever total computation the current code uses; verify against pre-mod source
+            "total_tokens": (usage.get("input_tokens") or 0) + (usage.get("output_tokens") or 0),
+            "cost_usd": metadata.get("total_cost_usd"),
+            "duration_ms": metadata.get("duration_ms"),
+            "num_turns": metadata.get("num_turns"),
+        }
+    else:
+        shared["llm_usage"] = {}
+
+    # No schema path
+    if not has_schema:
+        shared["result"] = result_text
+        return
+
+    # Schema success path
+    if structured_output is not None:
+        shared["result"] = structured_output
+        if is_error_from_sdk and node_id is not None:
+            shared.setdefault("__warnings__", {})[node_id] = {
+                "kind": "claude_code.sdk_error_with_structured_output",
+                "text": (
+                    "Claude CLI reported is_error=True but structured_output was produced. "
+                    "Using structured_output as result; check provider for partial-response details."
+                ),
+                "context": {"node_type": "claude-code"},
+            }
+        return
+
+    # Soft-fail path: schema set but no structured_output
+    shared["result"] = result_text
+    if is_error_from_sdk:
+        msg = (
+            "Claude CLI reported an error and did not produce structured output. "
+            "Raw text stored in result."
+        )
+        kind = "claude_code.sdk_error_no_structured_output"
+    else:
+        msg = (
+            "Model did not return structured output matching the schema. "
+            "Raw text stored in result."
+        )
+        kind = "claude_code.schema_not_satisfied"
+    shared["_schema_error"] = msg
+    if node_id is not None:
+        shared.setdefault("__warnings__", {})[node_id] = {
+            "kind": kind,
+            "text": msg,
+            "context": {"node_type": "claude-code"},
+        }
+```
+
+**Notes**:
+- `__warnings__` shape matches `nodes/llm/llm.py:289-301`.
+- `node_id is not None` guard matches `llm.py:296`.
+- DEGRADED status is set automatically by `runtime/workflow_trace.py:457-466` when `__warnings__` is non-empty.
+
+### 1.8 Update `post` (665–679)
+
+Match the LLM node's `node_id` retrieval pattern:
+
+```python
+def post(self, shared: dict[str, Any], prep_res: dict[str, Any], exec_res: dict[str, Any]) -> str:
+    node_id = getattr(self, "node_id", None)  # set by compiler; see compilation/compiler.py:299
+    self._store_results(shared, prep_res, exec_res, node_id)
+    return "default"
+```
+
+(Reference: `src/pflow/nodes/llm/llm.py:795` for the canonical `getattr(self, "node_id", None)` pattern.)
+
+### 1.9 Update docstrings — module AND class
+
+Both the module-level docstring (lines 1–43) AND the class docstring (lines 94–180) declare an `Interface:` block. The registry's metadata extractor reads one; humans read both. Update both to prevent drift.
+
+**Module docstring (around line 10)** — replace the `Params`/`Writes` lines:
+
+```
+- Params: output_schema: dict  # JSON Schema for structured outputs (optional)
+- Writes: shared["result"]: str|dict  # Free-form text (str), or parsed JSON (dict/list/primitive) when output_schema is set, or raw text on soft schema failure
+- Writes: shared["_schema_error"]: str  # Error message when schema is set but parsing failed (optional)
+- Writes: shared["__warnings__"][node_id]: dict  # Workflow status -> DEGRADED on soft schema failure
+```
+
+**Class docstring "Output Schema Format" section (around lines 110–180)** — replace the Python-alias example with:
+
+```
+JSON Schema for structured outputs (optional):
+  {"type": "object", "properties": {"field": {"type": "string"}}, "required": ["field"]}
+```
+
+**Pre-existing doc drift fix**: class docstring lines 126–127 omit `disallowed_tools` from the Params list. Add it (the code at line 374 reads `disallowed_tools` from params).
+
+### 1.10 Imports cleanup
+
+After all deletions, verify and remove unused imports (grep the file first):
+
+```bash
+grep -nE "^[[:space:]]*import (re|json)$|^[[:space:]]*from (re|json)" src/pflow/nodes/claude/claude_code.py
+grep -nE "\b(re|json)\." src/pflow/nodes/claude/claude_code.py
+```
+
+Both `import re` and `import json` are very likely unused after this phase. Remove them if grep confirms no remaining references.
+
+### 1.11 Modern type hints
+
+Use `dict | None` not `Optional[dict]` for any signature touched in this task (`_validate_schema`, `_store_results`, anything new). Do NOT sweep-rewrite untouched signatures.
+
+### Phase 1 verification
+
+```bash
+uv run pytest tests/test_nodes/test_claude/ -v
+make check
+```
+
+Existing tests will fail until Phase 2 runs. That's expected; ensure the file compiles and imports cleanly first:
+
+```bash
+uv run python -c "from pflow.nodes.claude.claude_code import ClaudeCodeNode; print(ClaudeCodeNode)"
+```
+
+The import-time SDK probe should pass against the installed SDK 0.2.82.
+
+---
+
+## Phase 2 — Test mock + tests (`tests/test_nodes/test_claude/test_claude_code.py`)
+
+### 2.1 Add real `ResultMessage` class — load-bearing ordering
+
+Currently `ResultMessage` is auto-Mocked (`isinstance(x, AutoMock)` would `TypeError` if exercised — confirmed latent bug). The new tests need a real class.
+
+In the module-level mock block (around lines 35–94), add a `@dataclass` class mirroring the SDK's shape. **Register on `mock_sdk_types.ResultMessage` BEFORE the `sys.modules["claude_agent_sdk.types"] = mock_sdk_types` line (line ~93)**:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class ResultMessage:
+    """Test mock mirroring claude_agent_sdk.types.ResultMessage (v0.2.82+)."""
+    subtype: str = "success"
+    duration_ms: int = 0
+    duration_api_ms: int = 0
+    is_error: bool = False
+    num_turns: int = 1
+    session_id: str = "test-session"
+    total_cost_usd: float | None = None
+    usage: dict | None = None
+    result: str | None = None
+    structured_output: Any = None
+```
+
+`@dataclass` populates `__annotations__` automatically. The Phase 1.0 import-time probe (`"structured_output" in ResultMessage.__annotations__`) passes against this class.
+
+**Register**: add `mock_sdk_types.ResultMessage = ResultMessage` immediately after the existing `mock_sdk_types.AssistantMessage = AssistantMessage` (etc.) assignments. Confirm ordering: it MUST happen before `sys.modules["claude_agent_sdk.types"] = mock_sdk_types`.
+
+### 2.2 Delete obsolete tests
+
+| Test name | Line | Reason |
+|---|---|---|
+| `test_output_schema_invalid_keys` | 252 | "Valid Python identifier" check removed |
+| `test_output_schema_too_complex` | 271 | "≤50 keys" cap removed |
+| `test_schema_to_prompt_conversion` | 509 | `_build_schema_prompt` deleted |
+| `test_json_extraction_strategies` | 774 | `_extract_json*` deleted |
+| `test_schema_merged_with_user_prompt` | 675 | `_build_system_prompt` inlined; system_prompt pass-through doesn't need a dedicated test |
+
+### 2.3 Rewrite tests — substring assertions
+
+All `_schema_error` assertions must use substring matching (`"X" in shared["_schema_error"]`), never exact-string equality. Exact strings fragment on minor wording tweaks.
+
+| Test | Line | What changes |
+|---|---|---|
+| `test_valid_task_with_schema` | 215 | Mock yields `ResultMessage(structured_output={"risk_level": "low", "issues": []}, is_error=False)`. Assert dict in `shared["result"]`; `"_schema_error" not in shared`; `"__warnings__" not in shared` (or no entry for this node_id) |
+| `test_valid_json_response_storage` | 534 | Same pattern as above |
+| `test_invalid_json_response_fallback` | 583 | Mock yields `ResultMessage(structured_output=None, result="raw text", is_error=False)`. Assert `shared["result"] == "raw text"`; `"Model did not return" in shared["_schema_error"]`; `shared["__warnings__"][node_id]["kind"] == "claude_code.schema_not_satisfied"` |
+| `test_partial_json_response` → `test_sdk_is_error_branch` | 614 | Rename. Mock yields `ResultMessage(structured_output=None, is_error=True, result="error context")`. Assert `"Claude CLI reported an error" in shared["_schema_error"]`; `__warnings__[node_id]["kind"] == "claude_code.sdk_error_no_structured_output"` |
+
+**Keep unchanged** (no schema involved):
+- `test_no_response_content` (649)
+- `test_post_method` (813)
+
+**Behavior change to document**: with native SDK + JSON Schema `required`, "partial" responses no longer occur. The SDK either complies (full dict) or rejects (`is_error=True` / `structured_output=None`). The previous auto-fill-missing-keys-with-`None` behavior is gone — missing optional fields are simply absent from the result dict.
+
+### 2.4 Add new tests
+
+Each new test must set the node's params before running `prep` (follow whatever fixture pattern the existing test file uses — likely `claude_node.params = {...}` or a fixture parametrization).
+
+```python
+def test_output_schema_wrapped_and_passed_to_options(claude_node):
+    """JSON Schema is wrapped in {"type": "json_schema", "schema": ...} and reaches ClaudeAgentOptions."""
+    prep_res = {
+        "prompt": "test",
+        "output_schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+        # ... other required prep_res fields (model, max_turns, cwd, etc.)
+    }
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+    assert mock_options.call_args.kwargs["output_format"] == {
+        "type": "json_schema",
+        "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+    }
+
+def test_no_schema_means_no_output_format(claude_node):
+    """Without output_schema, output_format kwarg is absent."""
+    prep_res = {"prompt": "test", ...}  # no output_schema
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+    assert "output_format" not in mock_options.call_args.kwargs
+
+def test_legacy_python_alias_schema_rejected(claude_node):
+    """Old custom format raises with migration guidance."""
+    with pytest.raises(ValueError, match="legacy Python-alias format"):
+        claude_node._validate_schema(
+            {"risk_level": {"type": "str", "description": "high/medium/low"}}
+        )
+
+def test_legacy_format_detection_checks_all_values(claude_node):
+    """Detection must check ALL values, not just the first."""
+    # First value is non-dict (e.g. metadata marker); second is legacy format
+    schema = {"_meta": "comment", "risk": {"type": "str", "description": "..."}}
+    with pytest.raises(ValueError, match="legacy Python-alias format"):
+        claude_node._validate_schema(schema)
+
+def test_oneOf_top_level_schema_accepted(claude_node):
+    """JSON Schema with oneOf at top level (no top-level 'type') passes prep validation.
+    May be rejected by API at runtime — surfaces via soft-fail path. Phase 0 didn't probe."""
+    schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+    assert claude_node._validate_schema(schema) == schema
+
+def test_top_level_array_schema_rejected(claude_node):
+    """Phase 0 finding: API rejects non-object top-level schemas; catch at prep time."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"type": "array", "items": {"type": "string"}})
+
+def test_top_level_primitive_schema_rejected(claude_node):
+    """Phase 0 finding: type: string at top level is also rejected by API."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"type": "string", "enum": ["yes", "no"]})
+
+def test_max_turns_too_low_with_schema_rejected(claude_node):
+    """Phase 0 finding: structured output needs max_turns >= 2. Prep must reject 1."""
+    # Set params with output_schema and max_turns=1; assert ValueError mentioning max_turns
+    # Pattern: set claude_node.params = {"prompt": "test", "output_schema": {"type":"object",...}, "max_turns": 1, ...}
+    # with pytest.raises(ValueError, match="max_turns must be >= 2"):
+    #     claude_node.prep({})
+
+def test_empty_schema_dict_rejected(claude_node):
+    """Empty dict {} likely indicates a typo; raises."""
+    with pytest.raises(ValueError, match="empty"):
+        claude_node._validate_schema({})
+
+def test_none_schema_returns_none(claude_node):
+    """None means no schema; returns None silently."""
+    assert claude_node._validate_schema(None) is None
+
+def test_non_dict_schema_raises_typeerror(claude_node):
+    """Non-dict raises TypeError."""
+    with pytest.raises(TypeError):
+        claude_node._validate_schema(["not", "a", "dict"])
+
+def test_structured_output_stored_as_dict(claude_node, shared_store):
+    """ResultMessage.structured_output flows directly to shared['result']."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    async def mock_response(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text="done")])
+        yield ResultMessage(structured_output={"x": "hello"}, is_error=False)
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        # ... set params + run prep → exec → post lifecycle
+    assert shared_store["result"] == {"x": "hello"}
+    assert "_schema_error" not in shared_store
+    assert "__warnings__" not in shared_store  # or node_id not in shared_store["__warnings__"]
+
+def test_structured_output_none_writes_warning_and_schema_error(claude_node, shared_store):
+    """Schema set + structured_output None: soft-fail + __warnings__ + _schema_error."""
+    # mock yields ResultMessage(structured_output=None, result="raw", is_error=False)
+    # assert shared["result"] == "raw"
+    # assert "Model did not return" in shared["_schema_error"]
+    # assert shared["__warnings__"][node_id]["kind"] == "claude_code.schema_not_satisfied"
+
+def test_sdk_is_error_with_structured_output_emits_warning(claude_node, shared_store):
+    """is_error=True + structured_output present: structured_output wins, but warning is emitted."""
+    # mock yields ResultMessage(structured_output={"x": 1}, is_error=True)
+    # assert shared["result"] == {"x": 1}
+    # assert shared["__warnings__"][node_id]["kind"] == "claude_code.sdk_error_with_structured_output"
+
+def test_nested_array_schema(claude_node, shared_store):
+    """Array nested INSIDE an object works (top-level must be object per API limit)."""
+    # Schema: {"type": "object", "properties": {"items": {"type": "array", "items": {"type": "string"}}}, "required": ["items"]}
+    # mock yields ResultMessage(structured_output={"items": ["a","b","c"]}, is_error=False)
+    # assert shared["result"] == {"items": ["a","b","c"]}
+    # assert isinstance(shared["result"]["items"], list)
+
+def test_sticky_is_error_across_multiple_result_messages(claude_node, shared_store):
+    """is_error=True on an early ResultMessage persists even if a later one is False."""
+    # mock yields:
+    #   ResultMessage(is_error=True, structured_output=None)
+    #   ResultMessage(is_error=False, structured_output=None)
+    # assert "Claude CLI reported an error" in shared["_schema_error"]
+```
+
+### 2.5 `tests/CLAUDE.md` pitfall #17 update
+
+Update pitfall #17 to:
+- Note that `ResultMessage` is now a real `@dataclass` in the test file (no longer auto-Mocked)
+- Document the load-bearing ordering: `mock_sdk_types.ResultMessage = ResultMessage` MUST precede `sys.modules["claude_agent_sdk.types"] = mock_sdk_types`
+
+### 2.6 `tests/shared/markdown_utils.py:119` comment update
+
+Change the comment from `"Claude-code output schema"` to `"output_schema (JSON Schema) — node-agnostic"` so future maintainers don't mistake the helper for claude-code-specific. The behavior is unchanged.
+
+### Phase 2 verification
+
+```bash
+uv run pytest tests/test_nodes/test_claude/ -v
+make check
+```
+
+All tests should pass. If `make check` flags style issues on the new code, fix them.
+
+---
+
+## Phase 3 — Examples + docs
+
+### 3.1 Example workflow files
+
+For each of the 3 files below, convert the schema body inside the ` ```yaml output_schema ` block from Python-alias to JSON Schema using this rule:
+
+```yaml
+# Before (Python-alias, FLAT field map)
+field_name:
+  type: str       # → "string"
+  type: int       # → "integer"
+  type: bool      # → "boolean"
+  type: list      # → "array" + add items
+  type: float     # → "number"
+  description: ...
+
+# After (JSON Schema)
+type: object
+properties:
+  field_name:
+    type: string  # (etc.)
+    description: ...
+required: [field_name, ...]  # add for fields the workflow needs
+```
+
+**Files**:
+- `examples/nodes/claude-code/claude-code-schema.pflow.md` (lines 33–52, 6 fields)
+- `examples/nodes/claude-code/claude-code-debug.pflow.md` (lines 42–58, 6 fields)
+- `examples/nodes/claude-code/claude-code-git-workflow.pflow.md` (lines 35–50 AND 71–81 — two `output_schema` blocks)
+
+**Concrete example** for `claude-code-schema.pflow.md`:
+
+```yaml
+# Before:
+overall_quality:
+  type: str
+  description: Code quality (excellent/good/fair/poor)
+security_score:
+  type: int
+  description: Security score 1-10
+issues:
+  type: list
+  description: List of issues
+has_critical_issues:
+  type: bool
+  description: Whether critical issues exist
+
+# After:
+type: object
+properties:
+  overall_quality:
+    type: string
+    enum: [excellent, good, fair, poor]
+    description: Code quality rating
+  security_score:
+    type: integer
+    minimum: 1
+    maximum: 10
+    description: Security score 1-10
+  issues:
+    type: array
+    items:
+      type: string
+    description: List of issues
+  has_critical_issues:
+    type: boolean
+    description: Whether critical issues exist
+required: [overall_quality, security_score, issues, has_critical_issues]
+```
+
+### 3.2 Example README
+
+**`examples/nodes/claude-code/README.md`**:
+- Lines 35, 67–79, 83, 130, 144 — update format references
+- Line 83: `${node._schema_error}` documentation stays accurate (key name unchanged); add a sentence about `__warnings__` and DEGRADED status
+- Line 144: change "eliminates regex parsing" → "delegates to the SDK's native structured-output mode"
+
+### 3.3 User-facing docs
+
+**`docs/reference/nodes/claude-code.mdx`**:
+- Line 28 parameter table description: "JSON Schema for structured output"
+- Lines 103–123: replace Python-alias example with JSON Schema example (use the converted `claude-code-schema.pflow.md` as the source of truth)
+- Lines 175–184: same conversion
+- Add a new paragraph documenting:
+  - `shared["_schema_error"]` (set on soft-fail)
+  - `shared["__warnings__"][node_id]` (workflow status → DEGRADED)
+  - Distinction between schema_not_satisfied (model didn't comply) and sdk_error_no_structured_output (CLI reported an error)
+
+### 3.4 Architecture doc
+
+**`architecture/core-node-packages/claude-nodes.md`** — update BOTH lines 38 AND 39:
+
+- Line 38 (Params): keep "JSON schema for structured outputs (optional)" — already accurate
+- Line 39 (Writes): change `any  # Response - string or dict with schema keys` → `str|dict  # Free-form text (str), or parsed JSON (dict/list) when output_schema is set, or raw text on soft schema failure`
+- Add a new `Writes:` line documenting `__warnings__[node_id]` and the DEGRADED signal
+
+### 3.5 Validation gate
+
+```bash
+uv run pytest tests/test_docs/test_example_validation.py -v
+```
+
+The validator does NOT inspect `output_schema` content (`grep -rn output_schema src/pflow/core/workflow/` returns no matches), so migrated examples should pass. If any fail, inspect.
+
+---
+
+## Phase 4 — types.py, pyproject.toml, CHANGELOG
+
+### 4.1 `src/pflow/core/types.py` — delete "fourth surface" comment
+
+Lines 8–12 carve `output_schema` out of the S1 vocabulary because the Python-alias type names were embedded in the prompt template (`_build_schema_prompt`). After Phase 1.1 deletes that method, the reason no longer exists.
+
+**Delete the comment block entirely.** Do not rewrite to a one-liner — the relevant information already lives in `docs/reference/nodes/{llm,claude-code}.mdx`.
+
+### 4.2 `pyproject.toml` — bump SDK pin  ✅ DONE (prework)
+
+Already applied as prework: `"claude-agent-sdk>=0.2.82"` (was `>=0.1.17`). Lockfile resolved to 0.2.82. Existing Claude Code test suite passed against the upgraded SDK (47/47).
+
+**Implementing agent**: no action needed for 4.2. Verify with:
+```bash
+grep claude-agent-sdk pyproject.toml uv.lock | head -5
+```
+Should show `>=0.2.82` in `pyproject.toml` and `version = "0.2.82"` in `uv.lock`.
+
+### 4.3 CHANGELOG entry
+
+Add an entry in `CHANGELOG.md` documenting:
+- **Breaking change**: any local workflow using the legacy `{"field": {"type": "str", ...}}` format on a `claude-code` node will now fail validation with a migration error pointing at JSON Schema docs
+- **New behavior**: schema soft-failures now write to `shared["__warnings__"]` and surface as workflow status `DEGRADED` (visible in `pflow ... --output-format json`)
+- **Registry refresh note**: PyPI users may see the old Interface description in `pflow registry list claude-code` until the next pflow version bump (editable dev installs refresh automatically via mtime)
+
+---
+
+## Phase 5 — Verification
+
+### 5.1 Pre-Phase-3 checkpoint
+
+After Phases 1 and 2 are complete (claude_code.py + tests rewritten, all tests pass, `make check` clean):
+
+**Run `/code-review` on `src/pflow/nodes/claude/claude_code.py` and `tests/test_nodes/test_claude/test_claude_code.py`.** Resolve confirmed findings before proceeding to Phase 3.
+
+### 5.2 Final quality gates
+
+```bash
+uv run pytest tests/test_nodes/test_claude/ -v
+uv run pytest tests/test_docs/test_example_validation.py -v
+make test          # full suite, 4,600+ tests
+make check         # ruff + mypy
+make test-e2e
+```
+
+### 5.3 Registry refresh
+
+```bash
+pflow registry list claude-code
+```
+
+Confirm the new Interface description appears (editable install — mtime triggers refresh).
+
+### 5.4 Manual smoke test (real model call — subscription absorbs cost)
+
+```bash
+# Confirm no API key is set (use subscription auth)
+unset ANTHROPIC_API_KEY  # if it happens to be set
+uv run pflow examples/nodes/claude-code/claude-code-schema.pflow.md
+```
+
+If you're on a Claude Pro/Max/Team subscription, this is absorbed by the subscription (verified in Phase 0). If you don't have a subscription, set `ANTHROPIC_API_KEY` to use pay-as-you-go (~$0.05–0.50).
+
+Verify:
+- Workflow completes successfully
+- Downstream nodes receive a parsed dict in `${review.result.*}`
+- Template resolution works (e.g. `${review.result.overall_quality}`)
+- No `_schema_error` in trace
+
+### 5.5 Manual negative cases
+
+1. **Legacy format inline**: hand-write a temporary `.pflow.md` with `{"risk_level": {"type": "str"}}` inline in a code block. Confirm CLI shows the migration error with guidance.
+2. **Legacy format via file ref**: same legacy schema in `./schema.yaml`, referenced as `- output_schema: ./schema.yaml`. Confirm error surfaces. The error may not pinpoint the source file precisely (file_resolver does not preserve attribution); document that limitation if observed.
+3. **Empty dict**: `{}` in the schema body. Confirm clear "empty" error.
+4. **Top-level array schema**: `{"type": "array", "items": {"type": "string"}}` on a `claude-code` node. Confirm clear "top-level type: object" error pointing at the API limitation.
+5. **`max_turns: 1` with schema**: Confirm clear "max_turns must be >= 2" error.
+
+### 5.6 Cleanup
+
+```bash
+rm -rf scratchpads/task_126/   # Phase 0 smoke test artifacts
+```
+
+`phase-0-findings.md` lives in `.taskmaster/tasks/task_126/implementation/` and is preserved.
+
+---
+
+## Critical files reference
+
+### Code to modify
+| File | Phase |
+|---|---|
+| `src/pflow/nodes/claude/claude_code.py` | 1 — main refactor |
+| `src/pflow/core/types.py` | 4.1 — delete lines 8–12 |
+| `pyproject.toml` | 4.2 — bump claude-agent-sdk |
+| `CHANGELOG.md` | 4.3 — new entry |
+
+### Tests to modify
+| File | Phase |
+|---|---|
+| `tests/test_nodes/test_claude/test_claude_code.py` | 2 — mock + tests |
+| `tests/CLAUDE.md` | 2.5 — pitfall #17 |
+| `tests/shared/markdown_utils.py` | 2.6 — line 119 comment |
+
+### Docs/examples to modify
+| File | Phase |
+|---|---|
+| `examples/nodes/claude-code/claude-code-schema.pflow.md` | 3.1 |
+| `examples/nodes/claude-code/claude-code-debug.pflow.md` | 3.1 |
+| `examples/nodes/claude-code/claude-code-git-workflow.pflow.md` | 3.1 |
+| `examples/nodes/claude-code/README.md` | 3.2 |
+| `docs/reference/nodes/claude-code.mdx` | 3.3 |
+| `architecture/core-node-packages/claude-nodes.md` | 3.4 (lines 38 AND 39) |
+
+### Files to READ for context (do not modify)
+| File | Why |
+|---|---|
+| `src/pflow/nodes/llm/llm.py:795` | `node_id` retrieval pattern: `getattr(self, "node_id", None)` |
+| `src/pflow/nodes/llm/llm.py:289-301` | Canonical `__warnings__` write shape |
+| `src/pflow/nodes/llm/llm.py:296` | `if node_id is not None:` guard |
+| `src/pflow/core/llm_client.py:300-304` | LLM node's schema → response_format wrapping (analog for our output_format wrapping) |
+| `src/pflow/runtime/workflow_trace.py:457-466` | `__warnings__` → DEGRADED status mechanism |
+| `src/pflow/runtime/compilation/compiler.py:299` | Where `node.node_id` is set at compile time |
+| `claude_agent_sdk/types.py:587-680` (cache path) | SDK source: `ResultMessage` + `ClaudeAgentOptions` field definitions |
+| `claude_agent_sdk/_internal/transport/subprocess_cli.py:316-325` | SDK source: only `{"type": "json_schema", "schema": ...}` is wired |
+
+---
+
+## Edge case resolutions (implementation decisions)
+
+| Edge case | Implementation behavior |
+|---|---|
+| `output_schema = None` (key absent) | `_validate_schema` returns `None` → no-schema path |
+| `output_schema = {}` (empty) | `_validate_schema` raises with "did you forget the schema body?" |
+| `output_schema = [list, not, dict]` | `_validate_schema` raises `TypeError` |
+| Legacy Python-alias format | `_validate_schema` raises with migration guidance |
+| Legacy format where first value is non-dict | Detection iterates ALL values; still caught |
+| JSON Schema with `oneOf`/`anyOf`/`allOf`/`enum`/`const` (no top-level `type`) | Accepted as JSON Schema |
+| JSON Schema with `$ref` / external refs | Passed through to SDK; SDK/CLI decides |
+| Top-level `type: array` or primitive (`type: string`, etc.) | `_validate_schema` raises (Phase 0 finding: API rejects non-object top-level schemas in tool input_schema wrapping). Workflow author must wrap in an object. |
+| Top-level `oneOf`/`anyOf`/`allOf` (no top-level `type`) | Passes prep validation; may be rejected by API at runtime → soft-fail path |
+| Nested array (`{"type": "object", "properties": {"items": {"type": "array", ...}}}`) | Works normally; `structured_output` is the wrapping object |
+| Multiple `ResultMessage` instances | Last `structured_output` wins; `is_error_from_sdk` is sticky-true (defensive — Phase 0 did not observe multi-message) |
+| `structured_output` empty (`{}`) | Stored as-is — empty object is a valid structured response |
+| `max_turns = 1` with output_schema | `prep` raises (Phase 0 finding: structured output needs ≥2 turns) |
+| Schema typo (e.g. `type: intger`) | API silently accepts; soft-fail with generic "model did not return" message. Centralized validation in #398 will catch these early |
+| `is_error=True` AND `structured_output` present | `structured_output` becomes `shared["result"]`; `__warnings__` written for visibility |
+| `is_error=True` AND `structured_output` None | Soft-fail with CLI-error variant of `_schema_error` + `__warnings__` |
+| SDK raises before any `ResultMessage` | Existing `exec_fallback` path (line 681) handles — hard error, retries |
+| SDK has no `structured_output` field (version drift) | Phase 1.0 import-time probe raises `ImportError` |
+| `node_id` is `None` (uncompiled node, direct test) | `__warnings__` write skipped; `_schema_error` still set; matches LLM node pattern |
+
+---
+
+## Out of scope (deliberately deferred)
+
+- **`pflow guide` page for claude-code** — no existing page; file separately
+- **Centralized JSON Schema syntactic validation** — see GitHub issue #398 (cross-cutting concern; per-node validation duplicates work)
+- **`claude_client.py` adapter** analogous to `llm_client.py` — `claude_agent_sdk` has one consumer; premature abstraction
+- **Per-node retry on schema mismatch** — soft-fail is the chosen semantics
+- **Backwards compatibility shim** for legacy Python-alias format — no users (CLAUDE.md)
+- **Legacy → JSON Schema converter tool** — out of scope per "no users"
+- **JSON Schema validity validation at prep time** — deferred to #398
+
+---
+
+## Follow-up GitHub issue
+
+Filed as **#398**: https://github.com/spinje/pflow/issues/398 — "Centralized JSON Schema validation for output_schema across nodes". Will be picked up after Task 126 ships.

--- a/.taskmaster/tasks/task_126/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_126/implementation/implementation-plan.md
@@ -187,7 +187,7 @@ def _looks_like_legacy_python_alias_format(schema: dict) -> bool:
     )
 ```
 
-**Note on `oneOf`/`anyOf`/`allOf` top-level**: the legacy-format detector accepts these as JSON Schema markers and skips the migration error. The top-level-type check above only fires when `type` is explicitly set and != `"object"`. A pure `oneOf` top-level schema (no `type` key) would pass `_validate_schema` but may still be rejected by the API at runtime — surfacing via the existing soft-fail path. If users hit this in practice, tighten the validation (Phase 0 did not probe `oneOf` top-level).
+**Note on `oneOf`/`anyOf`/`allOf` top-level**: the legacy-format detector accepts these as JSON Schema markers and skips the migration error. **Update post-impl** (oneOf follow-up probe): the top-level-type check now fires whenever `type` is missing OR set to anything other than `"object"`, with a combinator-aware error message. All four (`oneOf`/`anyOf`/`allOf`/`enum`-only) return HTTP 400 from the Anthropic API. To use combinators, nest them inside a `type: object` wrapper.
 
 ### 1.2b Enforce `max_turns >= 2` when `output_schema` is set
 
@@ -894,10 +894,10 @@ rm -rf scratchpads/task_126/   # Phase 0 smoke test artifacts
 | `output_schema = [list, not, dict]` | `_validate_schema` raises `TypeError` |
 | Legacy Python-alias format | `_validate_schema` raises with migration guidance |
 | Legacy format where first value is non-dict | Detection iterates ALL values; still caught |
-| JSON Schema with `oneOf`/`anyOf`/`allOf`/`enum`/`const` (no top-level `type`) | Accepted as JSON Schema |
+| JSON Schema with `oneOf`/`anyOf`/`allOf`/`enum`/`const` (no top-level `type`) | Rejected at prep (oneOf follow-up probe: API returns HTTP 400). Wrap in `{"type": "object", ...}`. |
 | JSON Schema with `$ref` / external refs | Passed through to SDK; SDK/CLI decides |
 | Top-level `type: array` or primitive (`type: string`, etc.) | `_validate_schema` raises (Phase 0 finding: API rejects non-object top-level schemas in tool input_schema wrapping). Workflow author must wrap in an object. |
-| Top-level `oneOf`/`anyOf`/`allOf` (no top-level `type`) | Passes prep validation; may be rejected by API at runtime → soft-fail path |
+| Top-level `oneOf`/`anyOf`/`allOf` (no top-level `type`) | Rejected at prep (post-impl finding); error message names the combinator. |
 | Nested array (`{"type": "object", "properties": {"items": {"type": "array", ...}}}`) | Works normally; `structured_output` is the wrapping object |
 | Multiple `ResultMessage` instances | Last `structured_output` wins; `is_error_from_sdk` is sticky-true (defensive — Phase 0 did not observe multi-message) |
 | `structured_output` empty (`{}`) | Stored as-is — empty object is a valid structured response |

--- a/.taskmaster/tasks/task_126/implementation/phase-0-findings.md
+++ b/.taskmaster/tasks/task_126/implementation/phase-0-findings.md
@@ -1,0 +1,109 @@
+# Phase 0 Smoke Test Findings — SDK 0.2.82
+
+**Date**: 2026-05-15
+**SDK version**: `claude_agent_sdk==0.2.82` (released hours earlier on 2026-05-15)
+**CLI version**: `claude 2.1.142 (Claude Code)`
+**Auth**: Claude Max subscription (no `ANTHROPIC_API_KEY` set)
+**Test script**: `scratchpads/task_126/smoke_test.py`
+**Raw output**: `scratchpads/task_126/smoke-output.txt`
+
+## Summary
+
+| Probe | Result | Notes |
+|---|---|---|
+| happy_path_object | ✅ pass | `structured_output={'risk_level':'high','score':10}`, num_turns=2 |
+| array_top_level | ❌ **API 400** | `Input should be 'object'` — top-level non-object schemas rejected |
+| primitive_string_enum | ❌ **API 400** | Same error as array_top_level |
+| impossible_const | ❌ **API 400** | Same error (couldn't test impossible-schema branch with primitives) |
+| no_schema_baseline | ✅ pass | Free-form text, works as expected |
+| optional_fields_no_required | ✅ pass | Optional fields ABSENT (not None) when not produced |
+| malformed_schema_intger | ⚠️ silently accepted | Schema typo `type: intger` did NOT error; model produced no structured output and returned free-form text |
+
+## Plan-altering findings
+
+### 1. ⚠️ Top-level schema MUST be `type: object`
+
+```
+API Error: 400 tools.9.custom.input_schema.type: Input should be 'object'
+```
+
+The CLI wraps `output_format` schemas as a custom tool's input_schema and the Anthropic API rejects non-object input schemas for tools. **Top-level `type: array`, `type: string`, `type: integer`, etc. all fail with the same 400.**
+
+Note that this is the API's *tool-use limitation*, not a JSON Schema spec limitation. The LLM node's `output_schema` (which routes through LiteLLM's OpenAI-style `response_format`) does NOT have this restriction — OpenAI permits top-level arrays/primitives in JSON Schema.
+
+**Implication for Task 126**:
+- `_validate_schema` must reject top-level non-object schemas at prep time with a clear error. Without this, users get the opaque API 400 surfaced as `is_error=True` → "Claude CLI reported an error" soft-fail message — not actionable.
+- The plan's "Top-level type: array → list" and "primitive structured_output" edge cases must be REMOVED from the Claude Code edge case table (they're impossible on this node).
+- The plan's tests for `test_array_schema_top_level` and `test_primitive_structured_output` must be removed.
+- Document the limitation in `docs/reference/nodes/claude-code.mdx` (workflow authors who write top-level array schemas on this node need to wrap them in objects, OR use the LLM node instead).
+
+### 2. ⚠️ Malformed JSON Schema types are silently accepted by the API
+
+Probe `malformed_schema_intger` sent `{"type": "object", "properties": {"x": {"type": "intger"}}, "required": ["x"]}`. The API did NOT return an error. The model produced free-form text (no structured output). `is_error=False`, `structured_output=None`.
+
+**Implication**: schema typos fall through to our soft-fail path with the misleading "Model did not return structured output matching the schema" message — when the real issue is the schema typo. **Strengthens the case for the centralized validation in issue #398.**
+
+Until #398 lands, schema typos result in:
+- ✅ Soft-fail path triggers (`_schema_error` + `__warnings__` set)
+- ❌ User sees "model didn't comply" instead of "your schema is malformed"
+
+Consider adding a hint in the `_schema_error` message: *"If you suspect a schema typo, run `pflow validate` once issue #398 is resolved."* — small, low-cost, future-friendly UX.
+
+### 3. `max_turns: 1` is insufficient for structured output
+
+The happy-path probe needed `num_turns=2` to complete. With `max_turns=1` the SDK raises:
+```
+Claude Code returned an error result: Reached maximum number of turns (1)
+```
+
+Current `_validate_max_turns` (claude_code.py:260–271) allows `min=1`. **Recommendation**: raise minimum to `2` when `output_schema` is set, OR document this in the param docstring + raise a clearer error when it happens. Plan should mention this; implementation can be conservative (just doc).
+
+### 4. `total_cost_usd` is informational, not billed
+
+The smoke test consumed ~$0.20 worth of subscription quota total, but the user is on Claude Max — actually billed: $0. The `total_cost_usd` field on `ResultMessage` reports "what this would have cost via API" regardless of auth method.
+
+**Implication**: when the Claude Code node propagates `total_cost_usd` into `shared["llm_usage"]["cost_usd"]`, downstream tools/dashboards see API-equivalent cost even when on subscription. Worth a docstring note. No code change required.
+
+### 5. Subscription auth needs ZERO configuration
+
+The `claude` CLI (bundled by `claude_agent_sdk`) auto-detects subscription auth via OAuth/keychain. The SDK shells out to this CLI; auth flows through transparently. Don't set `ANTHROPIC_API_KEY` — its presence would force API-key billing.
+
+`claude auth status` confirms:
+```json
+{
+  "loggedIn": true,
+  "authMethod": "claude.ai",
+  "apiProvider": "firstParty",
+  "subscriptionType": "max"
+}
+```
+
+No env var, settings file, or token setup required for the developer running Phase 5 tests or running migrated example workflows.
+
+## Confirmed plan assumptions
+
+- ✅ `ResultMessage.structured_output` is populated when `output_format` is set and the model complies — exactly as the plan expects
+- ✅ Both `result` (text) and `structured_output` (parsed) are populated on success — the plan's "prefer structured_output, ignore result_text" logic is correct
+- ✅ `is_error=True` correlates with the soft-fail path (`structured_output=None`)
+- ✅ Optional fields (no `required`) are ABSENT (not None-filled) when the model doesn't produce them — matches plan's documented behavior
+- ✅ Single `ResultMessage` per session (no multi-message streaming observed); sticky-`is_error` logic is defensive but no probe exercised it
+- ✅ No `ANTHROPIC_API_KEY` needed; subscription auth via bundled CLI works flawlessly
+- ✅ SDK 0.2.82 is field-compatible with everything the plan assumes (verified via test suite + this smoke test)
+
+## SDK 0.2.82 new fields available (not used by plan, but noted for follow-ups)
+
+`ResultMessage` in 0.2.82 has new fields beyond what 0.1.18 had:
+- `errors: list` — structured per-error detail. Could enrich `__warnings__["context"]` in future
+- `stop_reason: str` — e.g. `"end_turn"`, `"stop_sequence"`. Helpful for distinguishing failure modes
+- `api_error_status` — distinguishes API errors from other failures
+- `permission_denials` — irrelevant to structured output
+- `deferred_tool_use`, `model_usage`, `uuid` — irrelevant to this task
+
+Don't bake these into Task 126 (scope creep), but they're available if Phase 1 implementation finds a natural use.
+
+## Cleanup
+
+- `scratchpads/task_126/auth_probe.py` — minimal probe; can be deleted
+- `scratchpads/task_126/smoke_test.py` — full probe; keep until Task 126 ships then delete in Phase 5.6
+- `scratchpads/task_126/smoke-output.txt` — raw output log; delete with scratchpads at end of Task 126
+- This file (`smoke-findings.md`) — keep until Task 126 ships, then either delete or move to `.taskmaster/tasks/task_126/implementation/` if useful as historical record

--- a/.taskmaster/tasks/task_126/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_126/implementation/progress-log.md
@@ -213,3 +213,54 @@ Ran `examples/nodes/claude-code/claude-code-schema.pflow.md` against the real An
 End-to-end result: `success: true`, `warnings: []`, `diagnostics: []`. All 4 nodes completed (`read_code`, `review`, `save_review`, `save_improved`). The `review` node returned a fully-conformant dict with all 6 required fields including `overall_quality: "poor"` (enum constraint honored), `security_score: 2` (1-10 minimum/maximum honored), and `has_critical_issues: true` (correctly typed boolean). Templates `${review.result.*}` resolved cleanly into both downstream `write-file` nodes — `.improved.py` and `.review.md` artifacts were produced with no escaping or template-resolution artifacts. Duration: 54.7s, API-equivalent cost: $0.135 (subscription: $0 billed), 2.6k output tokens, 19.8k cache-creation tokens.
 
 This closes the last open item from the plan's Phase 5 checklist. No regression to the happy path.
+
+## 2026-05-15 — PR #399 review evaluation + fix-ups
+
+Bot review on PR #399 (`claude[bot]`) flagged 0 critical / 2 warnings / 5 suggestions. Three subagents (`pflow-codebase-searcher`) verified each finding against the actual code in parallel.
+
+| # | Finding | Verdict | Action |
+|---|---|---|---|
+| 1 | Schema validation logic duplicated between `validator.py:683-829` and `claude_code.py:217-323` (predicate bodies byte-identical; drift risk) | Confirmed | Extracted predicates to new `src/pflow/nodes/claude/schema_validation.py` (`is_legacy_python_alias_schema`, `top_level_object_violation` returning a `TopLevelObjectViolation` NamedTuple, plus constants). Validator and runtime both import; per-call-site error framing preserved. |
+| 2 | `__warnings__` policy in `src/pflow/nodes/CLAUDE.md` reads as LLM-only | Confirmed but reframed — the doc says "one approved direct producer" (not "the only"); explicitly invites future contributors. Three-subagent inventory confirmed ClaudeCode's writes already conform to the canonical shape and round-trip through the generic memo cache rehydration. | Doc-only update naming both `LLMNode.post()` and `ClaudeCodeNode.post()` as approved producers; points at `_emit_soft_fail_signal` / `_emit_schema_resolved_null_warning`. |
+| 3 | Import probe fragile against auto-Mock `__annotations__` (`TypeError` instead of friendly `ImportError`) | Confirmed | Added `isinstance(ann, dict)` guard around the `in` check in `claude_code.py`. |
+| 4 | `_run_claude_session` catch-all wider than needed (proposed typed-only `except (ProcessError,)`) | **Disputed** | Subagent verified the current name-fallback (`type(exc).__name__ == "ProcessError"`) is a deliberate safety net for partial-import scenarios where `ProcessError` is None at module load. The proposed typed-only refactor degrades to `except ():` (empty tuple, catches nothing) in that case, dropping the soft-fail signal. Skipped the refactor; added regression test instead (see below). |
+| 5 | `_validate_tools` / `_validate_disallowed_tools` near-duplicates | Confirmed | Collapsed into `_validate_optional_tool_list(value, param_name)` helper. Both methods now one-line delegates preserving signatures. |
+| 6 | `TestValidateOnlyClaudeCodeStructuredOutput` builds inline 15-line IR dicts in 5 tests | Confirmed | Added module-level `make_claude_code_workflow` factory; refactored 5 cases. `test_dry_run.py` imports the same factory for parity. |
+| 7 | Mixed `__warnings__` assertion styles | Confirmed | Documented the deliberate split (fixture-init vs. early-return paths) in the test module's docstring. |
+
+Subtle issue discovered during action [1] implementation: `pflow.nodes.claude.__init__.py` eagerly imported `ClaudeCodeNode`, which triggered SDK loading before `test_claude_code.py`'s `sys.modules` mock could bind when the new `test_schema_validation.py` ran first. Fixed by switching to `__getattr__`-based lazy resolution. Behavior preserved for all consumers (registry uses filesystem walking, not `__init__.py` exports). Pin test added.
+
+### High-value test additions
+
+Stepped back from "coverage" framing to "what catches real bugs". Added three tests and pruned two shallow ones in the process.
+
+**Added — HIGH VALUE**:
+- `test_runtime_and_validator_agree_on_rejection` / `test_runtime_and_validator_agree_on_acceptance` (parametrized, 16 cases): the cross-surface parity contract that the validator's existence depends on. Shared predicates prevent drift at the predicate level, but call sites can still drift on which checks they run / in what order. Adding a new rejection rule to one side without the other now fires here with the `case_id` naming the gap. Out of scope: templated values, which differ by design.
+- `test_runtime_and_validator_agree_on_max_turns_with_schema`: pins the cross-rule `max_turns >= 2 when output_schema is set` is enforced on both surfaces.
+- `test_claude_code_node_resolves_identically_via_package_and_direct_import`: pin for the lazy `__init__.py` contract. Reverting to eager re-export breaks here with a clean signal, not in confusing cross-file ordering downstream.
+- `test_process_error_name_fallback_when_sdk_class_is_none`: pins the disputed Finding 4 decision. Patches `ProcessError` to None, raises a locally-defined `ProcessError`-named class, asserts the name-fallback still swallows after `is_error=True` so the soft-fail signal lands. A typed-only refactor would degrade to `except ():` and break this test.
+
+**Pruned — SHALLOW**:
+- `test_constants_contract`: pure membership snapshot fully redundant with behavioral predicate tests.
+- `test_violation_is_named_tuple`: `isinstance` + tuple unpacking; trivial and duplicative.
+
+**Reframed**:
+- `test_combinator_set_contract` → `test_top_level_const_named_in_cause`: replaced the set-equality snapshot with a behavioral test for `const`, achieving symmetry with the four other combinator tests and meaningful bug-catching (silent UX regression if `const` is removed from the tuple).
+
+### Verification (final pass)
+
+- `uv run pytest tests/test_nodes/test_claude/ tests/test_cli/test_validate_only.py tests/test_cli/test_dry_run.py tests/test_runtime/test_memoization_integration.py -q` → `154 passed`
+- `uv run pytest tests/test_nodes/ tests/test_cli/ tests/test_core/ tests/test_runtime/test_memoization_integration.py tests/test_runtime/test_instrumented_wrapper.py -q` → `4080 passed, 9 skipped, 0 failed`
+- `uv run ruff check` on all touched files → clean
+- `uv run mypy` on touched node files → success (8 pre-existing errors on conditional-None SDK exception assignments confirmed present on `main` before this branch; not introduced)
+
+Net file delta:
+- **New**: `src/pflow/nodes/claude/schema_validation.py` (66 lines, pure module)
+- **New**: `tests/test_nodes/test_claude/test_schema_validation.py` (17 direct predicate tests)
+- **Modified**: `src/pflow/nodes/claude/claude_code.py` (uses shared predicates, defensive import-probe shim, narrowed exception handler unchanged, tools-validator collapsed)
+- **Modified**: `src/pflow/nodes/claude/__init__.py` (lazy `__getattr__`)
+- **Modified**: `src/pflow/core/workflow/validator.py` (uses shared predicates, deletes duplicate `_looks_like_legacy_python_alias_schema`)
+- **Modified**: `src/pflow/nodes/CLAUDE.md` (names both LLM and Claude Code as `__warnings__` producers)
+- **Modified**: `tests/test_nodes/test_claude/test_claude_code.py` (parity tests, lazy-init pin, name-fallback pin, assertion-style convention docstring, Severity/WorkflowValidator imports)
+- **Modified**: `tests/test_cli/test_validate_only.py` (factory + refactor)
+- **Modified**: `tests/test_cli/test_dry_run.py` (imports shared factory)

--- a/.taskmaster/tasks/task_126/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_126/implementation/progress-log.md
@@ -177,3 +177,39 @@ Verification:
 
 Deliberate non-change:
 - Did NOT touch the LLM node's analogous `node_id is None` guard. The LLM node has the same pattern at `nodes/llm/llm.py:296`; this passes loses signal in the same way for the same reason. Consistency between the two nodes is preferable to one-off divergence; if the gap matters, fix both together in a follow-up touching both call sites.
+
+## 2026-05-15 — oneOf/anyOf/allOf follow-up probe + tightening
+
+Wrote `scratchpads/task_126_oneof_probe/probe.py` to close the open item Phase 0 left unanswered: do top-level combinator schemas work? Result: **all four (`oneOf`/`anyOf`/`allOf`/`enum`) return `api_error_status=400` from the Anthropic API**, same class as the Phase 0 `type: array`/primitive findings.
+
+Tightened both runtime and static validators:
+- `claude_code.py::_validate_schema` now requires `top_level_type == "object"` (was: rejected only when `type` was set to a non-`"object"` value; missing `type` slipped through).
+- New `_top_level_object_error` helper produces case-specific guidance: combinator-only schemas get a message naming the offending combinator; non-`"object"` types get the wrapping advice.
+- `validator.py::_validate_claude_code_params` mirrors the same logic so `--validate-only` and `--dry-run` reject these at preflight instead of letting them fail at runtime.
+
+Tests:
+- Flipped `test_oneOf_top_level_schema_accepted` → `test_top_level_oneOf_schema_rejected`.
+- Added `test_top_level_{anyOf,allOf,missing_type}_schema_rejected`.
+- Added `test_top_level_object_with_oneOf_accepted` to pin that combinators INSIDE an object wrapper still work.
+- Added two `TestValidateOnlyClaudeCodeStructuredOutput` cases: oneOf root + missing top-level type.
+
+Doc propagation:
+- `task-126.md` requirements and design decisions reflect the rejection (no longer "may pass").
+- `implementation-plan.md` edge case table updated.
+
+Also fixed unrelated pre-existing test-suite issues that were blocking `ruff check .` and turned up during verification:
+- 3× RUF043: raw-string the `pytest.raises(match=...)` regex patterns in `test_workflow_resolver_contract.py`, `test_execution_workflow.py`, `test_plan_workflow.py`.
+- 22× RUF059: prefix unused unpacked variables with `_` in `test_instrumented_wrapper.py`, `test_prepare_inputs_coercion.py`, `test_settings_env_integration.py`, `test_array_notation.py`.
+
+Verification:
+- `uv run pytest tests/test_nodes/test_claude/ tests/test_cli/test_validate_only.py tests/test_cli/test_dry_run.py -q` → `108 passed`
+- `uv run python -m ruff check .` → clean.
+- Pre-existing "fails in sandbox" tests (`test_failed_node_invariant.py`, `test_prep_error_action.py`) run clean on real dev environment: 39 passed in isolation, 1869 passed in the full `tests/test_runtime tests/test_integration` sweep.
+
+## 2026-05-15 — Phase 5.4 manual real-API smoke test
+
+Ran `examples/nodes/claude-code/claude-code-schema.pflow.md` against the real Anthropic API via Claude Max subscription (no `ANTHROPIC_API_KEY`). Reviewed an intentionally-flawed Python file (command injection + SQL injection).
+
+End-to-end result: `success: true`, `warnings: []`, `diagnostics: []`. All 4 nodes completed (`read_code`, `review`, `save_review`, `save_improved`). The `review` node returned a fully-conformant dict with all 6 required fields including `overall_quality: "poor"` (enum constraint honored), `security_score: 2` (1-10 minimum/maximum honored), and `has_critical_issues: true` (correctly typed boolean). Templates `${review.result.*}` resolved cleanly into both downstream `write-file` nodes — `.improved.py` and `.review.md` artifacts were produced with no escaping or template-resolution artifacts. Duration: 54.7s, API-equivalent cost: $0.135 (subscription: $0 billed), 2.6k output tokens, 19.8k cache-creation tokens.
+
+This closes the last open item from the plan's Phase 5 checklist. No regression to the happy path.

--- a/.taskmaster/tasks/task_126/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_126/implementation/progress-log.md
@@ -6,12 +6,12 @@
 |---|---|---|
 | Prework: SDK upgrade to 0.2.82 | ✅ done | `8cadd39c` |
 | Phase 0: SDK smoke test | ✅ done | `8cadd39c` |
-| Phase 1: Refactor claude_code.py | ⏳ next | — |
-| Phase 2: Tests | pending | — |
-| Code review checkpoint | pending | — |
-| Phase 3: Examples + docs | pending | — |
-| Phase 4: types.py + CHANGELOG | pending | — |
-| Phase 5: Final verification | pending | — |
+| Phase 1: Refactor claude_code.py | ✅ done | — |
+| Phase 2: Tests | ✅ done | — |
+| Code review checkpoint | ✅ done | — |
+| Phase 3: Examples + docs | ✅ done | — |
+| Phase 4: types.py + CHANGELOG | ✅ done | — |
+| Phase 5: Final verification | ⚠️ partial; blockers documented | — |
 
 GH follow-up issue filed: [#398](https://github.com/spinje/pflow/issues/398).
 
@@ -48,3 +48,132 @@ Smoke test run via Claude Max subscription (no `ANTHROPIC_API_KEY` set). Detaile
 - **`_build_llm_usage` extraction**: confirmed inline (no helper). Plan was ambiguous; pinned in `implementation-plan.md` Phase 1.7.
 - **`node_id` retrieval pattern**: confirmed `getattr(self, "node_id", None)` per `llm.py:795`; skip `__warnings__` if `None` per `llm.py:296`. Plan was ambiguous; pinned in Phase 1.8.
 - **Test mock for `ResultMessage`**: `@dataclass` (auto-populates `__annotations__` for the Phase 1.0 import probe). Plan was ambiguous; pinned in Phase 2.1.
+
+## 2026-05-15 — Implementation pass complete
+
+Replaced Claude Code schema prompt injection and regex JSON extraction with native SDK structured output:
+`ClaudeAgentOptions.output_format={"type": "json_schema", "schema": ...}` and `ResultMessage.structured_output`.
+`output_schema` now uses JSON Schema, rejects legacy Python-alias format, rejects empty dicts, rejects explicit non-object top-level `type`, and requires `max_turns >= 2` when schema is set.
+
+Code review checkpoint found two runtime issues beyond the original step list:
+
+| Finding | Resolution |
+|---|---|
+| SDK can yield `ResultMessage(is_error=True)` and then raise when the CLI exits non-zero, bypassing `post()` and losing intended soft-fail warnings | `_run_claude_session` now preserves accumulated result state when an error `ResultMessage` was seen before the trailing SDK exception; tests cover both `is_error` with and without structured output. |
+| Memo cache replay dropped root `__warnings__`, turning cached schema soft-failures from DEGRADED into SUCCESS | Memo writes now persist node warnings under reserved `__pflow_warnings__`; memo replay rehydrates `shared["__warnings__"][node_id]` while keeping reserved metadata out of `shared[node_id]`. Regression test added. |
+| Registry Interface exposed `__warnings__` as a template-visible node output | Removed from Interface blocks and docs output table; kept DEGRADED behavior documented in prose. Registry metadata test added. |
+| Agent-facing guidance still framed structured extraction as LLM-only or prompt-only | Updated core guide and MCP instruction resources to recommend templates for existing structured data and `output_schema` on `llm`/`claude-code` for model-derived structured data. |
+
+Deliberate deviations / non-changes:
+- Kept top-level `oneOf` / `anyOf` / `allOf` accepted at prep time. Reviewers recommended rejecting schemas without `type: object`, but the implementation plan explicitly says these pass prep and may fail at runtime; changing that would be a product decision, not an implementation correction.
+- Did not add local JSON Schema syntactic validation despite reviewer recommendation. The task explicitly defers centralized JSON Schema validation for both LLM and Claude Code nodes to issue #398; adding it here would create node drift.
+- Did not implement template-validator enrichment from static Claude Code schemas. That is useful, but not in Task 126's plan and would touch template validation/batch behavior broadly; should be a follow-up after #398 or alongside it.
+
+Verification performed:
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_nodes/test_claude/ tests/test_docs/test_example_validation.py tests/test_runtime/test_memoization_integration.py -q` → `71 passed`
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_core/test_markdown_parser.py::TestCodeBlockParsing::test_yaml_output_schema_block -q` → `1 passed`
+- Registry metadata probe confirmed outputs are `result`, `_schema_error`, `llm_usage` and params include `output_schema`, `disallowed_tools`, `max_turns`.
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m mypy` → success.
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m deptry src` → success.
+- Focused ruff on modified Python files → success.
+
+Verification blockers / residual failures:
+- Near-full sandbox pytest command reached `6780 passed, 19 skipped, 8 failed`. Five failures are subprocess tests invoking Homebrew `uv`, matching the sandbox-testing skill's known `uv` panic class (`Attempted to create a NULL object` / `Tokio executor failed`). Three additional workflow-executor/sub-workflow tests fail in isolation in files untouched by this task (`test_failed_node_invariant.py`, `test_prep_error_action.py`), returning `error` instead of expected routed actions or missing child trace events; treated as pre-existing branch blockers, not Task 126 regressions.
+- Full `ruff check .` fails on unrelated existing RUF043/RUF059 issues in tests outside this task. Focused ruff on modified Python files is clean.
+- Manual real Claude API smoke was not run because network/API workflows are outside this sandbox's reliable verification envelope; Phase 0 already covered real SDK/auth behavior and this pass preserved those findings.
+
+Cleanup:
+- Removed Phase 0 scratch artifacts from `scratchpads/task_126/`.
+
+## 2026-05-15 — Guide follow-up
+
+Added the missing `src/pflow/guide/nodes/claude-code.md` topic so `pflow guide claude-code` and workflow-scoped guide detection include the Claude Code node. Integrated it like the other node topics: dynamic registry interface injection, entry-menu and fallback listing, reserved workflow-name protection, and tests for direct topic rendering plus `.pflow.md` auto-detection.
+
+Kept the guide intentionally user-facing: it explains when to choose `claude-code`, the JSON Schema object-root requirement, `max_turns >= 2` with `output_schema`, and downstream result access. It deliberately does not mention SDK fields, warning-channel internals, or pflow implementation details.
+
+Verification:
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_cli/test_guide.py -q` -> `63 passed`
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m ruff check src/pflow/guide src/pflow/core/workflow/save_service.py tests/test_cli/test_guide.py` -> success
+- `HOME=/private/tmp/pflow-test-home .venv/bin/pflow guide claude-code` rendered the new topic with Parameters and Outputs appended from the registry.
+
+## 2026-05-15 — Manual CLI verification follow-up
+
+Manual pflow CLI verification created scratch workflows under `scratchpads/manual-pflow-verification/` and exercised:
+
+- `pflow --help`
+- `pflow guide core claude-code shell code file branching batch sub-workflows prompt-caching`
+- adjacent `pflow guide llm http mcp`
+- `--validate-only`, `--dry-run`, `--print`, `--output-format json`, `--only`, `-o`
+- `probe`, `read-fields`, `visualize`, `report`, `save`, `describe`, saved-name execution
+- real shell/code/file/sub-workflow execution with template JSON auto-parsing and branch convergence
+
+Finding: `claude-code` invalid `output_schema` shapes were rejected by normal execution prep, but `--validate-only` and `--dry-run` accepted them. This meant agents could get a clean preflight for workflows that would fail immediately at runtime before the SDK call.
+
+Fix: added static Claude Code structured-output parameter checks to `WorkflowValidator`, covering:
+
+- explicit non-object top-level `output_schema.type`
+- empty schema dict
+- legacy Python-alias schema format
+- `max_turns < 2` when `output_schema` is set
+- non-dict literal `output_schema`
+
+Regression tests:
+
+- `tests/test_cli/test_validate_only.py::TestValidateOnlyClaudeCodeStructuredOutput`
+- `tests/test_cli/test_dry_run.py::test_dry_run_rejects_claude_code_invalid_schema_before_plan`
+
+Verification:
+
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_cli/test_validate_only.py tests/test_cli/test_dry_run.py tests/test_nodes/test_claude/test_claude_code.py tests/test_runtime/test_memoization_integration.py -q` -> `105 passed`
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m ruff check src/pflow/core/workflow/validator.py tests/test_cli/test_validate_only.py tests/test_cli/test_dry_run.py` -> success
+- `HOME=/private/tmp/pflow-test-home .venv/bin/python -m mypy` -> success
+- Post-fix near-full sandbox pytest command reached `6790 passed, 19 skipped, 4 failed`. All four failures are subprocess tests invoking `/opt/homebrew/bin/uv`, matching the sandbox `uv` panic class (`Attempted to create a NULL object` / `Tokio executor failed`).
+
+Residual manual observation: an unauthenticated Claude CLI can yield `is_error=True` with result text like `Not logged in · Please run /login`; current Task 126 semantics treat schema-path SDK error results as DEGRADED soft-failures and memo-cacheable node outputs. That behavior is explicitly pinned by existing tests, so this pass did not change it.
+
+## 2026-05-15 — Independent verification pass + three fixes
+
+Adversarial CLI verification (real `claude` subscription auth, no API key) executed both happy path and edge cases through `pflow --validate-only`, `--dry-run`, and `--output-format json`. Live structured-output run succeeded: `{"status": "ok"}`, $0.087, ~14s. Confirmed cleanly working: DEGRADED propagation through batch/sub-workflow/`--only`, memo cache replay via `__pflow_warnings__`, recursive sub-workflow validation, all literal `_validate_claude_code_params` branches, registry exposes `_schema_error` as an output and hides `__warnings__`.
+
+Three real bugs found and fixed.
+
+| Finding | Fix | Verification |
+|---|---|---|
+| **#1 Validator regression**: Templated `output_schema: ${upstream.field}` rejected at preflight ("got str") even though runtime `_validate_schema` handles it correctly. Confirmed via `git stash` round-trip — pre-Task 126 accepted the composition pattern. Asymmetric within the same method (`max_turns` defers on `int()` failure; `output_schema` hard-rejects) and across nodes (LLM node has no equivalent gate). Zero test coverage. | `validator.py:701-706`: 5-line guard that defers template strings (substring `${`) to runtime, matching the `max_turns` policy. | Live `composed-schema.pflow.md`: upstream code node builds JSON Schema → claude consumes via template → returns `{"status": "ok"}`, status `success`. Manual breaking tests for empty/array/legacy/max_turns=1 still reject at preflight (no regression). |
+| **#2 Hard-error swallowing in `_run_claude_session`**: Once `is_error_from_sdk` was set on any earlier `ResultMessage`, the catch-all `except Exception` silently swallowed every subsequent raise — including `CLINotFoundError`, `CLIConnectionError`, `ProcessError`. Users lost the remediation messages in `exec_fallback` ("Install with: npm install -g …", "Run `claude doctor`"). | `claude_code.py:624-639`: narrowed the swallow to `ProcessError` only (the actual SDK pairing with `ResultMessage(is_error=True)`). Other exception types re-raise so the Node retry path delivers them to `exec_fallback`. | Two unit tests: `test_sdk_is_error_branch` (updated) and `test_sdk_is_error_with_structured_output_emits_warning` (updated) now use `ProcessError` with stderr; new `test_non_process_error_after_is_error_re_raises` asserts `CLIConnectionError` propagates instead of being swallowed. |
+| **#3 Templated `output_schema` resolving to `None` silently downgraded to free-form mode**: `_validate_schema(None)` returns None; `_build_claude_options` skipped wiring `output_format`; the run returned plain text with workflow status `success`. Author who wrote `output_schema:` got no signal that their schema reference missed. | `claude_code.py:418-424` + new `_emit_schema_resolved_null_warning` helper: detects "key present in `self.params` and value is None" in `prep()`, writes `__warnings__[node_id]` with kind `claude_code.output_schema_resolved_to_null`; falls back to `_schema_error` when no `node_id` is bound. | Live `null-templated-schema.pflow.md`: upstream returns None → claude runs free-form → workflow status `degraded`, warning surfaces with the new kind in both `warnings` and `diagnostics` JSON arrays. Three unit tests cover the three branches. |
+
+ProcessError test mock at `test_claude_code.py:68-75` updated so `str(exc)` returns the stderr text — matches the real SDK behavior and lets `sdk_exception_text` capture something meaningful.
+
+Verification:
+- `uv run pytest --ignore=tests/test_llm` → `6820 passed, 10 skipped` (5 net new tests).
+- `uv run ruff check` on touched files → clean.
+- `uv run mypy` → `Success: no issues found in 207 source files`.
+- Live `composed-schema.pflow.md` run → `success`, structured `{"status": "ok"}`.
+- Live `null-templated-schema.pflow.md` run → `degraded`, new warning visible.
+- Six existing breaking-test workflows under `scratchpads/manual-pflow-verification/breaking/` all still produce the correct preflight verdict.
+
+Three reviewer agents (review-validation-consistency, review-silent-failures, review-feature-interactions) ran in parallel against the original implementation; their full transcripts informed the three fixes plus a residual non-blocking observation: soft-fail message text does not currently overlap with `api_warning_detector`'s `"schema error"`/`"does not match"` patterns, but the messages are not pinned by a regression test — a future reword that includes those substrings would silently flip soft-fail → hard error. Worth pinning if message text changes.
+
+Out of scope for this pass (deliberate):
+- Finding #4 (warning lost when `node_id is None` and `is_error AND structured_output present`) — test-only path; the LLM node uses the same `node_id is not None` guard. Documented but not fixed.
+- Finding #5 (api_warning_detector pattern collision regression test) and #6 (docstring clarification that soft-fail returns `"default"`) — user-scoped to critical-only.
+- Centralized JSON Schema syntactic validation across nodes — already tracked at issue [#398](https://github.com/spinje/pflow/issues/398).
+
+## 2026-05-15 — Remaining verification findings (#4 / #5 / #6) addressed
+
+| Finding | Fix | Verification |
+|---|---|---|
+| **#4 Soft-fail signal lost when `node_id is None`**: in `_store_results`, the `is_error_from_sdk AND structured_output present` branch wrote `__warnings__[node_id]` only when `node_id` was bound — leaving callers in the test / direct-`node.run()` path with no signal at all. The no-output branch already wrote `_schema_error` unconditionally; this branch did not. | Added `_emit_soft_fail_signal` helper that writes `_schema_error` via `setdefault` (preserves prior writes) and `__warnings__[node_id]` when bound. Both schema-path branches now route through it. Also extracted a `_store_schema_result` helper to keep `_store_results` under the C901 complexity limit. Docstring + `_schema_error` interface description updated to broaden the semantics ("set when structured output was unavailable, the SDK reported an error alongside the output, or the schema reference resolved to None"). | New unit test `test_sdk_error_with_structured_output_no_node_id_falls_back_to_schema_error`. Existing `test_sdk_is_error_with_structured_output_emits_warning` still passes. |
+| **#5 No regression pin for soft-fail message strings vs `api_warning_detector`**: original reviewer concern was that a future reword of the soft-fail message into a `VALIDATION_PATTERNS` substring (e.g. `"schema error"`, `"does not match"`) would silently flip soft-fail → hard error. My first draft tested the message strings against `_is_validation_error` directly, which immediately fired on `"required fields"` — but `extract_error_message` is shape-gated (only fires on `ok: false` / `success: false` / `status: "error"` / GraphQL `errors` / `error` key), so claude-code's `{result, _schema_error, llm_usage}` shape never reaches `_is_validation_error` in production. False alarm. | Rewrote the test as a black-box integration check: build the exact `shared[node_id]` shape `_store_results` produces on the schema-not-satisfied path, then call `detect_api_warning("review", shared)` and assert it returns `None`. The invariant is now the actual production property (output shape doesn't match the detector's extraction gates), not a message-string equality. A future contributor adding an `error`/`ok`/`success`/`status` key to claude-code output for debug visibility breaks this test before the regression ships. | New unit test `test_soft_fail_output_shape_not_classified_as_api_warning`. |
+| **#6 Docstring did not document the `default`-only routing contract**: workflow authors wiring `- on-error: handler` could reasonably expect schema misses to route there; they don't. | Class docstring `Note:` block adds an explicit "Routing:" paragraph. Module + class `_store_results` docstring gains a "Lifecycle action" rule. `docs/reference/nodes/claude-code.mdx` Output table gets an `always returns default` paragraph. `src/pflow/guide/nodes/claude-code.md` adds a new "Recovering from schema soft-failures" section with a code-node branching pattern using `${node._schema_error ?? ""}`. `examples/nodes/claude-code/README.md` calls out the same invariant where it lists the soft-fail signals. | `pflow guide claude-code` rendered the new section. Existing guide-internals test (`test_claude_code_guide_documents_structured_output_without_internals`) caught a phrasing slip — "SDK" was banned from the user-facing guide; reworded to "provider error". |
+
+Verification:
+- `uv run pytest --ignore=tests/test_llm` → `6822 passed, 10 skipped` (2 net new tests, no regressions).
+- `uv run ruff check src/pflow/nodes/claude/claude_code.py …` → success (`_store_schema_result` + `_emit_soft_fail_signal` extraction kept `_store_results` under C901 limit of 10; the original Fix #4 in-place edit pushed it to 11).
+- `uv run mypy` → `Success: no issues found in 207 source files`.
+- Live `claude-code-structured-valid.pflow.md` re-run (cached) → `success`, `result: {"status": "ok"}`. No regression to happy path.
+- All 14 breaking-test workflows under `scratchpads/manual-pflow-verification/breaking/` still produce the correct preflight verdict.
+
+Deliberate non-change:
+- Did NOT touch the LLM node's analogous `node_id is None` guard. The LLM node has the same pattern at `nodes/llm/llm.py:296`; this passes loses signal in the same way for the same reason. Consistency between the two nodes is preferable to one-off divergence; if the gap matters, fix both together in a follow-up touching both call sites.

--- a/.taskmaster/tasks/task_126/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_126/implementation/progress-log.md
@@ -1,0 +1,50 @@
+# Task 126 Progress Log
+
+## Status
+
+| Phase | Status | Commit |
+|---|---|---|
+| Prework: SDK upgrade to 0.2.82 | ✅ done | `8cadd39c` |
+| Phase 0: SDK smoke test | ✅ done | `8cadd39c` |
+| Phase 1: Refactor claude_code.py | ⏳ next | — |
+| Phase 2: Tests | pending | — |
+| Code review checkpoint | pending | — |
+| Phase 3: Examples + docs | pending | — |
+| Phase 4: types.py + CHANGELOG | pending | — |
+| Phase 5: Final verification | pending | — |
+
+GH follow-up issue filed: [#398](https://github.com/spinje/pflow/issues/398).
+
+## 2026-05-15 — Prework complete
+
+`claude-agent-sdk` floor bumped `>=0.1.17` → `>=0.2.82`. Latest published version is 0.2.82 (released same day); chose it over 0.1.81 (last 0.1.x) per user direction. Field compatibility verified before bump: `ClaudeAgentOptions.output_format` and `ResultMessage.structured_output` both present; old-version fields are a strict subset of 0.2.82's.
+
+`uv lock` resolved cleanly. `uv sync` installed. **Existing test suite passes: 47/47 Claude Code tests** against the upgraded SDK without code changes — confirms field-level backwards compatibility.
+
+## 2026-05-15 — Phase 0 complete
+
+Smoke test run via Claude Max subscription (no `ANTHROPIC_API_KEY` set). Detailed findings: `phase-0-findings.md`. Plan-altering surprises propagated into `implementation-plan.md`:
+
+| Phase 0 surprise | Plan change |
+|---|---|
+| API rejects non-object top-level schemas (`type: array`, primitives) with `400 tools.9.custom.input_schema.type: Input should be 'object'` | `_validate_schema` (Phase 1.2) now rejects at prep time with clear error pointing to wrapper workaround. `test_array_top_level_schema` and `test_primitive_top_level_schema` removed; `test_top_level_array_schema_rejected` + `test_top_level_primitive_schema_rejected` added. Edge case table updated. |
+| `max_turns: 1` fails for structured output with opaque "Reached maximum number of turns" | New Phase 1.2b added: cross-cutting validation in `prep` requires `max_turns >= 2` when `output_schema` is set. New test `test_max_turns_too_low_with_schema_rejected`. |
+| Schema typos (e.g. `type: intger`) silently accepted by API → soft-fail with misleading "model didn't comply" message | No code change in Task 126 (would duplicate logic with LLM node). Documented in `_validate_schema` docstring; concretely motivates #398. |
+| Subscription auth via bundled `claude` CLI works zero-config | Phase 5.4 manual-smoke wording updated to drop API-key requirement for subscription users. |
+
+## Open items for implementing agent
+
+1. **First task**: Phase 1 of `implementation-plan.md` — refactor `src/pflow/nodes/claude/claude_code.py`. Read `phase-0-findings.md` first (linked from plan's Orientation section).
+
+2. **`oneOf`/`anyOf`/`allOf` top-level untested**: Phase 0 only probed `type: array` and primitive top-levels. `_validate_schema` currently passes these through (no top-level `type` key → no rejection). If real-world usage shows the API also rejects these wrappers, tighten the validation. Test `test_oneOf_top_level_schema_accepted` may need updating if behavior is discovered different.
+
+3. **SDK 0.2.82 added fields not yet used** (`ResultMessage.errors`, `stop_reason`, `api_error_status`). Not in scope; mentioned in `phase-0-findings.md` if a natural use emerges during Phase 1.
+
+4. **Scratchpads cleanup at Phase 5.6**: `scratchpads/task_126/` contains the smoke test script + raw output. Not committed. Delete in Phase 5.6.
+
+## Decisions made during prework (not in task spec or plan)
+
+- **Target SDK**: 0.2.82 (latest, released same-day) over 0.1.81 (last 0.1.x). User-directed choice. Risk acknowledged: 0.2.x is a fresh major bump; rolling back to 0.1.81 remains an option if Phase 1+ surfaces 0.2-specific breakage.
+- **`_build_llm_usage` extraction**: confirmed inline (no helper). Plan was ambiguous; pinned in `implementation-plan.md` Phase 1.7.
+- **`node_id` retrieval pattern**: confirmed `getattr(self, "node_id", None)` per `llm.py:795`; skip `__warnings__` if `None` per `llm.py:296`. Plan was ambiguous; pinned in Phase 1.8.
+- **Test mock for `ResultMessage`**: `@dataclass` (auto-populates `__annotations__` for the Phase 1.0 import probe). Plan was ambiguous; pinned in Phase 2.1.

--- a/.taskmaster/tasks/task_126/task-126.md
+++ b/.taskmaster/tasks/task_126/task-126.md
@@ -1,96 +1,206 @@
 # Task 126: Structured Output for Claude Code Node
 
 ## Description
-Add structured output support to the Claude Code node, allowing workflow authors to specify an expected output schema so Claude Code returns typed/structured data (e.g., JSON objects) rather than free-form text. This is the Claude Code equivalent of Task 66 (structured output for LLM node).
+
+Migrate the Claude Code node's `output_schema` from a custom Python-alias format with prompt-injection + regex JSON extraction to **native `claude_agent_sdk` structured output**, using **JSON Schema** as the user-facing format (consistent with the LLM node, Task 66). Soft-failures additionally emit a `__warnings__` entry so workflow status becomes `DEGRADED` (agent-visible).
 
 ## Status
-not started
 
-## Dependencies
-- Task 42: Claude Code Agentic Node (done)
+Ready for implementation. Prework completed:
+- SDK upgraded to `claude-agent-sdk>=0.2.82` (`pyproject.toml` + `uv.lock`); existing test suite passes (47/47 Claude Code tests)
+- Phase 0 smoke test executed; findings captured in [`implementation/phase-0-findings.md`](./implementation/phase-0-findings.md)
+
+Implementation plan: [`implementation/implementation-plan.md`](./implementation/implementation-plan.md).
 
 ## Priority
+
 medium
 
-## Details
+## Dependencies
 
-### Problem
-The Claude Code node currently returns free-form text output. When used as part of a larger workflow, downstream nodes often need structured data (JSON objects, lists, specific fields). Without structured output, workflow authors must parse free-form text or add explicit "return JSON" instructions to prompts — which is fragile and error-prone.
+- Task 42: Claude Code Agentic Node (done)
+- Task 66: Structured Output for LLM Node (done — sets the LLM node baseline this task aligns with)
 
-### Proposed Solution
-Add an `output_schema` parameter to the Claude Code node that instructs Claude to return data matching a specified schema.
+## Problem
+
+The Claude Code node already supports `output_schema`, but in a custom format inconsistent with the LLM node:
 
 ```yaml
-- id: analyze_pr
-  type: claude-code
-  params:
-    prompt: "Analyze this PR and identify issues"
-    output_schema:
-      type: object
-      properties:
-        issues:
-          type: array
-          items:
-            type: object
-            properties:
-              file: { type: string }
-              line: { type: integer }
-              severity: { type: string, enum: [critical, warning, info] }
-              description: { type: string }
-        summary: { type: string }
-        approval_recommendation: { type: boolean }
+# Current Claude Code (Python-alias custom format)
+risk_level:
+  type: str          # ← Python alias, not JSON Schema
+  description: high/medium/low
+score:
+  type: int
+  description: 1-10
 ```
 
-### Implementation Considerations
-
-1. **Claude Agent SDK support**: Investigate whether the Claude Agent SDK / CLI supports structured output natively (e.g., via `--output-format json` or similar). If so, leverage that mechanism.
-
-2. **Prompt-based fallback**: If no native SDK support, inject schema instructions into the system prompt and parse/validate the response.
-
-3. **Validation**: Validate the returned output against the schema. If validation fails, consider retry with error feedback (similar to how LLM structured output tools work).
-
-4. **Output key**: The structured output should be placed in the node's output key as a parsed object (dict/list), not as a JSON string, so downstream template resolution works naturally (e.g., `${analyze_pr.issues[0].severity}`).
-
-### Relationship to Task 66
-Task 66 covers structured output for the LLM node. The implementation patterns should be consistent across both nodes where possible, but the mechanisms may differ since Claude Code uses the Agent SDK while the LLM node uses Simon Willison's `llm` library.
-
-### Example Usage (Markdown Workflow Format)
-
-```markdown
-## analyze_pr
-- type: claude-code
-- prompt: "Analyze the codebase for security vulnerabilities"
-- output_schema:
-    type: object
-    properties:
-      vulnerabilities:
-        type: array
-        items:
-          type: object
-          properties:
-            file: { type: string }
-            severity: { type: string }
-            description: { type: string }
-      risk_score: { type: number }
-
-## report
-- type: llm
-- prompt: "Write a security report based on: ${analyze_pr.vulnerabilities}"
+```yaml
+# Current LLM node (real JSON Schema, since Task 66)
+type: object
+properties:
+  risk_level: { type: string, enum: [high, medium, low] }
+  score: { type: integer, minimum: 1, maximum: 10 }
+required: [risk_level, score]
 ```
 
-## Test Strategy
+The current Claude Code implementation works via:
+1. **Prompt-injection** — `_build_schema_prompt` embeds a 30-line "RESPOND WITH JSON ONLY" instruction block into the system prompt, with the Python-alias type names rendered literally (e.g., `"<str: high/medium/low>"`)
+2. **Regex extraction** — three fallback strategies (`_extract_json_from_code_block`, `_extract_json_from_raw_object`, `_extract_json_from_last_brace`) attempt to recover JSON from the model's free-form text response
 
-### Unit Tests
-1. Schema parameter parsing and validation
-2. Output validation against provided schema
-3. Structured output placed as parsed object in shared store (not JSON string)
-4. Missing `output_schema` → default behavior (free-form text output)
+Costs of the status quo:
+- **Inconsistent user-facing syntax** between LLM and Claude Code nodes (workflow authors write JSON Schema for one, custom format for the other)
+- **Fragile** — relies on the model honoring prompt instructions; no provider-side enforcement
+- **Verbose system prompt** competes with the user's own system_prompt
+- **Regex extraction** can silently mis-parse complex/nested JSON
+- **`core/types.py:8-12`** carved `output_schema` out of the type-vocabulary unification (Task 154) specifically because the Python-alias names were embedded in the prompt template — an architectural debt
 
-### Integration Tests
-1. End-to-end: Claude Code returns structured data matching schema (mocked SDK)
-2. Downstream template resolution works with structured output fields
+`claude_agent_sdk` v0.2.82+ now natively supports structured output via `ClaudeAgentOptions.output_format={"type": "json_schema", "schema": ...}`, which the SDK forwards to the underlying CLI via `--json-schema`. The CLI returns the parsed result as `ResultMessage.structured_output: Any`. This makes prompt-injection and regex extraction unnecessary.
 
-### Edge Cases
-1. Claude returns invalid JSON → appropriate error message
-2. Claude returns JSON that doesn't match schema → validation error with details
-3. Empty/null output handling
+## Solution
+
+Replace the prompt-injection + regex-extraction approach with direct SDK usage:
+
+1. Pass the user's `output_schema` (now JSON Schema) to `ClaudeAgentOptions.output_format` (SDK handles wire-format and provider negotiation)
+2. Read `ResultMessage.structured_output` directly — already parsed by the CLI
+3. Delete `_build_schema_prompt`, `_extract_json`, and the three extraction helpers
+4. Add `_validate_schema` legacy-format detection that points old workflows at the new format
+5. Migrate the 3 example workflows + docs to JSON Schema
+
+Preserve the existing **soft-failure** semantics (`action="default"`, `shared["_schema_error"]` set when the schema isn't satisfied — diverges from the LLM node's hard-error path because Claude Code agentic sessions are expensive and downstream nodes may still want the raw text). Additionally write a `__warnings__` entry so workflow status surfaces as `DEGRADED` — important for agent-readable error visibility.
+
+## Design Decisions
+
+### Native SDK `output_format`, not prompt-injection upgrade
+
+The Claude Code SDK (`claude_agent_sdk>=0.2.82`) natively translates `output_format` to a `--json-schema` CLI flag that constrains the model's final output at the provider level. This is strictly better than prompt-injection: provider-enforced compliance, no regex parsing of free-form text, no verbose prompt boilerplate competing with the user's own system_prompt.
+
+Alternative considered: keep prompt-injection but switch the format to JSON Schema. Rejected — still fragile, still requires regex extraction, still bloats the system prompt.
+
+### JSON Schema, hard cutover (no backwards compatibility)
+
+Per `CLAUDE.md`: "We have NO USERS yet. No backwards compatibility concerns." The Python-alias format is a Task-42-era artifact predating the LLM node's JSON Schema adoption. Aligning both nodes on JSON Schema gives workflow authors a single mental model.
+
+A legacy-format detector in `_validate_schema` produces a clear migration error for any local workflow still using the old format. No silent acceptance, no shim, no dual-format support.
+
+### Soft-failure preserved (action="default" + `_schema_error`), with `__warnings__` added
+
+The LLM node returns `action="error"` on schema parse failure — hard error, retry path possible. The Claude Code node has historically returned `action="default"` with `shared["_schema_error"]` set, treating schema failure as graceful degradation.
+
+Reason for the divergence: Claude Code sessions are expensive (~$0.05+ per attempt) and often agentic (file edits, tool use). On schema failure, the raw text is frequently still useful for downstream nodes to salvage. Forcing a hard error and triggering retries can waste $$ on the same model behavior.
+
+**New in this task**: also write `shared["__warnings__"][node_id] = {kind, text, context}` so workflow status transitions to `DEGRADED` (via `runtime/workflow_trace.py:457-466`). This makes schema failures visible to AI agents reading `pflow ... --output-format json` without requiring them to know about the `_schema_error` side-channel.
+
+### `is_error=True` AND `structured_output` present: prefer `structured_output`
+
+The CLI may report `is_error=True` for non-fatal sub-errors while still producing valid structured output. Treat as success (use `structured_output` as the result), but emit a `__warnings__` entry so the error signal isn't silently dropped.
+
+### Top-level `type: object` enforced (Claude-API-specific limitation)
+
+Phase 0 smoke test discovered that the Anthropic API rejects non-object top-level schemas when the SDK wraps `output_format` as a tool's `input_schema` (error: `400 tools.9.custom.input_schema.type: Input should be 'object'`). This affects `type: array`, `type: string`, `type: integer`, and other primitive top-level types.
+
+This is **specific to the Claude Code node** — the LLM node has no such restriction (LiteLLM/OpenAI accept top-level non-object schemas).
+
+`_validate_schema` catches this at prep time with a clear error pointing the user at the workaround (wrap in `{"type": "object", "properties": {"items": <user_schema>}}`) and noting the LLM node alternative. Without this check, users would see the opaque API 400 surface as a `is_error=True` soft-fail with the generic "Claude CLI reported an error" message.
+
+### `max_turns >= 2` enforced when `output_schema` is set
+
+Phase 0 smoke test discovered that `max_turns: 1` is insufficient for structured output — the agent needs at least 2 turns (one to plan, one to emit). The SDK raises `"Reached maximum number of turns (1)"` otherwise. `prep` catches this cross-cutting constraint with a clear error.
+
+### Empty schema `{}` is an error, not a no-op
+
+`output_schema: None` (key absent) = "no schema requested" → no-op (correct).
+`output_schema: {}` (empty dict) → almost certainly a user typo (e.g., forgot to populate the YAML block). Raise with explicit guidance instead of silently disabling structured output.
+
+### Sticky `is_error` across multiple `ResultMessage`s
+
+If the SDK streams multiple `ResultMessage`s in one session, `is_error=True` on any of them persists through subsequent messages (`is_error_from_sdk = is_error_from_sdk or message.is_error`). Prevents silent error swallowing when a later message claims success after an intermediate failure.
+
+### SDK field-presence probe at module import
+
+`hasattr(ResultMessage, "__annotations__") and "structured_output" in ResultMessage.__annotations__` — fails the import loudly if the SDK is too old or has renamed the field. Without this, a renamed field would silently return `None` via `getattr`, and every Claude Code workflow would soft-fail with a "model didn't comply" message blaming the model when pflow is at fault.
+
+### JSON Schema syntactic validation deferred to issue #398
+
+Neither node currently validates that `output_schema` is itself well-formed JSON Schema (typos like `type: intger`, malformed nesting, etc.). Adding this to the Claude Code node alone would duplicate logic with the LLM node, which deserves the same treatment.
+
+The architecturally correct placement (`WorkflowValidator` step between current 8 and 9, with a `JSON_SCHEMA_PARAMS` frozenset) is a cross-cutting concern. Filed as **GitHub issue #398**. This task trusts the SDK boundary, matching the LLM node's current behavior; the follow-up issue adds local validation to both nodes uniformly.
+
+### Inline `_build_prompt` and `_build_system_prompt`
+
+After removing schema-related framing, both methods become one-liner pass-throughs. Inline at call sites — top-10% codebases avoid trivial wrapper methods.
+
+### Delete the `core/types.py` "fourth surface" carve-out
+
+The comment at `core/types.py:8-12` exists specifically because the Python-alias names were load-bearing in `_build_schema_prompt`'s template strings. After this task, the comment's premise no longer holds. Delete entirely (don't rewrite) — the relevant information lives in the user-facing docs.
+
+## Requirements
+
+### User-facing behavior
+
+- Workflow authors write JSON Schema in ` ```yaml output_schema ` blocks on `claude-code` nodes, identical syntax to LLM nodes
+- **Top-level MUST be `type: object`** on this node (Claude API tool-input-schema limitation discovered in Phase 0; the LLM node has no such restriction). For array/primitive outputs, wrap in an object. Validation surfaces a clear error at `prep` time.
+- `oneOf`/`anyOf`/`allOf` at the top level pass `prep` validation; runtime success depends on the API (Phase 0 did not probe — may also be rejected)
+- Schemas can be inlined or referenced via `- output_schema: ./schema.yaml` (no change to file_resolver behavior)
+- The legacy Python-alias format (`{"field": {"type": "str", ...}}`) produces a clear migration error at `prep` time
+- Empty schema `{}` produces a clear "did you forget the schema body?" error
+- `max_turns >= 2` is enforced at `prep` time when `output_schema` is set (Phase 0 finding: structured output needs at least 2 turns)
+- Auth: subscription users (Claude Pro/Max/Team via the bundled `claude` CLI's OAuth login) work zero-config — no `ANTHROPIC_API_KEY` needed. Setting `ANTHROPIC_API_KEY` forces pay-as-you-go billing.
+
+### Result placement (`shared["result"]`)
+
+- No schema set: free-form text (`str`)
+- Schema set + `structured_output` populated: parsed dict / list / primitive
+- Schema set + `structured_output` is `None`: raw text fallback (preserves Claude Code's soft-fail tradition)
+
+### Error/warning signaling
+
+- Soft-fail (schema set but unsatisfied): `shared["_schema_error"]` set to a human-readable string AND `shared["__warnings__"][node_id]` set to `{kind, text, context}` → workflow status `DEGRADED`
+- `is_error=True` + `structured_output` present: `structured_output` becomes `shared["result"]` BUT a `__warnings__` entry is still emitted
+- `kind` strings: `"claude_code.schema_not_satisfied"` (model didn't comply) and `"claude_code.sdk_error_no_structured_output"` (CLI reported error) and `"claude_code.sdk_error_with_structured_output"` (CLI errored but structured output is usable)
+- Hard errors (SDK raises, timeout, network) continue to flow through existing `exec_fallback` — unchanged
+
+### Compatibility / drift protection
+
+- Module-import-time probe raises `ImportError` if `claude_agent_sdk.types.ResultMessage` lacks the `structured_output` field — prevents silent failures when the SDK is too old or has renamed the field
+- `pyproject.toml` `claude-agent-sdk` floor bumped to `>=0.2.82` (already done as prework before plan handoff; lockfile resolved to 0.2.82, existing test suite passes)
+
+### Documentation parity
+
+- Module docstring AND class docstring on `claude_code.py` both updated (registry reads one; humans read both)
+- `docs/reference/nodes/claude-code.mdx`, `architecture/core-node-packages/claude-nodes.md`, and `examples/nodes/claude-code/README.md` all reflect JSON Schema format + the new `__warnings__`/`DEGRADED` behavior
+- 3 example workflows under `examples/nodes/claude-code/` migrated to JSON Schema
+- `core/types.py` "fourth surface" carve-out comment (lines 8–12) deleted
+- `tests/CLAUDE.md` pitfall #17 updated to describe the new `ResultMessage` mock class
+
+### Test coverage
+
+- New tests for: `output_format` wiring, legacy-format rejection, all-values legacy detection, `oneOf` top-level (accepted by prep), top-level array/primitive (rejected by prep), `max_turns: 1` with schema rejected, empty `{}` rejection, `None` no-op, structured_output as dict, `__warnings__` writes on soft-fail and `is_error+structured_output`, sticky `is_error` across multi-message streams
+- Existing tests for "valid Python identifier keys" / "≤50 keys" / `_build_schema_prompt` / `_extract_json*` deleted
+- All `_schema_error` assertions use substring matching (`"X" in shared["_schema_error"]`), not exact equality
+
+### Verification
+
+- `make test` passes (full suite)
+- `make check` passes (ruff + mypy)
+- `tests/test_docs/test_example_validation.py` passes (migrated examples remain valid)
+- `pflow registry list claude-code` shows the updated Interface description
+- One migrated example runs end-to-end against the real API and produces structured downstream data accessible via templates like `${review.result.field}`
+
+## Out of scope
+
+- **Centralized JSON Schema syntactic validation across all nodes** — see GitHub issue #398
+- **`pflow guide` page for claude-code** — no existing page; file as a separate task
+- **`claude_client.py` adapter** module analogous to `llm_client.py` — `claude_agent_sdk` has one consumer; premature
+- **Per-node retry on schema mismatch** — soft-fail is the chosen semantics
+- **Backwards-compatibility shim** for the legacy Python-alias format — no users
+- **Legacy → JSON Schema converter tool** — out of scope per "no users yet"
+
+## References
+
+- **Implementation plan**: [`implementation/implementation-plan.md`](./implementation/implementation-plan.md) (the step-by-step *how*)
+- **Follow-up issue**: [#398](https://github.com/spinje/pflow/issues/398) — Centralized JSON Schema validation for `output_schema` across nodes
+- **Builds on**: Task 66 (LLM structured output, completed), Task 42 (Claude Code Agentic Node, completed)
+- **Related tasks**: Task 143 (Unified Diagnostic System), Task 147 (Validator Produces Diagnostics Natively), Task 150 (WorkflowValidator on save path), Task 154 (Type Vocabulary Coherence — claude_code carve-out resolved by this task), Task 158 (LiteLLM migration — LLM node's structured output path post-migration)
+- **Starting-context braindump** (pre-Task 158, partially outdated): [`starting-context/braindump-task66-completed-task126-next.md`](./starting-context/braindump-task66-completed-task126-next.md)
+- **SDK reference**: `claude_agent_sdk>=0.2.82` — `ClaudeAgentOptions.output_format`, `ResultMessage.structured_output`

--- a/.taskmaster/tasks/task_126/task-126.md
+++ b/.taskmaster/tasks/task_126/task-126.md
@@ -140,7 +140,7 @@ The comment at `core/types.py:8-12` exists specifically because the Python-alias
 
 - Workflow authors write JSON Schema in ` ```yaml output_schema ` blocks on `claude-code` nodes, identical syntax to LLM nodes
 - **Top-level MUST be `type: object`** on this node (Claude API tool-input-schema limitation discovered in Phase 0; the LLM node has no such restriction). For array/primitive outputs, wrap in an object. Validation surfaces a clear error at `prep` time.
-- `oneOf`/`anyOf`/`allOf` at the top level pass `prep` validation; runtime success depends on the API (Phase 0 did not probe — may also be rejected)
+- `oneOf`/`anyOf`/`allOf`/`enum` at the top level are rejected at `prep` time (verified via the oneOf follow-up probe: all return HTTP 400 from the Anthropic API). Combinators must live inside an object wrapper.
 - Schemas can be inlined or referenced via `- output_schema: ./schema.yaml` (no change to file_resolver behavior)
 - The legacy Python-alias format (`{"field": {"type": "str", ...}}`) produces a clear migration error at `prep` time
 - Empty schema `{}` produces a clear "did you forget the schema body?" error
@@ -175,7 +175,7 @@ The comment at `core/types.py:8-12` exists specifically because the Python-alias
 
 ### Test coverage
 
-- New tests for: `output_format` wiring, legacy-format rejection, all-values legacy detection, `oneOf` top-level (accepted by prep), top-level array/primitive (rejected by prep), `max_turns: 1` with schema rejected, empty `{}` rejection, `None` no-op, structured_output as dict, `__warnings__` writes on soft-fail and `is_error+structured_output`, sticky `is_error` across multi-message streams
+- New tests for: `output_format` wiring, legacy-format rejection, all-values legacy detection, top-level `oneOf`/`anyOf`/`allOf`/missing-`type` (rejected by prep), top-level array/primitive (rejected by prep), object wrapper with `oneOf` inside (accepted), `max_turns: 1` with schema rejected, empty `{}` rejection, `None` no-op, structured_output as dict, `__warnings__` writes on soft-fail and `is_error+structured_output`, sticky `is_error` across multi-message streams
 - Existing tests for "valid Python identifier keys" / "≤50 keys" / `_build_schema_prompt` / `_extract_json*` deleted
 - All `_schema_error` assertions use substring matching (`"X" in shared["_schema_error"]`), not exact equality
 

--- a/.taskmaster/tasks/task_126/task-review.md
+++ b/.taskmaster/tasks/task_126/task-review.md
@@ -1,0 +1,371 @@
+# Task 126 Review: Structured Output for Claude Code Node
+
+## Metadata
+
+- **Implementation Date**: 2026-05-15 (single day; SDK 0.2.82 released same day)
+- **Branch**: `feat/claude-code-structured-output`
+- **Commits**: `8cadd39c` (plan handoff + SDK bump) → `464d8181` (progress log) → `73128956` (implementation) → `6954cfb4` (post-impl fixes)
+- **Follow-up issue**: [#398](https://github.com/spinje/pflow/issues/398) — Centralized JSON Schema syntactic validation
+- **Companion docs**: `task-126.md` (what/why), `implementation/implementation-plan.md` (how), `implementation/phase-0-findings.md` (SDK smoke-test discoveries), `implementation/progress-log.md` (chronological journey including 3 verification passes)
+
+## Executive Summary
+
+Replaced Claude Code's prompt-injected + regex-extracted structured output with `claude_agent_sdk` v0.2.82's native `output_format`/`ResultMessage.structured_output`. JSON Schema is now the canonical user-facing format on both `llm` and `claude-code` nodes. Soft-failures additionally write `shared["__warnings__"][node_id]` so workflow status surfaces as `DEGRADED` (agent-visible without knowing the `_schema_error` side-channel). Scope grew during implementation to include four cross-cutting fixes — memo cache warning rehydration, validator/runtime preflight parity, narrowed SDK exception swallow, and a new `pflow guide claude-code` topic — none of which were in the original plan.
+
+## Implementation Overview
+
+### What Was Built
+
+**Core swap** (`src/pflow/nodes/claude/claude_code.py`, ~1060 lines, ~50% rewrite):
+- Deleted: `_build_schema_prompt` + 4-helper regex chain (`_extract_json`, `_extract_json_from_code_block`, `_extract_json_from_raw_object`, `_extract_json_from_last_brace`).
+- Added: `ClaudeAgentOptions.output_format={"type": "json_schema", "schema": <user-schema>}` wired in `_build_claude_options`; `structured_output` read directly from `ResultMessage` in `_run_claude_session`.
+- Added: module-import-time probe (`claude_code.py:78-83`) that raises `ImportError` if `ResultMessage` lacks `structured_output` annotation. Protects against silent SDK field renames.
+- Added: `_validate_schema` rejects empty `{}`, legacy Python-alias format, top-level non-object (including missing `type` and `oneOf`/`anyOf`/`allOf`/`enum` at root — Phase 0 + follow-up probe showed API rejects all of these).
+- Added: `prep()` cross-check requires `max_turns >= 2` when `output_schema` is set.
+- Added: `_emit_schema_resolved_null_warning` for templated `output_schema: ${upstream.field}` that resolved to None (silent downgrade catcher).
+- Added: `_emit_soft_fail_signal` + `_store_schema_result` + `_build_schema_warning_context` helpers — soft-fail writes go through one path; warning context packs schema properties, result preview, and SDK error metadata (`errors`, `stop_reason`, `api_error_status`) for agent diagnosis.
+- Sticky `is_error_from_sdk` accumulator across multiple `ResultMessage`s.
+- Narrowed `_run_claude_session` exception swallow to `ProcessError` only when a prior `ResultMessage(is_error=True)` was seen; other exceptions re-raise to `exec_fallback` so remediation messages survive.
+
+**Static validator parity** (`src/pflow/core/workflow/validator.py:165-166, 675-812`, +152 lines):
+- New step 9: `_validate_node_param_semantics` → `_validate_claude_code_params`. Statically mirrors `_validate_schema` + `max_turns` cross-check so `--validate-only` and `--dry-run` reject what `prep()` would reject.
+- Templated values (`${...}` strings) defer to runtime via the guard at `validator.py:704-705`.
+
+**Memo cache rehydration** (`src/pflow/runtime/engine/instrumentation.py:348-405, 476-479`):
+- Reserved keys `__pflow_stats__` and `__pflow_warnings__` stripped from `shared[node_id]` on replay.
+- `__pflow_warnings__` rehydrates to root `shared["__warnings__"][node_id]` so cached DEGRADED runs stay DEGRADED.
+- `write_memo_cache` persists `shared["__warnings__"][node_id]` into the cached blob under the reserved key.
+
+**Type-vocabulary cleanup** (`src/pflow/core/types.py`):
+- Deleted the "fourth surface" carve-out comment (lines 8-12 in pre-state). Its premise — that Python-alias type names were load-bearing in the prompt template — was removed by deleting `_build_schema_prompt`.
+
+**Guide** (new `src/pflow/guide/nodes/claude-code.md` + 4 wiring edits):
+- New topic; renders via `pflow guide claude-code`, integrated with dynamic registry-interface injection (`guide/__init__.py:_TOPIC_TO_NODE_TYPES`).
+- Added to entry menu, capability-map fallback, save_service reserved names (`save_service.py:RESERVED_WORKFLOW_NAMES`).
+- Deliberately user-facing: no SDK internals, no `__warnings__` channel mentions.
+
+**Agent-facing reframing** (`src/pflow/mcp_server/resources/instructions/*.md`, `instruction_resources.py`, `guide/core.md`):
+- Replaced "NEVER use LLM for structured extraction" prescriptions with "use templates for existing structured data; use `output_schema` on `llm`/`claude-code` for model-derived structured data." Claude Code constraints (top-level object, `max_turns >= 2`) noted.
+
+**Examples + docs** (3 `.pflow.md` files + README + reference + architecture):
+- Hard cutover from Python-alias format to JSON Schema. No back-compat shim.
+
+**Tests** (+~700 lines net):
+- Real `@dataclass ResultMessage` mock replaces auto-Mock (load-bearing ordering: must register on `mock_sdk_types` BEFORE `sys.modules` injection — `tests/CLAUDE.md` pitfall #17).
+- 5 obsolete tests deleted, 4 rewritten, 15+ new (legacy-detection, top-level-object enforcement, oneOf/anyOf/allOf rejection, max_turns guard, sticky `is_error`, soft-fail kind variants, null-templated, narrow exception swallow, black-box api_warning_detector invariant, memo cache rehydration, validator parity for `--validate-only`/`--dry-run`).
+
+### Implementation Approach
+
+Hard cutover, no back-compat (CLAUDE.md "no users yet"). Prework SDK bump + Phase 0 smoke test landed plan-altering API constraints before any code was written. Implementation followed `implementation-plan.md` for the core swap, then accumulated four scope expansions found by review/verification:
+
+1. **Code-review checkpoint** uncovered exception swallow + memo cache warning loss + registry exposure of `__warnings__` as template output + agent-instruction framing drift.
+2. **Manual CLI verification** revealed `--validate-only` / `--dry-run` accepted what `prep()` rejected → added validator step 9.
+3. **Independent adversarial verification** (review-validation-consistency + review-silent-failures + review-feature-interactions) caught the validator template-deferral regression (rejected `${upstream.schema}` composition), the `_run_claude_session` hard-error swallow, and the null-templated silent downgrade.
+4. **Open-item probe** (oneOf/anyOf/allOf) confirmed runtime rejection → tightened both validators.
+
+## Files Modified/Created
+
+### Core Changes
+
+- `src/pflow/nodes/claude/claude_code.py` — central refactor. New surface area: import probe, `_validate_schema` constraints, `_emit_schema_resolved_null_warning`, `_emit_soft_fail_signal`, `_store_schema_result`, `_build_schema_warning_context`. Narrowed `_run_claude_session` exception handling. Removed: `_build_schema_prompt`, `_build_prompt`, `_build_system_prompt`, 4 `_extract_json*` helpers.
+- `src/pflow/core/workflow/validator.py` — added step 9 (`_validate_node_param_semantics`) + `_validate_claude_code_params` + `_looks_like_legacy_python_alias_schema` + `_claude_code_param_error`. Defer-on-template guard at line 704.
+- `src/pflow/runtime/engine/instrumentation.py` — `apply_memo_hit` strips reserved keys + rehydrates warnings to root; `write_memo_cache` persists warnings under `__pflow_warnings__`.
+- `src/pflow/core/types.py` — deleted fourth-surface carve-out comment.
+- `src/pflow/core/workflow/save_service.py` — `"claude-code"` added to `RESERVED_WORKFLOW_NAMES`.
+- `src/pflow/guide/nodes/claude-code.md` (new), `guide/__init__.py`, `guide/entry.md`, `guide/core.md`, `guide/CLAUDE.md` — new topic + integration.
+- `src/pflow/mcp_server/resources/instruction_resources.py` + 2 instruction `.md` files — reframed structured-data guidance.
+- `pyproject.toml`, `uv.lock` — `claude-agent-sdk>=0.2.82`.
+
+### Test Files
+
+- `tests/test_nodes/test_claude/test_claude_code.py` — 628 lines net delta. Real `@dataclass` `ResultMessage` mock; 15+ new tests.
+- `tests/test_cli/test_validate_only.py` — new `TestValidateOnlyClaudeCodeStructuredOutput` class (5 cases).
+- `tests/test_cli/test_dry_run.py` — `test_dry_run_rejects_claude_code_invalid_schema_before_plan`.
+- `tests/test_cli/test_guide.py` — direct topic rendering + `.pflow.md` workflow-scoped auto-detection.
+- `tests/test_runtime/test_memoization_integration.py` — cache warning rehydration regression test.
+- `tests/CLAUDE.md` — pitfall #17 updated with the `@dataclass` ordering invariant.
+- `tests/shared/markdown_utils.py:119` — comment updated (output_schema is node-agnostic now).
+
+**Critical tests** (catch real regressions, not coverage):
+- `test_non_process_error_after_is_error_re_raises` — pins the narrow exception swallow against reverting to catch-all `except Exception`.
+- `test_soft_fail_output_shape_not_classified_as_api_warning` — black-box pin: claude-code's `{result, _schema_error, llm_usage}` shape never reaches `api_warning_detector._is_validation_error` because `extract_error_message` is shape-gated. Adding an `error`/`ok`/`success`/`status` key for debug visibility would break this test before regression ships.
+- `test_sdk_error_with_structured_output_no_node_id_falls_back_to_schema_error` — pins the `setdefault("_schema_error", ...)` fallback when `node_id` is unbound (test paths).
+- Memo cache rehydration test — pins DEGRADED preservation across cache hits.
+- `TestValidateOnlyClaudeCodeStructuredOutput` + dry-run mirror — pins validator/runtime preflight parity.
+
+## Integration Points & Dependencies
+
+### Incoming Dependencies (consumers of this work)
+
+- **`runtime/workflow_trace.py:457-466`** consumes `shared["__warnings__"]` to flip workflow status → `DEGRADED`. This is the agent-visible signal.
+- **`runtime/engine/instrumentation.py`** memo cache reads/writes the new `__pflow_warnings__` reserved key.
+- **CLI `--validate-only` and `--dry-run`** consume validator step 9 output.
+- **`pflow guide claude-code`** consumes the new topic + registry interface injection.
+- **`save_service.RESERVED_WORKFLOW_NAMES`** protects the new guide name from clobbering.
+- **Future**: issue #398 (centralized JSON Schema validator) will share `_looks_like_legacy_python_alias_schema` + the JSON Schema markers set with LLM node.
+
+### Outgoing Dependencies
+
+- **`claude_agent_sdk>=0.2.82`** for `ClaudeAgentOptions.output_format` + `ResultMessage.structured_output`. Floor pinned in `pyproject.toml`. Import probe at `claude_code.py:78-83` guards against future field renames in the SDK.
+- **`runtime/compilation/compiler.py:299`** sets `self.node_id` — retrieved via `getattr(self, "node_id", None)` in `post()`. Pattern mirrored from `nodes/llm/llm.py:795`.
+- **`runtime/template_resolver.TemplateResolver`** (validator step 9 uses substring `${` for template detection — not the full extractor; sufficient because the runtime `_validate_schema` does the dict-shape check anyway).
+
+### Shared Store Keys
+
+| Key | Type | Producer | Purpose |
+|---|---|---|---|
+| `result` | `str` \| `dict` \| `list` \| primitive | always written | Free-form text, parsed JSON on schema success, or raw text on soft-fail |
+| `_schema_error` | `str` | soft-fail paths only | Human-readable message. Written via `setdefault` — first writer wins (null-template warning beats later soft-fail signal). |
+| `__warnings__[node_id]` | `dict{kind, text, context}` | soft-fail paths only | Root-level warning channel → flips workflow status to DEGRADED. Kinds: `claude_code.schema_not_satisfied`, `claude_code.sdk_error_no_structured_output`, `claude_code.sdk_error_with_structured_output`, `claude_code.output_schema_resolved_to_null` |
+| `llm_usage` | `dict` | always written (`{}` if metadata unavailable) | Token counts, cost, duration, session_id |
+| `_claude_progress` | `list[dict]` | always written if non-empty | Streaming progress events for tracing |
+| `_claude_tools` | `list[dict]` | always written if non-empty | Tool-use audit trail |
+
+**Reserved memo-cache-only keys** (NEVER appear in live `shared[node_id]`):
+- `__pflow_stats__` — engine duration metadata for `--dry-run` historical estimates.
+- `__pflow_warnings__` — node warning blob (rehydrated to root `shared["__warnings__"][node_id]` on cache hit).
+
+## Architectural Decisions & Tradeoffs
+
+### Key Decisions
+
+| Decision | Reasoning | Alternative rejected |
+|---|---|---|
+| Native SDK `output_format`, hard cutover | Provider-enforced compliance; no prompt boilerplate competing with user system prompt; no regex parsing. No users → no back-compat cost. | Keep prompt-injection but switch the format to JSON Schema — still fragile, still requires regex extraction. |
+| Soft-fail (`action="default"` + `_schema_error` + `__warnings__`) | Claude Code sessions are expensive (~$0.05+) and agentic; raw text is often salvageable. Retries would burn $$ on the same model behavior. | Hard-error like LLM node — too costly for agentic sessions. |
+| `__warnings__` channel (new) | Agent-visible DEGRADED status without requiring agents to know about `_schema_error` side-channel. Reuses existing trace mechanism. | Make schema misses route through `on-error:` edges — would surprise authors and require explicit error handlers on every claude-code node. |
+| `setdefault("_schema_error", msg)` | First-writer-wins so null-template warning (written in `prep`) survives later soft-fail writes (written in `post`). | Last-writer-wins (`shared["_schema_error"] = msg`) — null-template warning would be silently stomped. |
+| Top-level `type: object` enforced at prep + preflight | Phase 0 + follow-up probe: API rejects ALL non-object top-level schemas (incl. `oneOf`/`anyOf`/`allOf`/`enum`/missing-type) with a 400 surfacing as opaque `is_error=True`. | Trust SDK to surface clear error — opaque 400 message blamed the model, not the schema. |
+| `max_turns >= 2` enforced | Phase 0: `max_turns: 1` fails for structured output with "Reached maximum number of turns" — not actionable. | Document only — users would still hit it without preflight catch. |
+| Module-import-time SDK probe | `getattr(ResultMessage, "structured_output", None)` would silently return None on rename → soft-fail every call → "model didn't comply" blame on model. Loud import failure is correct. | Runtime probe on first call — failure mode is delayed and per-workflow. |
+| Validator step 9 mirrors runtime `_validate_schema` | Without it, `--validate-only` and `--dry-run` give clean preflight for workflows that fail immediately at runtime. Asymmetric preflight is worse than no preflight. | Trust prep() — silent CLI/--dry-run drift. |
+| Defer-on-template policy at validator | Composition pattern `output_schema: ${upstream.schema}` is valid and tested live. Hard-rejecting templates at preflight would block this. | Hard-reject templates at preflight — caught by user-reported regression during verification pass. |
+| Narrow exception swallow to `ProcessError` only | SDK pairs `ResultMessage(is_error=True)` with non-zero CLI exit (raised as `ProcessError`). Catch-all `except Exception` was hiding `CLINotFoundError` ("install with: npm…") and `CLIConnectionError` ("run `claude doctor`") remediation paths. | Catch-all `except Exception` — silently drops every actionable SDK error after the first `is_error=True`. |
+| Memo cache reserved keys | Without `__pflow_warnings__` persistence, cached DEGRADED runs replay as SUCCESS (silent demotion). | Don't cache warnings — replay would re-run the node, defeating cache. |
+
+### Technical Debt Incurred
+
+- **Validator step 9 manually mirrors runtime `_validate_schema`.** Two places to update when constraints change. Issue #398 will consolidate this for both `llm` and `claude-code` nodes.
+- **Legacy-format heuristic has false-positive risk.** `_looks_like_legacy_python_alias_format` checks if any value is a dict with `type ∈ {str, int, bool, list, dict, float}` AND no JSON Schema markers at root. A schema like `{"my_field": {"type": "str"}}` with intentional non-standard usage would be rejected. No users today; acceptable.
+- **Soft-fail message strings are unpinned except via `api_warning_detector` black-box test.** A future reword adding `"error"`/`"ok"`/`"success"`/`"status"` keys (not strings) to claude-code output would flip soft-fail → hard error. The pin test catches the SHAPE drift, not message text drift.
+- **LLM node has the same `node_id is None` guard pattern.** Same blind-spot for direct `node.run()` test paths. Deliberately not fixed here — consistency between the two nodes matters more than fixing one. Both should be fixed together if the gap matters.
+- **`__pflow_warnings__` reserved key is engine-private.** Implicitly couples `claude_code.py`'s warning writes to `instrumentation.py`'s cache handling. If any other node starts writing root-level `__warnings__` from `post()`, it gets cache-rehydration for free — but the coupling is undocumented outside `apply_memo_hit`'s docstring.
+
+## Testing Implementation
+
+### Test Strategy Applied
+
+1. **Real `@dataclass ResultMessage` mock** replaces auto-Mock. Auto-Mock's `isinstance()` checks succeed silently against any type, masking real behavioral bugs (e.g., the import probe relies on `__annotations__` — auto-Mock has it as a `MagicMock` attribute, not the real dict).
+2. **Black-box invariant tests** preferred over substring-string tests. The `api_warning_detector` pin tests the production property (output shape doesn't match detector's extraction gates), not message text equality.
+3. **Defer-on-template guard tested via composition pattern** — `composed-schema.pflow.md` scratchpad workflow exercises upstream code node → JSON Schema → claude-code consumer. Lives in `scratchpads/manual-pflow-verification/` (not committed) but tested via direct unit tests.
+4. **Symmetric coverage for `--validate-only` and `--dry-run`** — every static check in `_validate_claude_code_params` has paired tests in both CLI test files.
+5. **Real-API smoke test** — `Phase 5.4` ran `examples/nodes/claude-code/claude-code-schema.pflow.md` against the real Anthropic API via Claude Max subscription. Live structured output succeeded; 4 nodes completed; templates `${review.result.*}` resolved cleanly. Confirmed zero-config subscription auth path.
+
+### Critical Test Cases
+
+- `test_non_process_error_after_is_error_re_raises` — guards the narrow swallow against future catch-all regression.
+- `test_soft_fail_output_shape_not_classified_as_api_warning` — black-box pin against `api_warning_detector` extraction-gate invariant.
+- `test_top_level_{oneOf,anyOf,allOf,missing_type}_schema_rejected` — pins follow-up probe findings.
+- `test_top_level_object_with_oneOf_accepted` — pins that combinators INSIDE an object wrapper still work (the workaround is sound).
+- `test_dry_run_rejects_claude_code_invalid_schema_before_plan` — pins validator/runtime preflight parity.
+- `test_sdk_error_with_structured_output_no_node_id_falls_back_to_schema_error` — pins `setdefault` fallback for test paths.
+- Memo cache rehydration test — pins DEGRADED preservation across cache hits.
+- `test_claude_code_guide_documents_structured_output_without_internals` — guards guide-user-facingness (e.g., reworded "SDK" → "provider error" caught here).
+
+## Unexpected Discoveries
+
+### Gotchas Encountered
+
+1. **Anthropic API rejects non-object top-level schemas in tool-use wrappers.** The SDK passes our `output_format` through as a custom tool's `input_schema`. The LLM node has no such restriction (LiteLLM/OpenAI accept top-level arrays/primitives). This is **Claude-Code-specific** and required explicit user-facing documentation.
+2. **`max_turns: 1` opaque failure.** Structured output requires at least 2 turns (one to plan, one to emit). SDK raises "Reached maximum number of turns" with no hint it's schema-related.
+3. **Schema typos like `type: intger` are silently accepted by the API.** No 400; model produces free-form text; soft-fail says "model didn't comply" — misleading. Motivates #398.
+4. **Memo cache replay silently demotes DEGRADED → SUCCESS.** Found via cross-feature review (review-feature-interactions agent). Without `__pflow_warnings__` rehydration, every cached schema soft-fail loses the warning signal. This was the highest-impact silent-failure bug uncovered.
+5. **`_run_claude_session`'s catch-all `except Exception` hid every SDK exception after the first `ResultMessage(is_error=True)`.** Users lost `CLINotFoundError` → "install with: npm install -g …", `CLIConnectionError` → "run `claude doctor`" remediation paths. Found via review-silent-failures agent.
+6. **Templated `output_schema: ${upstream.field}` resolving to None silently downgrades to free-form.** Workflow status returned `success` instead of `degraded`. Workflow author got no signal their schema reference missed. Found via independent adversarial verification.
+7. **Validator template-deferral asymmetry.** First-draft validator hard-rejected `output_schema: ${...}` strings ("got str"). Pre-Task-126 code accepted them via runtime resolution. The fix (5-line guard) restored the composition pattern.
+8. **Auto-Mock `ResultMessage` was a latent bug.** `isinstance(msg, ResultMessage)` would TypeError at runtime because the mock was an instance, not a class. Caught by codebase-searcher before tests ran. Fixed via real `@dataclass`.
+9. **Subscription auth (Claude Pro/Max) needs zero config.** No `ANTHROPIC_API_KEY` required; the bundled `claude` CLI auto-detects OAuth keychain. Setting `ANTHROPIC_API_KEY` forces pay-as-you-go billing. Phase 5 docs updated.
+
+### Edge Cases Found
+
+- Top-level `oneOf` / `anyOf` / `allOf` / `enum` / `const` / missing-`type` all fail at the API. Original plan said "may pass" — wrong. All rejected at preflight now.
+- Empty `{}` schema is a typo, not a no-op — rejected.
+- `output_schema = None` (key absent) is a no-op; `output_schema: ${none-producing-template}` is DEGRADED-worthy.
+- Sticky `is_error_from_sdk` across multi-message streams (defensive — Phase 0 didn't observe multi-message, but the logic is correct).
+- `node_id` is None in direct `node.run()` test paths → `__warnings__` write skipped but `_schema_error` still written via `setdefault`.
+
+## Patterns Established
+
+### Reusable Patterns
+
+**1. Module-import-time SDK field-presence probe** (`claude_code.py:78-83`):
+```python
+if "structured_output" not in getattr(ResultMessage, "__annotations__", {}):
+    raise ImportError(
+        "claude_agent_sdk.types.ResultMessage has no 'structured_output' field. "
+        "pflow's Claude Code node requires claude-agent-sdk>=0.2.82 ..."
+    )
+```
+Loud at import time beats silent `getattr(..., None)` returning None at runtime. Use this for any external library whose attribute layout matters.
+
+**2. Reserved memo-cache keys for root-level shared state** (`instrumentation.py:apply_memo_hit`, `write_memo_cache`):
+```python
+reserved_keys = {"__pflow_stats__", "__pflow_warnings__"}
+restored = {k: v for k, v in cached_output.items() if k not in reserved_keys}
+cached_warning = cached_output.get("__pflow_warnings__")
+if cached_warning is not None:
+    shared.setdefault("__warnings__", {})[node_id] = cached_warning
+```
+Any future node writing root-level shared state (`shared["__warnings__"]`, `shared["__errors__"]`, etc.) from `post()` needs cache rehydration or DEGRADED → SUCCESS silent demotion will hit. Add to the reserved set.
+
+**3. Per-node static param semantics validator step** (`validator.py:_validate_node_param_semantics`):
+```python
+def _validate_node_param_semantics(workflow_ir):
+    diagnostics = []
+    for node in workflow_ir.get("nodes", []):
+        if node.get("type") != "claude-code":
+            continue
+        diagnostics.extend(WorkflowValidator._validate_claude_code_params(node.get("id"), node.get("params", {})))
+    return diagnostics
+```
+Per-node static checks that mirror runtime `prep()`. Mandatory whenever a node adds a `prep`-only constraint with high false-acceptance cost (failed runtime calls cost $$).
+
+**4. Defer-on-template guard** (`validator.py:704-705`):
+```python
+if isinstance(output_schema, str) and "${" in output_schema:
+    return []  # defer to runtime resolution
+```
+Static validators that can't resolve templates must defer, not reject. Symmetric with `max_turns`' `try/except int()` defer policy.
+
+**5. First-writer-wins via `setdefault` for soft-fail signals** (`claude_code.py:_emit_soft_fail_signal`):
+```python
+shared.setdefault("_schema_error", msg)  # earlier null-template warning wins
+if node_id is not None:
+    shared.setdefault("__warnings__", {})[node_id] = {...}
+```
+Multiple code paths may write soft-fail signals (prep-time null-template detection, post-time schema-not-satisfied). First-writer-wins preserves the earliest, most-specific diagnosis.
+
+**6. Black-box invariant test for cross-feature contracts**:
+```python
+def test_soft_fail_output_shape_not_classified_as_api_warning():
+    shared = {"review": <produced_shape>}
+    assert detect_api_warning("review", shared) is None
+```
+Pin against production property (output shape vs. detector's extraction gates), not internals (message string substrings). A future contributor adding an `error` key to debug claude-code output breaks this test before the regression ships.
+
+**7. `@dataclass` test mock for SDK types** (test pattern):
+```python
+@dataclass
+class ResultMessage:
+    structured_output: Any = None
+    is_error: bool = False
+    ...
+```
+`@dataclass` auto-populates `__annotations__`, which the import probe checks. Register on `mock_sdk_types.ResultMessage` BEFORE the `sys.modules[...]` assignment.
+
+### Anti-Patterns to Avoid
+
+- **Catch-all `except Exception` in SDK loops.** Hides every actionable SDK error type. Narrow to the specific exception class that pairs with the soft-fail state.
+- **Pinning message strings via equality.** Brittle to rewording. Pin via substring (`"X" in shared["_schema_error"]`) or, better, via the production invariant (output shape).
+- **Auto-Mock for classes used in `isinstance()` checks.** `isinstance(x, AutoMock_instance)` raises TypeError. Use real `@dataclass` or real class.
+- **Hard-reject templated values at static validators.** Composition patterns like `${upstream.schema}` are legitimate. Defer to runtime.
+- **Writing soft-fail signals without `setdefault`.** Earlier prep-time signals get stomped by later post-time ones.
+
+## Breaking Changes
+
+### API/Interface Changes
+
+- **`output_schema` syntax** on `claude-code` nodes: Python-alias format → JSON Schema. Hard cutover. Legacy format produces a clear migration error at `prep()` time.
+- **Result type** on schema success: previously a dict with auto-filled `None` for missing optional fields; now matches the SDK's `structured_output` exactly (missing optional fields are simply absent).
+- **Result type** on schema soft-fail: was a dict-with-Nones; now raw text string + `_schema_error` + `__warnings__` signal. Downstream nodes that previously accessed `${node.result.field}` after a soft-fail now need to branch on `${node._schema_error}` first.
+- **Registry interface no longer exposes `__warnings__`** as a node output. The DEGRADED behavior is documented in prose; `${node.__warnings__}` will not resolve via template (it's root-level, not node-level).
+
+### Behavioral Changes
+
+- Schema soft-failures now flip workflow status to `DEGRADED` (was: `success` with side-channel `_schema_error` only).
+- `max_turns < 2` with `output_schema` is rejected at preflight (was: opaque SDK error at runtime).
+- Top-level non-object schemas rejected at preflight (was: opaque API 400 at runtime).
+- Templated `output_schema` resolving to None now emits a `claude_code.output_schema_resolved_to_null` warning (was: silent downgrade to free-form mode).
+- Memo cache replay preserves DEGRADED status (was: silently demoted to SUCCESS).
+- `claude-code` is now a reserved workflow name (was: collision possible with the new `pflow guide claude-code` topic).
+
+## Future Considerations
+
+### Extension Points
+
+- **Issue #398 (centralized JSON Schema validation)** will likely add a new step between current 8 and 9 in `WorkflowValidator.validate()`. The per-node step 9 should remain — it handles node-specific constraints beyond JSON Schema syntactic validity (top-level object enforcement, max_turns guard).
+- **`_build_schema_warning_context`** already threads SDK 0.2.82's new `errors` / `stop_reason` / `api_error_status` fields into the warning context. Future UX work could surface these in `pflow ... --output-format json` warnings without further node changes.
+- **Memo cache reserved-key pattern** is the template for any new root-level shared state. Add to the `reserved_keys` set in `apply_memo_hit` and the corresponding write in `write_memo_cache`.
+- **`pflow guide claude-code`** topic uses the same registry-interface-injection pattern as other node topics. Future agentic nodes should follow this pattern (entry: `_TOPIC_TO_NODE_TYPES` mapping).
+
+### Scalability Concerns
+
+- The legacy-format heuristic walks all values of the schema dict at every `prep()`. Negligible at current usage; non-issue.
+- Validator step 9 walks all nodes at every validation call. Trivial cost.
+
+## AI Agent Guidance
+
+### Quick Start for Related Tasks
+
+**If you're working on Task 99 (Expose pflow Tools to Claude Code Node):**
+1. Read `_build_claude_options` (`claude_code.py:545-589`) — this is where SDK options get wired. Adding tools means extending `options_kwargs`.
+2. Don't add `__warnings__` keys unless you also follow the reserved-cache-key pattern in `instrumentation.py`.
+3. The `allowed_tools` / `disallowed_tools` params already exist; check `_validate_tools` and `_validate_disallowed_tools` first.
+
+**If you're working on Issue #398 (centralized JSON Schema validation):**
+1. Read `_looks_like_legacy_python_alias_schema` in both `claude_code.py:287-294` AND `validator.py:783-789`. These are duplicated. Your job is to consolidate.
+2. The JSON Schema markers set `{"type", "$ref", "$schema", "oneOf", "anyOf", "allOf", "enum", "const"}` is the same in both places.
+3. Add validation between current steps 8 and 9 in `WorkflowValidator.validate()`. The per-node step 9 should remain for node-specific constraints (top-level-object, max_turns).
+4. The LLM node has NO top-level-object restriction (LiteLLM accepts arrays/primitives). Don't apply Claude Code's constraint there.
+
+**If you're adding `__warnings__` writes from any node's `post()`:**
+1. Use `shared.setdefault("__warnings__", {})[node_id] = {kind, text, context}` shape.
+2. Add your node's `__pflow_warnings__` reserved-key handling to `instrumentation.py:apply_memo_hit` and `write_memo_cache` — OR confirm the existing wildcard handling covers you (it does, as of 6954cfb4).
+3. The `kind` field is a dotted string namespaced by node type: `"<node_type>.<reason>"`. Reused kinds: `schema_not_satisfied`, `sdk_error_no_structured_output`, `sdk_error_with_structured_output`, `output_schema_resolved_to_null`.
+4. DEGRADED workflow status is automatic via `runtime/workflow_trace.py:457-466` — you don't write status directly.
+
+**If you're modifying `_validate_schema` or `_validate_claude_code_params`:**
+1. UPDATE BOTH. They mirror each other intentionally. Drift is silently breaking — runtime rejects what preflight accepts (or vice versa).
+2. Use the defer-on-template guard for any templated value: `if isinstance(value, str) and "${" in value: return [] / pass`.
+3. New cases need paired tests in `test_claude_code.py` + `test_validate_only.py` + `test_dry_run.py`.
+
+### Common Pitfalls
+
+1. **Reverting the narrow exception swallow** to catch-all `except Exception` in `_run_claude_session`. Breaks `test_non_process_error_after_is_error_re_raises`. Hides `CLINotFoundError` / `CLIConnectionError` remediation messages.
+2. **Removing `setdefault("_schema_error", ...)` in favor of `=`** — null-template warning gets clobbered by later soft-fail signals. Breaks templated-schema-resolving-to-None UX.
+3. **Adding `error`/`ok`/`success`/`status` keys to claude-code's `shared[node_id]` output**. Will trigger `api_warning_detector._is_validation_error` and flip soft-fail → hard error. Breaks `test_soft_fail_output_shape_not_classified_as_api_warning`.
+4. **Forgetting to use `@dataclass` when adding fields to the test `ResultMessage` mock.** The import probe checks `__annotations__`. Auto-Mock's `__annotations__` is a `MagicMock` attribute, not a real dict.
+5. **Registering `mock_sdk_types.ResultMessage` AFTER `sys.modules["claude_agent_sdk.types"] = mock_sdk_types`.** The import probe runs at the SDK import line, before the late registration. Re-read `tests/CLAUDE.md` pitfall #17.
+6. **Assuming schema misses route through `- on-error:` edges.** They don't — `post()` always returns `"default"`. Workflow authors must branch on `${node._schema_error}` (or check `DEGRADED` status).
+7. **Adding back `_build_prompt` / `_build_system_prompt` as wrappers.** They were inlined intentionally; the schema framing they used to do is now handled by the SDK.
+
+### Test-First Recommendations
+
+Before modifying claude_code.py or validator.py step 9, run:
+```bash
+uv run pytest tests/test_nodes/test_claude/ tests/test_cli/test_validate_only.py tests/test_cli/test_dry_run.py tests/test_runtime/test_memoization_integration.py -q
+```
+Should report ~105+ passed. If a baseline fails before your changes, you have an environment issue (likely sandbox `uv` panic class — see progress log "Verification blockers").
+
+After modifying `_validate_schema`:
+```bash
+uv run pytest tests/test_nodes/test_claude/test_claude_code.py -k "validate_schema or schema_rejected or top_level" -q
+uv run pytest tests/test_cli/test_validate_only.py::TestValidateOnlyClaudeCodeStructuredOutput -q
+uv run pytest tests/test_cli/test_dry_run.py::test_dry_run_rejects_claude_code_invalid_schema_before_plan -q
+```
+
+After modifying memo cache or warning writes:
+```bash
+uv run pytest tests/test_runtime/test_memoization_integration.py -q
+```
+
+For end-to-end smoke (subscription required — zero config if logged into `claude` CLI):
+```bash
+unset ANTHROPIC_API_KEY
+uv run pflow examples/nodes/claude-code/claude-code-schema.pflow.md
+```
+Expect: `success: true`, structured `review.result` dict, `${review.result.*}` templates resolve in downstream `write-file` nodes.
+
+---
+
+*Generated from implementation context of Task 126 (commits 8cadd39c → 6954cfb4 on `feat/claude-code-structured-output`)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,7 @@ MVP feature-complete. Published to PyPI (v0.8.0). See `.taskmaster/versions.md` 
 - ✅ Task 156: Add `--dry-run` flag with cache plan and cost/duration estimates
 - ✅ Task 157: Fix Dry-Run Batch Sub-Workflow Recursion
 - ✅ Task 158: Replace `llm` Library with LiteLLM
+- ✅ Task 126: Structured Output for Claude Code Node
 
 ### Planned Features (in order of priority)
 
@@ -247,7 +248,6 @@ MVP feature-complete. Published to PyPI (v0.8.0). See `.taskmaster/versions.md` 
 - Task 133: Unified Per-Node Storage for Trace and Cache
 
 **v1.0.0 - Security & Sandboxing:**
-- Task 126: Structured Output for Claude Code Node
 - Task 87: Sandboxed Execution Runtime
 - Task 91: Export as MCP Server Packages
 - Task 97: OAuth for Remote MCP Servers

--- a/architecture/core-node-packages/claude-nodes.md
+++ b/architecture/core-node-packages/claude-nodes.md
@@ -35,34 +35,35 @@ The Claude Agent SDK provides:
 
 **Interface**:
 - Params: `prompt`: str  # The prompt to send to Claude (required)
-- Params: `output_schema`: dict  # JSON schema for structured outputs (optional)
-- Writes: `shared["result"]`: any  # Response - string or dict with schema keys
+- Params: `output_schema`: dict  # JSON Schema for structured outputs (optional)
+- Writes: `shared["result"]`: str|dict  # Free-form text, parsed JSON (dict/list) when output_schema is set, or raw text on soft schema failure
 - Writes: `shared["llm_usage"]`: dict  # Token usage and execution metadata
 
 **Implementation Notes**:
-The claude-code node executes the Claude Agent SDK in headless mode, passing comprehensive instructions and extracting structured output including modified files, analysis, and implementation details.
+The claude-code node executes the Claude Agent SDK in headless mode, passing comprehensive instructions and optional JSON Schema structured-output configuration. Schema soft-failures write root-level execution warnings so workflow status becomes DEGRADED.
 
-**CLI Examples**:
-```bash
-# Comprehensive GitHub issue resolution (template-driven workflow)
-pflow github-get-issue --issue=1234 => \
-  claude-code --prompt="${comprehensive_fix_instructions}" => \
-  llm --prompt="Write commit message for: ${result}" => \
-  git-commit --message="${commit_message}"
+**Workflow Example**:
+```markdown
+### implement_fix
 
-# Generated instructions example (created by workflow tooling)
-# ${comprehensive_fix_instructions} = "Analyze issue #1234, understand the root cause,
-# search codebase for relevant files, implement a complete fix with proper error
-# handling, write tests, and ensure code quality standards are met..."
-
-# Direct usage with generated instructions
-echo "${generated_instructions}" | pflow claude-code --temperature=0.2
+- type: claude-code
+- prompt: ${comprehensive_fix_instructions}
+- max_turns: 5
 ```
 
 **Parameters**:
-- `model` (optional): Claude model (default: claude-sonnet-4-20250514)
-- `temperature` (optional): Creativity level 0.0-1.0 (default: 0.3)
-- `max_tokens` (optional): Maximum response length (default: 8192)
+- `prompt` (required): Instructions for Claude
+- `output_schema` (optional): JSON Schema for structured output; top-level type must be object
+- `cwd` (optional): Working directory
+- `model` (optional): Claude model (default: claude-sonnet-4-5)
+- `allowed_tools` (optional): Permitted tool names
+- `disallowed_tools` (optional): Tool names or patterns to deny
+- `max_turns` (optional): Maximum conversation turns; must be >=2 with `output_schema`
+- `max_thinking_tokens` (optional): Reasoning budget
+- `timeout` (optional): Execution timeout
+- `system_prompt` (optional): Custom system instructions
+- `resume` (optional): Session ID to resume
+- `sandbox` (optional): Command sandbox configuration
 
 ## Template-Driven Instruction Generation
 
@@ -183,11 +184,12 @@ The super node uses generated instructions:
 
 ### Natural Shared Store Keys
 
-The super node writes to comprehensive shared store keys following the [shared store pattern](../core-concepts/shared-store.md#natural-interfaces):
+The super node writes to shared store keys following the [shared store pattern](../core-concepts/shared-store.md#natural-interfaces):
 - `shared["result"]` for complete development output
-- `shared["analysis"]` for extracted analysis sections
-- `shared["implementation"]` for extracted implementation details
-- `shared["files_modified"]` for tracking file changes
+- `shared["llm_usage"]` for token usage, duration, session ID, and SDK-reported API-equivalent cost
+- `shared["_schema_error"]` when structured output soft-fails
+
+Additional structured fields such as `analysis`, `implementation`, or `files_modified` are available only when the workflow declares them inside `output_schema` and reads them under `shared["result"]`.
 
 ### Claude Agent SDK Integration
 The super node leverages the full capabilities of Claude Agent SDK:

--- a/docs/reference/nodes/claude-code.mdx
+++ b/docs/reference/nodes/claude-code.mdx
@@ -25,7 +25,7 @@ The claude-code node runs agentic tasks using Claude Code's capabilities. It can
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `prompt` | str | Yes | - | The prompt to send to Claude (max 10,000 chars) |
-| `output_schema` | dict | No | - | JSON schema for structured output |
+| `output_schema` | dict | No | - | JSON Schema for structured output |
 
 ### Execution parameters
 
@@ -34,7 +34,8 @@ The claude-code node runs agentic tasks using Claude Code's capabilities. It can
 | `cwd` | str | No | Current dir | Working directory for Claude |
 | `model` | str | No | `claude-sonnet-4-5` | Claude model to use |
 | `allowed_tools` | list | No | All tools | Permitted tools |
-| `max_turns` | int | No | `50` | Maximum conversation turns (1-100) |
+| `disallowed_tools` | list | No | - | Tools or patterns to deny |
+| `max_turns` | int | No | `50` | Maximum conversation turns (1-100; must be at least 2 with `output_schema`) |
 | `max_thinking_tokens` | int | No | `8000` | Reasoning budget (1000-100000) |
 | `timeout` | int | No | `300` | Execution timeout in seconds (30-3600) |
 | `system_prompt` | str | No | - | Custom system instructions |
@@ -57,9 +58,13 @@ The `sandbox` parameter controls command execution isolation. See the [Claude Ag
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `result` | str/dict | Response text or parsed schema dict |
+| `result` | str/dict | Free-form text, parsed structured output when `output_schema` succeeds, or raw text on soft schema failure |
 | `llm_usage` | dict | Token usage and execution metadata (same base format as [LLM node](/reference/nodes/llm), plus Claude-specific fields) |
-| `_schema_error` | str | JSON parse error (only if schema provided and parsing failed) |
+| `_schema_error` | str | Soft-failure message for structured-output mode — set when structured output was unavailable, the SDK reported an error alongside the output, or the schema reference resolved to None |
+
+Soft-failures also emit a root-level `shared["__warnings__"][node_id]` entry so workflow status becomes `DEGRADED`. This is an execution diagnostic channel, not a template output under the node.
+
+The node always returns `default` from `post()` — schema soft-failures and SDK soft-errors do NOT route through `- on-error:` edges. Read `${node._schema_error}` or check workflow `DEGRADED` status if downstream logic needs to react.
 
 ### llm_usage structure
 
@@ -77,6 +82,8 @@ The `sandbox` parameter controls command execution isolation. See the [Claude Ag
   "session_id": "abc123"
 }
 ```
+
+`cost_usd` is the SDK-reported API-equivalent estimated cost. Actual billing depends on auth method; Claude Pro/Max subscription runs may report an API-equivalent cost without a direct per-call charge.
 
 ## Authentication
 
@@ -100,7 +107,7 @@ The `sandbox` parameter controls command execution isolation. See the [Claude Ag
 
 ## Structured output
 
-Use `output_schema` to get structured JSON responses:
+Use `output_schema` to get structured responses through the Claude Agent SDK's native JSON Schema mode. The top-level schema must be `type: object` because the Claude API rejects non-object tool input schemas. For array or primitive outputs, wrap the value in an object property.
 
 ````markdown
 ### review
@@ -111,35 +118,37 @@ Review code for security issues and return structured results.
 - prompt: Review this code for security issues: ${code.content}
 
 ```yaml output_schema
-risk_level:
-  type: str
-  description: high, medium, or low
-issues:
-  type: list
-  description: List of security issues found
-score:
-  type: int
-  description: Security score 1-10
+type: object
+properties:
+  risk_level:
+    type: string
+    enum: [high, medium, low]
+    description: Risk level
+  issues:
+    type: array
+    items:
+      type: string
+    description: List of security issues found
+  score:
+    type: integer
+    minimum: 1
+    maximum: 10
+    description: Security score
+required: [risk_level, issues, score]
 ```
 ````
 
-The response is automatically parsed and available as a dict:
+The SDK returns parsed structured output, available as a dict:
 
 ```
-${review.result.risk_level}  → "medium"
-${review.result.issues}      → ["SQL injection risk", "Missing input validation"]
-${review.result.score}       → 6
+${review.result.risk_level}  -> "medium"
+${review.result.issues}      -> ["SQL injection risk", "Missing input validation"]
+${review.result.score}       -> 6
 ```
 
-### Schema field types
+If the schema is set but the SDK returns no structured output, pflow preserves the raw text in `${node.result}`, writes `${node._schema_error}`, and emits `shared["__warnings__"][node_id]` so JSON execution output reports workflow status as `DEGRADED`.
 
-| Type | Description |
-|------|-------------|
-| `str` | Text string |
-| `int` | Integer number |
-| `bool` | Boolean value |
-| `list` | Array/list |
-| `dict` | Object/dictionary |
+Warning kinds distinguish model/schema misses from SDK error signals: `claude_code.schema_not_satisfied` means the model did not produce matching structured output; `claude_code.sdk_error_no_structured_output` means the Claude CLI reported an error and no structured output was usable.
 
 ## Examples
 
@@ -152,7 +161,7 @@ Write a Python function to calculate Fibonacci numbers.
 
 - type: claude-code
 - prompt: Write a Python function to calculate Fibonacci numbers
-- max_turns: 1
+- max_turns: 2
 ```
 
 ### Code review with structured output
@@ -173,15 +182,22 @@ Review the authentication code and return structured findings.
 - prompt: Review this authentication code: ${read.content}
 
 ```yaml output_schema
-issues:
-  type: list
-  description: Problems found
-suggestions:
-  type: list
-  description: Improvements
-approved:
-  type: bool
-  description: Ready for production
+type: object
+properties:
+  issues:
+    type: array
+    items:
+      type: string
+    description: Problems found
+  suggestions:
+    type: array
+    items:
+      type: string
+    description: Improvements
+  approved:
+    type: boolean
+    description: Ready for production
+required: [issues, suggestions, approved]
 ```
 ````
 
@@ -233,6 +249,7 @@ For read-only analysis, use `["Read", "Glob", "Grep", "LS"]`. For full capabilit
 - **Restricted directories**: Cannot use `/`, `/etc`, `/usr`, `/bin`, `/sbin`, `/lib`, `/sys`, `/proc` as working directory
 - **Timeout**: 5 minutes (300 seconds) default, configurable up to 1 hour
 - **Cost**: More expensive than simple LLM calls - use for tasks that need file access and iteration
+- **Structured output root**: `output_schema` must be a top-level object on this node
 
 ## Error handling
 

--- a/docs/reference/nodes/claude-code.mdx
+++ b/docs/reference/nodes/claude-code.mdx
@@ -107,7 +107,7 @@ The node always returns `default` from `post()` — schema soft-failures and SDK
 
 ## Structured output
 
-Use `output_schema` to get structured responses through the Claude Agent SDK's native JSON Schema mode. The top-level schema must be `type: object` because the Claude API rejects non-object tool input schemas. For array or primitive outputs, wrap the value in an object property.
+Use `output_schema` to get structured responses through the Claude Agent SDK's native JSON Schema mode. The top-level schema must declare `type: object` because the Claude API rejects any tool input schema without it — including top-level `oneOf`/`anyOf`/`allOf`/`enum` combinators. For array, primitive, or combinator-only outputs, wrap them inside an object property. Combinators nested inside a `type: object` schema work normally.
 
 ````markdown
 ### review

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -50,7 +50,6 @@ Where pflow is today (v0.12.0):
 **Security and sandboxing**
 
 - **Sandboxed execution runtime** — isolated execution for shell and code nodes. Needed before running agent-generated workflows you haven't reviewed.
-- **Structured output for Claude Code node** — typed JSON responses from agentic coding tasks
 - **Export as MCP server packages** — distribute workflows as standalone MCP servers that work without pflow installed
 
 **MCP ecosystem**

--- a/examples/nodes/claude-code/README.md
+++ b/examples/nodes/claude-code/README.md
@@ -4,14 +4,14 @@ Examples for the `claude-code` node: an agentic super node that integrates with 
 
 Features:
 
-- Dynamic schema-driven output for structured responses
+- Native JSON Schema structured output
 - Metadata capture (cost, duration, token usage) in `llm_usage`
 - Tool use (Read, Write, Edit, Bash, Glob, Grep, LS, WebFetch, WebSearch)
 - Dual authentication: API key or Claude Pro/Max CLI
 
 ## Examples
 
-### 1. Simple code generation — `claude-code-basic.pflow.md`
+### 1. Simple code generation - `claude-code-basic.pflow.md`
 
 ```bash
 pflow examples/nodes/claude-code/claude-code-basic.pflow.md
@@ -24,7 +24,7 @@ Demonstrates:
 - Cost tracking via `${node.llm_usage.cost_usd}`
 - Duration and token usage
 
-### 2. Structured code review — `claude-code-schema.pflow.md`
+### 2. Structured code review - `claude-code-schema.pflow.md`
 
 ```bash
 pflow examples/nodes/claude-code/claude-code-schema.pflow.md file_path=your_script.py
@@ -37,7 +37,7 @@ Demonstrates:
 - Declared workflow inputs referenced as `${file_path}`
 - Multiple output files from a single analysis
 
-### 3. Debugging assistant — `claude-code-debug.pflow.md`
+### 3. Debugging assistant - `claude-code-debug.pflow.md`
 
 ```bash
 pflow examples/nodes/claude-code/claude-code-debug.pflow.md error_message="TypeError: ..."
@@ -49,7 +49,7 @@ Demonstrates:
 - Optional inputs (`code_context`, `stack_trace`)
 - Confidence scoring and prevention tips
 
-### 4. Git workflow integration — `claude-code-git-workflow.pflow.md`
+### 4. Git workflow integration - `claude-code-git-workflow.pflow.md`
 
 ```bash
 pflow examples/nodes/claude-code/claude-code-git-workflow.pflow.md
@@ -57,30 +57,39 @@ pflow examples/nodes/claude-code/claude-code-git-workflow.pflow.md
 
 Demonstrates:
 
-- Multi-stage analysis pipeline (shell → claude-code → claude-code → write-file)
+- Multi-stage analysis pipeline (shell -> claude-code -> claude-code -> write-file)
 - Passing upstream node output into the prompt via `${node_id.field}` interpolation
 - System prompts for specific personas
 - Cost aggregation across multiple calls
 
 ## Schema-driven output
 
-When you provide `output_schema`, the result is parsed into a structured dict:
+When you provide `output_schema`, pflow passes JSON Schema to the Claude Agent SDK's native structured-output mode. The top-level schema must be `type: object`.
 
 ```yaml output_schema
-summary:
-  type: str
-  description: Brief summary
-score:
-  type: int
-  description: Score from 1-10
-items:
-  type: list
-  description: List of items
+type: object
+properties:
+  summary:
+    type: string
+    description: Brief summary
+  score:
+    type: integer
+    minimum: 1
+    maximum: 10
+    description: Score from 1-10
+  items:
+    type: array
+    items:
+      type: string
+    description: List of items
+required: [summary, score, items]
 ```
 
 Access fields directly: `${node.result.summary}`, `${node.result.score}`, `${node.result.items}`.
 
-If JSON parsing fails, the raw text is available at `${node.result}` and an error message at `${node._schema_error}`.
+If the SDK returns no structured output, the raw text is available at `${node.result}`, an error message is available at `${node._schema_error}`, and `shared["__warnings__"][node_id]` marks the workflow status `DEGRADED`.
+
+The node always returns `default` from `post()` — schema soft-failures DO NOT route through `- on-error:` edges. Wire schema-recovery logic by inspecting `${node._schema_error}` or the workflow `DEGRADED` status, not the error edge.
 
 ## Passing context into the prompt
 
@@ -117,22 +126,24 @@ ${node.llm_usage.num_turns}                     # Conversation turns used
 ${node.llm_usage.session_id}                    # Resumable session ID
 ```
 
+`cost_usd` is the SDK-reported API-equivalent estimated cost. Actual billing depends on auth method; Claude Pro/Max subscription runs may report an API-equivalent cost without a direct per-call charge.
+
 ## Authentication
 
-- **API key**: `export ANTHROPIC_API_KEY=sk-ant-...` — billed to your Anthropic Console account.
-- **Claude Pro/Max subscription**: `claude setup-token` (or `claude auth login`) — uses subscription entitlements.
+- **API key**: `export ANTHROPIC_API_KEY=sk-ant-...` - billed to your Anthropic Console account.
+- **Claude Pro/Max subscription**: `claude setup-token` (or `claude auth login`) - uses subscription entitlements.
 
 ## Parameters
 
 | Parameter             | Default             | Description                                                 |
 |-----------------------|---------------------|-------------------------------------------------------------|
 | `prompt`              | required            | Prompt to send to Claude                                    |
-| `output_schema`       | None                | Schema for structured output (see above)                    |
+| `output_schema`       | None                | JSON Schema for structured output (see above)               |
 | `cwd`                 | `os.getcwd()`       | Working directory                                           |
 | `model`               | `claude-sonnet-4-5` | Claude model identifier                                     |
 | `allowed_tools`       | All tools           | Permitted tool names (e.g., `["Read", "Write"]`)            |
 | `disallowed_tools`    | None                | Tool names or patterns to deny (e.g., `["Bash(git:*)"]`)    |
-| `max_turns`           | 50                  | Maximum conversation turns                                  |
+| `max_turns`           | 50                  | Maximum conversation turns (must be >=2 with schema)        |
 | `max_thinking_tokens` | 8000                | Maximum tokens for extended reasoning                       |
 | `timeout`             | 300                 | Execution timeout in seconds (30–3600)                      |
 | `system_prompt`       | None                | System instructions                                         |
@@ -141,20 +152,21 @@ ${node.llm_usage.session_id}                    # Resumable session ID
 
 ## Best practices
 
-- Use `output_schema` whenever you need specific fields — it eliminates regex parsing.
-- Set `max_turns` proportional to task complexity: 1 for simple generation, 2–3 for review, 5–10 for multi-step debugging.
+- Use `output_schema` whenever you need specific fields; it delegates enforcement to the SDK's native structured-output mode.
+- Set `max_turns` proportional to task complexity: 2 for simple structured output, 2-3 for review, 5-10 for multi-step debugging.
 - Track `${node.llm_usage.cost_usd}` for budget visibility.
-- Interpolate context directly into the `prompt` — there is no `context` parameter.
-- Check `${node._schema_error}` after structured calls if downstream logic depends on parsed fields.
+- Interpolate context directly into the `prompt`; there is no `context` parameter.
+- Check `${node._schema_error}` or workflow `DEGRADED` status after structured calls if downstream logic depends on parsed fields.
 
 ## Troubleshooting
 
-- **"Claude not outputting JSON despite schema"** — increase `max_turns` so Claude has room to refine.
-- **High cost** — reduce `max_turns`, tighten the prompt, or restrict `allowed_tools`.
-- **Timeouts** — break complex tasks into smaller steps or raise `timeout`.
-- **Authentication failed** — run `claude doctor` or verify `ANTHROPIC_API_KEY`.
+- **"Claude not producing structured output despite schema"** - check that the schema is valid JSON Schema and increase `max_turns` if needed.
+- **Top-level array schema rejected** - wrap arrays or primitives inside a top-level object property.
+- **High cost** - reduce `max_turns`, tighten the prompt, or restrict `allowed_tools`.
+- **Timeouts** - break complex tasks into smaller steps or raise `timeout`.
+- **Authentication failed** - run `claude doctor` or verify `ANTHROPIC_API_KEY`.
 
 ## See also
 
 - [Claude Agent SDK documentation](https://docs.anthropic.com/en/api/claude-agent-sdk)
-- `pflow guide` — top-level guide for workflow authoring
+- `pflow guide` - top-level guide for workflow authoring

--- a/examples/nodes/claude-code/claude-code-debug.pflow.md
+++ b/examples/nodes/claude-code/claude-code-debug.pflow.md
@@ -40,27 +40,35 @@ Analyze the error and provide structured debugging assistance.
 - system_prompt: You are an expert debugger. Be concise but thorough. Focus on practical solutions.
 
 ```yaml output_schema
-error_type:
-  type: str
-  description: Type of error (syntax/runtime/logic/configuration)
-root_cause:
-  type: str
-  description: Root cause analysis
-immediate_fix:
-  type: str
-  description: Quick fix to resolve the error
-long_term_solution:
-  type: str
-  description: Better long-term solution
-prevention_tips:
-  type: list
-  description: Tips to prevent similar errors
-code_snippet:
-  type: str
-  description: Fixed code snippet if applicable
-confidence:
-  type: int
-  description: Confidence level in the solution (1-10)
+type: object
+properties:
+  error_type:
+    type: string
+    enum: [syntax, runtime, logic, configuration, unknown]
+    description: Type of error
+  root_cause:
+    type: string
+    description: Root cause analysis
+  immediate_fix:
+    type: string
+    description: Quick fix to resolve the error
+  long_term_solution:
+    type: string
+    description: Better long-term solution
+  prevention_tips:
+    type: array
+    items:
+      type: string
+    description: Tips to prevent similar errors
+  code_snippet:
+    type: string
+    description: Fixed code snippet if applicable
+  confidence:
+    type: integer
+    minimum: 1
+    maximum: 10
+    description: Confidence level in the solution
+required: [error_type, root_cause, immediate_fix, long_term_solution, prevention_tips, code_snippet, confidence]
 ```
 
 ### format_report

--- a/examples/nodes/claude-code/claude-code-git-workflow.pflow.md
+++ b/examples/nodes/claude-code/claude-code-git-workflow.pflow.md
@@ -33,21 +33,29 @@ Analyze the git changes and commit history to understand what was implemented.
 - max_turns: 3
 
 ```yaml output_schema
-summary:
-  type: str
-  description: One-line summary of changes
-type_of_change:
-  type: str
-  description: "Type: feature/bugfix/refactor/docs/test"
-components_affected:
-  type: list
-  description: List of components or modules affected
-breaking_changes:
-  type: bool
-  description: Whether there are breaking changes
-testing_suggestions:
-  type: list
-  description: Suggested test scenarios
+type: object
+properties:
+  summary:
+    type: string
+    description: One-line summary of changes
+  type_of_change:
+    type: string
+    enum: [feature, bugfix, refactor, docs, test, chore]
+    description: Type of change
+  components_affected:
+    type: array
+    items:
+      type: string
+    description: List of components or modules affected
+  breaking_changes:
+    type: boolean
+    description: Whether there are breaking changes
+  testing_suggestions:
+    type: array
+    items:
+      type: string
+    description: Suggested test scenarios
+required: [summary, type_of_change, components_affected, breaking_changes, testing_suggestions]
 ```
 
 ```prompt
@@ -69,15 +77,20 @@ Generate a comprehensive pull request description based on the analysis.
 - system_prompt: You are a senior developer writing clear, professional PR descriptions. Use markdown formatting and be concise but thorough.
 
 ```yaml output_schema
-title:
-  type: str
-  description: PR title following conventional commits
-description:
-  type: str
-  description: Detailed PR description in markdown
-checklist:
-  type: list
-  description: PR checklist items
+type: object
+properties:
+  title:
+    type: string
+    description: PR title following conventional commits
+  description:
+    type: string
+    description: Detailed PR description in markdown
+  checklist:
+    type: array
+    items:
+      type: string
+    description: PR checklist items
+required: [title, description, checklist]
 ```
 
 ```prompt

--- a/examples/nodes/claude-code/claude-code-schema.pflow.md
+++ b/examples/nodes/claude-code/claude-code-schema.pflow.md
@@ -31,24 +31,34 @@ Review the code for quality, security issues, and best practices.
 - max_turns: 2
 
 ```yaml output_schema
-overall_quality:
-  type: str
-  description: "Overall quality assessment: excellent/good/fair/poor"
-security_score:
-  type: int
-  description: Security score from 1-10 (10 being most secure)
-issues:
-  type: list
-  description: List of specific issues found
-improvements:
-  type: list
-  description: List of recommended improvements
-has_critical_issues:
-  type: bool
-  description: Whether there are critical issues that must be fixed
-refactored_code:
-  type: str
-  description: Improved version of the code with issues fixed
+type: object
+properties:
+  overall_quality:
+    type: string
+    enum: [excellent, good, fair, poor]
+    description: Overall quality assessment
+  security_score:
+    type: integer
+    minimum: 1
+    maximum: 10
+    description: Security score from 1-10 (10 being most secure)
+  issues:
+    type: array
+    items:
+      type: string
+    description: List of specific issues found
+  improvements:
+    type: array
+    items:
+      type: string
+    description: List of recommended improvements
+  has_critical_issues:
+    type: boolean
+    description: Whether there are critical issues that must be fixed
+  refactored_code:
+    type: string
+    description: Improved version of the code with issues fixed
+required: [overall_quality, security_score, issues, improvements, has_critical_issues, refactored_code]
 ```
 
 ### save_review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pydantic", # IR/metadata validation
     "mcp[cli]>=1.17.0", # Model Context Protocol for MCP server support
     "requests>=2.32.5", # HTTP requests library for HttpNode (2.32.5 fixes SSLContext regression)
-    "claude-agent-sdk>=0.1.17", # Claude Agent SDK for agentic development node
+    "claude-agent-sdk>=0.2.82", # Claude Agent SDK for agentic development node (>=0.2.82 for native structured output via output_format + ResultMessage.structured_output)
     "PyYAML>=6.0.0", # YAML parsing for markdown workflow format params and frontmatter
     "litellm==1.83.14", # Provider-unified LLM client (the sole LLM seam — see src/pflow/core/llm_client.py and src/pflow/core/litellm_runtime.py). Pinned exactly: (a) 1.83.x transitively pins click==8.1.8 — ~95 CliRunner sites across 10 test files pass mix_stderr=False to compensate for click 8.1's mix_stderr=True default; (b) the bundled pricing-map backup contains claude-opus-4-7 so offline cache-analysis stays deterministic. TODO: when this pin is bumped past click 8.3, the mix_stderr=False kwargs become invalid (8.3+ removed the kwarg and made mix_stderr=False the only behavior) — strip them in lockstep with the bump. See GH #384 (offline pricing map) and GH #368 (Opus 4.7 thinking-mode reasoning_effort follow-up).
     "openai>=1.0", # Already a transitive dep via litellm; declared directly because the LLM adapter catches `openai.OpenAIError` (the real base of LiteLLM's exception hierarchy — see src/pflow/core/llm_client.py). 1.0 is the floor where the modern openai exception hierarchy stabilized.

--- a/src/pflow/core/types.py
+++ b/src/pflow/core/types.py
@@ -4,12 +4,6 @@ This module defines the Surface 1 (S1) type system for workflow-authored
 ``## Inputs`` / ``## Outputs`` declarations. It intentionally differs from the
 Python annotation vocabulary used inside code blocks and node Interface
 docstrings.
-
-The Claude Code node's ``output_schema`` is a deliberate fourth surface that
-continues to use Python-aliased names (``str``, ``int``, ``bool``, ``list``,
-``dict``). Those names are embedded literally into LLM prompt construction by
-``nodes/claude/claude_code.py::_build_schema_prompt`` — migrating them would
-change the LLM's instruction wording. Not in scope for the S1 vocabulary.
 """
 
 from __future__ import annotations

--- a/src/pflow/core/workflow/save_service.py
+++ b/src/pflow/core/workflow/save_service.py
@@ -46,6 +46,7 @@ RESERVED_WORKFLOW_NAMES: frozenset[str] = frozenset({
     "core",
     "http",
     "llm",
+    "claude-code",
     "code",
     "shell",
     "file",

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -162,14 +162,17 @@ class WorkflowValidator:
         if registry is not None:
             diagnostics.extend(WorkflowValidator._validate_unknown_params(workflow_ir, registry))
 
-        # 9. Sub-workflow validation (recursive)
+        # 9. Node-specific static parameter semantics
+        diagnostics.extend(WorkflowValidator._validate_node_param_semantics(workflow_ir))
+
+        # 10. Sub-workflow validation (recursive)
         diagnostics.extend(
             WorkflowValidator._validate_sub_workflows(
                 workflow_ir, extracted_params, registry, _seen, _ir_cache, skip_node_types, workflow_file
             )
         )
 
-        # 10. Cache lint — warn about input-less shell nodes
+        # 11. Cache lint — warn about input-less shell nodes
         diagnostics.extend(WorkflowValidator._warn_inputless_shell_nodes(workflow_ir))
 
         errors = [d for d in diagnostics if d.severity == Severity.ERROR]
@@ -666,7 +669,150 @@ class WorkflowValidator:
         return diagnostics
 
     # =========================================================================
-    # Sub-Workflow Validation (Step 8)
+    # Node-Specific Param Semantics (Step 9)
+    # =========================================================================
+
+    @staticmethod
+    def _validate_node_param_semantics(workflow_ir: dict[str, Any]) -> list[Diagnostic]:
+        """Validate node parameter combinations that are knowable statically.
+
+        Runtime ``prep()`` remains the enforcement boundary for values that need
+        actual input resolution. This validator catches literal node contracts so
+        ``--validate-only`` and ``--dry-run`` agree with normal execution.
+        """
+        diagnostics: list[Diagnostic] = []
+        for node in workflow_ir.get("nodes", []):
+            if node.get("type") != "claude-code":
+                continue
+            params = node.get("params", {})
+            if not isinstance(params, dict):
+                continue
+            diagnostics.extend(WorkflowValidator._validate_claude_code_params(node.get("id", "unknown"), params))
+        return diagnostics
+
+    @staticmethod
+    def _validate_claude_code_params(node_id: str, params: dict[str, Any]) -> list[Diagnostic]:
+        """Validate Claude Code structured-output constraints without SDK calls."""
+        output_schema = params.get("output_schema")
+        if output_schema is None:
+            return []
+
+        # Templated values resolve at runtime; matches max_turns' defer-on-template
+        # policy below. Without this, composition patterns like
+        # ``output_schema: ${upstream.schema}`` would be hard-rejected at preflight
+        # even though runtime ``_validate_schema`` handles them correctly.
+        if isinstance(output_schema, str) and "${" in output_schema:
+            return []
+
+        diagnostics: list[Diagnostic] = []
+        if not isinstance(output_schema, dict):
+            diagnostics.append(
+                WorkflowValidator._claude_code_param_error(
+                    node_id=node_id,
+                    message=f"output_schema must be a dict (JSON Schema), got {type(output_schema).__name__}.",
+                    path=f"nodes[id={node_id}].params.output_schema",
+                    suggestions=["Use a YAML `output_schema` block or remove the output_schema field."],
+                )
+            )
+            return diagnostics
+
+        if not output_schema:
+            diagnostics.append(
+                WorkflowValidator._claude_code_param_error(
+                    node_id=node_id,
+                    message=(
+                        "output_schema is an empty dict. Did you forget to populate the schema body? "
+                        'Use a real JSON Schema (e.g. {"type": "object", "properties": {...}}) '
+                        "or remove the output_schema field entirely."
+                    ),
+                    path=f"nodes[id={node_id}].params.output_schema",
+                    suggestions=["Populate the schema body or remove output_schema."],
+                )
+            )
+            return diagnostics
+
+        if WorkflowValidator._looks_like_legacy_python_alias_schema(output_schema):
+            diagnostics.append(
+                WorkflowValidator._claude_code_param_error(
+                    node_id=node_id,
+                    message=(
+                        "output_schema appears to use the legacy Python-alias format "
+                        '({"field": {"type": "str", ...}}). Use JSON Schema instead: '
+                        '{"type": "object", "properties": {...}, "required": [...]}.'
+                    ),
+                    path=f"nodes[id={node_id}].params.output_schema",
+                    suggestions=["Convert field definitions to JSON Schema under `properties`."],
+                )
+            )
+
+        top_level_type = output_schema.get("type")
+        if top_level_type is not None and top_level_type != "object":
+            diagnostics.append(
+                WorkflowValidator._claude_code_param_error(
+                    node_id=node_id,
+                    message=(
+                        "output_schema on claude-code nodes must have top-level type: object "
+                        f"(got type: {top_level_type!r})."
+                    ),
+                    path=f"nodes[id={node_id}].params.output_schema.type",
+                    suggestions=[
+                        "Wrap array or primitive outputs in an object property, "
+                        'e.g. {"type": "object", "properties": {"items": {"type": "array"}}}.'
+                    ],
+                )
+            )
+
+        max_turns = params.get("max_turns", 50)
+        try:
+            max_turns_int = int(max_turns)
+        except (TypeError, ValueError):
+            max_turns_int = None
+        if max_turns_int is not None and max_turns_int < 2:
+            diagnostics.append(
+                WorkflowValidator._claude_code_param_error(
+                    node_id=node_id,
+                    message=f"max_turns must be >= 2 when output_schema is set (got {max_turns_int}).",
+                    path=f"nodes[id={node_id}].params.max_turns",
+                    suggestions=["Set max_turns to 2 or higher, or remove output_schema."],
+                )
+            )
+
+        return diagnostics
+
+    @staticmethod
+    def _looks_like_legacy_python_alias_schema(schema: dict[str, Any]) -> bool:
+        """Detect the old custom Claude Code output_schema format."""
+        json_schema_markers = {"type", "$ref", "$schema", "oneOf", "anyOf", "allOf", "enum", "const"}
+        if any(marker in schema for marker in json_schema_markers):
+            return False
+        python_alias_types = {"str", "int", "bool", "list", "dict", "float"}
+        return any(isinstance(value, dict) and value.get("type") in python_alias_types for value in schema.values())
+
+    @staticmethod
+    def _claude_code_param_error(
+        *,
+        node_id: str,
+        message: str,
+        path: str,
+        suggestions: list[str],
+    ) -> Diagnostic:
+        return Diagnostic(
+            severity=Severity.ERROR,
+            source="validator",
+            title="Claude Code Structured Output Validation Error",
+            node_id=node_id,
+            message=message,
+            suggestions=suggestions,
+            context={
+                "category": "validation",
+                "node_type": "claude-code",
+                "path": path,
+            },
+            see_also=["claude-code"],
+        )
+
+    # =========================================================================
+    # Sub-Workflow Validation (Step 10)
     # =========================================================================
 
     @staticmethod

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -692,7 +692,17 @@ class WorkflowValidator:
 
     @staticmethod
     def _validate_claude_code_params(node_id: str, params: dict[str, Any]) -> list[Diagnostic]:
-        """Validate Claude Code structured-output constraints without SDK calls."""
+        """Validate Claude Code structured-output constraints without SDK calls.
+
+        Predicates live in ``pflow.nodes.claude.schema_validation`` so the
+        runtime path (``ClaudeCodeNode._validate_schema``) and this static
+        preflight path can't drift on shape detection.
+        """
+        from pflow.nodes.claude.schema_validation import (
+            is_legacy_python_alias_schema,
+            top_level_object_violation,
+        )
+
         output_schema = params.get("output_schema")
         if output_schema is None:
             return []
@@ -731,7 +741,7 @@ class WorkflowValidator:
             )
             return diagnostics
 
-        if WorkflowValidator._looks_like_legacy_python_alias_schema(output_schema):
+        if is_legacy_python_alias_schema(output_schema):
             diagnostics.append(
                 WorkflowValidator._claude_code_param_error(
                     node_id=node_id,
@@ -745,28 +755,19 @@ class WorkflowValidator:
                 )
             )
 
-        top_level_type = output_schema.get("type")
-        if top_level_type != "object":
-            # Covers non-"object" types AND schemas with no top-level type
-            # (top-level oneOf/anyOf/allOf/enum). Both classes return HTTP 400
-            # from the Anthropic API. Verified in Phase 0 and the oneOf probe.
-            if top_level_type is None:
-                combinators = sorted(k for k in ("oneOf", "anyOf", "allOf", "enum", "const") if k in output_schema)
-                cause = (
-                    f"top-level combinator {combinators[0]!r} with no top-level type"
-                    if combinators
-                    else "no top-level type"
-                )
+        violation = top_level_object_violation(output_schema)
+        if violation is not None:
+            # The shared predicate covers non-"object" types AND combinator-only
+            # schemas (oneOf/anyOf/allOf/enum without a top-level type). Both
+            # classes return HTTP 400 from the Anthropic API (Phase 0 + oneOf probe).
+            if violation.kind == "missing_type":
                 message = (
                     "output_schema on claude-code nodes must declare top-level type: object "
-                    f"({cause}). Combinators like oneOf/anyOf/allOf/enum must live inside an "
-                    "object wrapper."
+                    f"({violation.cause}). Combinators like oneOf/anyOf/allOf/enum must live "
+                    "inside an object wrapper."
                 )
             else:
-                message = (
-                    "output_schema on claude-code nodes must have top-level type: object "
-                    f"(got type: {top_level_type!r})."
-                )
+                message = f"output_schema on claude-code nodes must have top-level type: object ({violation.cause})."
             diagnostics.append(
                 WorkflowValidator._claude_code_param_error(
                     node_id=node_id,
@@ -795,15 +796,6 @@ class WorkflowValidator:
             )
 
         return diagnostics
-
-    @staticmethod
-    def _looks_like_legacy_python_alias_schema(schema: dict[str, Any]) -> bool:
-        """Detect the old custom Claude Code output_schema format."""
-        json_schema_markers = {"type", "$ref", "$schema", "oneOf", "anyOf", "allOf", "enum", "const"}
-        if any(marker in schema for marker in json_schema_markers):
-            return False
-        python_alias_types = {"str", "int", "bool", "list", "dict", "float"}
-        return any(isinstance(value, dict) and value.get("type") in python_alias_types for value in schema.values())
 
     @staticmethod
     def _claude_code_param_error(

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -746,18 +746,35 @@ class WorkflowValidator:
             )
 
         top_level_type = output_schema.get("type")
-        if top_level_type is not None and top_level_type != "object":
+        if top_level_type != "object":
+            # Covers non-"object" types AND schemas with no top-level type
+            # (top-level oneOf/anyOf/allOf/enum). Both classes return HTTP 400
+            # from the Anthropic API. Verified in Phase 0 and the oneOf probe.
+            if top_level_type is None:
+                combinators = sorted(k for k in ("oneOf", "anyOf", "allOf", "enum", "const") if k in output_schema)
+                cause = (
+                    f"top-level combinator {combinators[0]!r} with no top-level type"
+                    if combinators
+                    else "no top-level type"
+                )
+                message = (
+                    "output_schema on claude-code nodes must declare top-level type: object "
+                    f"({cause}). Combinators like oneOf/anyOf/allOf/enum must live inside an "
+                    "object wrapper."
+                )
+            else:
+                message = (
+                    "output_schema on claude-code nodes must have top-level type: object "
+                    f"(got type: {top_level_type!r})."
+                )
             diagnostics.append(
                 WorkflowValidator._claude_code_param_error(
                     node_id=node_id,
-                    message=(
-                        "output_schema on claude-code nodes must have top-level type: object "
-                        f"(got type: {top_level_type!r})."
-                    ),
+                    message=message,
                     path=f"nodes[id={node_id}].params.output_schema.type",
                     suggestions=[
-                        "Wrap array or primitive outputs in an object property, "
-                        'e.g. {"type": "object", "properties": {"items": {"type": "array"}}}.'
+                        'Wrap in an object, e.g. {"type": "object", "properties": '
+                        '{"result": <your schema>}, "required": ["result"]}.'
                     ],
                 )
             )

--- a/src/pflow/guide/CLAUDE.md
+++ b/src/pflow/guide/CLAUDE.md
@@ -16,7 +16,7 @@ src/pflow/guide/
 ├── entry.md             # Capability map — rendered by pflow --help and pflow guide (no args)
 ├── core.md              # Framework fundamentals (explicit topic, not auto-included)
 ├── nodes/               # Per-node-type guides (static prose + dynamic interface from registry)
-│   ├── http.md, llm.md, code.md, shell.md, file.md, mcp.md
+│   ├── http.md, llm.md, claude-code.md, code.md, shell.md, file.md, mcp.md
 └── features/            # Per-feature guides (static content only)
     ├── batch.md, branching.md, prompt-caching.md, sub-workflows.md
 ```
@@ -27,7 +27,7 @@ src/pflow/guide/
 
 ## Dynamic Interface Injection
 
-Node topics (http, llm, code, shell, file) get Parameters + Outputs sections appended at render time, read from the registry. This keeps interface info in sync with actual node implementations.
+Node topics (http, llm, claude-code, code, shell, file) get Parameters + Outputs sections appended at render time, read from the registry. This keeps interface info in sync with actual node implementations.
 
 The mapping is in `_TOPIC_TO_NODE_TYPES`. Topics not listed there (mcp, features, core) get static content only. The `file` topic maps to both `read-file` and `write-file` node types.
 

--- a/src/pflow/guide/__init__.py
+++ b/src/pflow/guide/__init__.py
@@ -25,6 +25,7 @@ _NODE_TYPE_TO_TOPIC: dict[str, str] = {
 _TOPIC_TO_NODE_TYPES: dict[str, list[str]] = {
     "http": ["http"],
     "llm": ["llm"],
+    "claude-code": ["claude-code"],
     "code": ["code"],
     "shell": ["shell"],
     "file": ["read-file", "write-file"],
@@ -406,7 +407,7 @@ def _format_param_line(param: dict) -> str:
 
 def _placeholder_entry_content() -> str:
     return """\
-pflow runs workflows — sequences of nodes (http, shell, llm, code, file, mcp) \
+pflow runs workflows — sequences of nodes (http, shell, llm, claude-code, code, file, mcp) \
 that chain together through a shared data store.
 
 Quick start:

--- a/src/pflow/guide/core.md
+++ b/src/pflow/guide/core.md
@@ -554,7 +554,7 @@ result: float = sum(i['pricing']['amount'] for i in items)
 ```
 ````
 
-**Before adding processing steps:** Can the source produce cleaner output? (LLM: use `output_schema`, HTTP: check for `format=json` param.) Fix at source instead of adding nodes.
+**Before adding processing steps:** Can the source produce cleaner output? (LLM/Claude Code: use `output_schema`; Claude Code schemas must be top-level objects and need `max_turns >= 2`. HTTP: check for `format=json` param.) Fix at source instead of adding nodes.
 
 **The golden rule:** Every transformation step must solve a verified problem, not prevent a hypothetical one.
 

--- a/src/pflow/guide/entry.md
+++ b/src/pflow/guide/entry.md
@@ -38,6 +38,7 @@ Load tailored content: `pflow guide <topic> <topic>` (prefer combining nodes and
 Nodes:
   http             JSON REST APIs
   llm              LLM inference (summarize, interpret, decide)
+  claude-code      Agentic coding in a repository (edit, test, debug)
   code             Python data transformation (filter, reshape, compute)
   shell            Shell commands and CLI tools (git, curl, docker)
   file             File read/write

--- a/src/pflow/guide/nodes/claude-code.md
+++ b/src/pflow/guide/nodes/claude-code.md
@@ -1,0 +1,105 @@
+# Claude Code Node
+
+**Use for**: Multi-step agentic tasks that require a fully autonomous agent.
+
+**Don't use Claude Code for**: Deterministic data reshaping (use `code`), simple shell commands (use `shell`), API calls (use `http`), or ordinary text analysis that does not need repository tools (use `llm`).
+
+**The test**: Does the task need an autonomous coding agent with access to multiple tools like reading files, editing code, bash etc? YES -> `claude-code`. NO -> use the smaller node that matches the operation.
+
+Use `output_schema` when downstream nodes need structured implementation results. Claude Code schemas must be JSON Schema objects with top-level `type: object`, and `max_turns` must be at least `2` when `output_schema` is set.
+
+Run with `--report` when iterating on prompts. The report shows the rendered prompt, result, tool usage, and cost so you can tighten the task without guessing.
+
+### Node Creation Pattern
+
+`````markdown
+### implement-fix
+
+Fix the failing behavior and report the exact files changed.
+
+- type: claude-code
+- max_turns: 6
+- allowed_tools:
+    - Read
+    - Edit
+    - Bash
+
+```yaml output_schema
+type: object
+properties:
+  summary:
+    type: string
+  files_changed:
+    type: array
+    items:
+      type: string
+  tests_run:
+    type: array
+    items:
+      type: string
+  follow_up:
+    type: string
+required:
+  - summary
+  - files_changed
+  - tests_run
+```
+
+```prompt
+Fix this issue in the current repository:
+
+${triage.result}
+
+Keep the change focused. Run the smallest relevant tests and include the
+commands in tests_run.
+```
+`````
+
+Downstream nodes can read structured fields directly:
+
+```markdown
+- content: ${implement-fix.result.summary}
+- content: ${implement-fix.result.files_changed}
+```
+
+### Claude Code Rules
+
+- Keep prompts specific: state the bug, success criteria, files or commands already known, and verification expectation.
+- Prefer narrow tool access with `allowed_tools` / `disallowed_tools` when the workflow should constrain what the agent can do.
+- Use `output_schema` for summaries that downstream nodes will route, save, or format.
+- Do not ask Claude Code to emit both prose and machine data in the same result; put all required fields in the schema.
+- If the task is only "transform this object into that object", use `code` instead.
+
+### Recovering from schema soft-failures
+
+`claude-code` always returns `default`. Schema soft-failures (model didn't comply, a provider error landed alongside the output, or a templated `output_schema` reference resolved to None) do NOT route through `- on-error:` edges. Branch on `${node._schema_error}` or workflow `DEGRADED` status instead:
+
+```markdown
+### review
+
+- type: claude-code
+- prompt: "..."
+- max_turns: 4
+- next: branch-on-schema
+
+```yaml output_schema
+type: object
+properties:
+  summary: { type: string }
+required: [summary]
+```
+
+### branch-on-schema
+
+- type: code
+- inputs:
+    schema_error: ${review._schema_error ?? ""}
+
+```python code
+schema_error: str
+if schema_error:
+    next: str = "fallback"
+else:
+    next: str = "use-result"
+```
+```

--- a/src/pflow/mcp_server/resources/instruction_resources.py
+++ b/src/pflow/mcp_server/resources/instruction_resources.py
@@ -213,7 +213,7 @@ Use these MCP tools to discover what you need:
 ## Key Principles (Quick Reference)
 
 1. **Always discover first**: Run `workflow_discover()` before building new
-2. **Use templates for extraction, code nodes for transformation**: Never use LLM for structured data extraction
+2. **Use templates for extraction, code nodes for transformation**: For already-structured data, use template paths. For model-derived structured data, use `output_schema` on `llm` or `claude-code`.
 3. **Sequential by default**: Workflows run top-to-bottom; use `on-error:` and code node `next` for conditional branching
 4. **Test MCP nodes**: Always test with `registry_run()` when accessing specific fields
 5. **Templates**: Use `${input}` for workflow inputs, `${node.output}` for node outputs

--- a/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-agent-instructions.md
@@ -1129,7 +1129,7 @@ Works with or without template variables. Handles nested objects and arrays.
 **Before adding processing steps:**
 
 1. **Can the source produce cleaner output?**
-   - LLM: Use `output_schema` (JSON Schema in a `yaml output_schema` code block) — guarantees valid JSON via constrained decoding, response stored as dict
+   - LLM or Claude Code: Use `output_schema` (JSON Schema in a `yaml output_schema` code block) to produce model-derived structured data at the source. Claude Code requires top-level `type: object` and `max_turns >= 2`.
    - HTTP: Check if API has a `format=json` parameter
    - **If yes → Fix at source instead of adding nodes**
 
@@ -2117,7 +2117,8 @@ Simple operations? → Skip
 Extract nested field? → Template variable ${node.path.to.field}
 Transform/compute?    → code node
 Combine/concatenate?  → code node or templates
-Parse text → structured? → code node (NEVER LLM)
+Parse existing text deterministically → structured? → code node
+Need model judgment as structured data? → LLM/Claude Code with output_schema
 Need meaning/reasoning? → LLM (only if creative decisions needed)
 Run external tool?    → shell node (git, curl, docker, ffmpeg)
 File download?        → shell+curl
@@ -2138,7 +2139,7 @@ Format: `verb-noun-qualifier`
 |---------|----------------|------------|
 | **Manual JSON string construction** | Trying to build `"{\"key\": \"${val}\"}"` | Use object syntax: `{"key": "${val}"}` - auto-serializes with proper escaping |
 | **Using Slack as default example** | Document bias from old examples | Rotate between service categories |
-| **Using LLM for JSON extraction** | Seems "safer" or more flexible | Templates extract paths, code node transforms |
+| **Using LLM for JSON extraction** | Seems "safer" or more flexible | Templates extract existing paths; use `output_schema` when the model must derive structured data |
 | **Over-testing nodes** | Uncertainty about structure | Test ONLY when accessing specific paths |
 | **Creating defensive extraction steps** | Fear of malformed data | Nodes handle parsing automatically |
 | **Ignoring workflow discovery** | Eager to build something new | ALWAYS check existing workflows first |
@@ -2152,7 +2153,7 @@ Format: `verb-noun-qualifier`
 2. **Understand step order vs templates** - Execution order vs data access
 3. **Test only when needed** - Skip if passing whole `${node.result}`
 4. **Phase complex workflows** - Build incrementally
-5. **Use templates for extraction, code node for transformation** - LLM only for meaning
+5. **Use templates for extraction, code node for transformation** - use `output_schema` on LLM/Claude Code for model-derived structured data
 6. **Every value becomes input** - Unless explicitly "always"
 7. **Format user-facing output** - Never show raw JSON
 8. **Document actual structures** - Not what docs claim

--- a/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
+++ b/src/pflow/mcp_server/resources/instructions/mcp-sandbox-agent-instructions.md
@@ -1109,7 +1109,7 @@ Works with or without template variables. Handles nested objects and arrays.
 **Before adding processing steps:**
 
 1. **Can the source produce cleaner output?**
-   - LLM: Add "Return ONLY valid JSON, no other text" to prompt
+   - LLM or Claude Code: Use `output_schema` (JSON Schema in a `yaml output_schema` code block) to produce model-derived structured data at the source. Claude Code requires top-level `type: object` and `max_turns >= 2`.
    - HTTP: Check if API has a `format=json` parameter
    - **If yes → Fix at source instead of adding nodes**
 
@@ -2098,7 +2098,8 @@ Simple operations? → Skip
 Extract nested field? → Template variable ${node.path.to.field}
 Transform/compute?    → code node
 Combine/concatenate?  → code node or templates
-Parse text → structured? → code node (NEVER LLM)
+Parse existing text deterministically → structured? → code node
+Need model judgment as structured data? → LLM/Claude Code with output_schema
 Need meaning/reasoning? → LLM (only if creative decisions needed)
 Run external tool?    → shell node (git, curl, docker, ffmpeg)
 File download?        → shell+curl
@@ -2119,7 +2120,7 @@ Format: `verb-noun-qualifier`
 |---------|----------------|------------|
 | **Manual JSON string construction** | Trying to build `"{\"key\": \"${val}\"}"` | Use object syntax: `{"key": "${val}"}` - auto-serializes with proper escaping |
 | **Using Slack as default example** | Document bias from old examples | Rotate between service categories |
-| **Using LLM for JSON extraction** | Seems "safer" or more flexible | Templates extract paths, code node transforms |
+| **Using LLM for JSON extraction** | Seems "safer" or more flexible | Templates extract existing paths; use `output_schema` when the model must derive structured data |
 | **Over-testing nodes** | Uncertainty about structure | Test ONLY when accessing specific paths |
 | **Creating defensive extraction steps** | Fear of malformed data | Nodes handle parsing automatically |
 | **Ignoring workflow discovery** | Eager to build something new | ALWAYS check existing workflows first |
@@ -2133,7 +2134,7 @@ Format: `verb-noun-qualifier`
 2. **Understand step order vs templates** - Execution order vs data access
 3. **Test only when needed** - Skip if passing whole `${node.result}`
 4. **Phase complex workflows** - Build incrementally
-5. **Use templates for extraction, code node for transformation** - LLM only for meaning
+5. **Use templates for extraction, code node for transformation** - use `output_schema` on LLM/Claude Code for model-derived structured data
 6. **Every value becomes input** - Unless explicitly "always"
 7. **Format user-facing output** - Never show raw JSON
 8. **Document actual structures** - Not what docs claim

--- a/src/pflow/nodes/CLAUDE.md
+++ b/src/pflow/nodes/CLAUDE.md
@@ -11,10 +11,10 @@ This directory contains all pflow nodes. **CRITICAL**: All nodes MUST follow the
 
 Rule of thumb: if the value changes between workflow runs, it's shared store data. If it's the same regardless of input, it's a param.
 
-`LLMNode.post()` is one approved direct producer of `shared["__warnings__"]`. The convention for choosing between `setdefault` and `=` is intent-based:
+`LLMNode.post()` and `ClaudeCodeNode.post()` are approved direct producers of `shared["__warnings__"]`. The convention for choosing between `setdefault` and `=` is intent-based:
 
-- **`setdefault` — preserve prior signal.** Used by `_emit_observed_below_min_cache_warning` (catalog-backed `cache.below-min-tokens` diagnostic emitted when provider telemetry reports zero cache creation/read for a node declaring `prompt_cache:`). Pre-existing warnings survive; this is supplementary observability that never overwrites earlier evidence.
-- **`=` — this signal takes precedence.** Used by `_emit_prewarm_disabled_warning` (when `prewarm: true` is declared but cache rendering can't fire — e.g., images present, or canonical/standard byte alignment failed) and by adapter-empty-response warnings emitted later in `post()`. These signals are authoritative for the run; clobbering prior writes is intentional.
+- **`setdefault` — preserve prior signal.** Used by `LLMNode._emit_observed_below_min_cache_warning` (catalog-backed `cache.below-min-tokens` diagnostic emitted when provider telemetry reports zero cache creation/read for a node declaring `prompt_cache:`). Pre-existing warnings survive; this is supplementary observability that never overwrites earlier evidence.
+- **`=` — this signal takes precedence.** Used by `LLMNode._emit_prewarm_disabled_warning` (when `prewarm: true` is declared but cache rendering can't fire — e.g., images present, or canonical/standard byte alignment failed), adapter-empty-response warnings emitted later in `LLMNode.post()`, and `ClaudeCodeNode._emit_soft_fail_signal` / `_emit_schema_resolved_null_warning` (schema soft-failures and templated-schema-resolved-to-None — both authoritative for the run). These signals clobber prior writes intentionally.
 
 Future contributors adding new direct `__warnings__` writes: pick the verb by asking "is this signal authoritative for the node's current run, or supplementary?" Authoritative → `=`. Supplementary → `setdefault`.
 

--- a/src/pflow/nodes/claude/__init__.py
+++ b/src/pflow/nodes/claude/__init__.py
@@ -1,5 +1,23 @@
-"""Claude Code Agentic Node package."""
+"""Claude Code Agentic Node package.
 
-from .claude_code import ClaudeCodeNode
+``ClaudeCodeNode`` is loaded lazily via ``__getattr__`` so importing the
+``schema_validation`` submodule (or any other lightweight submodule) doesn't
+eagerly drag in ``claude_agent_sdk``. The test suite injects an SDK mock at
+module load time (see ``tests/CLAUDE.md`` pitfall #17); an eager re-export
+here would resolve the real SDK before the mock binds.
+"""
+
+from typing import TYPE_CHECKING, Any
 
 __all__ = ["ClaudeCodeNode"]
+
+if TYPE_CHECKING:  # static type checkers see the symbol; runtime stays lazy
+    from .claude_code import ClaudeCodeNode
+
+
+def __getattr__(name: str) -> Any:
+    if name == "ClaudeCodeNode":
+        from .claude_code import ClaudeCodeNode
+
+        return ClaudeCodeNode
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -1,15 +1,14 @@
-"""Claude Code Agentic Node - AI-powered development assistant with schema-driven outputs.
+"""Claude Code Agentic Node - AI-powered development assistant with structured outputs.
 
 This node integrates with Claude Code Python SDK to execute comprehensive development tasks.
-Features a dynamic schema-driven output system where users provide an output schema that
-gets converted to system prompt instructions, enabling structured outputs from Claude's
-unstructured text generation.
+When users provide a JSON Schema output_schema, pflow passes it to the SDK's native
+structured-output mode and stores the parsed structured_output from the final result.
 
 Interface:
 - Params: prompt: str  # The prompt to send to Claude (required)
-- Params: output_schema: dict  # JSON schema for structured outputs (optional)
-- Writes: shared["result"]: any  # Response - string or dict with schema keys
-- Writes: shared["_schema_error"]: str  # Error message if JSON parsing fails (optional)
+- Params: output_schema: dict  # JSON Schema for structured outputs (optional)
+- Writes: shared["result"]: str|dict  # Free-form text (str), or parsed JSON (dict/list/primitive) when output_schema is set, or raw text on soft schema failure
+- Writes: shared["_schema_error"]: str  # Soft-failure message for structured-output mode: set when structured output was unavailable, the SDK reported an error alongside the output, or the schema reference resolved to None (optional)
 - Writes: shared["llm_usage"]: dict  # Token usage and execution metadata (empty dict {} if unavailable)
     - model: str  # Model identifier used
     - input_tokens: int  # Non-cached input tokens
@@ -37,16 +36,16 @@ Interface:
     - allowUnsandboxedCommands: bool  # Allow model to request unsandboxed execution
     - network: dict  # Network settings (allowLocalBinding, allowUnixSockets, etc.)
 
-Note: When output_schema is provided, the result is a dict with schema keys.
-Access values as shared["result"]["key"] in templates: ${node.result.key}
+Note: When output_schema is provided, the result is the SDK's parsed structured_output.
+Access object values as shared["result"]["key"] in templates: ${node.result.key}
+Soft schema failures also write a root-level `shared["__warnings__"][node_id]`
+entry so workflow status becomes DEGRADED.
 Session ID is available at ${node.llm_usage.session_id} for chaining sessions.
 """
 
 import asyncio
-import json
 import logging
 import os
-import re
 from typing import Any, Optional
 
 from pflow.core.node import Node
@@ -73,6 +72,16 @@ try:
 except ImportError as e:
     raise ImportError("Claude Agent SDK is not installed. Install with: pip install claude-agent-sdk") from e
 
+# Guard against SDK field renames that would silently break structured output.
+# If claude_agent_sdk renames `structured_output`, every schema call would
+# otherwise soft-fail with a misleading "model didn't comply" message.
+if "structured_output" not in getattr(ResultMessage, "__annotations__", {}):
+    raise ImportError(
+        "claude_agent_sdk.types.ResultMessage has no 'structured_output' field. "
+        "pflow's Claude Code node requires claude-agent-sdk>=0.2.82 with native "
+        "structured output support. Got an incompatible SDK version."
+    )
+
 logger = logging.getLogger(__name__)
 
 # Security patterns for bash command validation
@@ -94,22 +103,21 @@ class ClaudeCodeNode(Node):
     """Claude Code agentic super node for AI-assisted development tasks.
 
     This node integrates with Claude Code Python SDK to execute comprehensive development tasks.
-    Features a dynamic schema-driven output system where users provide an output schema that
-    gets converted to system prompt instructions, enabling structured outputs.
+    When users provide an output_schema, pflow passes the JSON Schema to the SDK's native
+    structured-output mode and stores the parsed structured_output.
 
     Output Schema Format:
-        Each field in the schema is a dict with "type" and "description" keys:
-        - "type": One of "str", "int", "bool", "list", "dict"
-        - "description": Human-readable description of the field
+        JSON Schema for structured outputs (optional):
+        {"type": "object", "properties": {"field": {"type": "string"}}, "required": ["field"]}
 
-        Example: {"risk_level": {"type": "str", "description": "high/medium/low"},
-                  "score": {"type": "int", "description": "Security score 1-10"}}
+        Top-level type must be "object" because the Claude API rejects non-object
+        schemas when the SDK wraps output_format as a tool input_schema.
 
     Interface:
     - Params: prompt: str  # The prompt to send to Claude (required)
-    - Params: output_schema: dict  # Schema for structured outputs (optional): {"field": {"type": "str", "description": "..."}}
-    - Writes: shared["result"]: any  # Response - string without schema, dict with schema
-    - Writes: shared["_schema_error"]: str  # Error message if JSON parsing fails (optional)
+    - Params: output_schema: dict  # JSON Schema for structured outputs (optional)
+    - Writes: shared["result"]: str|dict  # Free-form text, parsed JSON when output_schema succeeds, or raw text on soft schema failure
+    - Writes: shared["_schema_error"]: str  # Soft-failure message for structured-output mode: set when structured output was unavailable, the SDK reported an error alongside the output, or the schema reference resolved to None (optional)
     - Writes: shared["llm_usage"]: dict  # Token usage and execution metadata (empty dict {} if unavailable)
         - model: str  # Model identifier used
         - input_tokens: int  # Non-cached input tokens
@@ -124,6 +132,7 @@ class ClaudeCodeNode(Node):
     - Params: cwd: str  # Working directory for Claude (default: os.getcwd())
     - Params: model: str  # Claude model identifier (default: claude-sonnet-4-5)
     - Params: allowed_tools: list  # Permitted tools (default: None = all tools including Task for subagents)
+    - Params: disallowed_tools: list  # Tools to deny (default: None = no restrictions)
     - Params: max_turns: int  # Maximum conversation turns (default: 50)
     - Params: max_thinking_tokens: int  # Maximum tokens for reasoning (default: 8000)
     - Params: timeout: int  # Execution timeout in seconds (default: 300; valid: 30-3600)
@@ -154,7 +163,12 @@ class ClaudeCodeNode(Node):
     Note: Result type depends on schema usage:
     - Without schema: String response in ${node_id.result}
     - With schema (success): Dict with fields accessible via ${node_id.result.field_name}
-    - With schema (parse failure): Falls back to string in ${node_id.result} with error in _schema_error
+    - With schema (soft failure): Falls back to string in ${node_id.result}, with _schema_error and __warnings__
+      at the root warning channel so the workflow status becomes DEGRADED.
+
+    Routing: post() always returns "default". Schema soft-failures DO NOT route through
+    `- on-error:` edges — wire schema-validation recovery via inspection of
+    ${node._schema_error} or workflow DEGRADED status, not the error edge.
 
     Example:
         # Basic execution
@@ -166,17 +180,21 @@ class ClaudeCodeNode(Node):
         shared = {
             "prompt": "Review this code for security issues",
             "output_schema": {
-                "risk_level": {"type": "str", "description": "high/medium/low"},
-                "issues": {"type": "list", "description": "List of security issues"},
-                "score": {"type": "int", "description": "Security score 1-10"},
-                "needs_fix": {"type": "bool", "description": "True if critical issues found"}
+                "type": "object",
+                "properties": {
+                    "risk_level": {"type": "string", "enum": ["high", "medium", "low"]},
+                    "issues": {"type": "array", "items": {"type": "string"}},
+                    "score": {"type": "integer", "minimum": 1, "maximum": 10},
+                    "needs_fix": {"type": "boolean"},
+                },
+                "required": ["risk_level", "issues", "score", "needs_fix"],
             }
         }
         node = ClaudeCodeNode()
         node.run(shared)
         # Success: shared["result"] = {"risk_level": "low", "issues": [...], "score": 8, "needs_fix": False}
         # Access as: shared["result"]["risk_level"], shared["result"]["issues"], etc.
-        # Parse failure: shared["result"] = raw_text_string, shared["_schema_error"] = error
+        # Soft schema failure: shared["result"] = raw_text_string, shared["_schema_error"] = error
     """
 
     def __init__(self) -> None:
@@ -196,22 +214,84 @@ class ClaudeCodeNode(Node):
             raise ValueError("Prompt cannot be empty or whitespace only.")
         return prompt
 
-    def _validate_schema(self, output_schema: Any) -> Optional[dict]:
-        """Validate output schema parameter."""
-        if not output_schema:
+    def _validate_schema(self, output_schema: Any) -> dict | None:
+        """Validate output_schema parameter.
+
+        - None: no schema requested (returns None)
+        - {} (empty): likely a typo; raises with guidance
+        - Non-dict: TypeError
+        - Legacy Python-alias format: raises with migration guidance
+        - Non-object top-level: raises (Anthropic API tool-use limitation)
+        - Otherwise: returns as-is; SDK/CLI enforces remaining JSON Schema validity
+
+        Note on schema typos (e.g. type: "intger"): the Anthropic API silently accepts
+        them. Schema typos will result in a soft-fail at runtime (structured_output is
+        None) until centralized JSON Schema validation lands in issue #398.
+        """
+        if output_schema is None:
             return None
         if not isinstance(output_schema, dict):
-            raise TypeError(f"Output schema must be a dict, got {type(output_schema).__name__}")
-
-        # Validate schema keys are valid Python identifiers
-        for key in output_schema:
-            if not str(key).isidentifier():
-                raise ValueError(f"Invalid schema key '{key}'. Keys must be valid Python identifiers.")
-
-        # Check schema complexity
-        if len(output_schema) > 50:
-            raise ValueError(f"Schema too complex ({len(output_schema)} keys). Maximum 50 keys allowed.")
+            raise TypeError(f"output_schema must be a dict (JSON Schema), got {type(output_schema).__name__}")
+        if not output_schema:
+            raise ValueError(
+                "output_schema is an empty dict. Did you forget to populate the schema body? "
+                'Use a real JSON Schema (e.g. {"type": "object", "properties": {...}}) '
+                "or remove the output_schema field entirely."
+            )
+        if self._looks_like_legacy_python_alias_format(output_schema):
+            raise ValueError(
+                "output_schema appears to use the legacy Python-alias format "
+                '({"field": {"type": "str", ...}}). '
+                'Use JSON Schema instead: {"type": "object", "properties": {...}, "required": [...]}. '
+                "See docs/reference/nodes/claude-code.mdx for an example."
+            )
+        # Claude API limitation (verified in Phase 0 smoke test): the SDK wraps output_format
+        # as a tool's input_schema, and the API rejects non-object top-level schemas with a 400.
+        top_level_type = output_schema.get("type")
+        if top_level_type is not None and top_level_type != "object":
+            raise ValueError(
+                "output_schema on claude-code nodes must have top-level type: object "
+                f"(got type: {top_level_type!r}). "
+                "The Anthropic API rejects non-object top-level schemas in tool input_schema "
+                "wrappers. For array or primitive outputs, wrap in an object with a single "
+                'property, e.g. {"type": "object", "properties": {"items": {"type": "array", '
+                '"items": ...}}, "required": ["items"]}. '
+                "(The LLM node has no such restriction.)"
+            )
         return output_schema
+
+    def _emit_schema_resolved_null_warning(self, shared: dict[str, Any]) -> None:
+        """Warn when ``output_schema`` was declared but resolved to ``None``.
+
+        Same channel as soft-fail warnings — ``shared["__warnings__"][node_id]``
+        triggers DEGRADED workflow status. Falls back to ``shared["_schema_error"]``
+        when no ``node_id`` is bound (test paths, uncompiled nodes) so the signal
+        is never fully lost.
+        """
+        node_id = getattr(self, "node_id", None)
+        msg = (
+            "output_schema was declared but resolved to None — Claude Code is running "
+            "in free-form mode. If the schema came from an upstream node "
+            "(e.g. `output_schema: ${node.schema}`), verify that node produced a "
+            "JSON Schema dict. Remove `output_schema:` entirely to silence this warning."
+        )
+        if node_id is not None:
+            shared.setdefault("__warnings__", {})[node_id] = {
+                "kind": "claude_code.output_schema_resolved_to_null",
+                "text": msg,
+                "context": {"node_type": "claude-code"},
+            }
+        else:
+            shared.setdefault("_schema_error", msg)
+
+    @staticmethod
+    def _looks_like_legacy_python_alias_format(schema: dict) -> bool:
+        """Detect the old custom Python-alias output_schema format."""
+        json_schema_markers = {"type", "$ref", "$schema", "oneOf", "anyOf", "allOf", "enum", "const"}
+        if any(marker in schema for marker in json_schema_markers):
+            return False
+        python_alias_types = {"str", "int", "bool", "list", "dict", "float"}
+        return any(isinstance(value, dict) and value.get("type") in python_alias_types for value in schema.values())
 
     def _validate_cwd(self, cwd: Optional[str]) -> str:
         """Validate and normalize working directory."""
@@ -361,7 +441,14 @@ class ClaudeCodeNode(Node):
         prompt = self._validate_prompt(self.params.get("prompt"))
 
         # Validate optional parameters
-        output_schema = self._validate_schema(self.params.get("output_schema"))
+        raw_output_schema = self.params.get("output_schema")
+        output_schema = self._validate_schema(raw_output_schema)
+        # A declared ``output_schema:`` that resolved to None (e.g. templated
+        # from an upstream node that returned None) silently disables structured
+        # output. Emit a DEGRADED-triggering warning so the workflow author sees
+        # it instead of getting a free-form string where they expected a dict.
+        if output_schema is None and "output_schema" in self.params and raw_output_schema is None:
+            self._emit_schema_resolved_null_warning(shared)
         cwd = self._validate_cwd(self.params.get("cwd"))
 
         # Get model with fallback
@@ -376,6 +463,12 @@ class ClaudeCodeNode(Node):
         # Validate numeric parameters
         max_turns = self._validate_max_turns(self.params.get("max_turns", 50))
         max_thinking_tokens = self._validate_max_thinking_tokens(self.params.get("max_thinking_tokens", 8000))
+        if output_schema is not None and max_turns < 2:
+            raise ValueError(
+                f"max_turns must be >= 2 when output_schema is set (got {max_turns}). "
+                "Structured output requires the agent to take at least one turn beyond producing "
+                "the final response. Set max_turns to 2 or higher (default is typically sufficient)."
+            )
 
         # Get system prompt
         system_prompt = self.params.get("system_prompt", "")
@@ -434,11 +527,11 @@ class ClaudeCodeNode(Node):
         Returns:
             Dictionary with results to be processed by post()
         """
-        # Build the prompt
-        prompt = self._build_prompt(prep_res)
+        # Use the user prompt directly. Structured output is enforced by SDK options.
+        prompt = prep_res["prompt"]
 
-        # Build system prompt with schema instructions if needed
-        system_prompt = self._build_system_prompt(prep_res)
+        # User system prompt passes through unchanged; no schema prompt injection.
+        system_prompt = prep_res.get("system_prompt") or ""
 
         # Build Claude Code options
         options = self._build_claude_options(prep_res, system_prompt)
@@ -480,6 +573,14 @@ class ClaudeCodeNode(Node):
         # Add session resumption if provided
         if prep_res["resume"]:
             options_kwargs["resume"] = prep_res["resume"]
+
+        # Native structured output: SDK translates this to --json-schema CLI flag.
+        # subprocess_cli.py only wires the exact json_schema wrapper shape.
+        if prep_res.get("output_schema"):
+            options_kwargs["output_format"] = {
+                "type": "json_schema",
+                "schema": prep_res["output_schema"],
+            }
 
         # Add sandbox configuration if provided
         if prep_res.get("sandbox") is not None:
@@ -531,20 +632,45 @@ class ClaudeCodeNode(Node):
         message_count = 0
         metadata = {}
         progress_events = []  # Track streaming progress for tracing
+        structured_output: Any = None
+        is_error_from_sdk = False
+        sdk_exception_text: str | None = None
 
-        async for message in query(prompt=prompt, options=options):
-            message_count += 1
-            logger.debug(f"Received message {message_count}: type={type(message).__name__}")
+        try:
+            async for message in query(prompt=prompt, options=options):
+                message_count += 1
+                logger.debug(f"Received message {message_count}: type={type(message).__name__}")
 
-            if isinstance(message, AssistantMessage):
-                text_chunk, tools, events = self._process_assistant_message(message, result_text)
-                result_text += text_chunk
-                tool_uses.extend(tools)
-                progress_events.extend(events)
+                if isinstance(message, AssistantMessage):
+                    text_chunk, tools, events = self._process_assistant_message(message, result_text)
+                    result_text += text_chunk
+                    tool_uses.extend(tools)
+                    progress_events.extend(events)
 
-            elif isinstance(message, ResultMessage):
-                metadata = self._extract_metadata(message)
-                progress_events.append(self._create_completion_event(metadata))
+                elif isinstance(message, ResultMessage):
+                    metadata = self._extract_metadata(message)
+                    progress_events.append(self._create_completion_event(metadata))
+                    if message.result and not result_text:
+                        result_text = message.result
+                    structured_output = message.structured_output
+                    is_error_from_sdk = is_error_from_sdk or message.is_error
+        except Exception as exc:
+            # The SDK pairs ``ResultMessage(is_error=True)`` with a non-zero CLI
+            # exit raised as ``ProcessError``. That single class of exception is
+            # the same signal expressed two ways — soft-fail semantics in post()
+            # need the prior is_error state preserved instead of re-raising.
+            #
+            # Connection failures, missing CLI, timeouts and any other Exception
+            # subclass must still reach exec_fallback so the user sees the
+            # remediation message for that concrete failure mode.
+            exc_type_name = type(exc).__name__
+            is_process_error = (
+                ProcessError is not None and isinstance(exc, ProcessError)
+            ) or exc_type_name == "ProcessError"
+            if not is_error_from_sdk or not is_process_error:
+                raise
+            sdk_exception_text = str(exc)
+            logger.warning("Claude Code SDK raised after an error ResultMessage: %s", sdk_exception_text)
 
         # Log results
         self._log_session_results(tool_uses, result_text)
@@ -553,9 +679,11 @@ class ClaudeCodeNode(Node):
         return {
             "result_text": result_text,
             "tool_uses": tool_uses,
-            "output_schema": prep_res.get("output_schema"),
             "metadata": metadata,
             "progress_events": progress_events,
+            "structured_output": structured_output,
+            "is_error_from_sdk": is_error_from_sdk,
+            "sdk_exception_text": sdk_exception_text,
         }
 
     def _process_assistant_message(
@@ -620,6 +748,10 @@ class ClaudeCodeNode(Node):
             "num_turns": getattr(message, "num_turns", None),
             "session_id": getattr(message, "session_id", None),
             "usage": getattr(message, "usage", None),
+            "result": getattr(message, "result", None),
+            "errors": getattr(message, "errors", None),
+            "api_error_status": getattr(message, "api_error_status", None),
+            "stop_reason": getattr(message, "stop_reason", None),
         }
         logger.info(
             f"Captured metadata: cost=${metadata['total_cost_usd']}, "
@@ -673,8 +805,8 @@ class ClaudeCodeNode(Node):
         Returns:
             Always "default" because workflows may not declare explicit error edges
         """
-        # Store results based on schema or as raw text
-        self._store_results(shared, exec_res)
+        node_id = getattr(self, "node_id", None)  # set by compiler; see compilation/compiler.py
+        self._store_results(shared, prep_res, exec_res, node_id)
 
         return "default"
 
@@ -737,125 +869,35 @@ class ClaudeCodeNode(Node):
         # Generic error — pass through the SDK error message directly
         raise ValueError(f"Claude Code execution failed after {self.max_retries} attempts: {error_msg}") from None
 
-    def _build_prompt(self, prep_res: dict[str, Any]) -> str:
-        """Build the prompt for Claude Code.
-
-        Args:
-            prep_res: Prepared parameters
-
-        Returns:
-            Formatted prompt string
-        """
-        prompt = prep_res["prompt"]
-        output_schema = prep_res.get("output_schema")
-
-        # Build base prompt
-        prompt_parts = []
-
-        # If there's a schema, be very direct about JSON output requirement
-        if output_schema:
-            prompt_parts.append("RESPOND WITH JSON ONLY. Complete the following task and output the result as JSON:")
-            prompt_parts.append("")
-
-        prompt_parts.append(prompt)
-
-        # If there's a schema, remind again at the end
-        if output_schema:
-            prompt_parts.append("\nREMEMBER: Output JSON only, no explanatory text.")
-
-        return "\n".join(prompt_parts)
-
-    def _build_system_prompt(self, prep_res: dict[str, Any]) -> str:
-        """Build system prompt, merging schema instructions if needed.
-
-        Args:
-            prep_res: Prepared parameters
-
-        Returns:
-            System prompt with schema instructions prepended if applicable
-        """
-        prompts = []
-
-        # Add schema instructions if schema provided
-        if prep_res["output_schema"]:
-            schema_prompt = self._build_schema_prompt(prep_res["output_schema"])
-            prompts.append(schema_prompt)
-
-        # Add user's system prompt
-        if prep_res["system_prompt"]:
-            prompts.append(prep_res["system_prompt"])
-
-        return "\n\n".join(prompts) if prompts else ""
-
-    def _build_schema_prompt(self, output_schema: dict[str, dict]) -> str:
-        """Convert output schema to JSON format instructions.
-
-        This is the core innovation - converting schema to prompt instructions.
-
-        Args:
-            output_schema: Schema dictionary with keys and type/description
-
-        Returns:
-            Prompt instructions for structured JSON output
-        """
-        if not output_schema:
-            return ""
-
-        # Build JSON template
-        json_template = {}
-        descriptions = []
-
-        for key, config in output_schema.items():
-            type_str = config.get("type", "str")
-            desc = config.get("description", f"Value for {key}")
-
-            # Add to template
-            json_template[key] = f"<{type_str}: {desc}>"
-            descriptions.append(f"  - {key}: {desc}")
-
-        # Create instruction prompt - MUST output JSON ONLY
-        prompt = (
-            "YOU MUST RESPOND WITH JSON ONLY.\n\n"
-            "DO NOT output any preliminary text like 'I'll analyze...' or 'Let me examine...'.\n"
-            "DO NOT explain what you're doing.\n"
-            "ONLY output a single JSON code block with your analysis results.\n\n"
-            "Required JSON structure with these EXACT keys:\n"
-            f"{json.dumps(json_template, indent=2)}\n\n"
-            "Your COMPLETE response should be:\n"
-            "```json\n"
-            "{\n"
-            '  "key1": actual_value,\n'
-            '  "key2": [actual_values]\n'
-            "}\n"
-            "```\n\n"
-            "Field descriptions:\n" + "\n".join(descriptions) + "\n\n"
-            "START YOUR RESPONSE WITH ```json AND END WITH ```\n"
-            "NO OTHER TEXT ALLOWED."
-        )
-
-        return prompt
-
-    def _store_results(self, shared: dict[str, Any], exec_res: dict[str, Any]) -> None:
+    def _store_results(
+        self,
+        shared: dict[str, Any],
+        prep_res: dict[str, Any],
+        exec_res: dict[str, Any],
+        node_id: str | None,
+    ) -> None:
         """Store results in shared store.
 
-        When schema is provided:
-        - Success: shared["result"] = dict with parsed JSON values
-        - Failure: shared["result"] = raw_text, shared["_schema_error"] = error
+        Result placement rules:
+        - No schema: shared["result"] = raw text (str)
+        - Schema + structured_output present: shared["result"] = parsed JSON
+        - Schema + structured_output missing: soft-fail with raw text, _schema_error, and __warnings__
+        - is_error=True + structured_output present: structured_output wins; _schema_error
+          set as a soft-fail signal and __warnings__ written (when node_id is bound)
 
-        When no schema:
-        - shared["result"] = response_text
-
-        Also stores standardized LLM usage data for tracing and tool usage details.
-
-        Args:
-            shared: Shared store to write results to
-            exec_res: Execution results containing result_text, output_schema, metadata, and tool_uses
+        Lifecycle action: post() always returns "default". Soft-fail signals
+        (`_schema_error`, `__warnings__`) communicate the issue without
+        triggering on-error routing — a workflow's `- on-error:` edge does
+        NOT fire on schema misses or SDK soft-errors.
         """
         result_text = exec_res.get("result_text", "")
-        output_schema = exec_res.get("output_schema")
+        structured_output = exec_res.get("structured_output")
+        is_error_from_sdk = exec_res.get("is_error_from_sdk", False)
+        has_schema = prep_res.get("output_schema") is not None
         metadata = exec_res.get("metadata", {})
         tool_uses = exec_res.get("tool_uses", [])
         progress_events = exec_res.get("progress_events", [])
+        warning_context = self._build_schema_warning_context(prep_res, exec_res)
 
         # Store progress events for trace visibility (if any)
         if progress_events:
@@ -864,7 +906,7 @@ class ClaudeCodeNode(Node):
 
         # Store metadata in standardized llm_usage format
         if metadata:
-            usage = metadata.get("usage", {})
+            usage = metadata.get("usage") or {}
 
             # Store token counts separately - do NOT aggregate cache tokens into input_tokens
             base_input = usage.get("input_tokens", 0)
@@ -905,129 +947,113 @@ class ClaudeCodeNode(Node):
             ]
             logger.debug(f"Stored {len(tool_uses)} tool uses for tracing")
 
-        # If no result text, store empty string
-        if not result_text:
-            shared["result"] = ""
-            return
-
         # If no schema, store text directly
-        if not output_schema:
+        if not has_schema:
             shared["result"] = result_text
             return
 
-        # Try to extract and parse JSON
-        json_data = self._extract_json(result_text)
+        self._store_schema_result(
+            shared,
+            node_id,
+            result_text=result_text,
+            structured_output=structured_output,
+            is_error_from_sdk=is_error_from_sdk,
+            warning_context=warning_context,
+        )
 
-        if json_data:
-            # Successfully parsed JSON - create result dict with schema keys
-            result_dict = {}
-            for key in output_schema:
-                if key in json_data:
-                    result_dict[key] = json_data[key]
-                else:
-                    # Missing key - store None
-                    result_dict[key] = None
-                    logger.warning(f"Schema key '{key}' not found in JSON response")
+    def _store_schema_result(
+        self,
+        shared: dict[str, Any],
+        node_id: str | None,
+        *,
+        result_text: str,
+        structured_output: Any,
+        is_error_from_sdk: bool,
+        warning_context: dict[str, Any],
+    ) -> None:
+        """Place result + soft-fail signals on the schema path.
 
-            # Store the parsed dict in result
-            shared["result"] = result_dict
-            logger.info(f"Successfully parsed JSON with {len(output_schema)} schema values")
+        Branches:
+        - structured_output present + no SDK error → success (result only).
+        - structured_output present + SDK error → use structured_output but
+          record a soft-fail signal so the SDK error isn't silently dropped.
+        - structured_output missing → raw text fallback + soft-fail signal.
+
+        Soft-fail signals use ``setdefault("_schema_error", ...)`` (so any
+        prior write — like ``_emit_schema_resolved_null_warning`` — wins)
+        plus an ``__warnings__[node_id]`` write when ``node_id`` is bound.
+        """
+        if structured_output is not None:
+            shared["result"] = structured_output
+            if is_error_from_sdk:
+                self._emit_soft_fail_signal(
+                    shared,
+                    node_id,
+                    kind="claude_code.sdk_error_with_structured_output",
+                    msg=(
+                        "Claude CLI reported is_error=True but structured_output was produced. "
+                        "Using structured_output as result; check provider for partial-response details."
+                    ),
+                    warning_context=warning_context,
+                )
+            return
+
+        shared["result"] = result_text
+        if is_error_from_sdk:
+            msg = (
+                "Claude CLI reported an error and did not produce structured output. "
+                "Raw text stored in result. Check SDK error details and the output_schema."
+            )
+            kind = "claude_code.sdk_error_no_structured_output"
         else:
-            # Failed to parse JSON - fallback to raw text
-            shared["result"] = result_text
-            shared["_schema_error"] = "Failed to parse JSON from response. Raw text stored in result"
-            logger.warning("Could not extract JSON from response, stored raw text in result")
+            msg = (
+                "Model did not return structured output matching the schema. "
+                "Raw text stored in result. Check JSON Schema type spelling, required fields, "
+                "and impossible enum/const constraints."
+            )
+            kind = "claude_code.schema_not_satisfied"
+        self._emit_soft_fail_signal(shared, node_id, kind=kind, msg=msg, warning_context=warning_context)
 
-    def _extract_json(self, text: str) -> Optional[dict]:
-        """Extract JSON from Claude's response with multiple strategies.
+    @staticmethod
+    def _emit_soft_fail_signal(
+        shared: dict[str, Any],
+        node_id: str | None,
+        *,
+        kind: str,
+        msg: str,
+        warning_context: dict[str, Any],
+    ) -> None:
+        """Centralized soft-fail signaling for structured-output mode.
 
-        Args:
-            text: Response text that may contain JSON
-
-        Returns:
-            Parsed JSON dictionary or None if extraction fails
+        Writes ``_schema_error`` (via ``setdefault`` so an earlier writer wins)
+        and a structured ``__warnings__[node_id]`` entry when ``node_id`` is
+        bound. The ``__warnings__`` entry is what flips workflow status to
+        ``DEGRADED``; ``_schema_error`` is the fallback signal that survives
+        when ``node_id`` is unbound (test paths).
         """
-        if not text:
-            return None
+        shared.setdefault("_schema_error", msg)
+        if node_id is not None:
+            shared.setdefault("__warnings__", {})[node_id] = {
+                "kind": kind,
+                "text": msg,
+                "context": warning_context,
+            }
 
-        # Try extraction strategies in order of likelihood
-        strategies = [
-            self._extract_json_from_code_block,
-            self._extract_json_from_raw_object,
-            self._extract_json_from_last_brace,
-        ]
-
-        for strategy in strategies:
-            result = strategy(text)
-            if result is not None:
-                return result
-
-        return None  # Failed to extract JSON
-
-    def _extract_json_from_code_block(self, text: str) -> Optional[dict]:
-        """Extract JSON from markdown code blocks.
-
-        Args:
-            text: Response text that may contain code blocks
-
-        Returns:
-            Parsed JSON dictionary or None if extraction fails
-        """
-        code_block_pattern = r"```(?:json)?\s*\n(.*?)\n```"
-        matches = re.findall(code_block_pattern, text, re.DOTALL)
-
-        for match in matches:
-            try:
-                return json.loads(match)
-            except json.JSONDecodeError:
-                continue
-
-        return None
-
-    def _extract_json_from_raw_object(self, text: str) -> Optional[dict]:
-        """Extract raw JSON objects from text.
-
-        Args:
-            text: Response text that may contain raw JSON
-
-        Returns:
-            Parsed JSON dictionary or None if extraction fails
-        """
-        json_pattern = r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}"
-        matches = re.findall(json_pattern, text)
-
-        for match in matches:
-            try:
-                return json.loads(match)
-            except json.JSONDecodeError:
-                continue
-
-        return None
-
-    def _extract_json_from_last_brace(self, text: str) -> Optional[dict]:
-        """Extract JSON by finding the last opening brace and its matching close.
-
-        Args:
-            text: Response text that may contain JSON
-
-        Returns:
-            Parsed JSON dictionary or None if extraction fails
-        """
-        try:
-            start = text.rfind("{")
-            if start == -1:
-                return None
-
-            depth = 0
-            for i, char in enumerate(text[start:], start):
-                if char == "{":
-                    depth += 1
-                elif char == "}":
-                    depth -= 1
-                    if depth == 0:
-                        potential_json = text[start : i + 1]
-                        return json.loads(potential_json)
-        except Exception as e:
-            logger.debug(f"Failed to extract JSON using last brace method: {e}")
-
-        return None
+    @staticmethod
+    def _build_schema_warning_context(prep_res: dict[str, Any], exec_res: dict[str, Any]) -> dict[str, Any]:
+        """Build compact, agent-actionable context for structured-output warnings."""
+        output_schema = prep_res.get("output_schema") or {}
+        properties = output_schema.get("properties") if isinstance(output_schema, dict) else None
+        metadata = exec_res.get("metadata") or {}
+        result_text = exec_res.get("result_text") or ""
+        return {
+            "node_type": "claude-code",
+            "schema_properties": list(properties) if isinstance(properties, dict) else [],
+            "schema_required": output_schema.get("required") if isinstance(output_schema, dict) else None,
+            "result_preview": result_text[:500],
+            "sdk_result": metadata.get("result"),
+            "sdk_errors": metadata.get("errors"),
+            "sdk_error_status": metadata.get("api_error_status"),
+            "sdk_stop_reason": metadata.get("stop_reason"),
+            "sdk_exception": exec_res.get("sdk_exception_text"),
+        }

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -49,6 +49,11 @@ import os
 from typing import Any, Optional
 
 from pflow.core.node import Node
+from pflow.nodes.claude.schema_validation import (
+    TopLevelObjectViolation,
+    is_legacy_python_alias_schema,
+    top_level_object_violation,
+)
 
 # Import Claude Agent SDK (renamed from Claude Code SDK)
 try:
@@ -75,7 +80,11 @@ except ImportError as e:
 # Guard against SDK field renames that would silently break structured output.
 # If claude_agent_sdk renames `structured_output`, every schema call would
 # otherwise soft-fail with a misleading "model didn't comply" message.
-if "structured_output" not in getattr(ResultMessage, "__annotations__", {}):
+# The ``isinstance(..., dict)`` check upgrades a forgotten test mock
+# (auto-``Mock`` with synthetic ``__annotations__``) from an opaque
+# ``TypeError`` on ``in`` to this friendly ``ImportError``.
+_resolved_annotations = getattr(ResultMessage, "__annotations__", {})
+if not isinstance(_resolved_annotations, dict) or "structured_output" not in _resolved_annotations:
     raise ImportError(
         "claude_agent_sdk.types.ResultMessage has no 'structured_output' field. "
         "pflow's Claude Code node requires claude-agent-sdk>=0.2.82 with native "
@@ -244,7 +253,7 @@ class ClaudeCodeNode(Node):
                 'Use a real JSON Schema (e.g. {"type": "object", "properties": {...}}) '
                 "or remove the output_schema field entirely."
             )
-        if self._looks_like_legacy_python_alias_format(output_schema):
+        if is_legacy_python_alias_schema(output_schema):
             raise ValueError(
                 "output_schema appears to use the legacy Python-alias format "
                 '({"field": {"type": "str", ...}}). '
@@ -253,38 +262,33 @@ class ClaudeCodeNode(Node):
             )
         # Claude API limitation (verified in Phase 0 + oneOf follow-up): the SDK wraps
         # output_format as a tool's input_schema, and the API rejects any top-level
-        # schema that isn't `type: object` with a 400. This covers non-"object" types
-        # AND combinator-only schemas (oneOf/anyOf/allOf/enum without a top-level type).
-        top_level_type = output_schema.get("type")
-        if top_level_type != "object":
-            raise ValueError(self._top_level_object_error(top_level_type, output_schema))
+        # schema that isn't `type: object` with a 400. The shared predicate covers
+        # non-"object" types AND combinator-only schemas (oneOf/anyOf/allOf/enum
+        # without a top-level type).
+        violation = top_level_object_violation(output_schema)
+        if violation is not None:
+            raise ValueError(self._top_level_object_error(violation))
         return output_schema
 
     @staticmethod
-    def _top_level_object_error(top_level_type: Any, output_schema: dict[str, Any]) -> str:
+    def _top_level_object_error(violation: TopLevelObjectViolation) -> str:
         """Format the "top-level type: object" error with case-specific guidance."""
         wrapper_example = (
             'Wrap in an object, e.g. {"type": "object", '
             '"properties": {"result": <your schema>}, "required": ["result"]}. '
             "(The LLM node has no such restriction.)"
         )
-        if top_level_type is None:
-            combinators = sorted(k for k in ("oneOf", "anyOf", "allOf", "enum", "const") if k in output_schema)
-            cause = (
-                f"top-level combinator {combinators[0]!r} with no top-level type"
-                if combinators
-                else "no top-level type"
-            )
+        if violation.kind == "missing_type":
             return (
                 "output_schema on claude-code nodes must declare top-level type: object "
-                f"({cause}). The Anthropic API rejects schemas without a top-level "
+                f"({violation.cause}). The Anthropic API rejects schemas without a top-level "
                 "type:object when the SDK wraps output_format as a tool input_schema — "
                 "combinators like oneOf/anyOf/allOf/enum must live inside an object "
                 f"wrapper. {wrapper_example}"
             )
         return (
             "output_schema on claude-code nodes must have top-level type: object "
-            f"(got type: {top_level_type!r}). "
+            f"({violation.cause}). "
             "The Anthropic API rejects non-object top-level schemas in tool input_schema "
             f"wrappers. {wrapper_example}"
         )
@@ -313,15 +317,6 @@ class ClaudeCodeNode(Node):
         else:
             shared.setdefault("_schema_error", msg)
 
-    @staticmethod
-    def _looks_like_legacy_python_alias_format(schema: dict) -> bool:
-        """Detect the old custom Python-alias output_schema format."""
-        json_schema_markers = {"type", "$ref", "$schema", "oneOf", "anyOf", "allOf", "enum", "const"}
-        if any(marker in schema for marker in json_schema_markers):
-            return False
-        python_alias_types = {"str", "int", "bool", "list", "dict", "float"}
-        return any(isinstance(value, dict) and value.get("type") in python_alias_types for value in schema.values())
-
     def _validate_cwd(self, cwd: Optional[str]) -> str:
         """Validate and normalize working directory."""
         if not cwd:
@@ -341,30 +336,25 @@ class ClaudeCodeNode(Node):
             raise ValueError(f"Restricted directory: {cwd}")
         return cwd
 
-    def _validate_tools(self, allowed_tools: Optional[list]) -> Optional[list]:
-        """Validate allowed tools list.
+    def _validate_optional_tool_list(self, value: Optional[list], param_name: str) -> Optional[list]:
+        """Validate a tool-list parameter.
 
-        If None or empty, all tools are available (SDK default).
-        If provided, pass through to SDK without validation - let SDK handle unknown tools.
+        Empty / falsy → ``None`` (SDK default applies — meaning differs by
+        caller: ``allowed_tools=None`` opens all tools, ``disallowed_tools=None``
+        blocks none). Non-list raises ``TypeError``; otherwise pass through and
+        let the SDK reject unknown tool names / patterns.
         """
-        if not allowed_tools:
-            return None  # All tools available
-        if not isinstance(allowed_tools, list):
-            raise TypeError(f"allowed_tools must be a list, got {type(allowed_tools).__name__}")
-        return allowed_tools
+        if not value:
+            return None
+        if not isinstance(value, list):
+            raise TypeError(f"{param_name} must be a list, got {type(value).__name__}")
+        return value
+
+    def _validate_tools(self, allowed_tools: Optional[list]) -> Optional[list]:
+        return self._validate_optional_tool_list(allowed_tools, "allowed_tools")
 
     def _validate_disallowed_tools(self, disallowed_tools: Optional[list]) -> Optional[list]:
-        """Validate disallowed tools list.
-
-        If None or empty, no tools are blocked (SDK default).
-        If provided, pass through to SDK without validation - let SDK handle unknown patterns.
-        Supports pattern matching like "Bash(git:*)", "Bash(pflow:*)".
-        """
-        if not disallowed_tools:
-            return None  # No restrictions
-        if not isinstance(disallowed_tools, list):
-            raise TypeError(f"disallowed_tools must be a list, got {type(disallowed_tools).__name__}")
-        return disallowed_tools
+        return self._validate_optional_tool_list(disallowed_tools, "disallowed_tools")
 
     def _validate_max_turns(self, max_turns: Any) -> int:
         """Validate and convert max_turns parameter."""

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -221,8 +221,14 @@ class ClaudeCodeNode(Node):
         - {} (empty): likely a typo; raises with guidance
         - Non-dict: TypeError
         - Legacy Python-alias format: raises with migration guidance
-        - Non-object top-level: raises (Anthropic API tool-use limitation)
+        - Missing or non-"object" top-level type: raises (Anthropic API tool-use limitation)
         - Otherwise: returns as-is; SDK/CLI enforces remaining JSON Schema validity
+
+        The top-level-type check covers both `type: array`/primitives AND schemas
+        that omit `type` entirely (top-level oneOf/anyOf/allOf/enum). All four
+        return HTTP 400 from the Anthropic API when wrapped as a tool's
+        input_schema, verified by Phase 0 (`type: array`/primitives) and the
+        oneOf follow-up probe.
 
         Note on schema typos (e.g. type: "intger"): the Anthropic API silently accepts
         them. Schema typos will result in a soft-fail at runtime (structured_output is
@@ -245,20 +251,43 @@ class ClaudeCodeNode(Node):
                 'Use JSON Schema instead: {"type": "object", "properties": {...}, "required": [...]}. '
                 "See docs/reference/nodes/claude-code.mdx for an example."
             )
-        # Claude API limitation (verified in Phase 0 smoke test): the SDK wraps output_format
-        # as a tool's input_schema, and the API rejects non-object top-level schemas with a 400.
+        # Claude API limitation (verified in Phase 0 + oneOf follow-up): the SDK wraps
+        # output_format as a tool's input_schema, and the API rejects any top-level
+        # schema that isn't `type: object` with a 400. This covers non-"object" types
+        # AND combinator-only schemas (oneOf/anyOf/allOf/enum without a top-level type).
         top_level_type = output_schema.get("type")
-        if top_level_type is not None and top_level_type != "object":
-            raise ValueError(
-                "output_schema on claude-code nodes must have top-level type: object "
-                f"(got type: {top_level_type!r}). "
-                "The Anthropic API rejects non-object top-level schemas in tool input_schema "
-                "wrappers. For array or primitive outputs, wrap in an object with a single "
-                'property, e.g. {"type": "object", "properties": {"items": {"type": "array", '
-                '"items": ...}}, "required": ["items"]}. '
-                "(The LLM node has no such restriction.)"
-            )
+        if top_level_type != "object":
+            raise ValueError(self._top_level_object_error(top_level_type, output_schema))
         return output_schema
+
+    @staticmethod
+    def _top_level_object_error(top_level_type: Any, output_schema: dict[str, Any]) -> str:
+        """Format the "top-level type: object" error with case-specific guidance."""
+        wrapper_example = (
+            'Wrap in an object, e.g. {"type": "object", '
+            '"properties": {"result": <your schema>}, "required": ["result"]}. '
+            "(The LLM node has no such restriction.)"
+        )
+        if top_level_type is None:
+            combinators = sorted(k for k in ("oneOf", "anyOf", "allOf", "enum", "const") if k in output_schema)
+            cause = (
+                f"top-level combinator {combinators[0]!r} with no top-level type"
+                if combinators
+                else "no top-level type"
+            )
+            return (
+                "output_schema on claude-code nodes must declare top-level type: object "
+                f"({cause}). The Anthropic API rejects schemas without a top-level "
+                "type:object when the SDK wraps output_format as a tool input_schema — "
+                "combinators like oneOf/anyOf/allOf/enum must live inside an object "
+                f"wrapper. {wrapper_example}"
+            )
+        return (
+            "output_schema on claude-code nodes must have top-level type: object "
+            f"(got type: {top_level_type!r}). "
+            "The Anthropic API rejects non-object top-level schemas in tool input_schema "
+            f"wrappers. {wrapper_example}"
+        )
 
     def _emit_schema_resolved_null_warning(self, shared: dict[str, Any]) -> None:
         """Warn when ``output_schema`` was declared but resolved to ``None``.

--- a/src/pflow/nodes/claude/schema_validation.py
+++ b/src/pflow/nodes/claude/schema_validation.py
@@ -1,0 +1,78 @@
+"""Pure predicates for Claude Code ``output_schema`` validation.
+
+These helpers are shared between the runtime path
+(``ClaudeCodeNode._validate_schema``) and the static preflight path
+(``WorkflowValidator._validate_claude_code_params``). Sharing the predicates
+prevents drift between ``--validate-only`` / ``--dry-run`` and runtime
+``prep()``.
+
+Error message *framing* (``ValueError`` vs ``Diagnostic``, wrapper-example
+text, suggestion lists) intentionally stays at the call site so each caller
+can shape the surface appropriately. Issue #398 may consolidate further once
+LLM-side validation is added.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, Literal, NamedTuple
+
+JSON_SCHEMA_MARKERS: Final[frozenset[str]] = frozenset({
+    "type",
+    "$ref",
+    "$schema",
+    "oneOf",
+    "anyOf",
+    "allOf",
+    "enum",
+    "const",
+})
+"""Keys that mark a dict as JSON Schema rather than the pre-Task-126 alias format."""
+
+PYTHON_ALIAS_TYPES: Final[frozenset[str]] = frozenset({"str", "int", "bool", "list", "dict", "float"})
+"""Python type names that flag the legacy alias format when used as ``type`` values."""
+
+TOP_LEVEL_COMBINATORS: Final[tuple[str, ...]] = ("oneOf", "anyOf", "allOf", "enum", "const")
+"""JSON Schema combinator keys that the Anthropic API rejects at the schema root."""
+
+
+class TopLevelObjectViolation(NamedTuple):
+    """Reason a schema fails the Claude API's top-level-object requirement.
+
+    ``kind`` lets callers choose message framing without re-parsing ``cause``.
+    """
+
+    cause: str
+    kind: Literal["non_object_type", "missing_type"]
+
+
+def is_legacy_python_alias_schema(schema: dict[str, Any]) -> bool:
+    """Return True if ``schema`` uses the pre-Task-126 Python-alias format.
+
+    Heuristic: no JSON Schema marker at the top level AND at least one value
+    is a dict whose ``type`` is a Python type name (``str``, ``int``, ...).
+    This is the shape the old prompt-injection format used.
+    """
+    if any(marker in schema for marker in JSON_SCHEMA_MARKERS):
+        return False
+    return any(isinstance(value, dict) and value.get("type") in PYTHON_ALIAS_TYPES for value in schema.values())
+
+
+def top_level_object_violation(schema: dict[str, Any]) -> TopLevelObjectViolation | None:
+    """Return a violation when ``schema`` doesn't have top-level ``type: object``, else None.
+
+    The Anthropic API rejects any top-level schema that isn't ``type: object``
+    when the SDK wraps ``output_format`` as a tool's ``input_schema``. This
+    covers both ``type: array``/primitives AND schemas that omit ``type``
+    entirely (combinator-only schemas like top-level ``oneOf``). Verified in
+    Phase 0 and the oneOf follow-up probe.
+    """
+    top_level_type = schema.get("type")
+    if top_level_type == "object":
+        return None
+    if top_level_type is None:
+        combinators = sorted(k for k in TOP_LEVEL_COMBINATORS if k in schema)
+        cause = (
+            f"top-level combinator {combinators[0]!r} with no top-level type" if combinators else "no top-level type"
+        )
+        return TopLevelObjectViolation(cause=cause, kind="missing_type")
+    return TopLevelObjectViolation(cause=f"got type: {top_level_type!r}", kind="non_object_type")

--- a/src/pflow/runtime/engine/instrumentation.py
+++ b/src/pflow/runtime/engine/instrumentation.py
@@ -348,11 +348,11 @@ def apply_memo_hit(
 ) -> None:
     """Apply a memoization cache hit to shared state.
 
-    `__pflow_stats__` is engine-injected metadata (duration, etc.) that lives
-    in the stored blob for --dry-run historical estimates but must NOT leak
-    into the live `shared` dict — a fresh execution would never produce that
-    key, so restoring it would make cached and fresh paths observably differ
-    (template resolution, equality checks, trace output).
+    `__pflow_stats__` and `__pflow_warnings__` are engine-injected metadata
+    that live in the stored blob but must NOT leak into `shared[node_id]`.
+    Stats feed --dry-run historical estimates; warnings are rehydrated to the
+    root `shared["__warnings__"]` channel so cached degraded executions retain
+    the same status as fresh executions.
 
     Task 159 E.1: when ``_should_write_cache_metadata(node_type_name)``
     fires, augment the restored ``llm_usage`` dict with ``cache_source =
@@ -367,10 +367,11 @@ def apply_memo_hit(
     node_actions = execution.setdefault("node_actions", {})
     node_hashes = execution.setdefault("node_hashes", {})
 
-    if "__pflow_stats__" in cached_output:
-        restored = {k: v for k, v in cached_output.items() if k != "__pflow_stats__"}
-    else:
-        restored = cached_output
+    reserved_keys = {"__pflow_stats__", "__pflow_warnings__"}
+    restored = {k: v for k, v in cached_output.items() if k not in reserved_keys}
+    cached_warning = cached_output.get("__pflow_warnings__")
+    if cached_warning is not None:
+        shared.setdefault("__warnings__", {})[node_id] = cached_warning
     shared[node_id] = restored
     completed_nodes.append(node_id)
     node_actions[node_id] = cached_action
@@ -475,6 +476,9 @@ def write_memo_cache(
             _log_skipped_cache_metadata(node_type_name, node_output)
         workflow_path = shared.get("_pflow_workflow_file")
         output_dict = dict(node_output) if isinstance(node_output, dict) else {"value": node_output}
+        node_warning = shared.get("__warnings__", {}).get(node_id)
+        if node_warning is not None:
+            output_dict["__pflow_warnings__"] = node_warning
         if duration_ms is not None:
             output_dict["__pflow_stats__"] = {"duration_ms": float(duration_ms)}
         memo_cache.put(cache_key, node_id, workflow_path, action or "default", output_dict)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -325,6 +325,8 @@ def test_warns(caplog):
 ### 17. `claude_agent_sdk` Mocked via `sys.modules` (Session-Wide)
 `test_nodes/test_claude/test_claude_code.py` injects mock `claude_agent_sdk` into `sys.modules` **at module level** (not in a fixture). This happens at import time, persists for the entire pytest session, and has no cleanup. If you need to test real `claude_agent_sdk` integration, it won't work in the same pytest run.
 
+`ResultMessage` is a real `@dataclass` in that test file, not an auto-Mock. This is load-bearing: the Claude Code node probes `ResultMessage.__annotations__` at import time to verify SDK structured-output support. Keep `mock_sdk_types.ResultMessage = ResultMessage` before `sys.modules["claude_agent_sdk.types"] = mock_sdk_types`, or imports will fail before tests run.
+
 ### 18. Rewritten Tests That Assert Less Are Regression Signals
 When rewriting tests during a refactor, if the new test asserts LESS than the original, the new implementation likely dropped behavior — the old test wasn't over-specified. Investigate before weakening the assertion.
 

--- a/tests/shared/markdown_utils.py
+++ b/tests/shared/markdown_utils.py
@@ -116,7 +116,7 @@ def ir_to_markdown(  # noqa: C901
                     lines.append(yaml.dump(value, default_flow_style=False, sort_keys=False).rstrip())
                     lines.append("```")
                 elif key == "output_schema" and isinstance(value, (dict, list)):
-                    # Claude-code output schema → yaml code block
+                    # output_schema (JSON Schema) - node-agnostic
                     lines.append("")
                     lines.append("```yaml output_schema")
                     lines.append(yaml.dump(value, default_flow_style=False, sort_keys=False).rstrip())

--- a/tests/test_cli/test_dry_run.py
+++ b/tests/test_cli/test_dry_run.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import patch
 
 from tests.shared.markdown_utils import write_workflow_file
+from tests.test_cli.test_validate_only import make_claude_code_workflow
 from tests.test_cli.test_workflow_commands import invoke_cli
 
 
@@ -90,20 +91,10 @@ def test_dry_run_rejects_claude_code_invalid_schema_before_plan(tmp_path) -> Non
     """Dry-run must share validation-only's Claude Code schema checks."""
     workflow_path = tmp_path / "claude-invalid-schema-dry-run.pflow.md"
     write_workflow_file(
-        {
-            "nodes": [
-                {
-                    "id": "review",
-                    "type": "claude-code",
-                    "params": {
-                        "prompt": "Return an array.",
-                        "max_turns": 2,
-                        "output_schema": {"type": "array", "items": {"type": "string"}},
-                    },
-                }
-            ],
-            "edges": [],
-        },
+        make_claude_code_workflow(
+            output_schema={"type": "array", "items": {"type": "string"}},
+            prompt="Return an array.",
+        ),
         workflow_path,
     )
 

--- a/tests/test_cli/test_dry_run.py
+++ b/tests/test_cli/test_dry_run.py
@@ -86,6 +86,33 @@ def test_dry_run_exits_one_on_missing_required_input(tmp_path) -> None:
     assert result.exit_code == 1
 
 
+def test_dry_run_rejects_claude_code_invalid_schema_before_plan(tmp_path) -> None:
+    """Dry-run must share validation-only's Claude Code schema checks."""
+    workflow_path = tmp_path / "claude-invalid-schema-dry-run.pflow.md"
+    write_workflow_file(
+        {
+            "nodes": [
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return an array.",
+                        "max_turns": 2,
+                        "output_schema": {"type": "array", "items": {"type": "string"}},
+                    },
+                }
+            ],
+            "edges": [],
+        },
+        workflow_path,
+    )
+
+    result = invoke_cli(["--dry-run", str(workflow_path)])
+
+    assert result.exit_code == 1
+    assert "top-level type: object" in result.stderr
+
+
 def test_dry_run_exits_one_when_plan_contains_error_diagnostic(tmp_path) -> None:
     """Plans that build but carry an ERROR-severity diagnostic must exit 1.
 

--- a/tests/test_cli/test_guide.py
+++ b/tests/test_cli/test_guide.py
@@ -175,6 +175,19 @@ def test_llm_guide_points_to_prompt_caching_without_duplication() -> None:
     assert "`1m` through `60m`" not in result
 
 
+def test_claude_code_guide_documents_structured_output_without_internals() -> None:
+    result = compose_guide(["claude-code"])
+    assert "# Claude Code Node" in result
+    assert "type: claude-code" in result
+    assert "top-level `type: object`" in result
+    assert "`max_turns` must be at least `2`" in result
+    assert "### Parameters" in result
+    assert "`output_schema: dict`" in result
+    assert "__warnings__" not in result
+    assert "structured_output" not in result
+    assert "SDK" not in result
+
+
 def test_compose_deduplicates_topics() -> None:
     result_once = compose_guide(["http"])
     result_twice = compose_guide(["http", "http"])
@@ -262,6 +275,20 @@ def test_compose_from_workflow_detects_multiple_types(tmp_path: Path) -> None:
     result = compose_guide([str(wf)])
     assert "HTTP" in result
     assert "Code" in result
+
+
+def test_compose_from_workflow_detects_claude_code(tmp_path: Path) -> None:
+    wf = tmp_path / "claude.pflow.md"
+    wf.write_text(
+        "# Claude\n\nUse Claude Code.\n\n## Steps\n\n"
+        "### fix\n\nFix code.\n\n"
+        "- type: claude-code\n"
+        "- max_turns: 2\n\n"
+        "```prompt\nFix the failing test.\n```\n"
+    )
+    result = compose_guide([str(wf)])
+    assert "# Claude Code Node" in result
+    assert "### Parameters" in result
 
 
 def test_compose_from_realistic_workflow_detects_all_topic_types(tmp_path: Path) -> None:

--- a/tests/test_cli/test_validate_only.py
+++ b/tests/test_cli/test_validate_only.py
@@ -388,6 +388,64 @@ class TestValidateOnlyClaudeCodeStructuredOutput:
         assert "max_turns must be >= 2" in result.output
         assert "review" in result.output
 
+    def test_validate_only_rejects_claude_code_oneof_root_schema(self, tmp_path: Path) -> None:
+        """Top-level oneOf (no top-level type) is rejected at preflight.
+        Verified via real-API probe: the API returns HTTP 400 for combinator-only schemas.
+        """
+        workflow = {
+            "nodes": [
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return a verdict.",
+                        "max_turns": 2,
+                        "output_schema": {
+                            "oneOf": [
+                                {"type": "object", "properties": {"yes": {"type": "boolean"}}},
+                                {"type": "object", "properties": {"no": {"type": "boolean"}}},
+                            ]
+                        },
+                    },
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "claude-oneof-root.pflow.md"
+        write_workflow_file(workflow, workflow_path)
+
+        result = invoke_cli(["--validate-only", str(workflow_path)])
+
+        assert result.exit_code != 0
+        assert "top-level type: object" in result.output
+        assert "oneOf" in result.output
+        assert "review" in result.output
+
+    def test_validate_only_rejects_claude_code_missing_top_level_type(self, tmp_path: Path) -> None:
+        """A schema dict without top-level `type` is rejected — the API requires `type: object`."""
+        workflow = {
+            "nodes": [
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return status.",
+                        "max_turns": 2,
+                        "output_schema": {"properties": {"status": {"type": "string"}}},
+                    },
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "claude-missing-type.pflow.md"
+        write_workflow_file(workflow, workflow_path)
+
+        result = invoke_cli(["--validate-only", str(workflow_path)])
+
+        assert result.exit_code != 0
+        assert "top-level type: object" in result.output
+        assert "review" in result.output
+
     def test_validate_only_rejects_claude_code_legacy_schema(self, tmp_path: Path) -> None:
         workflow = {
             "nodes": [

--- a/tests/test_cli/test_validate_only.py
+++ b/tests/test_cli/test_validate_only.py
@@ -333,6 +333,128 @@ class TestValidateOnlyJSONOutput:
         assert warning["suggestions"]
 
 
+class TestValidateOnlyClaudeCodeStructuredOutput:
+    """Validation-only must catch Claude Code schema contracts before execution."""
+
+    def test_validate_only_rejects_claude_code_array_root_schema(self, tmp_path: Path) -> None:
+        workflow = {
+            "nodes": [
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return an array.",
+                        "max_turns": 2,
+                        "output_schema": {"type": "array", "items": {"type": "string"}},
+                    },
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "claude-array-root.pflow.md"
+        write_workflow_file(workflow, workflow_path)
+
+        result = invoke_cli(["--validate-only", str(workflow_path)])
+
+        assert result.exit_code != 0
+        assert "top-level type: object" in result.output
+        assert "review" in result.output
+
+    def test_validate_only_rejects_claude_code_max_turns_one_with_schema(self, tmp_path: Path) -> None:
+        workflow = {
+            "nodes": [
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return status.",
+                        "max_turns": 1,
+                        "output_schema": {
+                            "type": "object",
+                            "properties": {"status": {"type": "string"}},
+                            "required": ["status"],
+                        },
+                    },
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "claude-max-turns.pflow.md"
+        write_workflow_file(workflow, workflow_path)
+
+        result = invoke_cli(["--validate-only", str(workflow_path)])
+
+        assert result.exit_code != 0
+        assert "max_turns must be >= 2" in result.output
+        assert "review" in result.output
+
+    def test_validate_only_rejects_claude_code_legacy_schema(self, tmp_path: Path) -> None:
+        workflow = {
+            "nodes": [
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return status.",
+                        "max_turns": 2,
+                        "output_schema": {"status": {"type": "str", "description": "Legacy schema style"}},
+                    },
+                }
+            ],
+            "edges": [],
+        }
+        workflow_path = tmp_path / "claude-legacy-schema.pflow.md"
+        write_workflow_file(workflow, workflow_path)
+
+        result = invoke_cli(["--validate-only", str(workflow_path)])
+
+        assert result.exit_code != 0
+        assert "legacy Python-alias format" in result.output
+        assert "review" in result.output
+
+    def test_validate_only_defers_templated_output_schema(self, tmp_path: Path) -> None:
+        """Templated ``output_schema`` (e.g. from an upstream code node) must
+        survive preflight. Runtime ``_validate_schema`` checks the resolved
+        value after template resolution.
+
+        Regression: an earlier validator added in Task 126 hard-rejected the
+        templated form because the IR value is a string at parse time. That
+        broke the composition pattern of ``output_schema: ${upstream.field}``.
+        """
+        workflow = {
+            "nodes": [
+                {
+                    "id": "build_schema",
+                    "type": "code",
+                    "params": {
+                        "code": (
+                            'result: dict = {"type": "object", '
+                            '"properties": {"status": {"type": "string"}}, '
+                            '"required": ["status"]}'
+                        ),
+                    },
+                },
+                {
+                    "id": "review",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "Return status.",
+                        "max_turns": 2,
+                        "output_schema": "${build_schema.result}",
+                    },
+                },
+            ],
+            "edges": [{"from": "build_schema", "to": "review", "action": "default"}],
+        }
+        workflow_path = tmp_path / "claude-templated-schema.pflow.md"
+        write_workflow_file(workflow, workflow_path)
+
+        result = invoke_cli(["--validate-only", str(workflow_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "must be a dict" not in result.output
+
+
 class TestValidationErrorDiagnosticShape:
     """Regression guard for Task 144: validation errors are Diagnostic objects.
 

--- a/tests/test_cli/test_validate_only.py
+++ b/tests/test_cli/test_validate_only.py
@@ -333,24 +333,44 @@ class TestValidateOnlyJSONOutput:
         assert warning["suggestions"]
 
 
+def make_claude_code_workflow(
+    *,
+    output_schema: Any,
+    max_turns: int = 2,
+    prompt: str = "Return a result.",
+    node_id: str = "review",
+) -> dict[str, Any]:
+    """Build a single-node claude-code workflow IR for preflight tests.
+
+    Centralizes the 15-line shape that every ``TestValidateOnlyClaudeCodeStructuredOutput``
+    case used to inline. Tests pass only the field(s) they're actually exercising
+    (typically ``output_schema``, sometimes ``max_turns``); other fields take
+    test-safe defaults.
+    """
+    return {
+        "nodes": [
+            {
+                "id": node_id,
+                "type": "claude-code",
+                "params": {
+                    "prompt": prompt,
+                    "max_turns": max_turns,
+                    "output_schema": output_schema,
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+
 class TestValidateOnlyClaudeCodeStructuredOutput:
     """Validation-only must catch Claude Code schema contracts before execution."""
 
     def test_validate_only_rejects_claude_code_array_root_schema(self, tmp_path: Path) -> None:
-        workflow = {
-            "nodes": [
-                {
-                    "id": "review",
-                    "type": "claude-code",
-                    "params": {
-                        "prompt": "Return an array.",
-                        "max_turns": 2,
-                        "output_schema": {"type": "array", "items": {"type": "string"}},
-                    },
-                }
-            ],
-            "edges": [],
-        }
+        workflow = make_claude_code_workflow(
+            output_schema={"type": "array", "items": {"type": "string"}},
+            prompt="Return an array.",
+        )
         workflow_path = tmp_path / "claude-array-root.pflow.md"
         write_workflow_file(workflow, workflow_path)
 
@@ -361,24 +381,15 @@ class TestValidateOnlyClaudeCodeStructuredOutput:
         assert "review" in result.output
 
     def test_validate_only_rejects_claude_code_max_turns_one_with_schema(self, tmp_path: Path) -> None:
-        workflow = {
-            "nodes": [
-                {
-                    "id": "review",
-                    "type": "claude-code",
-                    "params": {
-                        "prompt": "Return status.",
-                        "max_turns": 1,
-                        "output_schema": {
-                            "type": "object",
-                            "properties": {"status": {"type": "string"}},
-                            "required": ["status"],
-                        },
-                    },
-                }
-            ],
-            "edges": [],
-        }
+        workflow = make_claude_code_workflow(
+            output_schema={
+                "type": "object",
+                "properties": {"status": {"type": "string"}},
+                "required": ["status"],
+            },
+            max_turns=1,
+            prompt="Return status.",
+        )
         workflow_path = tmp_path / "claude-max-turns.pflow.md"
         write_workflow_file(workflow, workflow_path)
 
@@ -392,25 +403,15 @@ class TestValidateOnlyClaudeCodeStructuredOutput:
         """Top-level oneOf (no top-level type) is rejected at preflight.
         Verified via real-API probe: the API returns HTTP 400 for combinator-only schemas.
         """
-        workflow = {
-            "nodes": [
-                {
-                    "id": "review",
-                    "type": "claude-code",
-                    "params": {
-                        "prompt": "Return a verdict.",
-                        "max_turns": 2,
-                        "output_schema": {
-                            "oneOf": [
-                                {"type": "object", "properties": {"yes": {"type": "boolean"}}},
-                                {"type": "object", "properties": {"no": {"type": "boolean"}}},
-                            ]
-                        },
-                    },
-                }
-            ],
-            "edges": [],
-        }
+        workflow = make_claude_code_workflow(
+            output_schema={
+                "oneOf": [
+                    {"type": "object", "properties": {"yes": {"type": "boolean"}}},
+                    {"type": "object", "properties": {"no": {"type": "boolean"}}},
+                ]
+            },
+            prompt="Return a verdict.",
+        )
         workflow_path = tmp_path / "claude-oneof-root.pflow.md"
         write_workflow_file(workflow, workflow_path)
 
@@ -423,20 +424,10 @@ class TestValidateOnlyClaudeCodeStructuredOutput:
 
     def test_validate_only_rejects_claude_code_missing_top_level_type(self, tmp_path: Path) -> None:
         """A schema dict without top-level `type` is rejected — the API requires `type: object`."""
-        workflow = {
-            "nodes": [
-                {
-                    "id": "review",
-                    "type": "claude-code",
-                    "params": {
-                        "prompt": "Return status.",
-                        "max_turns": 2,
-                        "output_schema": {"properties": {"status": {"type": "string"}}},
-                    },
-                }
-            ],
-            "edges": [],
-        }
+        workflow = make_claude_code_workflow(
+            output_schema={"properties": {"status": {"type": "string"}}},
+            prompt="Return status.",
+        )
         workflow_path = tmp_path / "claude-missing-type.pflow.md"
         write_workflow_file(workflow, workflow_path)
 
@@ -447,20 +438,10 @@ class TestValidateOnlyClaudeCodeStructuredOutput:
         assert "review" in result.output
 
     def test_validate_only_rejects_claude_code_legacy_schema(self, tmp_path: Path) -> None:
-        workflow = {
-            "nodes": [
-                {
-                    "id": "review",
-                    "type": "claude-code",
-                    "params": {
-                        "prompt": "Return status.",
-                        "max_turns": 2,
-                        "output_schema": {"status": {"type": "str", "description": "Legacy schema style"}},
-                    },
-                }
-            ],
-            "edges": [],
-        }
+        workflow = make_claude_code_workflow(
+            output_schema={"status": {"type": "str", "description": "Legacy schema style"}},
+            prompt="Return status.",
+        )
         workflow_path = tmp_path / "claude-legacy-schema.pflow.md"
         write_workflow_file(workflow, workflow_path)
 

--- a/tests/test_execution/test_workflow_resolver_contract.py
+++ b/tests/test_execution/test_workflow_resolver_contract.py
@@ -185,5 +185,5 @@ Calls an LLM with a prompt file that doesn't exist on disk.
 """
     )
 
-    with pytest.raises(CompilationError, match="file_resolution|missing"):
+    with pytest.raises(CompilationError, match=r"file_resolution|missing"):
         resolve_workflow(str(workflow_path))

--- a/tests/test_mcp_server/test_execution_workflow.py
+++ b/tests/test_mcp_server/test_execution_workflow.py
@@ -91,7 +91,7 @@ class TestExecuteWorkflowErrors:
     def test_nonexistent_workflow_raises_value_error(self):
         """When given a workflow name that does not exist anywhere,
         execute_workflow raises ValueError with 'not found' in the message."""
-        with pytest.raises(ValueError, match="(?i)not found"):
+        with pytest.raises(ValueError, match=r"(?i)not found"):
             ExecutionService.execute_workflow("nonexistent-workflow-xyz")
 
     def test_unknown_node_type_raises_validation_error(self, tmp_path):

--- a/tests/test_mcp_server/test_plan_workflow.py
+++ b/tests/test_mcp_server/test_plan_workflow.py
@@ -71,7 +71,7 @@ def test_plan_workflow_matches_cli_json_shape(tmp_path) -> None:
 
 def test_plan_workflow_not_found_raises_value_error_with_suggestion() -> None:
     """Unknown workflow names should raise ValueError."""
-    with pytest.raises(ValueError, match="(?i)not found"):
+    with pytest.raises(ValueError, match=r"(?i)not found"):
         ExecutionService.plan_workflow("definitely-not-a-real-workflow")
 
 

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -13,6 +13,20 @@ Tests criteria from the specification:
 10. Schema soft-failures write _schema_error and __warnings__
 11. SDK error signals preserve structured output when available and warn
 12. SDK/process/rate-limit/timeout errors are transformed by exec_fallback
+
+``__warnings__`` assertion conventions (deliberate split — both are used):
+
+- ``shared = {"__warnings__": {}}`` + ``assert not shared["__warnings__"]``
+  Tests that EXERCISE a happy path. Pre-initializing the channel makes the
+  "empty after run" assertion semantic ("we ran successfully and didn't write
+  any warnings"). The pre-init also matches what the production engine seeds
+  into shared state for full runs.
+
+- ``shared = {}`` + ``assert "__warnings__" not in shared``
+  Tests that exercise EARLY-RETURN paths in ``prep`` (no ``node_id`` bound,
+  schema-absent, etc.) where the production code intentionally never touches
+  the channel. The strict "key absent" assertion catches accidental
+  ``setdefault`` calls that would create the empty dict as a side effect.
 """
 
 import asyncio
@@ -110,6 +124,8 @@ sys.modules["claude_agent_sdk.types"] = mock_sdk_types
 sys.modules["claude_agent_sdk.exceptions"] = mock_sdk_exceptions
 
 # Now import the node after SDK mocking - E402 is expected here
+from pflow.core.diagnostic import Severity  # noqa: E402
+from pflow.core.workflow.validator import WorkflowValidator  # noqa: E402
 from pflow.nodes.claude.claude_code import ClaudeCodeNode  # noqa: E402
 from pflow.registry.metadata_extractor import PflowMetadataExtractor  # noqa: E402
 
@@ -904,6 +920,57 @@ def test_non_process_error_after_is_error_re_raises(claude_node):
             claude_node.exec(prep_res)
 
 
+def test_process_error_name_fallback_when_sdk_class_is_none(claude_node):
+    """Pin the name-based ProcessError fallback against a typed-only "cleanup."
+
+    The exception handler in ``_run_claude_session`` combines an
+    ``isinstance(exc, ProcessError)`` check with a runtime
+    ``type(exc).__name__ == "ProcessError"`` name fallback. The name fallback
+    matters when ``ProcessError`` is ``None`` at module load — happens in
+    partial / vendored SDK install scenarios where ``from claude_agent_sdk
+    import ProcessError`` failed but the SDK can still emit a class spelled
+    ``ProcessError`` at runtime.
+
+    A "clean refactor" to typed-only ``except (ProcessError,)`` would degrade
+    to ``except ():`` in that case (empty tuple catches nothing), the soft-fail
+    state would be lost, and the user would see a hard error instead of the
+    intended DEGRADED signal. This test exercises that exact scenario.
+    """
+    import pflow.nodes.claude.claude_code as cc
+
+    # A locally-defined exception class with the load-bearing name. NOT a
+    # subclass of the test module's mock ``ProcessError`` — that ``isinstance``
+    # match would let the typed approach pass too.
+    class StandaloneProcessError(Exception):
+        def __init__(self, message: str = "stderr text") -> None:
+            super().__init__(message)
+
+    StandaloneProcessError.__name__ = "ProcessError"
+
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    claude_node.node_id = "review"
+    shared: dict = {}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(structured_output=None, result="partial", is_error=True)
+        raise StandaloneProcessError("CLI exit 1")
+
+    with (
+        patch.object(cc, "ProcessError", None),
+        patch("pflow.nodes.claude.claude_code.query") as mock_query,
+    ):
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        # MUST NOT raise — name fallback swallows after is_error=True.
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
+
+    # Soft-fail signal preserved end-to-end.
+    assert "Claude CLI reported an error" in shared["_schema_error"]
+    assert shared["__warnings__"]["review"]["kind"] == "claude_code.sdk_error_no_structured_output"
+
+
 def test_output_schema_resolved_to_null_emits_warning(claude_node):
     """A declared output_schema that resolves to None must warn the workflow author.
 
@@ -1325,3 +1392,139 @@ def test_soft_fail_output_shape_not_classified_as_api_warning(claude_node):
         "keys in _store_results, or (b) any change to api_warning_detector's "
         "extract_error_message shape gates."
     )
+
+
+# ---------------------------------------------------------------------------
+# Runtime ↔ Validator parity
+# ---------------------------------------------------------------------------
+#
+# ``pflow.nodes.claude.schema_validation`` shares the *predicates* between the
+# runtime path (``ClaudeCodeNode._validate_schema``) and the static preflight
+# path (``WorkflowValidator._validate_claude_code_params``). The shared
+# predicates prevent drift on shape detection, but the CALL SITES can still
+# drift on:
+#
+# * which checks they run (one side adds a rule, the other doesn't),
+# * the order of checks (an early-return on one side shadows a later check),
+# * which inputs are rejected vs. accepted.
+#
+# These parametrized tables encode the cross-surface contract. Adding a new
+# rejection rule means adding a row to ``_PARITY_REJECT``; if either surface
+# doesn't implement it, the test fires with the case_id naming the gap.
+#
+# Out of scope: templated values (``output_schema: "${upstream}"``). Those
+# differ by design — the validator defers strings to runtime; the runtime
+# never sees a string because the resolver replaces it first. The defer
+# behavior is pinned separately in ``test_validate_only_defers_templated_output_schema``.
+
+_PARITY_REJECT: list[tuple[str, Any]] = [
+    ("empty_dict", {}),
+    ("non_dict_list", ["not", "a", "dict"]),
+    ("legacy_python_alias", {"risk": {"type": "str"}}),
+    ("legacy_detection_all_values", {"_meta": "x", "risk": {"type": "int"}}),
+    ("top_level_array", {"type": "array", "items": {"type": "string"}}),
+    ("top_level_string", {"type": "string"}),
+    ("top_level_oneOf", {"oneOf": [{"type": "object"}]}),
+    ("top_level_anyOf", {"anyOf": [{"type": "object"}]}),
+    ("top_level_allOf", {"allOf": [{"type": "object"}]}),
+    ("top_level_enum", {"enum": ["a", "b"]}),
+    ("top_level_const", {"const": {"x": 1}}),
+    ("missing_top_level_type", {"properties": {"x": {"type": "string"}}}),
+]
+
+_PARITY_ACCEPT: list[tuple[str, Any]] = [
+    ("none_schema", None),
+    ("minimal_object", {"type": "object"}),
+    ("object_with_properties", {"type": "object", "properties": {"x": {"type": "string"}}}),
+    (
+        "object_with_inner_oneOf",
+        {
+            "type": "object",
+            "properties": {"choice": {"oneOf": [{"type": "string"}, {"type": "integer"}]}},
+        },
+    ),
+]
+
+
+def _runtime_rejects(node: ClaudeCodeNode, schema: Any) -> bool:
+    try:
+        node._validate_schema(schema)
+        return False
+    except (ValueError, TypeError):
+        return True
+
+
+def _validator_rejects(schema: Any) -> bool:
+    diagnostics = WorkflowValidator._validate_claude_code_params("review", {"output_schema": schema})
+    return any(d.severity == Severity.ERROR for d in diagnostics)
+
+
+@pytest.mark.parametrize("case_id,schema", _PARITY_REJECT, ids=[c[0] for c in _PARITY_REJECT])
+def test_runtime_and_validator_agree_on_rejection(case_id: str, schema: Any, claude_node: Any) -> None:
+    """Schemas rejected by one surface must be rejected by both.
+
+    Add a row to ``_PARITY_REJECT`` when adding a rejection rule; if either
+    surface doesn't implement it, this test fires with the case_id naming
+    the gap.
+    """
+    validator_rejected = _validator_rejects(schema)
+    runtime_rejected = _runtime_rejects(claude_node, schema)
+    assert validator_rejected == runtime_rejected, (
+        f"Surface drift on '{case_id}': validator_rejected={validator_rejected}, runtime_rejected={runtime_rejected}"
+    )
+    assert validator_rejected, f"'{case_id}' should be rejected — neither surface caught it"
+
+
+@pytest.mark.parametrize("case_id,schema", _PARITY_ACCEPT, ids=[c[0] for c in _PARITY_ACCEPT])
+def test_runtime_and_validator_agree_on_acceptance(case_id: str, schema: Any, claude_node: Any) -> None:
+    """Schemas accepted by one surface must be accepted by both."""
+    validator_rejected = _validator_rejects(schema)
+    runtime_rejected = _runtime_rejects(claude_node, schema)
+    assert validator_rejected == runtime_rejected, (
+        f"Surface drift on '{case_id}': validator_rejected={validator_rejected}, runtime_rejected={runtime_rejected}"
+    )
+    assert not validator_rejected, f"'{case_id}' should be accepted — at least one surface wrongly rejected"
+
+
+def test_claude_code_node_resolves_identically_via_package_and_direct_import() -> None:
+    """Pin the lazy ``pflow.nodes.claude.__init__.py`` contract.
+
+    The ``__getattr__``-based lazy resolution is load-bearing: it lets
+    ``test_schema_validation.py`` import the predicates without dragging in
+    ``claude_agent_sdk`` before the SDK mock binds (``tests/CLAUDE.md`` #17).
+    A revert to ``from .claude_code import ClaudeCodeNode`` at package load
+    would break that test file's coexistence with the mock — producing
+    confusing ProcessError-style failures spread across unrelated tests
+    rather than a clean signal that this contract changed.
+
+    This test makes the contract explicit. Reverting the lazy init breaks
+    HERE, not in cross-file ordering downstream.
+    """
+    import pflow.nodes.claude as pkg
+    from pflow.nodes.claude.claude_code import ClaudeCodeNode as direct
+
+    assert pkg.ClaudeCodeNode is direct
+
+
+def test_runtime_and_validator_agree_on_max_turns_with_schema(claude_node: Any) -> None:
+    """The cross-rule ``max_turns >= 2 when output_schema is set`` is enforced
+    on both surfaces. Runtime checks happen in ``prep()`` (not ``_validate_schema``),
+    so this case tests the full ``prep()`` path.
+    """
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    params = {"output_schema": schema, "max_turns": 1, "prompt": "test"}
+
+    diagnostics = WorkflowValidator._validate_claude_code_params("review", params)
+    validator_rejected = any(d.severity == Severity.ERROR for d in diagnostics)
+
+    claude_node.params = params
+    runtime_rejected = False
+    try:
+        claude_node.prep({})
+    except ValueError:
+        runtime_rejected = True
+
+    assert validator_rejected == runtime_rejected, (
+        f"max_turns parity drift: validator={validator_rejected}, runtime={runtime_rejected}"
+    )
+    assert validator_rejected

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -4,29 +4,21 @@ Tests criteria from the specification:
 1. Prompt missing → ValueError with "No prompt provided"
 2. Prompt empty string → ValueError with "Prompt cannot be empty"
 3. Prompt > 10000 chars → ValueError with "Prompt too long"
-4. Working directory missing → ValueError with path
-5. Working directory restricted → ValueError with "Restricted directory"
-6-7. Authentication now handled by SDK (tests removed)
-8. Valid task without schema → "success" and shared["result"] populated
-9. Valid task with schema → "success" and schema keys in shared
-10. Output schema invalid keys → ValueError with details
-11. Output schema 50+ keys → ValueError "Schema too complex"
-12. Rate limit error → ValueError with retry message
-13. Timeout at 300s → ValueError with timeout message
-14. CLINotFoundError handling → Correct error transformation
-15. CLIConnectionError handling → Correct error transformation
-16. ProcessError handling → Includes exit code
-17. Tool whitelist enforcement → Only ["Read", "Write", "Edit", "Bash"] allowed
-18. Schema to prompt conversion → System prompt contains JSON format
-19. Valid JSON response → Values stored in schema keys
-20. Invalid JSON response → Raw text in result, error in _schema_error
-21. Partial JSON response → Missing keys stored as None
-22. No response content → Empty result stored
-23. Schema merged with user prompt → Both instructions present
+4. Working directory missing/restricted → clear ValueError
+5. Native SDK structured output is wired through ClaudeAgentOptions.output_format
+6. JSON Schema validation catches legacy format, empty schemas, and top-level non-object schemas
+7. max_turns >= 2 is required when output_schema is set
+8. Valid task without schema → shared["result"] populated with text
+9. Valid task with schema → shared["result"] populated from ResultMessage.structured_output
+10. Schema soft-failures write _schema_error and __warnings__
+11. SDK error signals preserve structured output when available and warn
+12. SDK/process/rate-limit/timeout errors are transformed by exec_fallback
 """
 
 import asyncio
 import sys
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -49,6 +41,22 @@ class ToolUseBlock:
         self.input = input_data
 
 
+@dataclass
+class ResultMessage:
+    """Test mock mirroring claude_agent_sdk.types.ResultMessage (v0.2.82+)."""
+
+    subtype: str = "success"
+    duration_ms: int = 0
+    duration_api_ms: int = 0
+    is_error: bool = False
+    num_turns: int = 1
+    session_id: str = "test-session"
+    total_cost_usd: float | None = None
+    usage: dict | None = None
+    result: str | None = None
+    structured_output: Any = None
+
+
 class CLINotFoundError(Exception):
     pass
 
@@ -59,7 +67,10 @@ class CLIConnectionError(Exception):
 
 class ProcessError(Exception):
     def __init__(self, exit_code=1, stderr=""):
-        super().__init__()
+        # ``str(exc)`` returns ``stderr`` so ``_run_claude_session`` captures
+        # something meaningful into ``sdk_exception_text`` (the real SDK
+        # ProcessError's ``__str__`` is similarly stderr-derived).
+        super().__init__(stderr)
         self.exit_code = exit_code
         self.stderr = stderr
 
@@ -68,11 +79,16 @@ class ClaudeSDKError(Exception):
     pass
 
 
+class QueryError(Exception):
+    pass
+
+
 # Mock the SDK module before importing the node
 mock_sdk_types = Mock()
 mock_sdk_types.AssistantMessage = AssistantMessage
 mock_sdk_types.TextBlock = TextBlock
 mock_sdk_types.ToolUseBlock = ToolUseBlock
+mock_sdk_types.ResultMessage = ResultMessage
 
 mock_sdk_exceptions = Mock()
 mock_sdk_exceptions.CLINotFoundError = CLINotFoundError
@@ -95,6 +111,7 @@ sys.modules["claude_agent_sdk.exceptions"] = mock_sdk_exceptions
 
 # Now import the node after SDK mocking - E402 is expected here
 from pflow.nodes.claude.claude_code import ClaudeCodeNode  # noqa: E402
+from pflow.registry.metadata_extractor import PflowMetadataExtractor  # noqa: E402
 
 
 # Fixtures for common test setup
@@ -125,7 +142,7 @@ def mock_query_success():
 # Test Criteria 1: Prompt missing → ValueError with "No prompt provided"
 def test_task_missing(claude_node):
     """Test that missing prompt raises ValueError."""
-    shared = {}
+    shared = {"__warnings__": {}}
     with pytest.raises(ValueError) as exc_info:
         claude_node.prep(shared)
     assert "No prompt provided" in str(exc_info.value)
@@ -135,7 +152,7 @@ def test_task_missing(claude_node):
 def test_task_empty_string(claude_node):
     """Test that empty string prompt raises ValueError."""
     claude_node.params = {"prompt": "   "}  # Whitespace only
-    shared = {}
+    shared = {"__warnings__": {}}
     with pytest.raises(ValueError) as exc_info:
         claude_node.prep(shared)
     assert "cannot be empty" in str(exc_info.value)
@@ -145,7 +162,7 @@ def test_task_empty_string(claude_node):
 def test_task_too_long(claude_node):
     """Test that prompt over 10000 chars raises ValueError."""
     claude_node.params = {"prompt": "x" * 10001}
-    shared = {}
+    shared = {"__warnings__": {}}
     with pytest.raises(ValueError) as exc_info:
         claude_node.prep(shared)
     assert "Prompt too long" in str(exc_info.value)
@@ -156,7 +173,7 @@ def test_task_too_long(claude_node):
 def test_working_directory_missing(claude_node):
     """Test that non-existent working directory raises ValueError."""
     claude_node.params = {"prompt": "test prompt", "cwd": "/nonexistent/path"}
-    shared = {}
+    shared = {"__warnings__": {}}
 
     with pytest.raises(ValueError) as exc_info:
         claude_node.prep(shared)
@@ -167,7 +184,7 @@ def test_working_directory_missing(claude_node):
 # Test Criteria 5: Working directory restricted → ValueError with "Restricted directory"
 def test_working_directory_restricted(claude_node):
     """Test that restricted directories raise ValueError."""
-    shared = {}
+    shared = {"__warnings__": {}}
 
     # Test multiple restricted directories
     for restricted in ["/", "/etc", "/usr", "/bin"]:
@@ -200,7 +217,6 @@ def test_valid_task_without_schema(claude_node):
 
         assert isinstance(result, dict)
         assert result["result_text"] == "def hello_world():\n    print('Hello, World!')"
-        assert result["output_schema"] is None
         assert result["tool_uses"] == []
 
         # Check post() stores results (now string format without schema)
@@ -214,21 +230,24 @@ def test_valid_task_without_schema(claude_node):
 # Test Criteria 9: Valid prompt with schema → "success" and schema keys in shared
 def test_valid_task_with_schema(claude_node):
     """Test successful execution with output schema."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "risk_level": {"type": "string", "enum": ["high", "medium", "low"]},
+            "issues": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["risk_level", "issues"],
+    }
     claude_node.params = {
         "prompt": "Review this code for issues",
-        "output_schema": {
-            "risk_level": {"type": "str", "description": "high/medium/low"},
-            "issues": {"type": "list", "description": "List of issues"},
-        },
+        "output_schema": schema,
     }
-    shared = {}
+    shared = {"__warnings__": {}}
     claude_node.shared = shared
 
-    # Mock query response with JSON
     async def mock_response(*args, **kwargs):
-        yield AssistantMessage(
-            content=[TextBlock(text='Analysis complete.\n```json\n{"risk_level": "low", "issues": []}\n```')]
-        )
+        yield AssistantMessage(content=[TextBlock(text="Analysis complete.")])
+        yield ResultMessage(structured_output={"risk_level": "low", "issues": []}, is_error=False)
 
     with patch("pflow.nodes.claude.claude_code.query") as mock_query:
         mock_query.return_value = mock_response()
@@ -238,57 +257,127 @@ def test_valid_task_with_schema(claude_node):
         result = claude_node.exec(prep_res)
 
         assert isinstance(result, dict)
-        assert result["result_text"] == 'Analysis complete.\n```json\n{"risk_level": "low", "issues": []}\n```'
-        assert result["output_schema"] == claude_node.params["output_schema"]
+        assert result["result_text"] == "Analysis complete."
+        assert result["structured_output"] == {"risk_level": "low", "issues": []}
 
-        # Check post() stores and parses JSON
         claude_node.post(shared, prep_res, result)
-        assert isinstance(shared["result"], dict)
-        assert shared["result"]["risk_level"] == "low"
-        assert shared["result"]["issues"] == []
+        assert shared["result"] == {"risk_level": "low", "issues": []}
+        assert "_schema_error" not in shared
+        assert not shared["__warnings__"]
 
 
-# Test Criteria 10: Output schema invalid keys → ValueError with details
-def test_output_schema_invalid_keys(claude_node):
-    """Test that invalid schema keys raise ValueError."""
-    claude_node.params = {
-        "prompt": "test prompt",
-        "output_schema": {
-            "valid_key": {"type": "str"},
-            "invalid-key": {"type": "str"},  # Invalid: contains hyphen
-        },
+def test_legacy_python_alias_schema_rejected(claude_node):
+    """Old custom output_schema format raises with migration guidance."""
+    with pytest.raises(ValueError, match="legacy Python-alias format"):
+        claude_node._validate_schema({"risk_level": {"type": "str", "description": "high/medium/low"}})
+
+
+def test_legacy_format_detection_checks_all_values(claude_node):
+    """Legacy detection checks all values, not just the first."""
+    schema = {"_meta": "comment", "risk": {"type": "str", "description": "high/medium/low"}}
+    with pytest.raises(ValueError, match="legacy Python-alias format"):
+        claude_node._validate_schema(schema)
+
+
+def test_oneOf_top_level_schema_accepted(claude_node):
+    """Top-level oneOf passes prep validation; runtime compatibility is API-dependent."""
+    schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+    assert claude_node._validate_schema(schema) == schema
+
+
+def test_top_level_array_schema_rejected(claude_node):
+    """The Claude API rejects non-object top-level schemas; prep catches this."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"type": "array", "items": {"type": "string"}})
+
+
+def test_top_level_primitive_schema_rejected(claude_node):
+    """Primitive top-level schemas must be wrapped in an object."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"type": "string", "enum": ["yes", "no"]})
+
+
+def test_empty_schema_dict_rejected(claude_node):
+    """Empty dict likely means the schema body was omitted."""
+    with pytest.raises(ValueError, match="empty dict"):
+        claude_node._validate_schema({})
+
+
+def test_none_schema_returns_none(claude_node):
+    """None means no schema was requested."""
+    assert claude_node._validate_schema(None) is None
+
+
+def test_non_dict_schema_raises_typeerror(claude_node):
+    """output_schema must be a JSON Schema dict."""
+    with pytest.raises(TypeError):
+        claude_node._validate_schema(["not", "a", "dict"])
+
+
+def test_registry_interface_outputs_exclude_root_warnings():
+    """Root __warnings__ is diagnostic state, not a node template output."""
+    metadata = PflowMetadataExtractor().extract_metadata(ClaudeCodeNode)
+    output_keys = {item["key"] for item in metadata["outputs"]}
+    assert "result" in output_keys
+    assert "_schema_error" in output_keys
+    assert "__warnings__" not in output_keys
+
+
+def test_output_schema_wrapped_and_passed_to_options(claude_node):
+    """JSON Schema is wrapped in the SDK's native output_format shape."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    prep_res = claude_node.prep({})
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert mock_options.call_args.kwargs["output_format"] == {
+        "type": "json_schema",
+        "schema": schema,
     }
-    shared = {}
-
-    with pytest.raises(ValueError) as exc_info:
-        claude_node.prep(shared)
-
-    assert "Invalid schema key" in str(exc_info.value)
-    assert "invalid-key" in str(exc_info.value)
 
 
-# Test Criteria 11: Output schema 50+ keys → ValueError "Schema too complex"
-def test_output_schema_too_complex(claude_node):
-    """Test that overly complex schema raises ValueError."""
-    schema = {f"key_{i}": {"type": "str"} for i in range(51)}
-    claude_node.params = {
-        "prompt": "test prompt",
-        "output_schema": schema,
+def test_exec_passes_structured_options_to_query(claude_node):
+    """The execution path must pass the ClaudeAgentOptions object into query()."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    sentinel_options = object()
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(structured_output={"x": "ok"}, is_error=False)
+
+    with (
+        patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions", return_value=sentinel_options) as mock_options,
+        patch("pflow.nodes.claude.claude_code.query") as mock_query,
+    ):
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep({})
+        claude_node.exec(prep_res)
+
+    assert mock_options.call_args.kwargs["output_format"] == {
+        "type": "json_schema",
+        "schema": schema,
     }
-    shared = {}
+    assert mock_query.call_args.kwargs["options"] is sentinel_options
 
-    with pytest.raises(ValueError) as exc_info:
-        claude_node.prep(shared)
 
-    assert "Schema too complex" in str(exc_info.value)
-    assert "51" in str(exc_info.value)
+def test_no_schema_means_no_output_format(claude_node):
+    """Without output_schema, output_format is omitted."""
+    claude_node.params = {"prompt": "test prompt"}
+    prep_res = claude_node.prep({})
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert "output_format" not in mock_options.call_args.kwargs
 
 
 # Test Criteria 12: Rate limit error → ValueError with retry message
 def test_rate_limit_error(claude_node):
     """Test rate limit error handling."""
     claude_node.params = {"prompt": "test prompt"}
-    shared = {}
+    shared = {"__warnings__": {}}
     claude_node.shared = shared
 
     async def mock_error(*args, **kwargs):
@@ -505,61 +594,34 @@ def test_timeout_parameter(claude_node):
     assert "between 30 and 3600" in str(exc_info.value)
 
 
-# Test Criteria 18: Schema to prompt conversion → System prompt contains JSON format
-def test_schema_to_prompt_conversion(claude_node):
-    """Test that schema is converted to JSON format instructions in system prompt."""
-    claude_node.params = {
-        "prompt": "test prompt",
-        "output_schema": {
-            "summary": {"type": "str", "description": "Brief summary"},
-            "score": {"type": "int", "description": "Score from 1-10"},
-        },
-    }
-    shared = {}
-
-    prep_res = claude_node.prep(shared)
-    system_prompt = claude_node._build_system_prompt(prep_res)
-
-    # Check that system prompt contains JSON instructions (updated prompt text)
-    assert "YOU MUST RESPOND WITH JSON ONLY" in system_prompt
-    assert "```json" in system_prompt
-    assert '"summary": "<str: Brief summary>"' in system_prompt
-    assert '"score": "<int: Score from 1-10>"' in system_prompt
-    assert "Field descriptions:" in system_prompt
-    assert "- summary: Brief summary" in system_prompt
-    assert "- score: Score from 1-10" in system_prompt
-
-
 # Test Criteria 19: Valid JSON response → Values stored in schema keys
 def test_valid_json_response_storage(claude_node):
-    """Test that valid JSON response is correctly parsed and stored."""
+    """Test that structured_output is stored directly."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "complexity": {"type": "string"},
+            "lines": {"type": "integer"},
+            "functions": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["complexity", "lines", "functions"],
+    }
     claude_node.params = {
         "prompt": "Analyze code",
-        "output_schema": {
-            "complexity": {"type": "str", "description": "Code complexity"},
-            "lines": {"type": "int", "description": "Number of lines"},
-            "functions": {"type": "list", "description": "List of functions"},
-        },
+        "output_schema": schema,
     }
-    shared = {}
+    shared = {"__warnings__": {}}
     claude_node.shared = shared
 
-    # Mock response with valid JSON
     async def mock_response(*args, **kwargs):
-        yield AssistantMessage(
-            content=[
-                TextBlock(
-                    text="""Analysis complete.
-            ```json
-            {
+        yield AssistantMessage(content=[TextBlock(text="Analysis complete.")])
+        yield ResultMessage(
+            structured_output={
                 "complexity": "medium",
                 "lines": 42,
-                "functions": ["main", "helper", "utils"]
-            }
-            ```
-            """
-                )
-            ]
+                "functions": ["main", "helper", "utils"],
+            },
+            is_error=False,
         )
 
     with patch("pflow.nodes.claude.claude_code.query") as mock_query:
@@ -570,30 +632,31 @@ def test_valid_json_response_storage(claude_node):
 
         assert isinstance(result, dict)
 
-        # Check post() stores parsed JSON values
         claude_node.post(shared, prep_res, result)
-        assert isinstance(shared["result"], dict)
-        assert shared["result"]["complexity"] == "medium"
-        assert shared["result"]["lines"] == 42
-        assert shared["result"]["functions"] == ["main", "helper", "utils"]
-        assert "_schema_error" not in shared  # Should not have error when parsing succeeds
+        assert shared["result"] == {
+            "complexity": "medium",
+            "lines": 42,
+            "functions": ["main", "helper", "utils"],
+        }
+        assert "_schema_error" not in shared
+        assert not shared["__warnings__"]
 
 
 # Test Criteria 20: Invalid JSON response → Raw text in result, error in _schema_error
 def test_invalid_json_response_fallback(claude_node):
-    """Test that invalid JSON falls back to raw text storage."""
+    """Schema set + no structured_output falls back to raw text and warns."""
+    schema = {"type": "object", "properties": {"summary": {"type": "string"}}, "required": ["summary"]}
     claude_node.params = {
         "prompt": "Analyze code",
-        "output_schema": {
-            "summary": {"type": "str", "description": "Summary"},
-        },
+        "output_schema": schema,
     }
+    claude_node.node_id = "review"
     shared = {}
     claude_node.shared = shared
 
-    # Mock response with invalid JSON
     async def mock_response(*args, **kwargs):
         yield AssistantMessage(content=[TextBlock(text="This is not JSON at all, just plain text response.")])
+        yield ResultMessage(structured_output=None, result="This is not JSON at all, just plain text response.")
 
     with patch("pflow.nodes.claude.claude_code.query") as mock_query:
         mock_query.return_value = mock_response()
@@ -603,30 +666,30 @@ def test_invalid_json_response_fallback(claude_node):
 
         assert isinstance(result, dict)
 
-        # Check post() handles invalid JSON (now stores as string)
         claude_node.post(shared, prep_res, result)
-        assert isinstance(shared["result"], str)  # Falls back to string when JSON fails
         assert shared["result"] == "This is not JSON at all, just plain text response."
-        assert shared["_schema_error"] == "Failed to parse JSON from response. Raw text stored in result"
+        assert "Model did not return" in shared["_schema_error"]
+        assert shared["__warnings__"]["review"]["kind"] == "claude_code.schema_not_satisfied"
 
 
-# Test Criteria 21: Partial JSON response → Missing keys stored as None
-def test_partial_json_response(claude_node):
-    """Test that partial JSON response stores None for missing keys."""
+def test_sdk_is_error_branch(claude_node):
+    """SDK is_error without structured_output uses the CLI-error soft-fail warning."""
+    schema = {"type": "object", "properties": {"found": {"type": "string"}}, "required": ["found"]}
     claude_node.params = {
         "prompt": "Analyze code",
-        "output_schema": {
-            "found": {"type": "str", "description": "Found key"},
-            "missing": {"type": "str", "description": "Missing key"},
-            "also_missing": {"type": "int", "description": "Also missing"},
-        },
+        "output_schema": schema,
     }
+    claude_node.node_id = "review"
     shared = {}
     claude_node.shared = shared
 
-    # Mock response with partial JSON (only has "found" key)
     async def mock_response(*args, **kwargs):
-        yield AssistantMessage(content=[TextBlock(text='```json\n{"found": "present"}\n```')])
+        yield AssistantMessage(content=[TextBlock(text="error context")])
+        yield ResultMessage(structured_output=None, result="error context", is_error=True)
+        # The SDK pairs ResultMessage(is_error=True) with a ProcessError raise
+        # when the CLI exits non-zero; the node must preserve the is_error state
+        # rather than re-raise. Other exception types are tested separately.
+        raise ProcessError(exit_code=1, stderr="Claude Code returned an error result: error context")
 
     with patch("pflow.nodes.claude.claude_code.query") as mock_query:
         mock_query.return_value = mock_response()
@@ -636,13 +699,11 @@ def test_partial_json_response(claude_node):
 
         assert isinstance(result, dict)
 
-        # Check post() handles partial JSON
         claude_node.post(shared, prep_res, result)
-        assert isinstance(shared["result"], dict)
-        assert shared["result"]["found"] == "present"
-        assert shared["result"]["missing"] is None
-        assert shared["result"]["also_missing"] is None
-        assert "_schema_error" not in shared  # No error since JSON was parsed
+        assert shared["result"] == "error context"
+        assert "Claude CLI reported an error" in shared["_schema_error"]
+        assert shared["__warnings__"]["review"]["kind"] == "claude_code.sdk_error_no_structured_output"
+        assert shared["__warnings__"]["review"]["context"]["sdk_exception"]
 
 
 # Test Criteria 22: No response content → Empty result stored
@@ -669,26 +730,6 @@ def test_no_response_content(claude_node):
         claude_node.post(shared, prep_res, result)
         assert isinstance(shared["result"], str)
         assert shared["result"] == ""
-
-
-# Test Criteria 23: Schema merged with user prompt → Both instructions present
-def test_schema_merged_with_user_prompt(claude_node):
-    """Test that schema instructions and user system prompt are both present."""
-    claude_node.params = {
-        "prompt": "test prompt",
-        "output_schema": {
-            "result": {"type": "str", "description": "Result"},
-        },
-        "system_prompt": "You are a helpful assistant.",
-    }
-    shared = {}
-
-    prep_res = claude_node.prep(shared)
-    system_prompt = claude_node._build_system_prompt(prep_res)
-
-    # Check both prompts are present (updated prompt text)
-    assert "YOU MUST RESPOND WITH JSON ONLY" in system_prompt
-    assert "You are a helpful assistant." in system_prompt
 
 
 # Additional tests for edge cases and integration
@@ -738,6 +779,17 @@ def test_max_turns_validation(claude_node):
     assert "Invalid max_turns" in str(exc_info.value)
 
 
+def test_max_turns_too_low_with_schema_rejected(claude_node):
+    """Structured output needs at least two turns."""
+    claude_node.params = {
+        "prompt": "test prompt",
+        "output_schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+        "max_turns": 1,
+    }
+    with pytest.raises(ValueError, match="max_turns must be >= 2"):
+        claude_node.prep({})
+
+
 def test_tool_use_logging(claude_node, caplog):
     """Test that tool uses are logged."""
     import logging
@@ -771,29 +823,144 @@ def test_tool_use_logging(claude_node, caplog):
         assert "Claude Code used 2 tools" in caplog.text
 
 
-def test_json_extraction_strategies(claude_node):
-    """Test all JSON extraction strategies."""
-    node = claude_node
+def test_sdk_is_error_with_structured_output_emits_warning(claude_node):
+    """If SDK reports an error but structured_output exists, structured output wins and warning persists."""
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    claude_node.node_id = "review"
+    shared = {}
 
-    # Strategy 1: JSON in code block
-    text1 = '```json\n{"key": "value"}\n```'
-    result1 = node._extract_json(text1)
-    assert result1 == {"key": "value"}
+    async def mock_response(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text="done")])
+        yield ResultMessage(structured_output={"x": 1}, is_error=True)
+        # See test_sdk_is_error_branch — only ProcessError is the paired-with-
+        # is_error=True case the node swallows.
+        raise ProcessError(exit_code=1, stderr="partial")
 
-    # Strategy 2: Raw JSON object
-    text2 = 'Some text {"key": "value"} more text'
-    result2 = node._extract_json(text2)
-    assert result2 == {"key": "value"}
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
 
-    # Strategy 3: Nested JSON
-    text3 = 'Text {"outer": {"inner": "value"}} end'
-    result3 = node._extract_json(text3)
-    assert result3 == {"outer": {"inner": "value"}}
+    assert shared["result"] == {"x": 1}
+    assert shared["__warnings__"]["review"]["kind"] == "claude_code.sdk_error_with_structured_output"
 
-    # Failed extraction
-    text4 = "No JSON here at all"
-    result4 = node._extract_json(text4)
-    assert result4 is None
+
+def test_non_process_error_after_is_error_re_raises(claude_node):
+    """Hard errors after a ResultMessage(is_error=True) must NOT be swallowed.
+
+    Regression: an earlier fix preserved is_error state by swallowing every
+    ``Exception``, which masked ``CLIConnectionError``/``CLINotFoundError``-class
+    failures so the user never saw the remediation message from ``exec_fallback``.
+    Only ``ProcessError`` (the paired non-zero-exit case) is the swallow candidate.
+    """
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    claude_node.node_id = "review"
+    shared = {}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(structured_output=None, result="partial", is_error=True)
+        raise CLIConnectionError("Lost connection to Claude CLI mid-stream")
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        # ``exec()`` runs the SDK loop directly (no retry/fallback wrapper).
+        # The connection error must escape ``_run_claude_session`` so the
+        # Node retry path eventually delivers it to ``exec_fallback``.
+        with pytest.raises(CLIConnectionError, match="Lost connection"):
+            claude_node.exec(prep_res)
+
+
+def test_output_schema_resolved_to_null_emits_warning(claude_node):
+    """A declared output_schema that resolves to None must warn the workflow author.
+
+    Regression: silently dropping schema mode caused workflows that templated
+    the schema from upstream nodes (``output_schema: ${x.schema}``) to report
+    SUCCESS even when the schema reference missed and the run produced free-form
+    text instead of structured output.
+    """
+    # Simulate engine post-template-resolution: key present, value resolved to None.
+    claude_node.params = {"prompt": "test prompt", "output_schema": None}
+    claude_node.node_id = "review"
+    shared: dict = {}
+
+    claude_node.prep(shared)
+
+    warning = shared["__warnings__"]["review"]
+    assert warning["kind"] == "claude_code.output_schema_resolved_to_null"
+    assert "resolved to None" in warning["text"]
+    assert warning["context"]["node_type"] == "claude-code"
+
+
+def test_output_schema_absent_does_not_warn(claude_node):
+    """If the workflow author never declared output_schema, no warning fires."""
+    claude_node.params = {"prompt": "test prompt"}  # no output_schema key
+    shared: dict = {}
+
+    claude_node.prep(shared)
+
+    assert "__warnings__" not in shared
+
+
+def test_output_schema_resolved_null_no_node_id_falls_back_to_schema_error(claude_node):
+    """Test-path / uncompiled nodes preserve signal via ``_schema_error``."""
+    claude_node.params = {"prompt": "test prompt", "output_schema": None}
+    shared: dict = {}
+
+    claude_node.prep(shared)
+
+    # Without a bound node_id, __warnings__ writes would be keyed under None and
+    # are lost downstream — fall back to _schema_error so the signal survives.
+    assert "resolved to None" in shared["_schema_error"]
+
+
+def test_nested_array_schema(claude_node):
+    """Arrays nested inside a top-level object are supported."""
+    schema = {
+        "type": "object",
+        "properties": {"items": {"type": "array", "items": {"type": "string"}}},
+        "required": ["items"],
+    }
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    shared = {}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(structured_output={"items": ["a", "b", "c"]}, is_error=False)
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
+
+    assert shared["result"] == {"items": ["a", "b", "c"]}
+    assert isinstance(shared["result"]["items"], list)
+
+
+def test_sticky_is_error_across_multiple_result_messages(claude_node):
+    """An early ResultMessage.is_error=True remains visible even if a later message is false."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    claude_node.node_id = "review"
+    shared = {}
+
+    async def mock_response(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text="raw")])
+        yield ResultMessage(is_error=True, structured_output=None)
+        yield ResultMessage(is_error=False, structured_output=None)
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
+
+    assert shared["result"] == "raw"
+    assert "Claude CLI reported an error" in shared["_schema_error"]
+    assert shared["__warnings__"]["review"]["kind"] == "claude_code.sdk_error_no_structured_output"
 
 
 def test_working_directory_expansion(claude_node):
@@ -1031,3 +1198,100 @@ def test_disallowed_tools_with_allowed_tools(claude_node):
     prep_res = claude_node.prep(shared)
     assert prep_res["allowed_tools"] == ["Read", "Write", "Bash"]
     assert prep_res["disallowed_tools"] == ["Bash(rm:*)"]
+
+
+# ---------------------------------------------------------------------------
+# Soft-fail signal preservation when node_id is unbound (test path)
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_error_with_structured_output_no_node_id_falls_back_to_schema_error(claude_node):
+    """When the SDK reports an error alongside valid structured output AND no
+    ``node_id`` is bound, ``_schema_error`` preserves the signal.
+
+    Production engine paths always bind ``node_id``, so this is the test /
+    direct-``node.run(shared)`` path. Matches the fallback established by
+    ``_emit_schema_resolved_null_warning``: ``__warnings__[node_id]`` is the
+    primary channel; ``_schema_error`` is the recovery channel.
+    """
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    # No ``claude_node.node_id`` assignment — simulates uncompiled / direct test path.
+    shared: dict = {}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(structured_output={"x": 1}, is_error=True)
+        raise ProcessError(exit_code=1, stderr="partial")
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
+
+    # Structured output still wins as the result.
+    assert shared["result"] == {"x": 1}
+    # Signal preserved via _schema_error even without node_id.
+    assert "structured_output was produced" in shared["_schema_error"]
+    # __warnings__ guarded by node_id; no warning entry expected.
+    assert "__warnings__" not in shared
+
+
+# ---------------------------------------------------------------------------
+# Soft-fail message strings must not collide with api_warning_detector
+# ---------------------------------------------------------------------------
+
+
+def test_soft_fail_output_shape_not_classified_as_api_warning(claude_node):
+    """Regression pin: a claude-code soft-fail must NOT be detected by
+    ``api_warning_detector.detect_api_warning`` — otherwise the engine would
+    override the node's ``"default"`` action to ``"error"`` and silently flip
+    soft-fail (DEGRADED) into hard fail (FAILED).
+
+    Today the detector is shape-gated — it only extracts an error message from
+    outputs containing ``ok: false`` / ``success: false`` / ``status: "error"`` /
+    GraphQL ``errors`` / an ``error`` key at the dict root. The claude-code node
+    writes ``result``, ``_schema_error``, and ``llm_usage`` — none of those keys
+    match. This test pins that invariant: the output shape from a soft-fail
+    must continue to bypass the detector, regardless of message wording.
+
+    A future contributor adding an ``error`` key to ``shared[node_id]`` for
+    debug visibility would break soft-fail routing — this test fails first.
+    """
+    from pflow.runtime.engine.api_warning_detector import detect_api_warning
+
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}
+    claude_node.params = {"prompt": "test prompt", "output_schema": schema}
+    claude_node.node_id = "review"
+    # Simulate engine namespacing: a claude-code node writes its outputs under
+    # ``shared[node_id]`` via NamespacedSharedStore. Build that shape directly
+    # so the test exercises exactly what the detector will see in production.
+    shared: dict = {}
+    namespaced = {}
+
+    async def mock_response(*args, **kwargs):
+        # No structured output → soft-fail branch with the longest message.
+        yield ResultMessage(structured_output=None, result="raw fallback text", is_error=False)
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        # Capture the node-output shape exactly as namespaced_store would write it.
+        # _store_results writes ``shared["result"]``, ``shared["_schema_error"]``,
+        # ``shared["llm_usage"]`` — under namespacing these become
+        # ``shared[node_id][...]``.
+        claude_node.post(namespaced, prep_res, result)
+
+    # Promote namespaced writes into the shared store shape the engine produces.
+    shared["review"] = {k: v for k, v in namespaced.items() if not k.startswith("__")}
+
+    # The canonical invariant: claude-code soft-fail must NOT be detected as
+    # an API warning. If detect_api_warning returns non-None, the engine would
+    # convert action="default" → "error" and lose the entire soft-fail design.
+    assert detect_api_warning("review", shared) is None, (
+        "claude-code soft-fail output was classified as an API warning; engine "
+        "would flip action to 'error'. Inspect: (a) any new error/ok/success/status "
+        "keys in _store_results, or (b) any change to api_warning_detector's "
+        "extract_error_message shape gates."
+    )

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -279,10 +279,30 @@ def test_legacy_format_detection_checks_all_values(claude_node):
         claude_node._validate_schema(schema)
 
 
-def test_oneOf_top_level_schema_accepted(claude_node):
-    """Top-level oneOf passes prep validation; runtime compatibility is API-dependent."""
-    schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
-    assert claude_node._validate_schema(schema) == schema
+def test_top_level_oneOf_schema_rejected(claude_node):
+    """Verified via real-API probe: oneOf top-level returns HTTP 400.
+    Combinators must live inside an object wrapper.
+    """
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"oneOf": [{"type": "string"}, {"type": "integer"}]})
+
+
+def test_top_level_anyOf_schema_rejected(claude_node):
+    """anyOf at top level is rejected by the API — same class as oneOf."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"anyOf": [{"type": "object"}, {"type": "object"}]})
+
+
+def test_top_level_allOf_schema_rejected(claude_node):
+    """allOf at top level is rejected by the API — same class as oneOf."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"allOf": [{"type": "object"}, {"type": "object"}]})
+
+
+def test_top_level_missing_type_rejected(claude_node):
+    """A dict without top-level `type` is rejected — the API requires `type: object`."""
+    with pytest.raises(ValueError, match="top-level type: object"):
+        claude_node._validate_schema({"properties": {"x": {"type": "string"}}})
 
 
 def test_top_level_array_schema_rejected(claude_node):
@@ -295,6 +315,16 @@ def test_top_level_primitive_schema_rejected(claude_node):
     """Primitive top-level schemas must be wrapped in an object."""
     with pytest.raises(ValueError, match="top-level type: object"):
         claude_node._validate_schema({"type": "string", "enum": ["yes", "no"]})
+
+
+def test_top_level_object_with_oneOf_accepted(claude_node):
+    """oneOf INSIDE a top-level `type: object` is fine — the wrapper is what the API requires."""
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "oneOf": [{"required": ["x"]}, {"required": []}],
+    }
+    assert claude_node._validate_schema(schema) == schema
 
 
 def test_empty_schema_dict_rejected(claude_node):

--- a/tests/test_nodes/test_claude/test_schema_validation.py
+++ b/tests/test_nodes/test_claude/test_schema_validation.py
@@ -1,0 +1,114 @@
+"""Tests for the pure predicates in ``pflow.nodes.claude.schema_validation``.
+
+These predicates are imported by both ``ClaudeCodeNode._validate_schema``
+(runtime) and ``WorkflowValidator._validate_claude_code_params`` (preflight).
+Drift-at-the-predicate-level was the motivating risk for extracting them; the
+tests below pin behavior at the predicate boundary so changes that alter
+acceptance/rejection shape surface here, not via the call-site test files.
+"""
+
+from __future__ import annotations
+
+from pflow.nodes.claude.schema_validation import (
+    is_legacy_python_alias_schema,
+    top_level_object_violation,
+)
+
+
+class TestIsLegacyPythonAliasSchema:
+    def test_legacy_flat_field_map_detected(self) -> None:
+        schema = {"risk_level": {"type": "str", "description": "high/medium/low"}}
+        assert is_legacy_python_alias_schema(schema) is True
+
+    def test_legacy_detection_checks_all_values_not_just_first(self) -> None:
+        # First value is non-dict (metadata-style marker); second is legacy shape.
+        schema = {"_meta": "comment", "risk": {"type": "str", "description": "..."}}
+        assert is_legacy_python_alias_schema(schema) is True
+
+    def test_real_json_schema_with_top_level_type_not_legacy(self) -> None:
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        assert is_legacy_python_alias_schema(schema) is False
+
+    def test_real_json_schema_with_combinator_not_legacy(self) -> None:
+        schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+        assert is_legacy_python_alias_schema(schema) is False
+
+    def test_real_json_schema_with_ref_not_legacy(self) -> None:
+        # $ref counts as a JSON Schema marker even without a top-level `type`.
+        schema = {"$ref": "#/definitions/Status"}
+        assert is_legacy_python_alias_schema(schema) is False
+
+    def test_empty_dict_not_legacy(self) -> None:
+        assert is_legacy_python_alias_schema({}) is False
+
+    def test_field_with_canonical_string_type_not_legacy(self) -> None:
+        # "string" is the JSON Schema spelling, NOT the Python alias "str".
+        # Without a top-level JSON Schema marker, the predicate's only signal
+        # is whether values look Python-aliased. "string" doesn't.
+        schema = {"my_field": {"type": "string"}}
+        assert is_legacy_python_alias_schema(schema) is False
+
+
+class TestTopLevelObjectViolation:
+    def test_top_level_object_returns_none(self) -> None:
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        assert top_level_object_violation(schema) is None
+
+    def test_top_level_array_classified_as_non_object_type(self) -> None:
+        violation = top_level_object_violation({"type": "array", "items": {"type": "string"}})
+        assert violation is not None
+        assert violation.kind == "non_object_type"
+        assert "'array'" in violation.cause
+
+    def test_top_level_string_classified_as_non_object_type(self) -> None:
+        violation = top_level_object_violation({"type": "string", "enum": ["yes", "no"]})
+        assert violation is not None
+        assert violation.kind == "non_object_type"
+        assert "'string'" in violation.cause
+
+    def test_top_level_oneOf_classified_as_missing_type(self) -> None:
+        violation = top_level_object_violation({"oneOf": [{"type": "object"}, {"type": "object"}]})
+        assert violation is not None
+        assert violation.kind == "missing_type"
+        assert "oneOf" in violation.cause
+
+    def test_top_level_anyOf_named_in_cause(self) -> None:
+        violation = top_level_object_violation({"anyOf": [{"type": "object"}]})
+        assert violation is not None
+        assert violation.kind == "missing_type"
+        assert "anyOf" in violation.cause
+
+    def test_top_level_allOf_named_in_cause(self) -> None:
+        violation = top_level_object_violation({"allOf": [{"type": "object"}]})
+        assert violation is not None
+        assert violation.kind == "missing_type"
+        assert "allOf" in violation.cause
+
+    def test_top_level_enum_named_in_cause(self) -> None:
+        violation = top_level_object_violation({"enum": ["yes", "no"]})
+        assert violation is not None
+        assert violation.kind == "missing_type"
+        assert "enum" in violation.cause
+
+    def test_no_type_no_combinator(self) -> None:
+        violation = top_level_object_violation({"properties": {"x": {"type": "string"}}})
+        assert violation is not None
+        assert violation.kind == "missing_type"
+        assert violation.cause == "no top-level type"
+
+    def test_top_level_const_named_in_cause(self) -> None:
+        # Behavioral symmetry with oneOf/anyOf/allOf/enum. ``const`` is in the
+        # combinator set; removing it would silently degrade UX (cause string
+        # falls back to "no top-level type" instead of naming "const").
+        violation = top_level_object_violation({"const": {"x": 1}})
+        assert violation is not None
+        assert violation.kind == "missing_type"
+        assert "const" in violation.cause
+
+    def test_combinator_inside_object_wrapper_accepted(self) -> None:
+        # The supported workaround: wrap combinator in an object root.
+        schema = {
+            "type": "object",
+            "properties": {"choice": {"oneOf": [{"type": "string"}, {"type": "integer"}]}},
+        }
+        assert top_level_object_violation(schema) is None

--- a/tests/test_runtime/test_instrumented_wrapper.py
+++ b/tests/test_runtime/test_instrumented_wrapper.py
@@ -157,7 +157,7 @@ class TestTimingCapture:
     def test_metrics_receive_timing(self):
         """Test that metrics collector receives timing data from a real workflow run."""
         metrics = Mock()
-        shared, action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"}, metrics=metrics)
+        _shared, _action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"}, metrics=metrics)
 
         # Metrics collector should have been called with node_id and duration_ms
         metrics.record_node_execution.assert_called_once()
@@ -432,7 +432,7 @@ class TestCollectorIntegration:
     def test_metrics_collector_integration(self):
         """Test integration with metrics collector."""
         metrics = Mock()
-        shared, action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"}, metrics=metrics)
+        _shared, _action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"}, metrics=metrics)
 
         # Verify metrics collector was called correctly
         metrics.record_node_execution.assert_called_once()
@@ -443,7 +443,7 @@ class TestCollectorIntegration:
     def test_trace_collector_integration(self):
         """Test integration with trace collector."""
         trace = WorkflowTraceCollector("test")
-        shared, action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"}, trace=trace)
+        _shared, _action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"}, trace=trace)
 
         # Verify trace collector was called correctly
         assert len(trace.events) == 1
@@ -459,7 +459,7 @@ class TestCollectorIntegration:
         """Test with both metrics and trace collectors."""
         metrics = Mock()
         trace = WorkflowTraceCollector("test")
-        shared, action = _run_single_node_workflow(
+        _shared, _action = _run_single_node_workflow(
             "shell", {"command": "printf '%s' hello"}, metrics=metrics, trace=trace
         )
 
@@ -469,7 +469,7 @@ class TestCollectorIntegration:
 
     def test_no_collectors(self):
         """Test that workflow works without any collectors."""
-        shared, action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"})
+        shared, _action = _run_single_node_workflow("shell", {"command": "printf '%s' hello"})
 
         # Verify node executed successfully without collectors
         assert shared["test"]["stdout"] == "hello"
@@ -485,14 +485,14 @@ class TestTransparency:
 
     def test_engine_transparency_via_workflow(self):
         """Test that engine execution produces correct node outputs."""
-        shared, action = _run_single_node_workflow("shell", {"command": "printf '%s' 'hello world'"})
+        shared, _action = _run_single_node_workflow("shell", {"command": "printf '%s' 'hello world'"})
 
         # shell node writes output to shared[node_id]
         assert shared["test"]["stdout"] == "hello world"
 
     def test_shared_store_modifications_preserved(self):
         """Test that modifications to shared store are preserved through the engine."""
-        shared, action = _run_single_node_workflow("shell", {"command": "echo 'hello world'"})
+        shared, _action = _run_single_node_workflow("shell", {"command": "echo 'hello world'"})
 
         # Shell node writes stdout to shared[node_id]
         assert "test" in shared
@@ -550,7 +550,7 @@ class TestEdgeCases:
 
     def test_empty_shared_store(self):
         """Test execution with empty shared store via compile_workflow + WorkflowEngine."""
-        shared, action = _run_single_node_workflow("shell", {"command": "printf '%s' test"})
+        shared, _action = _run_single_node_workflow("shell", {"command": "printf '%s' test"})
 
         # __llm_calls__ is no longer initialized by the engine
         assert "__llm_calls__" not in shared

--- a/tests/test_runtime/test_memoization_integration.py
+++ b/tests/test_runtime/test_memoization_integration.py
@@ -228,6 +228,47 @@ def test_memo_cache_records_execution_state(tmp_path: Any) -> None:
     assert "state-node" in execution["node_hashes"]
 
 
+def test_memo_cache_rehydrates_node_warning(tmp_path: Any) -> None:
+    """Memo hits must preserve node warnings so degraded status does not become success."""
+    from pflow.runtime.engine.instrumentation import apply_memo_hit, write_memo_cache
+
+    cache = MemoizationCache(db_path=tmp_path / "cache.db")
+    warning = {
+        "kind": "claude_code.schema_not_satisfied",
+        "text": "Model did not return structured output matching the schema.",
+        "context": {"node_type": "claude-code"},
+    }
+    shared = {
+        "__memoization_cache__": cache,
+        "__warnings__": {"review": warning},
+        "_pflow_workflow_file": "workflow.pflow.md",
+        "review": {"result": "raw text", "_schema_error": warning["text"]},
+    }
+
+    write_memo_cache(
+        "review",
+        shared,
+        "cache-key",
+        node_type_name="ClaudeCodeNode",
+    )
+    cached = cache.get("cache-key")
+    assert cached is not None
+    cached_action, cached_output = cached
+
+    replay_shared: dict[str, Any] = {}
+    apply_memo_hit(
+        "review",
+        replay_shared,
+        cached_action,
+        cached_output,
+        "config-hash",
+        node_type_name="ClaudeCodeNode",
+    )
+
+    assert replay_shared["review"] == {"result": "raw text", "_schema_error": warning["text"]}
+    assert replay_shared["__warnings__"]["review"] == warning
+
+
 def test_memo_cache_no_write_on_error(tmp_path: Any) -> None:
     """When node returns 'error', the result is NOT written to the memo cache."""
     cache = MemoizationCache(db_path=tmp_path / "cache.db")

--- a/tests/test_runtime/test_prepare_inputs_coercion.py
+++ b/tests/test_runtime/test_prepare_inputs_coercion.py
@@ -29,7 +29,7 @@ class TestPrepareInputsTypeCoercion:
         # Simulates CLI's infer_type() converting "1458..." to int
         provided_params = {"channel_id": 1458059302022549698}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # Coerced value should be in defaults
@@ -50,7 +50,7 @@ class TestPrepareInputsTypeCoercion:
         }
         provided_params = {"channel_id": "already-a-string"}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # No coercion needed, so not in defaults
@@ -68,7 +68,7 @@ class TestPrepareInputsTypeCoercion:
         }
         provided_params = {"value": 123}  # Stays as int
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # No coercion, not in defaults
@@ -89,7 +89,7 @@ class TestPrepareInputsTypeCoercion:
             "enabled": "yes",  # string → bool
         }
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         assert defaults["channel_id"] == "123456789"
@@ -109,7 +109,7 @@ class TestPrepareInputsTypeCoercion:
         }
         provided_params = {"limit": "100"}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         assert defaults["limit"] == 100
@@ -133,7 +133,7 @@ class TestPrepareInputsCoercionEdgeCases:
         large_int = 1458059302022549698
         provided_params = {"snowflake": large_int}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # Verify exact string representation (no precision loss)
@@ -144,7 +144,7 @@ class TestPrepareInputsCoercionEdgeCases:
         workflow_ir = {"inputs": {"value": {"type": "string", "required": True}}}
         provided_params = {"value": 3.14159265359}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # Should convert cleanly
@@ -155,7 +155,7 @@ class TestPrepareInputsCoercionEdgeCases:
         workflow_ir = {"inputs": {"flag": {"type": "string", "required": True}}}
         provided_params = {"flag": True}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         assert defaults["flag"] == "True"
@@ -173,7 +173,7 @@ class TestPrepareInputsCoercionEdgeCases:
         }
         provided_params = {"count": "not-a-number"}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         # No error from prepare_inputs (coercion failure is graceful)
         # Value stays as-is - downstream validation will catch if needed
@@ -195,7 +195,7 @@ class TestPrepareInputsIntegrationWithDefaults:
         }
         provided_params = {"channel_id": 123456}  # Needs coercion
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # Coerced value
@@ -212,7 +212,7 @@ class TestPrepareInputsIntegrationWithDefaults:
         }
         provided_params = {"limit": "50"}  # User provided, needs coercion
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         # Coerced user value, not default
@@ -249,7 +249,7 @@ class TestPrepareInputsEnvSettingsCoercion:
         provided_params = {}
         settings_env = {"enabled": "true"}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params, settings_env=settings_env)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params, settings_env=settings_env)
 
         assert errors == []
         assert defaults["enabled"] is True
@@ -268,7 +268,7 @@ class TestPrepareInputsEnvSettingsCoercion:
         }
         provided_params = {}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         assert defaults["count"] == 100  # Coerced to int
@@ -287,7 +287,7 @@ class TestPrepareInputsEnvSettingsCoercion:
         }
         provided_params = {}
 
-        errors, defaults, env_params = prepare_inputs(workflow_ir, provided_params)
+        errors, defaults, _env_params = prepare_inputs(workflow_ir, provided_params)
 
         assert errors == []
         assert defaults["optional"] is None  # Not "None" string

--- a/tests/test_runtime/test_settings_env_integration.py
+++ b/tests/test_runtime/test_settings_env_integration.py
@@ -205,7 +205,7 @@ class TestSettingsEnvPopulation:
         provided_params = {"model": "cli_model"}
         settings_env = {"api_key": ""}  # Empty string for required input
 
-        errors, defaults, _env_param_names = prepare_inputs(sample_workflow_ir, provided_params, settings_env)
+        errors, _defaults, _env_param_names = prepare_inputs(sample_workflow_ir, provided_params, settings_env)
 
         assert len(errors) == 1
         assert "api_key" in errors[0][0]
@@ -587,7 +587,7 @@ class TestShellEnvironmentVariables:
         provided_params = {}
         settings_env = {"api_key": "non_empty_value"}
 
-        errors, defaults, _env_param_names = prepare_inputs(workflow_ir, provided_params, settings_env)
+        errors, _defaults, _env_param_names = prepare_inputs(workflow_ir, provided_params, settings_env)
 
         assert len(errors) == 1
         assert "api_key" in errors[0][0]

--- a/tests/test_runtime/test_template_validation/test_array_notation.py
+++ b/tests/test_runtime/test_template_validation/test_array_notation.py
@@ -268,7 +268,7 @@ class TestBatchResultsIndexAccessGate:
         }
 
         with self._make_registry() as registry:
-            errors, warnings = split_template_diagnostics(workflow_ir, {}, registry)
+            errors, _warnings = split_template_diagnostics(workflow_ir, {}, registry)
             gate_errors = [e for e in errors if "Index-based access" in e.message]
             assert len(gate_errors) == 1
             assert "error_handling: continue" in gate_errors[0].message

--- a/uv.lock
+++ b/uv.lock
@@ -372,19 +372,21 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.18"
+version = "0.2.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/3d/a8c6ad873e8448696d44441c9eb2c24dded620fb32415d68f576a542ccde/claude_agent_sdk-0.1.18.tar.gz", hash = "sha256:4fcb8730cc77dea562fbe9aa48c65eced3ef58a6bb1f34f77e50e8258902477d", size = 56162, upload-time = "2025-12-18T00:42:57.926Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/3d/f75aaecf476c2b2a903dbba6042171b6683eb91c1f97f3ad894784cec270/claude_agent_sdk-0.2.82.tar.gz", hash = "sha256:3e907b7d2bf52a5917d96a3ce336b8aa5546ea31e29ce826a7f346622cf7f4bf", size = 252053, upload-time = "2026-05-15T03:45:34.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/14/f529f7c4bab7c71dcbcc8c66f12f491e644ee8a027ac5111d13705df207e/claude_agent_sdk-0.1.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9e45b4e3c20c072c3e3325fa60bab9a4b5a7cbbce64ca274b8d7d0af42dd9dd8", size = 54560828, upload-time = "2025-12-18T00:42:44.71Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/68/6e83005aa7bb9056bfad0aef0605249f877dc0c78724c9c0fadebff600fb/claude_agent_sdk-0.1.18-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3c41bd8f38848609ae0d5da8d7327a4c2d7057a363feafb6fd70df611ea204cc", size = 68743107, upload-time = "2025-12-18T00:42:48.255Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/85/7d6dd85f402135a610894734c442f1166ffed61d03eced39d6bfd14efccd/claude_agent_sdk-0.1.18-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:983f15e51253f40c55136a86d7cc63e023a3576428b05fa1459093d461b2d215", size = 70444964, upload-time = "2025-12-18T00:42:51.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fa/d2b22b7a713c4c049cbd5f9f635836ea5429ff65c1f3bcf4658a8e1c1cf5/claude_agent_sdk-0.1.18-py3-none-win_amd64.whl", hash = "sha256:36f5b84d5c3c8773ee9b56aeb5ab345d1033231db37f80d1f20ac15239bef41c", size = 72637215, upload-time = "2025-12-18T00:42:55.269Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/27cf3aec2a24f2ed1f60277de795496b808a761d2a7a3fd34602a2fec37d/claude_agent_sdk-0.2.82-py3-none-macosx_11_0_arm64.whl", hash = "sha256:24ad8ccbcee9afe206ae5d621a9e40a5022ca3eb8c2c672b36916d3e70746e42", size = 61473506, upload-time = "2026-05-15T03:45:38.745Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/95a83f018dbc8c113233eb542bccf17c1a3f5f689448700daf950602bf5e/claude_agent_sdk-0.2.82-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:13e54d5163d9d4f899c4e2a3f14df597f4e050d5afa104618ccf7bb37b372ad1", size = 63541975, upload-time = "2026-05-15T03:45:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/be/07/9356fe0e30f988bade6b116ecc602b4a9ae4df34fa055305187a835e36e0/claude_agent_sdk-0.2.82-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3b0a0e3f0927737f1fc91ee4549185172243a4e8f135d4c1e4f1f1eba91373e1", size = 71212904, upload-time = "2026-05-15T03:45:51.121Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d9/e2920b4b6c75cf79ec87ebfb4cc4447c78a4f26317cb3fed77e79fcc804e/claude_agent_sdk-0.2.82-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:b05873f9df01c5894930b87f6ca9315f0d97f1563bc2e4dc0fafe0d4a1e31997", size = 71381948, upload-time = "2026-05-15T03:45:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/89/80/c3ec5a89c735a96d35fe12b6262517169b396ff366149a3b9f4387f797c1/claude_agent_sdk-0.2.82-py3-none-win_amd64.whl", hash = "sha256:71e85e4f50d04cd95e687898092f03648e74e1cd2537583de93370d2da1c0586", size = 71990462, upload-time = "2026-05-15T03:46:01.646Z" },
 ]
 
 [[package]]
@@ -1492,7 +1494,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "claude-agent-sdk", specifier = ">=0.1.17" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.82" },
     { name = "click" },
     { name = "jsonschema", specifier = ">=4.20.0" },
     { name = "litellm", specifier = "==1.83.14" },


### PR DESCRIPTION
## Summary

Replace Claude Code node's prompt-injection + regex JSON extraction with `claude_agent_sdk` v0.2.82's native structured output. JSON Schema is now the canonical format on both `llm` and `claude-code` nodes. Schema soft-failures additionally flip workflow status to `DEGRADED` so AI agents see the signal without needing to know the `_schema_error` side-channel.

## Task

126

## Changes

**Core swap** — `src/pflow/nodes/claude/claude_code.py`
- Native `ClaudeAgentOptions.output_format={"type": "json_schema", "schema": ...}` wired in `_build_claude_options`; `ResultMessage.structured_output` read directly. Module-import-time probe guards against silent SDK field renames.
- Deleted `_build_schema_prompt` + 4-helper regex extraction chain (`_extract_json*`).
- New `_validate_schema` rejects empty `{}`, legacy Python-alias format, and top-level non-object (incl. `oneOf` / `anyOf` / `allOf` / `enum` / missing-`type` — Phase 0 + follow-up probe showed the Anthropic API rejects all of these in tool input-schema wrappers).
- `prep()` enforces `max_turns >= 2` when `output_schema` is set.
- New `_emit_schema_resolved_null_warning` catches templated `output_schema: ${upstream}` resolving to None (silent free-form downgrade).
- Soft-fail signals routed through `_emit_soft_fail_signal` (`setdefault("_schema_error", ...)` + `__warnings__[node_id]` write). Sticky `is_error_from_sdk` across multi-message streams.
- Narrowed `_run_claude_session` exception swallow to `ProcessError` only when a prior `ResultMessage(is_error=True)` was seen — other exceptions re-raise so `CLINotFoundError` / `CLIConnectionError` remediation messages survive.

**Static validator parity** — `src/pflow/core/workflow/validator.py`
- New step 9 `_validate_node_param_semantics` → `_validate_claude_code_params`. Mirrors runtime `_validate_schema` so `--validate-only` and `--dry-run` reject what `prep()` rejects. Templated values defer to runtime via the `if isinstance(v, str) and "${" in v` guard.

**Memo cache rehydration** — `src/pflow/runtime/engine/instrumentation.py`
- Reserved `__pflow_warnings__` key persists root-level warnings into the cached blob; replay rehydrates `shared["__warnings__"][node_id]` so cached DEGRADED stays DEGRADED. Pattern matches existing `__pflow_stats__` carve-out.

**Surrounding cleanup**:
- `core/types.py` — deleted the "fourth surface" carve-out comment (premise removed once `_build_schema_prompt` was deleted).
- `core/workflow/save_service.py` — `claude-code` added to reserved workflow names.
- 3 example `.pflow.md` workflows + reference docs + architecture migrated to JSON Schema.
- New `pflow guide claude-code` topic with dynamic registry-interface injection.
- MCP server instruction docs reframed: "use templates for existing structured data; use `output_schema` on `llm` / `claude-code` for model-derived structured data."
- `pyproject.toml` floor: `claude-agent-sdk>=0.2.82`.

## Explanation

The pre-Task-126 implementation worked via prompt-injection (a "RESPOND WITH JSON ONLY" instruction block) plus three regex fallbacks to extract JSON from free-form text. It was fragile (relied on the model honoring prompt instructions), inconsistent with the LLM node's JSON Schema syntax (Task 66 cutover), and carved a special case out of pflow's type vocabulary (`core/types.py:8-12`) specifically because the Python-alias type names were load-bearing in the prompt template.

SDK 0.2.82 translates `output_format` to a `--json-schema` CLI flag, constraining the model's final output at the provider level. This makes prompt-injection and regex extraction unnecessary. Hard cutover, no backwards-compat shim (CLAUDE.md "no users yet"). Legacy schemas produce a clear migration error at `prep()` time.

Scope grew during implementation by four cross-cutting fixes, each found by a different review pass:

1. **Memo cache silently demoted DEGRADED → SUCCESS on replay** (review-feature-interactions). Reserved `__pflow_warnings__` key pattern fixes this; same shape as the existing `__pflow_stats__` carve-out.
2. **`--validate-only` and `--dry-run` accepted what `prep()` rejected** (manual CLI verification). Without the static mirror, agents got clean preflights for workflows that fail immediately at runtime. Validator step 9 mirrors runtime checks while deferring templated values.
3. **`_run_claude_session`'s catch-all `except Exception` hid every actionable SDK exception** after the first `is_error=True` (review-silent-failures). Users lost `CLINotFoundError` → "install with: npm install -g …" and `CLIConnectionError` → "run `claude doctor`" remediation paths. Narrowed to `ProcessError` only — the actual SDK pairing with `ResultMessage(is_error=True)`.
4. **Templated `output_schema` resolving to None silently downgraded to free-form** (independent adversarial verification). Workflow author who wrote `output_schema: ${upstream.field}` and got None back saw `success` instead of `degraded`. New warning kind `claude_code.output_schema_resolved_to_null` fixes this.

Stats: 41 files, +3455 / -762.

## Created Docs

- `.taskmaster/tasks/task_126/task-126.md` — what/why spec (revised)
- `.taskmaster/tasks/task_126/implementation/implementation-plan.md` — step-by-step plan (~928 lines)
- `.taskmaster/tasks/task_126/implementation/phase-0-findings.md` — SDK smoke-test discoveries
- `.taskmaster/tasks/task_126/implementation/progress-log.md` — chronological implementation journey through 3 verification passes
- `.taskmaster/tasks/task_126/task-review.md` — agent-first knowledge transfer (patterns, pitfalls, integration points)
- `src/pflow/guide/nodes/claude-code.md` — new `pflow guide claude-code` topic (deliberately user-facing, no SDK internals)

User-facing doc updates:
- `docs/reference/nodes/claude-code.mdx` — JSON Schema example, soft-fail signal contract, DEGRADED status, `default`-only routing invariant
- `examples/nodes/claude-code/` — 3 example workflows + README migrated from Python-alias to JSON Schema
- `architecture/core-node-packages/claude-nodes.md` — JSON Schema params, `__warnings__` documentation

## Testing

Symmetric coverage for runtime + preflight + cache:

- `test_top_level_{array,primitive,oneOf,anyOf,allOf,missing_type}_schema_rejected` — pins Phase 0 + follow-up probe findings (API rejects all non-object top-level schemas)
- `test_top_level_object_with_oneOf_accepted` — pins the workaround (combinators INSIDE an object wrapper still work)
- `test_max_turns_too_low_with_schema_rejected` — pins prep-time `max_turns >= 2` check
- `test_legacy_python_alias_schema_rejected` + `test_legacy_format_detection_checks_all_values` — pins migration error for old Python-alias format
- `test_non_process_error_after_is_error_re_raises` — pins narrow exception swallow against catch-all regression (this regression hid every actionable SDK error after the first `is_error=True`)
- `test_soft_fail_output_shape_not_classified_as_api_warning` — black-box pin: claude-code's `{result, _schema_error, llm_usage}` output shape never reaches `api_warning_detector._is_validation_error` because `extract_error_message` is shape-gated. Adding `error` / `ok` / `success` / `status` keys for debug visibility breaks this test BEFORE the regression ships
- `test_sdk_error_with_structured_output_no_node_id_falls_back_to_schema_error` — pins `setdefault("_schema_error", ...)` fallback for direct `node.run()` test paths where `node_id` is unbound
- `test_output_schema_resolved_to_null_emits_warning` — pins templated-schema-resolving-to-None DEGRADED warning
- `test_dry_run_rejects_claude_code_invalid_schema_before_plan` + `TestValidateOnlyClaudeCodeStructuredOutput` (5 cases) — pins runtime/preflight parity for `--validate-only` and `--dry-run`
- `test_memoization_integration` cache rehydration test — pins DEGRADED preservation across cache hits (regression test for the silent demotion bug)
- `test_claude_code_guide_documents_structured_output_without_internals` — pins user-facing guide content (caught a reworded "SDK" slip before merge)

End-to-end real-API smoke (Phase 5.4): ran `examples/nodes/claude-code/claude-code-schema.pflow.md` against the real Anthropic API via Claude Max subscription (no `ANTHROPIC_API_KEY`). All 4 nodes completed; `review` returned a fully-conformant dict honoring `enum` / `minimum` / `maximum` / type constraints; templates `${review.result.*}` resolved cleanly into both downstream `write-file` nodes. 54.7s, $0.135 API-equivalent (subscription absorbed).

Quality gates:
- `uv run pytest --ignore=tests/test_llm` → 6822 passed, 10 skipped
- `uv run mypy` → success (207 source files)
- `uv run ruff check .` → clean

**Follow-up**: Centralized JSON Schema syntactic validation for both LLM and Claude Code nodes is tracked at issue #398 (filed during this task, not closed by this PR). It will catch typos like `type: intger` that the API currently silently accepts.