### PR TITLE
fix(cli): dotted -o paths, walk-to-failure hints, compact batch summary (#400)

### DIFF
--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -101,7 +101,17 @@ def _handle_workflow_success(
         diagnostic for diagnostic in getattr(result, "diagnostics", []) if diagnostic.severity == Severity.WARNING
     ]
 
-    output_produced = _handle_workflow_output(
+    # ``_handle_workflow_output`` writes to stdout when there's a value to
+    # write and returns a boolean — but we don't act on the boolean. When no
+    # output is produced (``-o`` miss, no declared outputs, no auto-detect
+    # match), stdout stays empty so pipe consumers receive a clean stream;
+    # the stderr summary emitted by ``_emit_summary_or_only_indicator``
+    # already signals success / degraded / failed status. Duplicating that
+    # signal on stdout would mean ``pflow ... -o nonexistent | jq .`` crashed
+    # on the literal English fallback (jq parses ``"Workflow executed
+    # successfully"`` as invalid JSON) — that fallback was the pre-existing
+    # wart this branch removes as part of the GH #400 fix.
+    _handle_workflow_output(
         shared_storage,
         output_key,
         ir_data,
@@ -114,18 +124,6 @@ def _handle_workflow_success(
         status=status,
         warnings=result_warnings,
     )
-
-    if not output_produced:
-        if status and hasattr(status, "value"):
-            status_str = status.value
-            if status_str == "degraded":
-                click.echo("⚠️ Workflow completed with warnings")
-            elif status_str == "failed":
-                click.echo("❌ Workflow execution failed")
-            else:
-                click.echo("Workflow executed successfully")
-        else:
-            click.echo("Workflow executed successfully")
 
 
 def _save_trace_and_report(ctx: click.Context, workflow_trace: Any | None) -> None:

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -101,16 +101,7 @@ def _handle_workflow_success(
         diagnostic for diagnostic in getattr(result, "diagnostics", []) if diagnostic.severity == Severity.WARNING
     ]
 
-    # ``_handle_workflow_output`` writes to stdout when there's a value to
-    # write and returns a boolean — but we don't act on the boolean. When no
-    # output is produced (``-o`` miss, no declared outputs, no auto-detect
-    # match), stdout stays empty so pipe consumers receive a clean stream;
-    # the stderr summary emitted by ``_emit_summary_or_only_indicator``
-    # already signals success / degraded / failed status. Duplicating that
-    # signal on stdout would mean ``pflow ... -o nonexistent | jq .`` crashed
-    # on the literal English fallback (jq parses ``"Workflow executed
-    # successfully"`` as invalid JSON) — that fallback was the pre-existing
-    # wart this branch removes as part of the GH #400 fix.
+    # Writes data to stdout, summary/advice to stderr; rationale in docstring.
     _handle_workflow_output(
         shared_storage,
         output_key,

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from typing import Any
 
 import click
 
 from pflow.core.diagnostic import Diagnostic
 from pflow.core.diagnostic_render import format_diagnostic
+from pflow.runtime.template_resolver import TemplateResolver
 
 
 def safe_output(value: Any) -> bool:
@@ -146,15 +148,21 @@ def _handle_text_output(
     # Now show the actual output
     output_found = False
 
-    # User-specified key takes priority
+    # User-specified key takes priority. Supports dotted paths (e.g.
+    # ``batch-llm.success_count``, ``items[0].title``) by delegating to
+    # ``TemplateResolver``, which is the same primitive used by ``${...}``
+    # templates inside workflow files and by ``pflow read-fields``.
     if output_key:
-        if output_key in shared_storage:
-            _output_with_header(shared_storage[output_key], print_flag)
+        if TemplateResolver.variable_exists(output_key, shared_storage):
+            value = TemplateResolver.resolve_value(output_key, shared_storage)
+            _output_with_header(value, print_flag)
             output_found = True
-        else:
-            # Suppress warnings in -p mode
-            if not print_flag:
-                click.echo(f"cli: Warning - output key '{output_key}' not found in shared store", err=True)
+        elif not print_flag:
+            hint = _diagnose_path_failure(shared_storage, output_key)
+            click.echo(
+                f"cli: Warning - output key '{output_key}' not found. {hint}",
+                err=True,
+            )
 
     # --only targets are explicit data-routing requests. Declared workflow
     # outputs describe full runs, so they must not shadow the targeted node.
@@ -192,13 +200,27 @@ def _emit_only_output(shared_storage: dict[str, Any], print_flag: bool) -> bool:
             # action is actionable — without enumeration the agent must either
             # introspect the trace or guess key names.
             available = _list_routable_keys_for_only_target(shared_storage)
-            keys_hint = f" Available shared-store keys: {', '.join(available)}." if available else ""
+            keys_hint = f" Available keys: {', '.join(available)}." if available else ""
             click.echo(
                 f"cli: --only target '{only_node}' produced no output. "
-                f"Pass -o <key> to select a specific shared-store key.{keys_hint}",
+                f"Pass -o <key> to select a specific output.{keys_hint}",
                 err=True,
             )
         return False
+
+    # Batch nodes write a {results, count, success_count, error_count, errors,
+    # batch_metadata} aggregate to shared[node_id]. Dumping that whole dict
+    # consumes tens of KB of agent context; replace with a 2-line summary that
+    # surfaces success ratio + the explicit ``-o`` paths to drill in.
+    # Detection is shape-only (``"batch_metadata" in value``) — the canonical
+    # marker used by execution_state and instrumentation for batch detection.
+    # The label uses ``key_found`` (the actual shared-store key holding the
+    # aggregate, e.g. ``sub-wf``) rather than ``only_node`` (which may be a
+    # dotted target like ``sub-wf.inner``) so the hint ``-o <key>.results``
+    # points at a path that actually resolves.
+    if isinstance(value, dict) and "batch_metadata" in value:
+        _render_batch_compact_summary(key_found, value, print_flag)
+        return True
 
     if not print_flag:
         click.echo(
@@ -221,6 +243,141 @@ def _list_routable_keys_for_only_target(shared_storage: dict[str, Any]) -> list[
     absence.
     """
     return sorted(k for k in shared_storage if isinstance(k, str) and not k.startswith("_"))
+
+
+_PATH_SEGMENT_PATTERN = re.compile(r"[a-zA-Z_][\w-]*|\[\d+\]")
+
+
+def _diagnose_path_failure(shared_storage: dict[str, Any], key: str) -> str:
+    """Walk a failing ``-o`` path; return a hint describing the deepest valid prefix.
+
+    Called when ``TemplateResolver.variable_exists(key, shared_storage)`` has
+    returned False. Walks segment-by-segment from the root, keeping track of
+    the deepest prefix that resolves, then describes what's there so the
+    agent can pick a valid next path.
+
+    The token regex matches either a dotted name segment (``[a-zA-Z_][\\w-]*``)
+    or a bracketed index (``[\\d+]``) — the same token classes
+    ``TemplateResolver.resolve_value`` accepts. Any other character in ``key``
+    is silently ignored by ``re.findall``, which would produce a misleading
+    hint about a path the agent didn't type. Defend against that by
+    reconstructing the path from matched tokens and bailing out with a
+    generic syntax hint when the reconstruction doesn't equal the input.
+    """
+    segments = _PATH_SEGMENT_PATTERN.findall(key)
+    if not segments:
+        return _describe_at("", shared_storage)
+
+    reconstructed = ""
+    for seg in segments:
+        if seg.startswith("["):
+            reconstructed += seg
+        elif reconstructed:
+            reconstructed += "." + seg
+        else:
+            reconstructed = seg
+    if reconstructed != key:
+        return (
+            f"'{key}' contains characters that aren't valid in a path. "
+            f"Use `<name>`, `<name>.<sub>`, or `<name>[N]` syntax."
+        )
+
+    valid_prefix = ""
+    parent: Any = shared_storage
+    for seg in segments:
+        if seg.startswith("["):
+            trial = valid_prefix + seg
+        elif valid_prefix:
+            trial = valid_prefix + "." + seg
+        else:
+            trial = seg
+        if TemplateResolver.variable_exists(trial, shared_storage):
+            valid_prefix = trial
+            parent = TemplateResolver.resolve_value(trial, shared_storage)
+        else:
+            return _describe_at(valid_prefix, parent)
+    return _describe_at(valid_prefix, parent)
+
+
+def _describe_at(prefix: str, parent: Any) -> str:
+    """Describe what's at ``parent`` (the deepest-valid path); used for ``-o`` miss hints."""
+    if isinstance(parent, dict):
+        keys = sorted(k for k in parent if isinstance(k, str) and not k.startswith("_"))
+        if not keys:
+            return f"'{prefix}' has no subkeys." if prefix else "No top-level keys available."
+        if prefix:
+            return f"Available subkeys of '{prefix}': {', '.join(keys)}."
+        return f"Available top-level keys: {', '.join(keys)}."
+    if isinstance(parent, list):
+        n = len(parent)
+        if n == 0:
+            return f"'{prefix}' is an empty list."
+        if n == 1:
+            return f"'{prefix}' is a list of length 1. Valid index: 0."
+        return f"'{prefix}' is a list of length {n}. Valid indices: 0 to {n - 1}."
+    value_repr = _short_repr(parent)
+    return (
+        f"'{prefix}' is a {_friendly_type(parent)} (value: {value_repr}), "
+        f"cannot descend. Drop the trailing segments to read it."
+    )
+
+
+def _friendly_type(value: Any) -> str:
+    """Map Python types to agent-friendly names for error messages."""
+    if value is None:
+        return "null value"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return type(value).__name__
+
+
+def _short_repr(value: Any, max_len: int = 60) -> str:
+    """Render a short, agent-readable value preview for scalar dead-end messages."""
+    rendered = repr(value)
+    if len(rendered) > max_len:
+        return rendered[: max_len - 1] + "…"
+    return rendered
+
+
+def _render_batch_compact_summary(node_id: str, value: dict[str, Any], print_flag: bool) -> None:
+    """Emit a compact summary for ``--only <batch-node>`` instead of the full batch dict.
+
+    Replaces dumping the full ``{results, count, success_count, error_count,
+    errors, batch_metadata}`` aggregate, which can run tens of KB on a real
+    batch. The summary surfaces success ratio + the explicit ``-o`` paths to
+    drill into the parts the agent actually needs.
+
+    The errors hint is appended only when ``error_count > 0`` because batch
+    nodes write ``errors: None`` (not ``[]``) when no items failed (see
+    ``src/pflow/runtime/engine/batch_executor.py``).
+
+    Under ``-p`` (print mode) the hint line is suppressed — the contract for
+    ``-p`` is clean stdout for pipes; the data line stays, the discoverability
+    hint would be noise in a pipeline.
+    """
+    count = value.get("count", 0)
+    success_count = value.get("success_count", 0)
+    error_count = value.get("error_count", 0)
+
+    if count == 0:
+        safe_output(f"batch {node_id}: ran with no items")
+        return
+
+    timing = (value.get("batch_metadata") or {}).get("timing") or {}
+    total_ms = timing.get("total_items_ms")
+    duration = f" in {total_ms / 1000:.1f}s" if isinstance(total_ms, (int, float)) else ""
+
+    safe_output(f"batch {node_id}: {success_count}/{count} items succeeded{duration}")
+    if print_flag:
+        return
+    hint = f"use `-o {node_id}.results` for full payload"
+    if error_count > 0:
+        hint += f", `-o {node_id}.errors` for failures"
+    safe_output(f"  {hint}")
 
 
 def _emit_auto_detected_output(

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -113,12 +113,20 @@ def _handle_text_output(
     workflow_metadata: dict[str, Any] | None = None,
     status: Any = None,
     warnings: list[Any] | None = None,
-) -> bool:
+) -> None:
     """Handle text formatted output with execution summary.
 
-    Shows execution summary first, then workflow output.
+    Shows execution summary first, then workflow output. When ``print_flag``
+    (``-p``) is True, suppresses stderr warnings/advice.
 
-    When print_flag (-p) is True, suppresses all warnings.
+    When no output is produced (``-o`` miss, no declared outputs, no
+    auto-detect match), stdout stays empty so pipe consumers receive a clean
+    stream. The stderr summary emitted by ``_emit_summary_or_only_indicator``
+    already signals success / degraded / failed status, so duplicating it on
+    stdout would mean ``pflow ... -o nonexistent | jq .`` crashed on a literal
+    English fallback (jq parses ``"Workflow executed successfully"`` as
+    invalid JSON). That fallback was the pre-existing wart this branch
+    removes as part of the GH #400 fix.
 
     Args:
         shared_storage: The shared store after execution
@@ -128,9 +136,6 @@ def _handle_text_output(
         print_flag: Whether -p flag is set (suppress warnings)
         metrics_collector: Optional MetricsCollector for execution metrics
         workflow_metadata: Optional workflow metadata
-
-    Returns:
-        True if output was produced, False otherwise.
     """
     # Display execution summary or --only mode indicator (dispatch in helper)
     _emit_summary_or_only_indicator(
@@ -145,9 +150,6 @@ def _handle_text_output(
         print_flag=print_flag,
     )
 
-    # Now show the actual output
-    output_found = False
-
     # User-specified key takes priority. Supports dotted paths (e.g.
     # ``batch-llm.success_count``, ``items[0].title``) by delegating to
     # ``TemplateResolver``, which is the same primitive used by ``${...}``
@@ -156,33 +158,34 @@ def _handle_text_output(
         if TemplateResolver.variable_exists(output_key, shared_storage):
             value = TemplateResolver.resolve_value(output_key, shared_storage)
             _output_with_header(value, print_flag)
-            output_found = True
         elif not print_flag:
             hint = _diagnose_path_failure(shared_storage, output_key)
             click.echo(
                 f"cli: Warning - output key '{output_key}' not found. {hint}",
                 err=True,
             )
+        return
 
     # --only targets are explicit data-routing requests. Declared workflow
     # outputs describe full runs, so they must not shadow the targeted node.
-    elif shared_storage.get("__execution__", {}).get("only_node"):
-        output_found = _emit_only_output(shared_storage, print_flag)
+    if shared_storage.get("__execution__", {}).get("only_node"):
+        _emit_only_output(shared_storage, print_flag)
+        return
 
-    # Check workflow-declared outputs for full runs.
-    elif workflow_ir and "outputs" in workflow_ir and workflow_ir["outputs"]:
-        if _try_declared_outputs(shared_storage, workflow_ir, verbose and not print_flag, print_flag):
-            output_found = True
+    # Check workflow-declared outputs for full runs. Declared outputs that
+    # fail to resolve do NOT fall through to auto-detect — the workflow
+    # author's declared contract is authoritative; an unresolved declared
+    # output is a workflow-author error, not a cue to guess.
+    if workflow_ir and "outputs" in workflow_ir and workflow_ir["outputs"]:
+        _try_declared_outputs(shared_storage, workflow_ir, verbose and not print_flag, print_flag)
+        return
 
     # Fall back to auto-detect from common keys (using unified function)
-    else:
-        output_found = _emit_auto_detected_output(
-            shared_storage,
-            print_flag,
-            "cli: No outputs declared — showing auto-detected key '{key}'. Declare outputs for reliable results.",
-        )
-
-    return output_found
+    _emit_auto_detected_output(
+        shared_storage,
+        print_flag,
+        "cli: No outputs declared — showing auto-detected key '{key}'. Declare outputs for reliable results.",
+    )
 
 
 def _emit_only_output(shared_storage: dict[str, Any], print_flag: bool) -> bool:
@@ -245,6 +248,12 @@ def _list_routable_keys_for_only_target(shared_storage: dict[str, Any]) -> list[
     return sorted(k for k in shared_storage if isinstance(k, str) and not k.startswith("_"))
 
 
+# Token grammar: dotted name (``[a-zA-Z_][\w-]*``) or bracket index (``[N]``).
+# Bare digits are intentionally NOT a name segment — that makes inputs like
+# ``batch.results.0.r`` (dot-notation indexing, a documented misuse from #400)
+# fail the reconstruction check and fall into the syntax-hint branch, which
+# explicitly nudges the agent toward ``<name>[N]`` syntax. Pinned by
+# ``test_output_key_miss_with_dot_notation_for_list_index_nudges_to_brackets``.
 _PATH_SEGMENT_PATTERN = re.compile(r"[a-zA-Z_][\w-]*|\[\d+\]")
 
 
@@ -367,6 +376,10 @@ def _render_batch_compact_summary(node_id: str, value: dict[str, Any], print_fla
         safe_output(f"batch {node_id}: ran with no items")
         return
 
+    # ``batch_metadata`` is guaranteed dict-or-absent per ``batch_executor.py``
+    # contract; the outer ``or {}`` covers absent. ``timing`` is dict-or-None
+    # per ``batch_executor.py:823`` (None when ``item_timings`` is empty); the
+    # second ``or {}`` covers that real case.
     timing = (value.get("batch_metadata") or {}).get("timing") or {}
     total_ms = timing.get("total_items_ms")
     duration = f" in {total_ms / 1000:.1f}s" if isinstance(total_ms, (int, float)) else ""
@@ -377,7 +390,10 @@ def _render_batch_compact_summary(node_id: str, value: dict[str, Any], print_fla
     hint = f"use `-o {node_id}.results` for full payload"
     if error_count > 0:
         hint += f", `-o {node_id}.errors` for failures"
-    safe_output(f"  {hint}")
+    # Hint is advisory (drill-deeper guidance), not data — stderr matches the
+    # module-wide convention (data → stdout, advice → stderr) used by the
+    # ``-o`` miss hint and the ``--only`` no-output advisory.
+    click.echo(f"  {hint}", err=True)
 
 
 def _emit_auto_detected_output(
@@ -839,12 +855,12 @@ def _handle_json_output(
     workflow_trace: Any | None = None,
     status: Any = None,
     warnings: list[Any] | None = None,
-) -> bool:
+) -> None:
     """Handle JSON formatted output.
 
-    Returns all declared outputs or specified key as JSON, optionally with metrics.
-    Emits execution summary to stderr (same as text mode) — ``--output-format``
-    controls stdout format, ``-p`` controls stderr verbosity.
+    Emits all declared outputs (or the specified key) as JSON, optionally with
+    metrics. Execution summary still flows to stderr — ``--output-format``
+    controls stdout format only; ``-p`` controls stderr verbosity.
     """
     # Use shared formatter for consistency with MCP
     from pflow.execution.formatters.success_formatter import format_execution_success
@@ -877,7 +893,7 @@ def _handle_json_output(
         print_flag=print_flag,
     )
 
-    return _serialize_json_result(result, verbose)
+    _serialize_json_result(result, verbose)
 
 
 def _create_workflow_metadata(name: str | None, action: str) -> dict[str, Any]:
@@ -943,8 +959,11 @@ def _handle_workflow_output(
     workflow_trace: Any | None = None,
     status: Any = None,
     warnings: list[Any] | None = None,
-) -> bool:
+) -> None:
     """Handle output from workflow execution.
+
+    Dispatches to ``_handle_json_output`` or ``_handle_text_output`` based on
+    ``output_format``. Stream contract: data → stdout, summary/advice → stderr.
 
     Args:
         shared_storage: The shared store after execution
@@ -956,12 +975,9 @@ def _handle_workflow_output(
         print_flag: Whether -p flag is set (suppress warnings)
         workflow_metadata: Optional workflow metadata for JSON output
         workflow_trace: Optional workflow trace collector for saving JSON output
-
-    Returns:
-        True if output was produced, False otherwise.
     """
     if output_format == "json":
-        return _handle_json_output(
+        _handle_json_output(
             shared_storage,
             output_key,
             workflow_ir,
@@ -973,15 +989,16 @@ def _handle_workflow_output(
             status=status,
             warnings=warnings,
         )
-    else:  # text format (default)
-        return _handle_text_output(
-            shared_storage,
-            output_key,
-            workflow_ir,
-            verbose,
-            print_flag,
-            metrics_collector,
-            workflow_metadata,
-            status=status,
-            warnings=warnings,
-        )
+        return
+
+    _handle_text_output(
+        shared_storage,
+        output_key,
+        workflow_ir,
+        verbose,
+        print_flag,
+        metrics_collector,
+        workflow_metadata,
+        status=status,
+        warnings=warnings,
+    )

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -20,6 +20,7 @@ from pflow.execution.formatters.batch_errors import (
 from pflow.execution.formatters.batch_errors import (
     format_batch_errors_section as _shared_format_batch_errors_section,
 )
+from pflow.runtime.template_resolver import TemplateResolver
 
 
 def format_execution_success(
@@ -196,8 +197,6 @@ def _collect_outputs(
         # inside workflows. ``variable_exists`` distinguishes "path missing"
         # from "path resolved to None" so a legitimately-None value is
         # preserved in the JSON output.
-        from pflow.runtime.template_resolver import TemplateResolver
-
         if TemplateResolver.variable_exists(output_key, shared_storage):
             resolved: Any = TemplateResolver.resolve_value(output_key, shared_storage)
             result[output_key] = compact_batch_output_value(parse_json_or_original(resolved))

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -190,9 +190,17 @@ def _collect_outputs(
     result = {}
 
     if output_key:
-        # Specific key requested
-        if output_key in shared_storage:
-            result[output_key] = compact_batch_output_value(parse_json_or_original(shared_storage[output_key]))
+        # Specific key requested. Supports dotted paths (e.g.
+        # ``batch.success_count``, ``items[0].title``) via ``TemplateResolver`` —
+        # the same primitive used by CLI text mode and ``${...}`` templates
+        # inside workflows. ``variable_exists`` distinguishes "path missing"
+        # from "path resolved to None" so a legitimately-None value is
+        # preserved in the JSON output.
+        from pflow.runtime.template_resolver import TemplateResolver
+
+        if TemplateResolver.variable_exists(output_key, shared_storage):
+            resolved: Any = TemplateResolver.resolve_value(output_key, shared_storage)
+            result[output_key] = compact_batch_output_value(parse_json_or_original(resolved))
 
     elif (
         workflow_ir

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -544,18 +544,17 @@ class TestWorkflowOutputHandling:
             ],
         }
 
-        assert (
-            _handle_text_output(
-                shared,
-                output_key=None,
-                workflow_ir=workflow_ir,
-                verbose=False,
-                print_flag=True,
-                metrics_collector=metrics,
-            )
-            is True
+        _handle_text_output(
+            shared,
+            output_key=None,
+            workflow_ir=workflow_ir,
+            verbose=False,
+            print_flag=True,
+            metrics_collector=metrics,
         )
 
+        # Behavior under -p + --only: data line on stdout, --only mode
+        # indicator on stderr, routing note ("--only active...") suppressed.
         captured = capsys.readouterr()
         assert "UPSTREAM_TARGET_OUTPUT" in captured.out
         assert "--only active" not in captured.err
@@ -1695,6 +1694,10 @@ class TestOnlyBatchCompactSummary:
     """``--only <batch-node>`` compact-summary rendering (text mode)."""
 
     def test_only_batch_node_emits_compact_summary(self, capsys):
+        """Data line on stdout, advisory hint on stderr (stream-discipline parity
+        with the rest of ``workflow_output.py``: ``-o`` miss hint, ``--only``
+        no-output advisory, declared-output warnings all use stderr for advice).
+        """
         from pflow.cli.workflow_output import _handle_text_output
 
         shared = {
@@ -1706,12 +1709,15 @@ class TestOnlyBatchCompactSummary:
         }
         _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
         captured = capsys.readouterr()
-        lines = captured.out.strip().split("\n")
-        assert lines[0] == "batch summarize-docs: 2/2 items succeeded in 1.4s"
-        assert lines[1] == "  use `-o summarize-docs.results` for full payload"
+        # Data line — stdout, alone.
+        assert captured.out.strip() == "batch summarize-docs: 2/2 items succeeded in 1.4s"
         assert "alpha" not in captured.out
         assert "beta" not in captured.out
-        assert "errors" not in captured.out
+        # Hint line — stderr.
+        assert "use `-o summarize-docs.results` for full payload" in captured.err
+        # error_count == 0, so no errors hint.
+        assert "for failures" not in captured.err
+        # The advisory line from the non-batch path must not appear.
         assert "streaming auto-detected" not in captured.err
 
     def test_only_batch_node_with_errors_includes_errors_hint(self, capsys):
@@ -1727,9 +1733,11 @@ class TestOnlyBatchCompactSummary:
         }
         _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
         captured = capsys.readouterr()
-        lines = captured.out.strip().split("\n")
-        assert lines[0] == "batch batch-llm: 1/2 items succeeded in 1.4s"
-        assert "`-o batch-llm.errors` for failures" in lines[1]
+        # Data line — stdout.
+        assert captured.out.strip() == "batch batch-llm: 1/2 items succeeded in 1.4s"
+        # Hint line — stderr, includes the failures hint when error_count > 0.
+        assert "`-o batch-llm.errors` for failures" in captured.err
+        assert "use `-o batch-llm.results` for full payload" in captured.err
 
     def test_only_batch_node_no_timing_omits_duration(self, capsys):
         """``batch_metadata.timing`` is None → no ' in Xs' suffix (not '0.0s')."""
@@ -1756,6 +1764,7 @@ class TestOnlyBatchCompactSummary:
         assert "0/0" not in captured.out
 
     def test_only_batch_node_print_mode_suppresses_hint(self, capsys):
+        """``-p`` keeps the data line on stdout, suppresses the stderr hint."""
         from pflow.cli.workflow_output import _handle_text_output
 
         shared = {
@@ -1770,9 +1779,10 @@ class TestOnlyBatchCompactSummary:
             print_flag=True,
         )
         captured = capsys.readouterr()
-        lines = captured.out.strip().split("\n")
-        assert len(lines) == 1
-        assert lines[0] == "batch batch-llm: 2/2 items succeeded in 1.4s"
+        assert captured.out.strip() == "batch batch-llm: 2/2 items succeeded in 1.4s"
+        # Hint must be suppressed on BOTH streams under -p.
+        assert "for full payload" not in captured.err
+        assert "for full payload" not in captured.out
 
     def test_only_batch_node_with_explicit_output_key_yields_full_payload(self, capsys):
         """``--only batch -o batch.results`` opts back into the full list (escape hatch)."""

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -8,6 +8,7 @@ and various edge cases.
 import json
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import click.testing
@@ -16,6 +17,50 @@ import pytest
 from pflow.cli.main import main
 from pflow.core.node import BaseNode
 from tests.shared.markdown_utils import ir_to_markdown
+
+
+def make_batch_shape(
+    *,
+    results: list[dict[str, Any]] | None = None,
+    errors: list[dict[str, Any]] | None = None,
+    total_items_ms: float | None = 1400.23,
+    parallel: bool = True,
+) -> dict[str, Any]:
+    """Build a realistic batch-aggregate dict matching ``_aggregate_batch_results``.
+
+    Source of truth: ``src/pflow/runtime/engine/batch_executor.py``. Tests that
+    use this helper stay in sync as the schema evolves — single update point.
+    """
+    results = results or []
+    error_list = errors or []
+    count = len(results) + len(error_list)
+    success_count = len(results)
+    error_count = len(error_list)
+    timing: dict[str, float] | None
+    if total_items_ms is not None and count > 0:
+        timing = {
+            "total_items_ms": total_items_ms,
+            "avg_item_ms": total_items_ms / count,
+            "min_item_ms": total_items_ms,
+            "max_item_ms": total_items_ms,
+        }
+    else:
+        timing = None
+    return {
+        "results": results,
+        "count": count,
+        "success_count": success_count,
+        "error_count": error_count,
+        "errors": error_list if error_list else None,
+        "batch_metadata": {
+            "parallel": parallel,
+            "max_concurrent": 10 if parallel else None,
+            "max_retries": 3,
+            "retry_wait": None,
+            "execution_mode": "parallel" if parallel else "sequential",
+            "timing": timing,
+        },
+    }
 
 
 class MockOutputNode(BaseNode):
@@ -335,8 +380,11 @@ class TestWorkflowOutputHandling:
             # Should warn about the missing declared output (warning → stderr)
             assert "expected_output" in result.stderr
             assert "but none could be resolved" in result.stderr
-            # Should show success message since no output was produced (success → stdout)
-            assert "Workflow executed successfully" in result.output
+            # Stdout stays empty when no output is produced. The stderr
+            # summary signals success; stdout is reserved for data so pipe
+            # consumers receive a clean stream.
+            assert result.output == ""
+            assert "Workflow executed successfully" not in result.output
         finally:
             Path(workflow_file).unlink()
 
@@ -770,8 +818,11 @@ class TestWorkflowOutputHandling:
             result = runner.invoke(main, [workflow_file])
 
             assert result.exit_code == 0
-            # Should show success message when no output is produced
-            assert "Workflow executed successfully" in result.output
+            # Stdout stays empty when no output is produced (auto-detect
+            # filtered the ``_``-prefixed internal key). The stderr summary
+            # signals success; stdout is reserved for data so pipe consumers
+            # receive a clean stream.
+            assert result.output == ""
             # Should not show the internal value
             assert "Internal value" not in result.output
         finally:
@@ -801,9 +852,14 @@ class TestWorkflowOutputHandling:
 
             assert result.exit_code == 0
             # Should warn about missing key (warning → stderr)
-            assert "Warning - output key 'nonexistent_key' not found in shared store" in result.stderr
-            # Should still show success message (success → stdout)
-            assert "Workflow executed successfully" in result.output
+            assert "Warning - output key 'nonexistent_key' not found." in result.stderr
+            assert "Available top-level keys:" in result.stderr
+            assert "shared store" not in result.stderr
+            # Stdout stays empty on ``-o`` miss. The stderr summary signals
+            # success; pipe consumers (``pflow ... -o nonexistent | jq .``)
+            # receive a clean stream rather than the literal English fallback.
+            assert result.output == ""
+            assert "Workflow executed successfully" not in result.output
         finally:
             Path(workflow_file).unlink()
 
@@ -1383,3 +1439,427 @@ class TestWorkflowOutputHandling:
             assert "missing" not in actual_result
         finally:
             Path(workflow_file).unlink()
+
+
+class TestOutputKeyDottedPath:
+    """Direct tests of ``_handle_text_output`` for dotted ``-o`` resolution.
+
+    These call the function directly (capsys-based) instead of going through
+    the CLI runner — fast, deterministic, and bypasses the
+    ``_emit_summary_or_only_indicator`` early-return on ``metrics_collector=None``.
+    """
+
+    def test_output_key_dotted_path_resolves_nested_value(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "a"}, {"result": "b"}])}
+        _handle_text_output(shared, output_key="batch-llm.success_count", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "2"
+        assert "Warning" not in captured.err
+
+    def test_output_key_dotted_path_resolves_list_index(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "alpha"}, {"result": "beta"}])}
+        _handle_text_output(shared, output_key="batch-llm.results[0].result", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "alpha"
+
+    def test_output_key_dotted_path_returns_null_for_none_value(self, capsys):
+        """``-o node.errors`` on a successful batch emits JSON ``null``, NOT a warning.
+
+        Pins the ``variable_exists`` + ``resolve_value`` design — a future
+        refactor that uses just ``resolve_value`` and checks for None would fail
+        this test.
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "ok"}])}
+        assert shared["batch-llm"]["errors"] is None
+        _handle_text_output(shared, output_key="batch-llm.errors", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "null"
+        assert "Warning" not in captured.err
+        assert "not found" not in captured.err
+
+    def test_output_key_flat_hyphenated_key_unchanged(self, capsys):
+        """``-o batch-llm`` (flat lookup, hyphenated key) returns the full batch dict."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "x"}])}
+        _handle_text_output(shared, output_key="batch-llm", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        out = captured.out
+        assert '"success_count": 1' in out
+        assert '"count": 1' in out
+        assert "Warning" not in captured.err
+
+    def test_output_key_dotted_path_crosses_sub_workflow_namespace(self, capsys):
+        """``-o sub-wf.batch-llm.success_count`` traverses a sub-workflow namespace."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "sub-wf": {
+                "batch-llm": make_batch_shape(results=[{"r": 1}, {"r": 2}, {"r": 3}]),
+            },
+        }
+        _handle_text_output(shared, output_key="sub-wf.batch-llm.success_count", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "3"
+
+
+class TestOutputKeyMissHints:
+    """Walk-to-failure hint generation for missing ``-o`` paths."""
+
+    def test_output_key_miss_lists_top_level_keys(self, capsys):
+        """Flat miss lists top-level keys, drops 'shared store' vocabulary."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}]), "result": "hi"}
+        _handle_text_output(shared, output_key="nonexistent", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "Warning - output key 'nonexistent' not found." in captured.err
+        assert "Available top-level keys: batch-llm, result." in captured.err
+        assert "shared store" not in captured.err
+
+    def test_output_key_miss_lists_subkeys_at_failure_point(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}])}
+        _handle_text_output(shared, output_key="batch-llm.missing", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        expected_keys = "batch_metadata, count, error_count, errors, results, success_count"
+        assert f"Available subkeys of 'batch-llm': {expected_keys}." in captured.err
+
+    def test_output_key_miss_describes_list_bounds(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{}, {}])}
+        _handle_text_output(shared, output_key="batch-llm.results[99]", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'batch-llm.results' is a list of length 2. Valid indices: 0 to 1." in captured.err
+
+    def test_output_key_miss_describes_list_length_one(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}])}
+        _handle_text_output(shared, output_key="batch-llm.results[99]", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'batch-llm.results' is a list of length 1. Valid index: 0." in captured.err
+
+    def test_output_key_miss_describes_empty_list(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"data": {"items": []}}
+        _handle_text_output(shared, output_key="data.items[0]", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'data.items' is an empty list." in captured.err
+
+    def test_output_key_miss_describes_scalar_dead_end_with_value(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}, {"r": 2}])}
+        _handle_text_output(shared, output_key="batch-llm.success_count.foo", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'batch-llm.success_count' is a number (value: 2), cannot descend." in captured.err
+
+    def test_output_key_miss_describes_string_dead_end(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"node": {"text": "hello world"}}
+        _handle_text_output(shared, output_key="node.text.foo", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'node.text' is a string (value: 'hello world'), cannot descend." in captured.err
+
+    def test_output_key_miss_describes_null_dead_end(self, capsys):
+        """None mid-path uses 'null value' type label (likely real-world hit:
+        ``node.errors.field`` where ``errors`` is None on a successful batch).
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}])}
+        _handle_text_output(shared, output_key="batch-llm.errors.first", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'batch-llm.errors' is a null value (value: None), cannot descend." in captured.err
+
+    def test_output_key_miss_describes_boolean_dead_end(self, capsys):
+        """Boolean uses its own label, not 'number' (bool subclasses int)."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"node": {"done": True}}
+        _handle_text_output(shared, output_key="node.done.foo", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'node.done' is a boolean (value: True), cannot descend." in captured.err
+
+    def test_output_key_miss_dict_with_only_internal_keys(self, capsys):
+        """Dict containing only underscore-prefixed keys reports as having no subkeys."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"data": {"_internal": "secret", "__hidden__": 1}}
+        _handle_text_output(shared, output_key="data.missing", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "'data' has no subkeys." in captured.err
+        assert "_internal" not in captured.err
+        assert "__hidden__" not in captured.err
+
+    def test_output_key_miss_suppressed_under_print_mode(self, capsys):
+        """``-p`` suppresses the warning and hint entirely."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}])}
+        _handle_text_output(
+            shared,
+            output_key="batch-llm.missing",
+            workflow_ir=None,
+            verbose=False,
+            print_flag=True,
+        )
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+        assert "Available" not in captured.err
+
+    def test_output_key_miss_invalid_path_syntax(self, capsys):
+        """Invalid characters yield a generic syntax hint, not a misleading miss."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}])}
+        _handle_text_output(shared, output_key="batch-llm$.count", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "contains characters that aren't valid in a path" in captured.err
+        assert "Use `<name>`, `<name>.<sub>`, or `<name>[N]` syntax." in captured.err
+
+    def test_output_key_miss_inside_list_element_lists_element_keys(self, capsys):
+        """``-o batch.results[0].typo`` — agent typo'd a field name INSIDE a
+        list element. Walker must advance through three segment kinds
+        (name → bracket-index → name) before reporting the miss, and the hint
+        must surface the actual subkeys of ``results[0]``.
+
+        Realistic "agent fat-fingered a field name on a per-item result"
+        failure mode. Walker logic that handles dotted names but not
+        bracket-index segments as ``valid_prefix`` extensions would
+        false-localize this to ``'batch-llm.results'`` and tell the agent the
+        path is wrong, when really the agent just typo'd a leaf.
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "alpha", "tokens": 5}, {"result": "beta"}])}
+        _handle_text_output(shared, output_key="batch-llm.results[0].typo", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        # Hint localizes to results[0] (NOT to results), proving the walker
+        # advanced PAST the bracket-index segment before failing.
+        assert "Available subkeys of 'batch-llm.results[0]': result, tokens." in captured.err, captured.err
+
+    def test_output_key_miss_with_dot_notation_for_list_index_nudges_to_brackets(self, capsys):
+        """``-o batch.results.0.result`` — the documented misuse from issue #400.
+
+        The issue's text itself used dot notation for list indices (``.0``).
+        The plan corrected this to bracket notation (``[0]``) to match
+        ``TemplateResolver``. This test pins the load-bearing UX promise:
+        when an agent makes this dot-notation mistake, the resulting hint
+        must mention the correct ``[N]`` syntax somewhere.
+
+        Two ways this could be delivered:
+        1. Syntax-error hint: bare-digit segments fail the regex
+           reconstruction check, producing the generic "invalid characters"
+           hint that explicitly lists ``<name>[N]`` syntax. (Current path.)
+        2. List-bounds hint: walker descends to ``batch-llm.results``, fails
+           at ``0``, emits "Valid indices: 0 to N".
+
+        Either is acceptable. The contract tested here is the OUTCOME
+        invariant — agent sees ``[N]`` syntax in the hint — not the specific
+        code path that delivers it. A future refactor that switches from
+        path 1 to path 2 (e.g., extending the regex to accept bare digits as
+        a recognized-but-walker-failing segment) would still pass this test
+        as long as the bracket nudge survives.
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "alpha"}, {"result": "beta"}, {"result": "gamma"}])}
+        _handle_text_output(
+            shared,
+            output_key="batch-llm.results.0.result",
+            workflow_ir=None,
+            verbose=False,
+        )
+        captured = capsys.readouterr()
+        # The miss is surfaced (not silently ignored).
+        assert "Warning - output key 'batch-llm.results.0.result' not found." in captured.err
+        # Whichever path delivers it, the hint MUST mention bracket syntax —
+        # this is the agent's only on-screen path to discovering the correct
+        # ``[N]`` notation when they typed ``.N``.
+        assert "[N]" in captured.err or "Valid indices:" in captured.err, captured.err
+
+
+class TestOnlyBatchCompactSummary:
+    """``--only <batch-node>`` compact-summary rendering (text mode)."""
+
+    def test_only_batch_node_emits_compact_summary(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "summarize-docs"},
+            "summarize-docs": make_batch_shape(
+                results=[{"result": "alpha"}, {"result": "beta"}],
+                total_items_ms=1400.0,
+            ),
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "batch summarize-docs: 2/2 items succeeded in 1.4s"
+        assert lines[1] == "  use `-o summarize-docs.results` for full payload"
+        assert "alpha" not in captured.out
+        assert "beta" not in captured.out
+        assert "errors" not in captured.out
+        assert "streaming auto-detected" not in captured.err
+
+    def test_only_batch_node_with_errors_includes_errors_hint(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "batch-llm"},
+            "batch-llm": make_batch_shape(
+                results=[{"result": "ok"}],
+                errors=[{"index": 0, "error": "boom"}],
+                total_items_ms=1400.0,
+            ),
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        lines = captured.out.strip().split("\n")
+        assert lines[0] == "batch batch-llm: 1/2 items succeeded in 1.4s"
+        assert "`-o batch-llm.errors` for failures" in lines[1]
+
+    def test_only_batch_node_no_timing_omits_duration(self, capsys):
+        """``batch_metadata.timing`` is None → no ' in Xs' suffix (not '0.0s')."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "batch-llm"},
+            "batch-llm": make_batch_shape(results=[{"r": 1}], total_items_ms=None),
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out.split("\n")[0] == "batch batch-llm: 1/1 items succeeded"
+
+    def test_only_batch_node_empty_batch(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "batch-llm"},
+            "batch-llm": make_batch_shape(results=[], total_items_ms=None),
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "batch batch-llm: ran with no items" in captured.out
+        assert "0/0" not in captured.out
+
+    def test_only_batch_node_print_mode_suppresses_hint(self, capsys):
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "batch-llm"},
+            "batch-llm": make_batch_shape(results=[{"r": 1}, {"r": 2}], total_items_ms=1400.0),
+        }
+        _handle_text_output(
+            shared,
+            output_key=None,
+            workflow_ir=None,
+            verbose=False,
+            print_flag=True,
+        )
+        captured = capsys.readouterr()
+        lines = captured.out.strip().split("\n")
+        assert len(lines) == 1
+        assert lines[0] == "batch batch-llm: 2/2 items succeeded in 1.4s"
+
+    def test_only_batch_node_with_explicit_output_key_yields_full_payload(self, capsys):
+        """``--only batch -o batch.results`` opts back into the full list (escape hatch)."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "batch-llm"},
+            "batch-llm": make_batch_shape(results=[{"result": "alpha"}, {"result": "beta"}]),
+        }
+        _handle_text_output(shared, output_key="batch-llm.results", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        out = captured.out
+        assert "alpha" in out
+        assert "beta" in out
+        assert "items succeeded" not in out
+
+    def test_only_dotted_into_batch_subworkflow_namespace(self, capsys):
+        """``--only sub-wf.inner`` where ``shared["sub-wf"]`` IS itself a batch aggregate.
+
+        Case A: the parent invoked the sub-workflow via batch. ``find_only_output``
+        returns ``shared["sub-wf"]`` for any dotted target; if that namespace has
+        ``batch_metadata``, compact summary fires.
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "sub-wf.inner"},
+            "sub-wf": make_batch_shape(results=[{"r": 1}, {"r": 2}], total_items_ms=2300.0),
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert "batch sub-wf: 2/2 items succeeded in 2.3s" in captured.out
+
+    def test_only_dotted_namespace_containing_batch_is_unchanged(self, capsys):
+        """Case B: ``shared["sub-wf"]`` is a regular sub-workflow namespace
+        CONTAINING a batch node — ``shared["sub-wf"]["inner-batch"]`` has
+        ``batch_metadata``, but ``shared["sub-wf"]`` itself does NOT.
+
+        Compact summary must NOT fire — ``find_only_output`` returns the parent
+        namespace dict for dotted targets, and our shape detector keys off
+        ``batch_metadata`` at the resolved value's TOP level, not recursively.
+        Regression-guards against a future change that "improves" detection by
+        recursing into namespaces — that would silently break the contract
+        documented in plan §6.
+        """
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {
+            "__execution__": {"only_node": "sub-wf.inner-batch"},
+            "sub-wf": {
+                "inner-batch": make_batch_shape(results=[{"r": 1}, {"r": 2}], total_items_ms=2300.0),
+                "other-node": {"result": "unrelated"},
+            },
+        }
+        _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        # Compact summary must NOT fire (no top-level batch_metadata).
+        assert "items succeeded" not in captured.out
+        # Full namespace payload leaks through instead — verify by inspecting
+        # the raw batch shape that would be hidden if compact summary had fired.
+        assert "batch_metadata" in captured.out
+        assert "inner-batch" in captured.out
+
+
+class TestCollectOutputsOnlyBatchUnchanged:
+    """JSON-mode out-of-scope contract: ``--only batch-node`` (no ``-o``) keeps
+    emitting the full batch aggregate. The compact summary is a text-mode UX;
+    JSON consumers want structured data they parse programmatically.
+
+    Locks the plan §2 out-of-scope decision so a future "let's give JSON the
+    same UX" change doesn't silently break MCP consumers' structured-output
+    expectations.
+    """
+
+    def test_json_mode_only_batch_returns_full_aggregate(self):
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {
+            "__execution__": {"only_node": "batch-llm"},
+            "batch-llm": make_batch_shape(results=[{"r": 1}, {"r": 2}], total_items_ms=1400.0),
+        }
+        outputs = _collect_outputs(shared, workflow_ir={}, output_key=None)
+
+        # Returned under the root key, with full batch shape preserved.
+        assert "batch-llm" in outputs
+        value = outputs["batch-llm"]
+        assert "results" in value
+        assert "batch_metadata" in value
+        assert value["success_count"] == 2
+        assert value["count"] == 2

--- a/tests/test_execution/formatters/test_output_utils.py
+++ b/tests/test_execution/formatters/test_output_utils.py
@@ -388,8 +388,10 @@ class TestAutoDetectionWarning:
         # ``-o`` candidates from shared storage (covered by
         # ``test_only_no_output_enumerates_available_keys``).
         assert (
-            "cli: --only target 'fetch' produced no output. Pass -o <key> to select a specific shared-store key."
+            "cli: --only target 'fetch' produced no output. Pass -o <key> to select a specific output."
         ) in captured.err
+        assert "shared-store" not in captured.err
+        assert "shared store" not in captured.err
         assert "No outputs declared" not in captured.err
         assert "Declared outputs skipped" not in captured.err
 
@@ -410,8 +412,10 @@ class TestAutoDetectionWarning:
         (leading underscore, including ``__execution__``) are filtered.
 
         Mutation contract: removing the enumeration in
-        ``_emit_only_output``'s no-output branch makes ``Available
-        shared-store keys:`` disappear from the error.
+        ``_emit_only_output``'s no-output branch makes ``Available keys:``
+        disappear from the error. The wording deliberately omits the pflow-
+        internal phrase "shared store" — agent-facing output must read as
+        plain English a non-pflow-developer can understand.
         """
         from pflow.cli.workflow_output import _handle_text_output
 
@@ -429,7 +433,9 @@ class TestAutoDetectionWarning:
         err = captured.err
         # Suggestion + concrete candidates must both appear.
         assert "produced no output" in err, err
-        assert "Available shared-store keys:" in err, err
+        assert "Available keys:" in err, err
+        assert "shared-store" not in err
+        assert "shared store" not in err
         # Routable top-level keys surfaced.
         assert "result" in err
         assert "extract" in err

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -1055,6 +1055,79 @@ class TestAppendOutputsCliMcpParity:
         # The repr fallback is exercised (either "nan" or "NaN" visible somewhere)
         assert "nan" in text.lower()
 
+    def test_cli_mcp_parity_dotted_output_key(self):
+        """PARITY: CLI text mode and MCP text mode emit identical resolved values
+        for a dotted ``-o`` path against the same shared store.
+
+        Locks the §4.7 fix in ``_collect_outputs`` against drift — both surfaces
+        share that function, so a regression that re-introduces flat-only lookup
+        would silently break both at once.
+        """
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {
+            "batch-llm": {
+                "results": [{"r": "a"}],
+                "count": 1,
+                "success_count": 1,
+                "error_count": 0,
+                "errors": None,
+                "batch_metadata": {"timing": {"total_items_ms": 1400.0}},
+            }
+        }
+        outputs = _collect_outputs(shared, workflow_ir={}, output_key="batch-llm.success_count")
+        assert outputs == {"batch-llm.success_count": 1}
+
+        result_dict = {
+            "success": True,
+            "status": "success",
+            "duration_ms": 100,
+            "execution": {"nodes_executed": 1, "steps": []},
+            "result": outputs,
+        }
+        text = format_success_as_text(result_dict)
+        assert "\n1" in text or text.endswith("1")
+
+
+class TestCollectOutputsDottedPath:
+    """JSON-mode dotted ``-o`` resolution in ``_collect_outputs``.
+
+    Drives the same shared helper that backs both CLI ``--output-format json``
+    and MCP ``execute_workflow`` text/JSON output. Symmetric to the CLI text-
+    mode ``TestOutputKeyDottedPath`` in ``test_workflow_output_handling.py``.
+    """
+
+    def test_resolves_dotted_output_key(self):
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {"batch-llm": {"success_count": 2, "count": 2, "errors": None}}
+        result = _collect_outputs(shared, workflow_ir={}, output_key="batch-llm.success_count")
+        assert result == {"batch-llm.success_count": 2}
+
+    def test_resolved_none_emits_null(self):
+        """``-o batch.errors`` on a successful batch preserves the ``None`` value
+        in the JSON outputs dict — distinct from "key missing"."""
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {"batch-llm": {"errors": None, "success_count": 1, "count": 1}}
+        result = _collect_outputs(shared, workflow_ir={}, output_key="batch-llm.errors")
+        assert result == {"batch-llm.errors": None}
+
+    def test_missing_key_returns_empty(self):
+        """JSON-mode silently omits a missed key — no human-prose hint."""
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {"batch-llm": {"success_count": 2}}
+        result = _collect_outputs(shared, workflow_ir={}, output_key="nonexistent.foo")
+        assert result == {}
+
+    def test_list_index_path(self):
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {"batch-llm": {"results": [{"r": "alpha"}, {"r": "beta"}]}}
+        result = _collect_outputs(shared, workflow_ir={}, output_key="batch-llm.results[1].r")
+        assert result == {"batch-llm.results[1].r": "beta"}
+
 
 class TestStderrWarningsCliMcpParity:
     """Tests for ``format_stderr_warnings`` shared helper + MCP rendering parity.

--- a/tests/test_integration/test_cli_mcp_parity.py
+++ b/tests/test_integration/test_cli_mcp_parity.py
@@ -1,0 +1,162 @@
+"""End-to-end CLI/MCP parity tests for output routing (Issue #400 fixes).
+
+The unit tests in ``tests/test_cli/test_workflow_output_handling.py`` exercise
+``_handle_text_output`` directly with hand-built shared dicts. This file
+runs the same scenarios through ``WorkflowRunner().run()`` so a real batch
+node populates ``shared_after``, then routes the result through the CLI's
+output handler to verify the compact summary, dotted ``-o``, and dotted
+JSON-mode resolution all survive the full pipeline.
+
+Per ``tests/CLAUDE.md`` Pitfall #20: when a feature crosses runner →
+formatter → display, at least one test must walk the real pipeline rather
+than mocking the boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pflow.execution.result import RunnerConfig
+from pflow.execution.runner import WorkflowRunner
+
+
+@pytest.fixture
+def batch_shell_workflow_ir() -> dict[str, Any]:
+    """Minimal batch shell workflow — 2 echo items, no external dependencies."""
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "echo-items",
+                "type": "shell",
+                "purpose": "Batch echo two items so the run produces a real batch aggregate.",
+                "params": {"command": "echo ${item}"},
+                "batch": {
+                    "items": ["alpha", "beta"],
+                    "error_handling": "continue",
+                    "parallel": False,
+                },
+            },
+        ],
+        "edges": [],
+        "start_node": "echo-items",
+    }
+
+
+def _run_with_only(ir: dict[str, Any], only_node: str) -> dict[str, Any]:
+    """Run ``ir`` with ``--only`` targeting ``only_node`` and return ``shared_after``."""
+    result = WorkflowRunner().run(ir, {}, RunnerConfig(only_node=only_node))
+    assert result.success, f"workflow failed: {[d.message for d in result.diagnostics]}"
+    return result.shared_after
+
+
+def test_only_batch_node_compact_summary_end_to_end(batch_shell_workflow_ir, capsys):
+    """Real batch via ``WorkflowRunner``: ``--only`` triggers the compact summary,
+    full payload is suppressed, the hint line points at a resolvable ``-o`` path.
+    """
+    from pflow.cli.workflow_output import _handle_text_output
+
+    shared = _run_with_only(batch_shell_workflow_ir, only_node="echo-items")
+    aggregate = shared.get("echo-items")
+    assert isinstance(aggregate, dict)
+    assert "batch_metadata" in aggregate, (
+        "real batch node must produce the batch_metadata marker the compact summary path keys off"
+    )
+    assert aggregate["count"] == 2
+    assert aggregate["success_count"] == 2
+
+    _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
+    captured = capsys.readouterr()
+    out_lines = captured.out.strip().split("\n")
+
+    assert out_lines[0].startswith("batch echo-items: 2/2 items succeeded"), captured.out
+    assert out_lines[1] == "  use `-o echo-items.results` for full payload"
+    assert "alpha" not in captured.out
+    assert "beta" not in captured.out
+
+
+def test_dotted_output_key_resolves_end_to_end(batch_shell_workflow_ir, capsys):
+    """Real batch via ``WorkflowRunner``: ``-o echo-items.success_count`` resolves
+    to the nested integer through the real shared store the engine wrote.
+    """
+    from pflow.cli.workflow_output import _handle_text_output
+
+    result = WorkflowRunner().run(batch_shell_workflow_ir, {}, RunnerConfig())
+    assert result.success
+    shared = result.shared_after
+
+    _handle_text_output(shared, output_key="echo-items.success_count", workflow_ir=None, verbose=False)
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "2"
+    assert "Warning" not in captured.err
+
+
+def test_dotted_output_key_json_mode_end_to_end(batch_shell_workflow_ir):
+    """Real batch via ``WorkflowRunner`` → ``_collect_outputs`` JSON path:
+    dotted resolution lands the integer in the outputs dict (CLI/MCP parity).
+    """
+    from pflow.execution.formatters.success_formatter import _collect_outputs
+
+    result = WorkflowRunner().run(batch_shell_workflow_ir, {}, RunnerConfig())
+    assert result.success
+
+    outputs = _collect_outputs(result.shared_after, workflow_ir={}, output_key="echo-items.success_count")
+    assert outputs == {"echo-items.success_count": 2}
+
+
+def test_only_batch_node_runtime_empty_items_emits_compact_summary(capsys):
+    """The compact summary's ``count == 0`` branch is reachable in real
+    workflows — not just defensively in unit tests.
+
+    Pflow's IR validator rejects static ``items: []`` at parse time, so an
+    inline-empty batch can't reach runtime. But ``items: ${upstream.list}``
+    where ``upstream`` produces ``[]`` at runtime DOES reach
+    ``_aggregate_batch_results`` with ``count == 0`` — observed during
+    end-to-end verification (probe 27).
+
+    Without this test, the count==0 unit test in
+    ``test_workflow_output_handling.py`` could be argued as defensive-only
+    (validator blocks all empty batches). Real reachability is what makes
+    the ``ran with no items`` wording load-bearing rather than dead code.
+    """
+    from pflow.cli.workflow_output import _handle_text_output
+
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "produce-empty",
+                "type": "code",
+                "purpose": "Emit an empty list so the downstream batch has nothing to do.",
+                "params": {"code": "result: list = []"},
+            },
+            {
+                "id": "consume",
+                "type": "shell",
+                "purpose": "Batch over the runtime-empty upstream list.",
+                "params": {"command": "echo ${item}"},
+                "batch": {"items": "${produce-empty.result}", "parallel": False},
+            },
+        ],
+        "edges": [{"from": "produce-empty", "to": "consume", "action": "default"}],
+        "start_node": "produce-empty",
+    }
+
+    result = WorkflowRunner().run(ir, {}, RunnerConfig(only_node="consume"))
+    assert result.success, [d.message for d in result.diagnostics]
+
+    aggregate = result.shared_after.get("consume")
+    assert isinstance(aggregate, dict)
+    assert aggregate["count"] == 0, (
+        "runtime-empty batch must reach _aggregate_batch_results with count=0 — "
+        "this is the reachability proof for the compact summary's empty branch"
+    )
+    assert "batch_metadata" in aggregate
+
+    _handle_text_output(result.shared_after, output_key=None, workflow_ir=None, verbose=False)
+    captured = capsys.readouterr()
+    assert "batch consume: ran with no items" in captured.out
+    # The undefined '0/0 succeeded' wording must NOT appear.
+    assert "0/0" not in captured.out

--- a/tests/test_integration/test_cli_mcp_parity.py
+++ b/tests/test_integration/test_cli_mcp_parity.py
@@ -69,10 +69,10 @@ def test_only_batch_node_compact_summary_end_to_end(batch_shell_workflow_ir, cap
 
     _handle_text_output(shared, output_key=None, workflow_ir=None, verbose=False)
     captured = capsys.readouterr()
-    out_lines = captured.out.strip().split("\n")
 
-    assert out_lines[0].startswith("batch echo-items: 2/2 items succeeded"), captured.out
-    assert out_lines[1] == "  use `-o echo-items.results` for full payload"
+    # Data line on stdout; hint line on stderr (stream-discipline parity).
+    assert captured.out.strip().startswith("batch echo-items: 2/2 items succeeded"), captured.out
+    assert "use `-o echo-items.results` for full payload" in captured.err, captured.err
     assert "alpha" not in captured.out
     assert "beta" not in captured.out
 


### PR DESCRIPTION
## Summary
Closes three independent UX bugs in pflow's `-o` and `--only` output pipeline that compounded badly for AI agents iterating on batch workflows. Plus one co-shipped fix to a pre-existing stdout-pollution wart that made the `-o` improvement reachable end-to-end.

Fixes #400

## Changes

**Three bugs from the issue:**
1. **Dotted `-o` paths** — `-o batch.success_count`, `-o batch.results[0].title`, `-o sub-wf.batch.errors` now all resolve. Both text mode AND JSON mode (MCP text output rides the same code path — parity for free).
2. **Walk-to-failure hints on `-o` miss** — Instead of a bare "not found", the warning lists candidates at the deepest valid prefix: subkeys for dicts, valid indices for lists, type + value for scalar dead-ends. "Shared store" pflow-internal vocabulary removed from agent-facing output.
3. **Compact summary for `--only batch-node`** — Replaces the full batch dict (tens of KB of agent context) with a 2-line summary surfacing the success ratio and the explicit `-o` paths to drill in.

**Co-shipped:**
4. **Drop `"Workflow executed successfully"` stdout fallback** — Pre-existing wart where status text sat on stdout (wrong stream). Made `pflow ... -o nonexistent | jq .` crash on unparseable English. Stderr summary already signals success on the right stream.

## Explanation

**Why reuse `TemplateResolver`**: the same primitive backs `${...}` templates inside workflow files and `pflow read-fields`. Agents who know template syntax don't have to learn a second mini-language for the CLI. Bracket syntax `[N]` for list indexing matches jq, JMESPath, kubectl, jsonpath, terraform — the convergent norm.

**Why `variable_exists` + `resolve_value` (two calls)**: distinguishes "path missing" from "path resolved to None". Critical for `-o batch.errors` on a successful batch (where `errors` is `None` per `batch_executor.py:822`) — without disambiguation, a legitimately-None value would emit a misleading "not found" warning instead of the correct `null`.

**Why compact summary detection lives in `_emit_only_output` (not `find_only_output` or `_output_with_header`)**: keeping the render decision at the call site preserves `find_only_output` as a pure data-layer function and matches the canonical batch detection pattern (`"batch_metadata" in value`) used in `execution_state.py` and `runtime/engine/instrumentation.py`.

**Why drop the stdout fallback**: the stderr summary `✓ Workflow completed in 0.015s` already signals success. The stdout fallback was duplicate signaling on the wrong stream — pipe consumers like `jq` crashed on the literal English. With the fallback removed, `pflow ... -o batch.success_count | jq .` works; `pflow ... -o nonexistent | jq .` exits cleanly with empty input (and the warning + hint on stderr).

File stats: 7 files, +920 / -36 lines. Surface is small; the test/fixture additions are the bulk.

## Testing

**~35 new tests covering every output-shape branch:**

Path resolution:
- `test_output_key_dotted_path_resolves_nested_value` — `-o batch.success_count` → integer
- `test_output_key_dotted_path_resolves_list_index` — `-o batch.results[0].result` → list-element subkey
- `test_output_key_dotted_path_returns_null_for_none_value` — load-bearing: pins `variable_exists` + `resolve_value` design (a refactor that just uses `resolve_value` and checks for None would break this)
- `test_output_key_flat_hyphenated_key_unchanged` — kebab-case node IDs (most common case in real workflows)
- `test_output_key_dotted_path_crosses_sub_workflow_namespace` — two-level drilling

Miss hints (one per `_describe_at` branch — branch coverage via caller):
- Top-level keys, subkeys at failure point, list bounds (length N, length 1 singular wording, empty list), scalar dead-ends (number, string, null, boolean), dict-with-only-internal-keys, print-mode suppression, invalid path syntax

Compact summary:
- Two-line emission, errors hint conditional on `error_count > 0`, no-timing case, empty-batch (`count == 0`) defensive branch, print-mode hint suppression, `-o` escape hatch for full payload
- `test_only_dotted_into_batch_subworkflow_namespace` (Case A) + `test_only_dotted_namespace_containing_batch_is_unchanged` (Case B regression guard)

JSON-mode parity (`TestCollectOutputsDottedPath` + `TestAppendOutputsCliMcpParity`):
- Dotted resolution, null preservation, missing-key silent omit, list indexing — pinned for both CLI JSON and MCP text via the shared `_collect_outputs` function

End-to-end (`tests/test_integration/test_cli_mcp_parity.py`, per Pitfall #20):
- `test_only_batch_node_compact_summary_end_to_end` — real shell batch, real `WorkflowRunner.run()`, real shared store
- `test_dotted_output_key_resolves_end_to_end` — dotted resolution against the real shared store the engine wrote
- `test_dotted_output_key_json_mode_end_to_end` — same, JSON output path

Mutation-lens additions (caught by post-implementation audit):
- `test_output_key_miss_inside_list_element_lists_element_keys` — walker advancement through name→index→name segments
- `test_output_key_miss_with_dot_notation_for_list_index_nudges_to_brackets` — pins the UX promise that the issue's documented `.0` typo gets nudged to `[N]` syntax

Manual smoke (each verified against the issue's repro):
- `--only batch-shell` → 2-line compact summary, no full payload leaked
- `-o batch-shell.success_count` → `2` (the issue's headline scenario)
- `-o batch-shell.errors` → `null` (not a warning) when no errors
- `-o batch-shell.missing` → stderr lists 6 subkeys, stdout empty
- `-o 'batch-shell.results[99]'` → stderr says "list of length 2. Valid indices: 0 to 1"
- `-o batch-shell.count.foo` → "is a number (value: 2), cannot descend. Drop the trailing segments to read it."
- `-o 'batch-shell$.count'` → "contains characters that aren't valid in a path. Use ..."
- `--only batch-shell -p` → single data line, hint suppressed
- `--output-format json -o batch-shell.success_count` → `result: {"batch-shell.success_count": 2}`
- `pflow ... -o nonexistent | jq .` → exits 0 with empty input (was: jq crashed on `"Workflow executed successfully"`)

Verification: `make check` ✓ (ruff + mypy + deptry), `make test` ✓ (7000 passed, 1 skipped).

## Spinoff issues (filed during this PR's verification + review cycle)

Three concerns surfaced during the work; each was deliberately kept out of this PR to preserve scope discipline. Filed as separate issues with full context:

- **#406** — `--only` / `-o` on sub-workflow nodes leak the internal `_pflow_child_workflow_paths` key into agent output. Discovered during end-to-end verification probe 4. Pre-existing, same UX surface as #400, but conceptually orthogonal — it's dict-content filtering, not path resolution. Three suggested fix directions documented in the issue.

- **#408** — Explore unifying `--only` and `pflow probe` output rendering. Both commands answer the same agent question ("what does this one node produce?") with zero shared rendering code today. The probe path uses smart filtering, template-path syntax, ExecutionCache integration, and the `pflow read-fields` pivot; `--only` uses none of those. Framed as an exploration ticket — two reasonable directions (additive vs consolidating), 7 architectural decision points, implementation deferred until exploration produces a recommendation. Note: would close #406 incidentally.

## Review response (commit d414b076)

Addressed 6 of 7 findings from the claude[bot] review:
- Moved compact-summary hint line from stdout to stderr (stream-discipline parity with the rest of `workflow_output.py`)
- Dropped dead `bool` returns from `_handle_workflow_output` / `_handle_text_output` / `_handle_json_output`
- Replaced the long inline rationale at `commands/run.py:104` with a docstring
- Hoisted `TemplateResolver` import in `success_formatter.py` to module top
- Added clarifying comments to `_PATH_SEGMENT_PATTERN` (intentional bare-digit rejection) and the `_render_batch_compact_summary` `.get` chain (`batch_executor.py:823` contract pin)

The disputed finding — hoisting test-body imports to module level — was kept as-is because the sibling test file `tests/test_execution/formatters/test_output_utils.py` uses the same in-body import pattern; changing only this file would break the consistency. If the project wants to standardize across all test files, that's a separate sweep.

The seventh review suggestion (`_short_repr` could echo sensitive values in walk-to-failure hints) was investigated end-to-end and revealed the deeper duplication problem captured in #408 — neither `pflow probe`'s smart mode nor `--only` mask sensitive output values today. Filing as a narrow `_short_repr` fix would solve half the surface; #408's unification work gives a single point to add masking.
