### PR TITLE
fix: prewarm diagnostics account for declared prompt_cache chunks (#417)

### DIFF
--- a/src/pflow/core/cache_analysis/analyze.py
+++ b/src/pflow/core/cache_analysis/analyze.py
@@ -3967,6 +3967,7 @@ def _per_node_warnings(
     if prewarm is True and isinstance(batch, dict):
         alias = str(batch.get("as", "item"))
         prompt = node.get("params", {}).get("prompt", "") or ""
+        # Per-call _strip_below_min_cache_markers is authoritative for combined channels.
         has_declared_cache = bool(node.get("prompt_cache"))
         if isinstance(prompt, str) and not has_declared_cache:
             node_inputs = _node_inputs(node)

--- a/src/pflow/core/cache_analysis/analyze.py
+++ b/src/pflow/core/cache_analysis/analyze.py
@@ -3501,8 +3501,9 @@ def _configured_prewarm_projection_component(
     batch_prefix_tokens: int,
     has_images: bool,
     provider_trace_llm_calls: tuple[dict[str, Any], ...],
+    declared_active_tokens: int = 0,
 ) -> CacheProjectionComponent:
-    meets_min, provider_min, blocked = _provider_min_state(model, batch_prefix_tokens)
+    meets_min, provider_min, blocked = _provider_min_state(model, batch_prefix_tokens + declared_active_tokens)
     runtime_blocked = _runtime_trace_blocker(provider_trace_llm_calls, kind="prewarm")
     if runtime_blocked:
         blocked = runtime_blocked
@@ -3625,6 +3626,7 @@ def _build_cache_projection_components(
 
     cached_now = _provider_trace_cached_now(provider_trace_llm_call)
 
+    declared_active_tokens = 0
     if declared_subset:
         declared_component = _declared_projection_component(
             model=model,
@@ -3637,6 +3639,7 @@ def _build_cache_projection_components(
         configured.append(declared_component)
         ready.append(declared_component)
         if declared_component.affects_cost_projection:
+            declared_active_tokens = declared_component.tokens_estimated or 0
             active.append(replace(declared_component, affects_cost_projection=True, actionability="active"))
 
     prewarm = node.get("prewarm")
@@ -3648,6 +3651,7 @@ def _build_cache_projection_components(
             batch_prefix_tokens=batch_prefix_tokens,
             has_images=has_images,
             provider_trace_llm_calls=provider_trace_llm_calls,
+            declared_active_tokens=declared_active_tokens,
         )
         configured.append(prewarm_component)
         ready.append(prewarm_component)
@@ -3963,7 +3967,8 @@ def _per_node_warnings(
     if prewarm is True and isinstance(batch, dict):
         alias = str(batch.get("as", "item"))
         prompt = node.get("params", {}).get("prompt", "") or ""
-        if isinstance(prompt, str):
+        has_declared_cache = bool(node.get("prompt_cache"))
+        if isinstance(prompt, str) and not has_declared_cache:
             node_inputs = _node_inputs(node)
             first = first_per_item_position(prompt, alias, node_inputs)
             if first == 0:

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -140,6 +140,8 @@ def _should_disable_below_min_prewarm(
 ) -> bool:
     if not config.prewarm or config.batch_config is None or config.template_config is None:
         return False
+    if config.prompt_cache_items:
+        return False
 
     model_raw = config.template_config.template_params.get("model") or config.template_config.static_params.get("model")
     if model_raw is None:

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -141,6 +141,7 @@ def _should_disable_below_min_prewarm(
     if not config.prewarm or config.batch_config is None or config.template_config is None:
         return False
     if config.prompt_cache_items:
+        # Per-call _strip_below_min_cache_markers is authoritative for combined channels.
         return False
 
     model_raw = config.template_config.template_params.get("model") or config.template_config.static_params.get("model")

--- a/tests/test_core/test_cache_analysis_analyze.py
+++ b/tests/test_core/test_cache_analysis_analyze.py
@@ -7506,3 +7506,28 @@ def test_actually_paid_unchanged_when_trace_root_matches_analyzed_workflow(
     assert not any("trace file references workflow" in n for n in result.notes), (
         f"unexpected scope-mismatch note when trace.workflow_path == lookup_path: {result.notes}"
     )
+
+
+def test_configured_prewarm_projection_uses_cumulative_declared_tokens() -> None:
+    """The prewarm projection threshold check must add ``declared_active_tokens``
+    to ``batch_prefix_tokens`` — matching ``_strip_below_min_cache_markers``
+    which counts cumulatively across system blocks then user-message blocks.
+    """
+    from pflow.core.cache_analysis.analyze import _configured_prewarm_projection_component
+
+    base = {
+        "model": "anthropic/claude-sonnet-4-5",
+        "input_tokens": 10_000,
+        "batch_prefix_tokens": 10,
+        "has_images": False,
+        "provider_trace_llm_calls": (),
+    }
+
+    without = _configured_prewarm_projection_component(**base, declared_active_tokens=0)
+    assert without.meets_provider_min is False
+    assert without.affects_cost_projection is False
+
+    with_cumulative = _configured_prewarm_projection_component(**base, declared_active_tokens=5000)
+    assert with_cumulative.meets_provider_min is True
+    assert with_cumulative.affects_cost_projection is True
+    assert with_cumulative.tokens_estimated == 10

--- a/tests/test_core/test_cache_analysis_per_id_emission.py
+++ b/tests/test_core/test_cache_analysis_per_id_emission.py
@@ -478,12 +478,12 @@ def test_batch_prewarm_below_min_silent_when_first_per_item_at_position_zero() -
     assert "cache.batch-prewarm-below-min" not in warning_ids
 
 
-def test_batch_prewarm_below_min_emits_when_declared_prompt_cache_present() -> None:
-    """Declared ``prompt_cache:`` and ``prewarm: true`` are additive.
-
-    A too-short prewarm prompt-body prefix remains worth reporting even when a
-    separate declared cache chunk exists, because the two mechanisms emit
-    separate provider cache markers at runtime.
+def test_batch_prewarm_below_min_suppressed_when_declared_prompt_cache_present() -> None:
+    """When ``prompt_cache:`` chunks are declared, the runtime's
+    ``_strip_below_min_cache_markers`` counts tokens cumulatively across both
+    the declared system blocks and the user-message prefix.  The prompt-body-
+    only prefix check is incomplete; suppress the warning and let the per-call
+    cumulative strip handle correctness.
     """
     short_prefix = "tiny "
     workflow_ir = {
@@ -509,7 +509,40 @@ def test_batch_prewarm_below_min_emits_when_declared_prompt_cache_present() -> N
         auto_load_trace=False,
         memo_cache=None,
     )
-    assert "cache.batch-prewarm-below-min" in {d.id for d in result.warnings}
+    assert "cache.batch-prewarm-below-min" not in {d.id for d in result.warnings}
+
+
+def test_prewarm_no_prefix_suppressed_when_declared_prompt_cache_present() -> None:
+    """When ``prompt_cache:`` chunks are declared, a fully dynamic prompt body
+    (``first_per_item_position == 0``) should not trigger ``prewarm-no-prefix``
+    because the declared chunks provide the stable cache content.
+    """
+    workflow_ir = {
+        "cache": {"items": [{"name": "ctx", "var_expr": "ctx"}]},
+        "nodes": [
+            {
+                "id": "score",
+                "type": "llm",
+                "model": "anthropic/claude-sonnet-4-5",
+                "prewarm": True,
+                "prompt_cache": ["ctx"],
+                "batch": {"items": [{"text": "a"}, {"text": "b"}], "as": "item"},
+                "params": {"prompt": "${item.prompt}"},
+            }
+        ],
+        "inputs": {"ctx": {"type": "string"}},
+    }
+
+    result = analyze(
+        workflow_ir,
+        parameters={"ctx": "x"},
+        workflow_path="x.pflow.md",
+        auto_load_trace=False,
+        memo_cache=None,
+    )
+    warning_ids = {d.id for d in result.warnings}
+    assert "cache.prewarm-no-prefix" not in warning_ids
+    assert "cache.batch-prewarm-below-min" not in warning_ids
 
 
 def test_dynamic_before_static_silent_for_heterogeneous_batch_with_no_stable_tail(tmp_path: Path) -> None:

--- a/tests/test_execution/test_runner.py
+++ b/tests/test_execution/test_runner.py
@@ -319,6 +319,75 @@ def test_batch_prewarm_disabled_below_min_reaches_trace_json(mock_llm_client) ->
 
 
 @pytest.mark.trace_files
+def test_batch_prewarm_not_disabled_when_declared_prompt_cache_exists(mock_llm_client) -> None:
+    """When declared ``prompt_cache`` chunks exist, the pre-flight must not
+    disable prewarm — ``_strip_below_min_cache_markers`` counts tokens
+    cumulatively across both system blocks (declared chunks) and user-message
+    blocks (prewarm prefix), so a tiny prefix survives when declared chunks
+    push the cumulative count above the provider minimum.
+
+    Mirror of ``test_batch_prewarm_disabled_below_min_reaches_trace_json``
+    which verifies the disable DOES fire without declared chunks.
+    """
+    mock_llm_client.set_response(
+        "*",
+        None,
+        "ok",
+        cache_creation_input_tokens=500,
+        cache_read_input_tokens=2000,
+    )
+    large_context = "shared context token " * 600
+    workflow_ir = {
+        "cache": {"items": [{"name": "ctx", "var": "ctx", "prose_before": "Shared context:\n"}]},
+        "inputs": {
+            "ctx": {"type": "string"},
+            "items": {"type": "array"},
+        },
+        "nodes": [
+            {
+                "id": "score",
+                "type": "llm",
+                "prewarm": True,
+                "prompt_cache": ["ctx"],
+                "batch": {"items": "${items}", "as": "item", "parallel": True},
+                "params": {
+                    "model": "anthropic/claude-sonnet-4-5",
+                    "prompt": "Short stable prefix.\n\nItem: ${item.text}",
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+    result = WorkflowRunner().run(
+        workflow_ir,
+        {"ctx": large_context, "items": [{"text": "one"}, {"text": "two"}]},
+        RunnerConfig(),
+    )
+
+    assert result.success is True, f"diagnostics: {result.diagnostics}"
+    assert result.trace is not None
+    trace_path = result.trace.save_to_file()
+    trace_data = json.loads(trace_path.read_text(encoding="utf-8"))
+
+    batch_items = trace_data["nodes"][0]["batch_items"]
+    non_warmup = [item for item in batch_items if not item.get("llm_call", {}).get("is_warmup")]
+    for item in non_warmup:
+        assert item["llm_call"].get("prewarm_disabled_reason") is None, (
+            f"batch item {item.get('index')} has prewarm_disabled_reason="
+            f"{item['llm_call']['prewarm_disabled_reason']!r} — pre-flight should not disable "
+            f"prewarm when declared prompt_cache chunks exist"
+        )
+
+    assert not any(
+        warning.get("id") == "cache.prewarm-disabled-below-min" for warning in trace_data.get("warnings", [])
+    )
+
+    warmup_items = [item for item in batch_items if item.get("llm_call", {}).get("is_warmup")]
+    assert len(warmup_items) == 1, "synthetic warmup call should fire when declared chunks exist"
+
+
+@pytest.mark.trace_files
 def test_exception_trace_preserves_prior_runtime_cache_warnings(mock_llm_client, monkeypatch) -> None:
     """Runtime warnings emitted before a later exception must reach trace warnings."""
     monkeypatch.setattr("pflow.nodes.llm.llm._count_text_tokens", lambda text, model: 10)

--- a/tests/test_runtime/test_prompt_cache_dict.py
+++ b/tests/test_runtime/test_prompt_cache_dict.py
@@ -215,6 +215,41 @@ def test_builder_keeps_prewarm_when_static_prefix_clears_min(monkeypatch: pytest
     assert "__prewarm_disabled_below_min__" not in shared
 
 
+def test_builder_keeps_prewarm_when_declared_chunks_exist(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pre-flight skips the below-min check when declared ``prompt_cache``
+    chunks exist because ``_strip_below_min_cache_markers`` counts tokens
+    cumulatively across both system blocks (declared) and user-message blocks
+    (prewarm prefix).
+    """
+    monkeypatch.setattr(
+        "pflow.core.cache_analysis.token_estimation.estimate_tokens",
+        lambda model, text: (10, "test"),
+    )
+    config = NodeConfig(
+        node_id="score",
+        node_type_name="LLMNode",
+        template_config=TemplateConfig(
+            template_params={"prompt": "short prefix ${item.text}"},
+            static_params={"model": "anthropic/claude-sonnet-4-5"},
+            expected_types={},
+            resolution_mode="strict",
+        ),
+        batch_config=BatchConfig(items_template="${items}", item_alias="item"),
+        namespaced=True,
+        interface_metadata=None,
+        prewarm=True,
+        prompt_cache_items=("ctx",),
+    )
+    workflow = _make_workflow({"score": config})
+    shared: dict[str, Any] = {"items": [{"text": "a"}, {"text": "b"}], "_pflow_workflow_file": "wf.pflow.md"}
+
+    out = build_prompt_cache_dict(workflow, shared)
+
+    assert out["score"].prewarm is True
+    assert "__warnings__" not in shared
+    assert "__prewarm_disabled_below_min__" not in shared
+
+
 # --- Integration tests: engine save/restore --------------------------------
 
 


### PR DESCRIPTION
## Summary

When a batch LLM node has `prewarm: true` AND declared `prompt_cache: [chunks]`, diagnostics falsely warned about insufficient stable content — even though the runtime correctly fired the synthetic warmup and provider cache reads happened.

Fixes #417

## Changes

- `engine.py`: Early return in `_should_disable_below_min_prewarm` when `config.prompt_cache_items` exists
- `analyze.py`: Guard in `_per_node_warnings` suppressing `prewarm-no-prefix` and `batch-prewarm-below-min` when declared chunks exist
- `analyze.py`: Cumulative `declared_active_tokens` parameter in `_configured_prewarm_projection_component` so the provider-minimum check mirrors the runtime's cumulative counting

## Explanation

The runtime's `_strip_below_min_cache_markers` correctly uses cumulative token counting across both channels (system blocks from declared chunks, then user-message blocks from the prewarm prefix). Three diagnostic sites evaluated the prompt-body prefix in isolation:

1. **Engine pre-flight** (`_should_disable_below_min_prewarm`): tokenized only `prompt_raw[:first]`, ignoring declared chunks that provide 20,000+ tokens of stable system-block content. Fixed by skipping the check when `prompt_cache_items` is non-empty — the per-call cumulative strip handles the combined threshold correctly, including the edge case where all chunks resolve absent.

2. **Analyzer warnings** (`_per_node_warnings`): emitted `prewarm-no-prefix` (when `first == 0`) and `batch-prewarm-below-min` (when prefix below threshold) without checking for declared chunks. Fixed by adding `has_declared_cache = bool(node.get("prompt_cache"))` guard.

3. **Analyzer projection** (`_configured_prewarm_projection_component`): checked `_provider_min_state(model, batch_prefix_tokens)` without cumulative declared tokens, telling agents the prefix was "blocked" when it was actually cached at runtime. Fixed by adding `declared_active_tokens` to the threshold check.

```
 src/pflow/core/cache_analysis/analyze.py           |  9 ++-
 src/pflow/runtime/engine/engine.py                 |  2 +
 tests/test_core/test_cache_analysis_per_id_emission.py | 47 +++++++---
 tests/test_execution/test_runner.py                | 69 +++++++++++++++
 tests/test_runtime/test_prompt_cache_dict.py       | 35 ++++++++
 5 files changed, 153 insertions(+), 9 deletions(-)
```

## Testing

- `test_batch_prewarm_not_disabled_when_declared_prompt_cache_exists` — **WorkflowRunner integration test**: exercises the full pipeline (compiler → engine pre-flight → batch executor → LLM node prep → trace). Asserts no `prewarm_disabled_reason` on batch items, no `cache.prewarm-disabled-below-min` warning in trace, and synthetic warmup call fires.
- `test_builder_keeps_prewarm_when_declared_chunks_exist` — unit test: engine pre-flight returns False when `prompt_cache_items` is non-empty, even when prompt-body prefix is below provider minimum.
- `test_batch_prewarm_below_min_suppressed_when_declared_prompt_cache_present` — inverted existing test: analyzer suppresses `batch-prewarm-below-min` when `prompt_cache` is declared.
- `test_prewarm_no_prefix_suppressed_when_declared_prompt_cache_present` — analyzer suppresses `prewarm-no-prefix` when declared chunks provide the stable cache content.
- Manual CLI verification: `pflow analyze-cache` on 5 workflows (2 bug shapes, 1 control, 2 regression controls) — text and JSON output confirmed correct. `--dry-run` verified no false warnings.