### PR TITLE
feat(cli): `pflow settings llm providers` for LLM env var discovery (#420)

### DIFF
--- a/src/pflow/cli/commands/settings.py
+++ b/src/pflow/cli/commands/settings.py
@@ -1,6 +1,7 @@
 """Settings management CLI commands."""
 
 import json
+import os
 from typing import ClassVar
 
 import click
@@ -38,7 +39,9 @@ def settings() -> None:
     \b
     LLM provider keys (via environment variables or pflow settings):
       export ANTHROPIC_API_KEY=sk-ant-...
+      export GEMINI_API_KEY=AI...
       pflow settings set-env OPENAI_API_KEY "sk-..."
+      pflow settings llm providers                 # Full list of LLM providers and their env vars
     \b
     Stored credentials are available as fallbacks for declared workflow inputs.
     Precedence: CLI params > shell env > settings env > workflow defaults.
@@ -453,6 +456,155 @@ def llm_show() -> None:
     click.echo("  pflow settings llm set-default <model>")
     click.echo("  pflow settings llm set-discovery <model>")
     click.echo("  pflow settings llm set-filtering <model>")
+
+
+# Curated registry of LLM providers and their LiteLLM-recognized env vars.
+# Source: https://docs.litellm.ai/docs/providers (verified against
+# litellm.validate_environment for the canonical short-list).
+#
+# Schema: (provider_name, env_vars_tuple, semantics, note)
+#   semantics: "single" | "or" | "and" | "local"
+#   - "or": any one of env_vars satisfies auth
+#   - "and": all of env_vars must be set
+#   - "local": no remote auth (env var, if any, is config like a server URL)
+#
+# Maintenance: when bumping LiteLLM, cross-check against
+# litellm.models_by_provider keys for any popular additions. The list is
+# curated — completeness < correctness. For providers not listed, the
+# convention is <PROVIDER>_API_KEY where <PROVIDER> matches the slash-prefix.
+_LLM_PROVIDERS: tuple[tuple[str, tuple[str, ...], str, str | None], ...] = (
+    # OR semantics — either key works.
+    ("gemini", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), "or", None),
+    # AND semantics — all required.
+    ("bedrock", ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"), "and", "Or use AWS IAM role / ~/.aws/credentials"),
+    ("azure", ("AZURE_API_KEY", "AZURE_API_BASE", "AZURE_API_VERSION"), "and", None),
+    ("vertex_ai", ("VERTEXAI_PROJECT", "VERTEXAI_LOCATION"), "and", "Or use gcloud GOOGLE_APPLICATION_CREDENTIALS"),
+    # Local — no key, just a server URL config.
+    ("ollama", ("OLLAMA_API_BASE",), "local", "URL of local Ollama server, not a key"),
+    ("vllm", (), "local", "Typically no auth required"),
+    ("hosted_vllm", (), "local", "Typically no auth required"),
+    # Single-key providers — alphabetical.
+    ("ai21", ("AI21_API_KEY",), "single", None),
+    ("anthropic", ("ANTHROPIC_API_KEY",), "single", None),
+    ("anyscale", ("ANYSCALE_API_KEY",), "single", None),
+    ("baseten", ("BASETEN_API_KEY",), "single", None),
+    ("cerebras", ("CEREBRAS_API_KEY",), "single", None),
+    ("cohere", ("COHERE_API_KEY",), "single", None),
+    ("databricks", ("DATABRICKS_API_KEY",), "single", None),
+    ("deepinfra", ("DEEPINFRA_API_KEY",), "single", None),
+    ("deepseek", ("DEEPSEEK_API_KEY",), "single", None),
+    ("fireworks_ai", ("FIREWORKS_AI_API_KEY",), "single", None),
+    ("groq", ("GROQ_API_KEY",), "single", None),
+    ("huggingface", ("HUGGINGFACE_API_KEY",), "single", None),
+    ("mistral", ("MISTRAL_API_KEY",), "single", None),
+    ("openai", ("OPENAI_API_KEY",), "single", None),
+    ("openrouter", ("OPENROUTER_API_KEY",), "single", None),
+    ("perplexity", ("PERPLEXITYAI_API_KEY",), "single", None),
+    ("replicate", ("REPLICATE_API_KEY",), "single", None),
+    ("together_ai", ("TOGETHERAI_API_KEY",), "single", "Note: not TOGETHER_API_KEY"),
+    ("voyage", ("VOYAGE_API_KEY",), "single", None),
+    ("xai", ("XAI_API_KEY",), "single", None),
+)
+
+
+def _provider_status(env_vars: tuple[str, ...], semantics: str) -> str:
+    """Return display status: "set" | "-" | "n/a"."""
+    if semantics == "local":
+        return "n/a"
+    if not env_vars:
+        return "-"
+
+    def _present(var: str) -> bool:
+        return bool(os.environ.get(var, "").strip())
+
+    ok = all(_present(v) for v in env_vars) if semantics == "and" else any(_present(v) for v in env_vars)
+    return "set" if ok else "-"
+
+
+def _format_env_vars(env_vars: tuple[str, ...], semantics: str) -> str:
+    if not env_vars:
+        return "(no key needed)"
+    if semantics == "single" or len(env_vars) == 1:
+        return env_vars[0]
+    joiner = " and " if semantics == "and" else " or "
+    return joiner.join(env_vars)
+
+
+@llm.command(name="providers")
+@click.argument("keyword", required=False)
+@click.option(
+    "--output-format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (text table or JSON for agent parsing).",
+)
+def llm_providers(keyword: str | None, output_format: str) -> None:
+    """List LLM providers and the API-key env vars each one needs.
+
+    Curated against LiteLLM provider docs. For the full LiteLLM provider
+    universe (including TTS/image/local providers not listed here), see
+    https://docs.litellm.ai/docs/providers — most follow the convention
+    <PROVIDER>_API_KEY where <PROVIDER> matches the slash-prefix.
+
+    \b
+    Examples:
+      pflow settings llm providers                       # Full table
+      pflow settings llm providers gemini                # Filter by substring
+      pflow settings llm providers --output-format json  # For agent parsing
+    """
+    from pflow.core.llm_config import inject_settings_env_vars
+
+    # Mirror pflow run startup: keys stored via `pflow settings set-env` must
+    # be visible in os.environ so the installed-status check sees them.
+    inject_settings_env_vars()
+
+    entries = _LLM_PROVIDERS
+    if keyword:
+        needle = keyword.lower()
+        entries = tuple(e for e in entries if needle in e[0].lower())
+
+    # Sort: actionable rows (single/or/and) first, then local. Alphabetical within each.
+    _priority = {"single": 0, "or": 0, "and": 0, "local": 1}
+    rows = sorted(entries, key=lambda e: (_priority.get(e[2], 2), e[0]))
+
+    if output_format == "json":
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "name": name,
+                        "env_vars": list(env_vars),
+                        "semantics": semantics,
+                        "status": _provider_status(env_vars, semantics),
+                        "note": note,
+                    }
+                    for name, env_vars, semantics, note in rows
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    if not rows:
+        click.echo(f"No providers match '{keyword}'.", err=True)
+        click.echo("Try: pflow settings llm providers              # see all", err=True)
+        return
+
+    vars_col = [_format_env_vars(env_vars, semantics) for _, env_vars, semantics, _ in rows]
+    name_w = max(max(len(r[0]) for r in rows), len("PROVIDER"))
+    vars_w = max(max(len(v) for v in vars_col), len("ENV VARS"))
+
+    click.echo(f"{'PROVIDER':<{name_w}}  {'ENV VARS':<{vars_w}}  STATUS")
+    for (name, env_vars, semantics, note), vars_str in zip(rows, vars_col, strict=True):
+        status = _provider_status(env_vars, semantics)
+        click.echo(f"{name:<{name_w}}  {vars_str:<{vars_w}}  {status}")
+        if note:
+            click.echo(f"{'':<{name_w}}  ({note})")
+
+    click.echo(f"\nShowing {len(rows)} curated provider(s).")
+    click.echo("Convention for unlisted providers: <PROVIDER>_API_KEY (matches slash-prefix).")
+    click.echo('Set a key:  pflow settings set-env <ENV_VAR> "<value>"')
+    click.echo("Full LiteLLM list: https://docs.litellm.ai/docs/providers")
 
 
 def _normalize_and_warn_model(model: str) -> str:

--- a/src/pflow/guide/nodes/llm.md
+++ b/src/pflow/guide/nodes/llm.md
@@ -20,6 +20,8 @@ analyzer tells you when to add a workflow-level `## Cache`, add
 move stable prompt text before per-item data. Load `pflow guide prompt-caching`
 for the full rules and examples.
 
+**API keys**: see `pflow settings llm providers` for the list of LiteLLM provider names and their required env vars.
+
 ### Node Creation Pattern
 
 `````markdown


### PR DESCRIPTION
## Summary

Adds `pflow settings llm providers` — a curated, static listing of LLM provider names, their required env vars, OR/AND semantics, alternate-auth notes, and live installed status. External AI agents now have a first-class CLI surface for discovering what to set, with no runtime LiteLLM probing.

Fixes #420

## Changes

- **New subcommand** `pflow settings llm providers [keyword]` (`src/pflow/cli/commands/settings.py`)
  - 27 curated providers spanning the popular long tail (OpenAI, Anthropic, Gemini, Groq, Mistral, Cohere, DeepSeek, Fireworks, OpenRouter, Together, xAI, Cerebras, Replicate, HuggingFace, Anyscale, etc.) plus the 6 non-obvious ones (Bedrock, Azure, Vertex, Gemini OR-keys, Together's odd naming, Ollama as URL config).
  - `--output-format json` for agent parsing.
  - Substring keyword filter (`pflow settings llm providers ai` → matches `ai21`, `fireworks_ai`, `openai`, `together_ai`, `vertex_ai`, `xai`).
  - Live STATUS column ("set" / "-" / "n/a") via `inject_settings_env_vars()` so keys stored with `pflow settings set-env` flip to "set" without needing a shell `export`.
  - Footer points at LiteLLM docs for the long tail and states the convention (`<PROVIDER>_API_KEY` matches the slash-prefix).
- **Discoverability breadcrumbs**:
  - `pflow settings --help` gains one line: `pflow settings llm providers   # Full list of LLM providers and their env vars`.
  - `pflow guide llm` gains a single sentence pointing at the same command (keeps the guide token-cheap; agents loading the LLM guide to build workflows don't pay for the auth table).

## Explanation

Originally explored a runtime LiteLLM probe (`litellm.validate_environment` for every provider in `litellm.models_by_provider`). Two structural problems made that approach wrong:

1. **Side effects**: `github_copilot` and `chatgpt` providers' `validate_environment` calls trigger OAuth device flows that block for minutes. Skip-listing is whack-a-mole; future LiteLLM releases could add more.
2. **Half-fiction**: ~50% of providers return empty `missing_keys` from `validate_environment` because the placeholder model doesn't route through their auth path. The list would ship with half its rows misleading.

Pivoted to a small curated static dict in `settings.py`. Same `DiscoveredProvider`-shaped output (name, env_vars, semantics, note). No LiteLLM import. Maintenance is "verify against LiteLLM docs when bumping the pin" — cheap, predictable.

Diff: 2 files, +154 lines (mostly the provider dict + rendering).

## Testing

- **Full suite**: `make test` — 7102 passed, 1 skipped.
- **Quality gates**: `make check` — ruff lint + ruff format + mypy (210 source files) + deptry all pass.
- **Manual verification (all 11 surfaces)**:
  - Default table renders 27 providers, sorted (single/or/and first, local last).
  - Filter `gemini` → single row with OR semantics shown.
  - Filter `ai` → 6 rows (substring match works).
  - No-match filter → clear error + fix hint, exit 0.
  - `--output-format json` → well-formed, parseable, 5 keys per row (name, env_vars, semantics, status, note).
  - `providers --help` → shows examples and option descriptions.
  - `settings llm --help` → `providers` appears in Commands list.
  - `settings --help` → breadcrumb to new command.
  - `guide llm` → one-line breadcrumb back to settings.
  - **Round-trip**: with `GROQ_API_KEY` unset, status shows `-`; after `pflow settings set-env GROQ_API_KEY dummy`, status flips to `set`; after `pflow settings unset-env`, back to `-`. Proves the settings-env injection path works.