### PR TITLE
fix: correct Gemini per-model prompt-cache thresholds (#432)

### DIFF
--- a/src/pflow/core/llm_capabilities.py
+++ b/src/pflow/core/llm_capabilities.py
@@ -38,7 +38,10 @@ from pflow.core.llm_providers import detect_provider, model_name_without_provide
 # Conservative fallback when the model isn't in the table or its provider is
 # unrecognized. Per DD#32: pick a value high enough that small/incidental cache
 # blocks DON'T silently no-op without a warning. 4096 covers the highest known
-# Anthropic minimum and matches Gemini's explicit-cache requirement.
+# Anthropic minimum and Gemini's Pro-tier explicit-cache minimum (Flash tiers
+# are lower and listed explicitly below; the deprecated gemini-1.5-* models are
+# actually HIGHER at ~32k and are intentionally under-served here — see the
+# Gemini catch-all row).
 CONSERVATIVE_FLOOR: int = 4096
 
 
@@ -66,9 +69,13 @@ class ModelCapability:
     prefix (provider prefix stripped) — the bare model id must START WITH this
     pattern for the row to apply. Most-specific (longest) match wins.
 
-    ``min_cache_tokens`` is the threshold in tokens; rendered prompt-cache
-    content below this value will silently no-op at the provider, so the
-    validator emits ``cache.below-min-predicted``.
+    ``min_cache_tokens`` is the threshold in tokens. Below it the provider
+    either silently no-ops the cache (OpenAI / Anthropic auto-cache) OR
+    HARD-FAILS the request (Gemini explicit ``cachedContents`` returns
+    ``BadRequestError``); either way the validator emits
+    ``cache.below-min-predicted``. Because the runtime also gates prewarm on
+    this value, it must be >= the provider's true minimum — a value set too low
+    makes prewarm create a too-small cache and crash the call.
     """
 
     provider: str
@@ -99,33 +106,50 @@ MODEL_CAPABILITIES: tuple[ModelCapability, ...] = (
     # Per DD#32; ``prompt_cache_retention`` controls TTL but not the threshold.
     ModelCapability("openai", "", 1024, notes="OpenAI auto-cache threshold"),
     # Gemini minimums per https://ai.google.dev/gemini-api/docs/caching
-    # (verified 2026-05-26): Flash-tier caches from 1024 tokens, Pro-tier from
-    # 4096. This threshold drives two things — whether `analyze-cache`
-    # RECOMMENDS caching, and whether the runtime fires a prewarm marker — so
-    # it must reflect where caching actually helps, NOT the explicit
-    # `cachedContents` API minimum. Earlier this was a flat 4096 (DD#32), which
-    # made `analyze-cache` wrongly tell users a 1024-4096 token Flash prefix
-    # "won't cache."
+    # (verified 2026-05-26): Flash-tier 1024, Pro-tier 4096.
+    #
+    # THIS VALUE IS A CRASH BOUNDARY, not just a recommendation knob. It gates
+    # both (a) whether `analyze-cache` recommends caching and (b) whether the
+    # runtime fires a prewarm marker — and prewarm creates an EXPLICIT
+    # `cachedContents`. If the threshold sits BELOW the provider's true
+    # explicit-cache minimum, prewarm builds a too-small cache and Gemini
+    # rejects the whole request (`BadRequestError`). So each value must be
+    # >= the explicit API minimum; set it as LOW as the provider actually
+    # accepts (so caching is recommended wherever it legitimately helps) but
+    # NEVER lower. Earlier this was a flat 4096 (DD#32), which over-stated the
+    # Flash floor and made `analyze-cache` wrongly tell users a 1024-4096 token
+    # Flash prefix "won't cache."
     #
     # Empirical basis (discriminator runs, gemini-2.5-flash, ~1514-token prefix):
     #   - marker stripped (prewarm off): 18/31 calls cache-read (implicit only)
     #   - prewarm on (threshold 1024):   31/31 calls cache-read
-    # The marker is NOT rejected below 4096 and reliably improves coverage, so
-    # Flash's functional minimum is 1024.
-    #
-    # PREFIX-MATCH NOTE: lookup is longest-prefix-wins, and
-    # "gemini-2.5-flash-lite".startswith("gemini-2.5-flash") is True, so
-    # flash-lite needs its OWN row or it would inherit the flash value.
+    # The marker is accepted at/above 1024 and reliably improves coverage, so
+    # Flash's explicit minimum is 1024 (matches the published table).
     #
     # flash-lite is 2048, NOT 1024 — verified 2026-05-26 from a live API error:
     # "Cached content is too small. total_token_count=1221, min_total_token_count=2048"
-    # (gemini-2.5-flash-lite). A too-small explicit cache HARD-FAILS the request,
-    # so this floor being correct prevents crashes, not just bad recommendations.
+    # (gemini-2.5-flash-lite). The crash boundary in action: the earlier inferred
+    # 1024 broke 27/31 calls. flash-lite is NOT in the published table; 2048
+    # comes from ground truth.
+    #
+    # PREFIX-MATCH NOTE: lookup is longest-prefix-wins, and
+    # "gemini-2.5-flash-lite".startswith("gemini-2.5-flash") is True, so
+    # flash-lite needs its OWN row or it would inherit the flash 1024 and crash.
+    # The same trap is latent for the 3.5 line: a future `gemini-3.5-flash-lite`
+    # would inherit 1024 from the `gemini-3.5-flash` prefix below — add an
+    # explicit (verified) row before that model ships.
     ModelCapability("gemini", "gemini-2.5-flash-lite", 2048),
     ModelCapability("gemini", "gemini-2.5-flash", 1024),
+    # gemini-3.5-flash is documented at 1024 in the same published table as 2.5-flash.
     ModelCapability("gemini", "gemini-3.5-flash", 1024),
-    # Pro-tier (2.5 Pro, 3 Pro Preview), the undocumented gemini-3-flash-preview,
-    # and any unrecognized/future Gemini name fall through to 4096.
+    # Catch-all (4096) for Pro-tier (2.5 Pro, 3 Pro Preview) and any
+    # unrecognized/future Gemini name. Unverified models route here ON PURPOSE
+    # rather than to an optimistic 1024 — e.g. gemini-3-flash-preview (min not
+    # published). This UNDER-states the deprecated gemini-1.5-flash/-pro (whose
+    # explicit minimum is ~32k), so they would hard-fail prewarm here; that is
+    # pre-existing, and they are NOT added at 1024 precisely because the crash
+    # boundary above forbids guessing low. Do not add 1.5/2.0-flash rows without
+    # a verified minimum.
     ModelCapability("gemini", "", 4096, notes="Gemini Pro / unknown — conservative floor"),
 )
 

--- a/src/pflow/core/llm_capabilities.py
+++ b/src/pflow/core/llm_capabilities.py
@@ -98,11 +98,35 @@ MODEL_CAPABILITIES: tuple[ModelCapability, ...] = (
     # OpenAI auto-cache fires at 1024 across all GPT/o-series families.
     # Per DD#32; ``prompt_cache_retention`` controls TTL but not the threshold.
     ModelCapability("openai", "", 1024, notes="OpenAI auto-cache threshold"),
-    # Gemini explicit ``cachedContents`` requires ~4k tokens. The implicit
-    # path fires at lower thresholds (free, automatic) but is independent of
-    # the cache_control marker pflow emits — so the threshold used by
-    # ``cache.below-min-predicted`` reflects the EXPLICIT path's requirement.
-    ModelCapability("gemini", "", 4096, notes="Gemini explicit cachedContents minimum"),
+    # Gemini minimums per https://ai.google.dev/gemini-api/docs/caching
+    # (verified 2026-05-26): Flash-tier caches from 1024 tokens, Pro-tier from
+    # 4096. This threshold drives two things — whether `analyze-cache`
+    # RECOMMENDS caching, and whether the runtime fires a prewarm marker — so
+    # it must reflect where caching actually helps, NOT the explicit
+    # `cachedContents` API minimum. Earlier this was a flat 4096 (DD#32), which
+    # made `analyze-cache` wrongly tell users a 1024-4096 token Flash prefix
+    # "won't cache."
+    #
+    # Empirical basis (discriminator runs, gemini-2.5-flash, ~1514-token prefix):
+    #   - marker stripped (prewarm off): 18/31 calls cache-read (implicit only)
+    #   - prewarm on (threshold 1024):   31/31 calls cache-read
+    # The marker is NOT rejected below 4096 and reliably improves coverage, so
+    # Flash's functional minimum is 1024.
+    #
+    # PREFIX-MATCH NOTE: lookup is longest-prefix-wins, and
+    # "gemini-2.5-flash-lite".startswith("gemini-2.5-flash") is True, so
+    # flash-lite needs its OWN row or it would inherit the flash value.
+    #
+    # flash-lite is 2048, NOT 1024 — verified 2026-05-26 from a live API error:
+    # "Cached content is too small. total_token_count=1221, min_total_token_count=2048"
+    # (gemini-2.5-flash-lite). A too-small explicit cache HARD-FAILS the request,
+    # so this floor being correct prevents crashes, not just bad recommendations.
+    ModelCapability("gemini", "gemini-2.5-flash-lite", 2048),
+    ModelCapability("gemini", "gemini-2.5-flash", 1024),
+    ModelCapability("gemini", "gemini-3.5-flash", 1024),
+    # Pro-tier (2.5 Pro, 3 Pro Preview), the undocumented gemini-3-flash-preview,
+    # and any unrecognized/future Gemini name fall through to 4096.
+    ModelCapability("gemini", "", 4096, notes="Gemini Pro / unknown — conservative floor"),
 )
 
 

--- a/tests/test_core/test_cache_analysis_analyze.py
+++ b/tests/test_core/test_cache_analysis_analyze.py
@@ -6460,8 +6460,10 @@ def test_real_trace_score_choruses_uses_trace_outputs_for_stable_prefix_opportun
     assert row.cache_ready.tokens_estimated is not None and row.cache_ready.tokens_estimated > 500
     assert row.cache_opportunity.tokens_estimated == row.cache_ready.tokens_estimated
     assert row.cache_opportunity.action == "add_prewarm"
-    assert row.cache_opportunity.meets_provider_min is False
-    assert row.cache_opportunity.blocked_reason == "below_provider_min"
+    # ~1129-token prefix clears gemini-2.5-flash's 1024 Flash-tier minimum
+    # (corrected from the prior flat-4096 assumption — see llm_capabilities.py).
+    assert row.cache_opportunity.meets_provider_min is True
+    assert row.cache_opportunity.blocked_reason == ""
     assert row.cache_opportunity.affects_cost_projection is False
     select_rows = [row for row in result.per_call if row.node_path == "select-chorus"]
     assert select_rows, "expected select-chorus row in lyrics-generator analysis"
@@ -6491,7 +6493,10 @@ def test_real_trace_score_choruses_uses_trace_outputs_for_stable_prefix_opportun
         for warning in result.warnings
         if warning.id == "cache.batch-prewarm-recommended" and warning.node_id == "score-choruses"
     ]
-    assert not score_actions, "unmeasurable score-choruses prefix must not produce a prewarm action"
+    assert score_actions, (
+        "score-choruses prefix (~1129 tokens) clears gemini-2.5-flash's 1024-token "
+        "Flash-tier minimum, so a prewarm action should now be recommended"
+    )
 
 
 def test_build_parameters_by_workflow_does_not_mutate_root_on_cycle() -> None:

--- a/tests/test_core/test_llm_capabilities.py
+++ b/tests/test_core/test_llm_capabilities.py
@@ -123,20 +123,60 @@ def test_openai_threshold_is_1024(model: str) -> None:
     "model",
     [
         "gemini/gemini-2.5-flash",
-        "gemini/gemini-2.5-pro",
-        "gemini/gemini-3-flash-preview",
-        "gemini/gemini-3.1-pro-preview",
+        "gemini/gemini-3.5-flash",
         "gemini-2.5-flash",
+    ],
+)
+def test_gemini_flash_cache_threshold_is_1024(model: str) -> None:
+    """Gemini Flash (non-lite) caches from 1024 tokens.
+
+    Per https://ai.google.dev/gemini-api/docs/caching, Flash-tier models cache
+    from 1024 tokens (Pro-tier from 4096). This threshold governs whether
+    ``analyze-cache`` recommends caching and whether the runtime fires a prewarm
+    marker — so it tracks where caching actually helps, not some abstract floor.
+
+    Supersedes the earlier flat-4096 assumption (DD#32). Discriminator runs on
+    gemini-2.5-flash confirmed the marker is accepted below 4096 and lifts
+    cache-read coverage from implicit-only to full with prewarm. NOTE: flash-LITE
+    is a separate 2048 floor (see test below) — do not fold it in here.
+    """
+    from pflow.core.llm_capabilities import get_min_cache_tokens
+
+    assert get_min_cache_tokens(model) == 1024
+
+
+def test_gemini_flash_lite_cache_threshold_is_2048() -> None:
+    """gemini-2.5-flash-lite requires 2048, unlike the 1024 of regular Flash.
+
+    Verified 2026-05-26 from a live API rejection: "Cached content is too small.
+    total_token_count=1221, min_total_token_count=2048". Because a too-small
+    explicit cache HARD-FAILS the request (not a graceful no-op), this floor must
+    be correct to avoid crashes — the earlier inferred 1024 broke 27/31 calls.
+    The prefix-match order means flash-lite needs its own row so it does not
+    inherit the 1024 of the gemini-2.5-flash prefix.
+    """
+    from pflow.core.llm_capabilities import get_min_cache_tokens
+
+    assert get_min_cache_tokens("gemini/gemini-2.5-flash-lite") == 2048
+    assert get_min_cache_tokens("gemini-2.5-flash-lite") == 2048
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gemini/gemini-2.5-pro",
+        "gemini/gemini-3.1-pro-preview",
+        "gemini/gemini-3-flash-preview",  # undocumented min → conservative floor
         "gemini-2.5-pro",
     ],
 )
-def test_gemini_explicit_cache_threshold_is_4096(model: str) -> None:
-    """Gemini's explicit ``cachedContents`` requires ~4k tokens (DD#32 + spec note).
+def test_gemini_pro_and_undocumented_cache_threshold_is_4096(model: str) -> None:
+    """Gemini Pro-tier (and any undocumented/future Gemini) uses the 4096 floor.
 
-    The implicit-cache mode is free at lower thresholds (1024 Flash / 2048 Pro),
-    but pflow's ``cache_control`` markers fire the EXPLICIT path; the threshold
-    used by ``cache.below-min-predicted`` must reflect when the marker won't fire,
-    which is the explicit minimum.
+    Pro-tier is documented at 4096. gemini-3-flash-preview's minimum is not
+    published, so it falls through the catch-all to the conservative 4096 rather
+    than being assumed to match the 1024 Flash-tier (avoids a wrong "caching
+    will fire" recommendation for an unverified model).
     """
     from pflow.core.llm_capabilities import get_min_cache_tokens
 


### PR DESCRIPTION
## Summary
pflow encoded a flat 4096-token prompt-cache minimum for all Gemini models. The real minimums differ by tier, so the flat value both under-recommended caching and could hard-fail requests.

Fixes #432

## Changes
- `llm_capabilities.py`: break out Gemini cache thresholds by tier — Flash (2.5/3.5) = 1024, flash-lite = 2048, Pro/unknown = 4096 (conservative catch-all)
- Tests: split the Gemini threshold test into flash / flash-lite / Pro; update the `analyze-cache` score-choruses canary (a ~1129-token flash prefix now clears 1024 → prewarm recommended)

## Explanation
The single `("gemini", "", 4096)` catch-all was over-conservative for Flash and outright wrong for flash-lite. Consequences: (1) `analyze-cache` wrongly reported a 1024–4096-token Flash prefix "won't cache"; (2) more seriously, prewarm creates an explicit `cachedContents` — when the table under-estimates the provider minimum, the cache is created too small and Google **rejects the whole request** (`BadRequestError`), so a wrong floor crashes calls rather than only degrading recommendations.

Verified against the live Gemini API: `gemini-2.5-flash` accepted a ~1,200-token cached prefix (0 errors); `flash-lite` rejected the same content — *"Cached content is too small. total_token_count=1221, min_total_token_count=2048"*. flash-lite's 2048 was previously inferred at 1024 (wrong); this corrects it from ground truth. Lookup is longest-prefix-wins, so flash-lite gets its own row to avoid inheriting the flash 1024 via the `gemini-2.5-flash` prefix.

## Testing
- `test_gemini_flash_cache_threshold_is_1024` — Flash 2.5/3.5 → 1024
- `test_gemini_flash_lite_cache_threshold_is_2048` — flash-lite → 2048 (regression guard for the crash)
- `test_gemini_pro_and_undocumented_cache_threshold_is_4096` — Pro + undocumented → conservative 4096
- `test_real_trace_score_choruses_uses_trace_outputs_for_stable_prefix_opportunity` — updated: ~1129-token flash prefix now meets the provider min → prewarm recommended