### PR TITLE
fix: validate LLM model IDs at validate-time, not after upstream burn (#439)

### DIFF
--- a/examples/test_llm_templates.pflow.md
+++ b/examples/test_llm_templates.pflow.md
@@ -35,7 +35,7 @@ Maximum word count.
 Generate text about a topic in the specified style and word count.
 
 - type: llm
-- model: anthropic/claude-3.5-haiku
+- model: anthropic/claude-haiku-4-5
 - temperature: 0.7
 - max_tokens: 200
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ markers = [
     "integration: marks integration tests that spawn subprocesses",
     "e2e: marks real process, shell, pipe, or external-boundary tests",
     "trace_files: allows tests to write workflow trace JSON files",
+    "no_fake_llm_keys: disable the autouse fake-LLM-key injection (for tests asserting the missing-key code path)",
 ]
 # Note: We don't set addopts with -n here to allow flexibility
 # Use 'make test' for parallel or 'make test-debug' for sequential

--- a/src/pflow/core/diagnostic.py
+++ b/src/pflow/core/diagnostic.py
@@ -229,12 +229,20 @@ CACHE_FAILURE_CATEGORY = "cache_failure"
 CACHE_WARNING_CATEGORY = "cache_warning"
 CACHE_ADVISORY_CATEGORY = "cache_advisory"
 
-# LLM validation category — for static-analysis ERROR-level diagnostics about
-# LLM node parameter compositions that will fail at the provider boundary.
-# Currently used by ``llm.thinking-temperature-mismatch`` (validate-time check
-# for Anthropic temperature=1.0 requirement when thinking is enabled). Distinct
-# from LLM_FAILURE_CATEGORY because no provider call has happened yet — the
-# fix is in the workflow file, not in the runtime.
+# LLM validation category — for validate-time diagnostics about LLM node
+# parameter compositions that would fail or warn at the provider boundary.
+# Producers include (non-exhaustive):
+#   - ``llm.thinking-temperature-mismatch`` — Anthropic temperature=1.0
+#     requirement when thinking is enabled (ERROR).
+#   - ``llm.model-not-string`` — wrong-type ``model:`` values (ERROR).
+#   - ``llm.model-not-in-catalog`` — model identifier not in the LiteLLM
+#     pricing catalog after upstream merge (WARNING).
+#   - ``llm.catalog-unreachable`` — INFO breadcrumb when the upstream
+#     catalog fetch fails during validation.
+#   - Validator-decorated ``MissingApiKeyError`` — canonical-provider model
+#     without a configured API key (ERROR).
+# Distinct from LLM_FAILURE_CATEGORY because no provider call has happened
+# yet — the fix is in the workflow file, not in the runtime.
 LLM_VALIDATION_CATEGORY = "llm_validation"
 
 

--- a/src/pflow/core/litellm_runtime.py
+++ b/src/pflow/core/litellm_runtime.py
@@ -66,6 +66,41 @@ _logger = logging.getLogger(__name__)
 _UPSTREAM_LOCK = threading.Lock()
 _upstream_attempted = False
 
+# Fields LiteLLM-shaped cost-map entries are known to carry. An upstream entry
+# must be a dict and contain at least one of these before we accept it for
+# registration. Without this filter, a malformed payload (single string per
+# key, dict-of-strings, partial JSON) would still register junk entries and
+# a subsequent ``model in litellm.model_cost`` check would silently report
+# them as known — both for the runtime cost-pricing path (``ensure_model_priced``)
+# and the validator's catalog-membership path (``try_load_upstream_catalog``).
+_RECOGNIZED_UPSTREAM_ENTRY_FIELDS = frozenset({
+    "litellm_provider",
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "mode",
+    "max_input_tokens",
+    "max_output_tokens",
+    "max_tokens",
+})
+
+
+def _filter_well_formed_upstream_entries(upstream_map: dict[str, Any]) -> dict[str, Any]:
+    """Drop upstream entries whose value isn't a dict carrying a recognized field.
+
+    Shared between ``ensure_model_priced`` (runtime cost-pricing path) and
+    ``try_load_upstream_catalog`` (validator catalog-membership path). Both
+    write to the same ``litellm.model_cost`` dict, so the filter must run on
+    BOTH paths — otherwise a runtime-side fetch landing first with malformed
+    payload could register junk entries that the validator's catalog check
+    later silently accepts via the documented non-dict fallback.
+    """
+    return {
+        k: v
+        for k, v in upstream_map.items()
+        if isinstance(v, dict) and _RECOGNIZED_UPSTREAM_ENTRY_FIELDS.intersection(v)
+    }
+
+
 # Validator-side latch — independent from the runtime-side ``_upstream_attempted``
 # above. See ``try_load_upstream_catalog`` for the rationale (the runtime path
 # treats fetch failure as best-effort; the validator path needs to know whether
@@ -176,14 +211,21 @@ def ensure_model_priced(model: str) -> None:
             upstream_map = response.json()
             if not isinstance(upstream_map, dict) or not upstream_map:
                 raise ValueError("upstream JSON is empty or not a dict")
-            # Filter to entries NOT already in bundled model_cost.
+            # Per-entry shape filter — see ``_filter_well_formed_upstream_entries``.
+            # Without this, a malformed payload would register junk into the
+            # shared ``litellm.model_cost`` dict and the validator's
+            # ``_catalog_form_known_for_provider`` membership check could
+            # silently accept a typo'd model that happened to coincide with
+            # a registered junk key.
+            well_formed = _filter_well_formed_upstream_entries(upstream_map)
+            # Then filter to entries NOT already in bundled model_cost.
             # litellm.register_model merges via
             # model_cost.setdefault(key, {}).update(value), which OVERWRITES
             # existing keys. Without this filter, an upstream price revision
             # for a bundled model would silently shift the bundled price for
             # the remaining process lifetime — breaking the "bundled prices
             # are fully deterministic" half of the contract documented above.
-            new_entries = {k: v for k, v in upstream_map.items() if k not in litellm.model_cost}
+            new_entries = {k: v for k, v in well_formed.items() if k not in litellm.model_cost}
             if not new_entries:
                 # All upstream models are already bundled — nothing to register.
                 # The asked-for ``model`` is still missing (we checked above),
@@ -249,25 +291,11 @@ def try_load_upstream_catalog() -> bool:
             upstream_map = response.json()
             if not isinstance(upstream_map, dict) or not upstream_map:
                 raise ValueError("upstream JSON is empty or not a dict")
-            # Per-entry shape validation: each value MUST be a dict carrying
-            # at least one recognized field. Without this guard, a malformed
-            # upstream payload (single string per key, missing fields, partial
-            # JSON) would still register junk entries — and a subsequent
-            # ``model in litellm.model_cost`` check would silently report the
-            # workflow's model as known even when the registered entry is
-            # garbage. Drop malformed entries; keep the well-formed ones.
-            recognized_fields = {
-                "litellm_provider",
-                "input_cost_per_token",
-                "output_cost_per_token",
-                "mode",
-                "max_input_tokens",
-                "max_output_tokens",
-                "max_tokens",
-            }
-            well_formed = {
-                k: v for k, v in upstream_map.items() if isinstance(v, dict) and recognized_fields.intersection(v)
-            }
+            # Per-entry shape filter — see ``_filter_well_formed_upstream_entries``.
+            # Shared with ``ensure_model_priced`` so a malformed payload
+            # registered through EITHER fetch path cannot poison
+            # ``litellm.model_cost`` (both paths share the same dict).
+            well_formed = _filter_well_formed_upstream_entries(upstream_map)
             if not well_formed:
                 raise ValueError("upstream payload contains no well-formed entries")
             new_entries = {k: v for k, v in well_formed.items() if k not in litellm.model_cost}

--- a/src/pflow/core/litellm_runtime.py
+++ b/src/pflow/core/litellm_runtime.py
@@ -66,6 +66,13 @@ _logger = logging.getLogger(__name__)
 _UPSTREAM_LOCK = threading.Lock()
 _upstream_attempted = False
 
+# Validator-side latch — independent from the runtime-side ``_upstream_attempted``
+# above. See ``try_load_upstream_catalog`` for the rationale (the runtime path
+# treats fetch failure as best-effort; the validator path needs to know whether
+# the membership check is authoritative).
+_validator_upstream_attempted = False
+_validator_upstream_fetch_succeeded = False
+
 
 def configure_litellm_defaults() -> None:
     """Apply pflow's LiteLLM runtime policy before importing LiteLLM.
@@ -199,3 +206,79 @@ def ensure_model_priced(model: str) -> None:
         except Exception as exc:
             _logger.debug("Upstream cost map fetch failed: %s", exc)
         _upstream_attempted = True
+
+
+def try_load_upstream_catalog() -> bool:
+    """Validator-side best-effort upstream catalog merge.
+
+    Independent of ``ensure_model_priced``'s runtime latch. Returns True if
+    the in-memory catalog is in a state usable for model-membership checks
+    (either bundled is sufficient, or upstream merge succeeded in this
+    process). Returns False if an upstream fetch was attempted in this
+    process and failed.
+
+    Two latches in this module:
+
+    - ``_upstream_attempted`` / runtime: permanent-on-attempt, ignores
+      whether the fetch succeeded. The runtime's cost-pricing path doesn't
+      care if a previous failure was transient — pricing is best-effort
+      and the ``cost_usd`` field falls back to None.
+    - ``_validator_upstream_attempted`` / validator: also permanent-on-
+      attempt within one process, but reports the success/failure status
+      via the return value. The validator's "is this model real?" question
+      is binary; the validator needs to know if its membership check is
+      authoritative.
+
+    Both functions share ``litellm.model_cost``, so a successful merge
+    from EITHER path benefits the other (no duplicate fetches).
+
+    Thread-safe via the existing module-level lock.
+    """
+    global _validator_upstream_attempted, _validator_upstream_fetch_succeeded
+    if _validator_upstream_attempted:
+        return _validator_upstream_fetch_succeeded
+    with _UPSTREAM_LOCK:
+        if _validator_upstream_attempted:
+            return _validator_upstream_fetch_succeeded
+        litellm = import_litellm()
+        try:
+            import httpx
+
+            response = httpx.get(litellm.model_cost_map_url, timeout=5)
+            response.raise_for_status()
+            upstream_map = response.json()
+            if not isinstance(upstream_map, dict) or not upstream_map:
+                raise ValueError("upstream JSON is empty or not a dict")
+            # Per-entry shape validation: each value MUST be a dict carrying
+            # at least one recognized field. Without this guard, a malformed
+            # upstream payload (single string per key, missing fields, partial
+            # JSON) would still register junk entries — and a subsequent
+            # ``model in litellm.model_cost`` check would silently report the
+            # workflow's model as known even when the registered entry is
+            # garbage. Drop malformed entries; keep the well-formed ones.
+            recognized_fields = {
+                "litellm_provider",
+                "input_cost_per_token",
+                "output_cost_per_token",
+                "mode",
+                "max_input_tokens",
+                "max_output_tokens",
+                "max_tokens",
+            }
+            well_formed = {
+                k: v for k, v in upstream_map.items() if isinstance(v, dict) and recognized_fields.intersection(v)
+            }
+            if not well_formed:
+                raise ValueError("upstream payload contains no well-formed entries")
+            new_entries = {k: v for k, v in well_formed.items() if k not in litellm.model_cost}
+            if new_entries:
+                litellm.suppress_debug_info = True
+                litellm.register_model(new_entries)
+            # Whether or not we had new entries to register, the fetch
+            # itself succeeded. The catalog is usable for membership checks.
+            _validator_upstream_fetch_succeeded = True
+        except Exception as exc:
+            _logger.debug("Validator upstream catalog merge failed: %s", exc)
+            _validator_upstream_fetch_succeeded = False
+        _validator_upstream_attempted = True
+        return _validator_upstream_fetch_succeeded

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -746,13 +746,34 @@ class WorkflowValidator:
         ``--validate-only`` and ``--dry-run`` agree with normal execution.
         """
         diagnostics: list[Diagnostic] = []
+        # Each entry: (node_id, display_model, provider_name, candidate_forms)
+        # ``provider_name`` is the canonical provider detected from the user's
+        # ``model:`` string (``anthropic`` / ``openai`` / ``gemini``). It's
+        # carried into the catalog check so a bare-form catalog hit can be
+        # rejected when the entry's ``litellm_provider`` field names a
+        # DIFFERENT canonical provider — that catches typos like
+        # ``anthropic/gpt-4`` (gpt-4 is bundled as bare under openai).
+        catalog_check_list: list[tuple[str, str, str, tuple[str, ...]]] = []
+
         for node in workflow_ir.get("nodes", []):
-            if node.get("type") != "claude-code":
-                continue
             params = node.get("params", {})
             if not isinstance(params, dict):
                 continue
-            diagnostics.extend(WorkflowValidator._validate_claude_code_params(node.get("id", "unknown"), params))
+            node_id = node.get("id", "unknown")
+            node_type = node.get("type")
+            if node_type == "claude-code":
+                diagnostics.extend(WorkflowValidator._validate_claude_code_params(node_id, params))
+            elif node_type == "llm":
+                llm_diags, display_model, provider_name, forms = WorkflowValidator._validate_llm_model_id_lite(
+                    node_id, params
+                )
+                diagnostics.extend(llm_diags)
+                if forms is not None and display_model is not None and provider_name is not None:
+                    catalog_check_list.append((node_id, display_model, provider_name, forms))
+
+        if catalog_check_list:
+            diagnostics.extend(WorkflowValidator._validate_llm_model_id_catalog(catalog_check_list))
+
         return diagnostics
 
     @staticmethod
@@ -883,6 +904,322 @@ class WorkflowValidator:
                 "path": path,
             },
             see_also=["claude-code"],
+        )
+
+    # =========================================================================
+    # LLM Model-Id Static Validation (Step 9 — LLM branch)
+    # =========================================================================
+
+    @staticmethod
+    def _strip_provider_prefix_case_preserving(model: str, provider_prefix: str) -> str:
+        """Return the bare model name with the user's case preserved.
+
+        Distinct from ``llm_providers.model_name_without_provider`` which
+        lowercases the result — this validator-local helper preserves case so
+        the catalog lookup mirrors what the runtime adapter would actually
+        send to LiteLLM. Without case preservation, a user writing
+        ``Anthropic/Claude-Sonnet-4-5`` would match a lowercase catalog entry
+        at validate time but the runtime call would use mixed case and
+        potentially fail.
+
+        Matches the prefix case-insensitively (``Anthropic/`` and
+        ``anthropic/`` both strip) but returns the SUFFIX with its original
+        case. When the model doesn't carry the prefix, returns it unchanged.
+        """
+        if model.lower().startswith(provider_prefix):
+            return model[len(provider_prefix) :]
+        return model
+
+    @staticmethod
+    def _validate_llm_model_id_lite(
+        node_id: str,
+        params: dict[str, Any],
+    ) -> tuple[list[Diagnostic], str | None, str | None, tuple[str, ...] | None]:
+        """Per-node lite check: type, template-defer, provider prefix, key.
+
+        Returns ``(diagnostics, display_model, provider_name, catalog_candidate_forms)``.
+
+        - ``diagnostics``: validate-time ERROR diagnostics (wrong type or
+          missing API key) for this node.
+        - ``display_model``: the model identifier as the user wrote it,
+          for use in subsequent diagnostic messages.
+        - ``provider_name``: the canonical provider name (``"anthropic"`` /
+          ``"openai"`` / ``"gemini"``) — carried into the catalog check so a
+          bare-form catalog hit can be rejected when the entry belongs to a
+          DIFFERENT canonical provider (closes the cross-provider FP class
+          where e.g. ``anthropic/gpt-4`` would silently pass because
+          ``gpt-4`` is bundled bare under openai).
+        - ``catalog_candidate_forms``: a tuple of strings to try against
+          ``litellm.model_cost``. The bundled catalog uses bare names for
+          most providers but prefixed names for some (e.g. gemini), so we
+          collect both forms and check each. All forms are case-preserving
+          to mirror the runtime call shape. ``None`` when this node should
+          be skipped from catalog checks.
+        """
+        from pflow.core.exceptions import MissingApiKeyError
+        from pflow.core.llm_config import _has_provider_key
+        from pflow.core.llm_providers import detect_provider, normalize_model_name
+
+        if "model" not in params:
+            return [], None, None, None  # compiler injects default; raises CompilationError if none
+
+        model = params["model"]
+        if model is None or model == "":
+            return [], None, None, None  # treat as absent — compiler handles
+
+        if not isinstance(model, str):
+            diag = Diagnostic(
+                severity=Severity.ERROR,
+                source="validator",
+                title="LLM Configuration",
+                node_id=node_id,
+                message=(f"LLM node 'model:' must be a string identifier, got {type(model).__name__} ({model!r})."),
+                suggestions=[
+                    "Set `- model: <provider>/<model-name>` (e.g. `- model: anthropic/claude-sonnet-4-5`).",
+                    "Run `pflow settings llm show` to see configured defaults.",
+                    "Remove the `- model:` line to use the workflow default.",
+                ],
+                context={
+                    "category": "llm_validation",
+                    "path": f"nodes[id={node_id}].params.model",
+                    "value": model,
+                    "value_type": type(model).__name__,
+                },
+                see_also=["llm"],
+                id="llm.model-not-string",
+            )
+            return [diag], None, None, None
+
+        if TemplateResolver.has_templates(model):
+            return [], None, None, None  # defer to runtime
+
+        provider = detect_provider(model)
+        if provider is None:
+            return [], None, None, None  # non-canonical provider, trust user
+
+        if not _has_provider_key(provider.name):
+            exc = MissingApiKeyError(
+                f"Missing API key for model '{model}'",
+                model=model,
+                kind="missing_key",
+            )
+            diag = exc.to_diagnostics()[0]
+            return [WorkflowValidator._decorate_llm_validator_diag(diag, node_id)], None, None, None
+
+        # Build candidate forms for catalog lookup. LiteLLM's bundled catalog
+        # uses bare names for most providers (e.g. ``gpt-4``,
+        # ``claude-sonnet-4-5``), so a user writing ``openai/gpt-4`` would
+        # false-positive as Unknown Model if we only checked the prefixed form.
+        # Conversely, some entries (gemini) are bundled with the prefix. We
+        # accept either form, then disambiguate with the per-entry
+        # ``litellm_provider`` field in ``_validate_llm_model_id_catalog`` so
+        # ``anthropic/gpt-4`` (wrong provider for gpt-4) doesn't silently pass.
+        # Use the case-preserving bare-strip so the lookup mirrors the
+        # runtime's case behavior (matters for users who write mixed-case
+        # model identifiers).
+        bare = WorkflowValidator._strip_provider_prefix_case_preserving(model, provider.provider_prefix)
+        candidate_forms = (model, normalize_model_name(model), bare)
+        # De-duplicate while preserving order so the upstream-merge benefit
+        # still applies when the user-written form differs from both
+        # normalized variants.
+        seen: dict[str, None] = {}
+        for form in candidate_forms:
+            if form and form not in seen:
+                seen[form] = None
+        return [], model, provider.name, tuple(seen.keys())
+
+    @staticmethod
+    def _catalog_form_known_for_provider(
+        litellm_module: Any,
+        canonical_provider_names: set[str],
+        form: str,
+        expected_provider: str,
+    ) -> bool:
+        """True iff ``form`` is in the catalog AND the entry doesn't
+        explicitly name a DIFFERENT canonical provider.
+
+        Accepting when ``litellm_provider`` is missing, non-canonical, or
+        matches ``expected_provider`` keeps the lookup permissive on
+        best-effort metadata (some bundled entries lack the field; others
+        use non-canonical values like ``vertex_ai-language-models`` for the
+        bare Gemini namespace). Only an explicit canonical mismatch rejects.
+        Closes the cross-provider FP class where e.g. ``anthropic/gpt-4``
+        would silently pass because ``gpt-4`` is bundled bare under openai.
+        """
+        entry = litellm_module.model_cost.get(form)
+        if not isinstance(entry, dict):
+            return form in litellm_module.model_cost  # truthy but non-dict — best-effort
+        entry_provider = entry.get("litellm_provider")
+        if entry_provider == expected_provider:
+            return True
+        # Reject ONLY explicit canonical mismatch. Unknown / non-canonical /
+        # missing values are accepted (best-effort).
+        return not (isinstance(entry_provider, str) and entry_provider in canonical_provider_names)
+
+    @staticmethod
+    def _build_catalog_unreachable_info(deferred_node_ids: list[str]) -> Diagnostic:
+        """Build the single INFO breadcrumb emitted when upstream fetch fails.
+
+        Network failure means we couldn't authoritatively check the catalog.
+        Rather than silently passing, we tell the user verification was
+        skipped — so the agent can interpret a runtime LLM error correctly.
+        """
+        deferred_count = len(deferred_node_ids)
+        return Diagnostic(
+            severity=Severity.INFO,
+            source="validator",
+            title="LLM Configuration",
+            message=(
+                f"Could not verify {deferred_count} model identifier(s) "
+                f"against the upstream catalog (network unavailable). "
+                f"Validation passed for these; model names will be "
+                f"checked at runtime."
+            ),
+            suggestions=[
+                "Check your network connection if this is unexpected.",
+                "The runtime will surface a precise error if the model is invalid.",
+            ],
+            context={
+                "category": "llm_validation",
+                "deferred_node_ids": deferred_node_ids,
+            },
+            see_also=["llm"],
+            id="llm.catalog-unreachable",
+        )
+
+    @staticmethod
+    def _validate_llm_model_id_catalog(
+        items: list[tuple[str, str, str, tuple[str, ...]]],
+    ) -> list[Diagnostic]:
+        """Batch catalog check across all LLM nodes that passed lite check.
+
+        Each item is ``(node_id, display_model, provider_name, candidate_forms)``.
+        A node is considered "known" when at least one candidate form is present
+        in ``litellm.model_cost`` AND the entry's ``litellm_provider`` field
+        doesn't explicitly name a DIFFERENT canonical provider (see
+        ``_catalog_form_known_for_provider``).
+
+        Severity policy: catalog-miss after successful upstream merge emits
+        Severity.WARNING (not ERROR). LiteLLM's ``model_cost`` is a pricing
+        catalog, not a "this name is callable" registry — fine-tunes
+        (``openai/ft:...``), custom endpoints, and brand-new models may be
+        callable but absent from the catalog. The WARNING signals the
+        condition without blocking ``--validate-only`` or save. The original
+        bug fix is preserved by the lite check's ERROR-severity missing-key
+        diagnostic, which still fires before any upstream node executes.
+
+        One litellm import. At most one HTTP request per process (latched
+        in ``try_load_upstream_catalog``). On network failure, emit a
+        single INFO breadcrumb instead of silently passing through.
+        """
+        from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+        from pflow.core.llm_providers import PROVIDERS
+
+        litellm = import_litellm()
+        canonical_provider_names = {p.name for p in PROVIDERS}
+
+        def _any_known(forms: tuple[str, ...], expected_provider: str) -> bool:
+            return any(
+                WorkflowValidator._catalog_form_known_for_provider(
+                    litellm, canonical_provider_names, form, expected_provider
+                )
+                for form in forms
+            )
+
+        to_check = [(nid, display, prov, forms) for nid, display, prov, forms in items if not _any_known(forms, prov)]
+        if not to_check:
+            return []
+
+        merge_ok = try_load_upstream_catalog()
+
+        diagnostics: list[Diagnostic] = []
+        deferred_node_ids: list[str] = []
+        for node_id, display_model, provider_name, forms in to_check:
+            if _any_known(forms, provider_name):
+                continue
+            if merge_ok:
+                diagnostics.append(
+                    WorkflowValidator._build_unknown_model_warning(node_id, display_model, provider_name)
+                )
+            else:
+                deferred_node_ids.append(node_id)
+
+        if deferred_node_ids:
+            diagnostics.append(WorkflowValidator._build_catalog_unreachable_info(deferred_node_ids))
+
+        return diagnostics
+
+    @staticmethod
+    def _build_unknown_model_warning(node_id: str, display_model: str, provider_name: str) -> Diagnostic:
+        """Build the WARNING-severity diagnostic for catalog-miss models.
+
+        Distinct from the runtime ``UnknownModelError`` ERROR diagnostic
+        (which fires when LiteLLM itself rejects the call): this validator
+        finding is best-effort against ``litellm.model_cost``, which is a
+        pricing catalog and not authoritative for callability. The wording
+        reflects that — naming legitimate uses (fine-tunes, brand-new
+        models, custom endpoints) the WARNING does NOT mean to reject.
+        """
+        return Diagnostic(
+            severity=Severity.WARNING,
+            source="validator",
+            title="LLM Configuration",
+            node_id=node_id,
+            message=(
+                f"Model '{display_model}' is not in the LiteLLM catalog. This may be a fine-tune, "
+                f"a brand-new release, or a custom endpoint — the runtime will confirm. If this "
+                f"is a typo, the LLM call will fail at execution time."
+            ),
+            suggestions=[
+                "If this is intentional (fine-tune, custom endpoint), the warning can be ignored.",
+                f"If this is a typo, fix the '- model:' line (provider prefix '{provider_name}/').",
+                "Run 'pflow settings llm show' to see your configured defaults.",
+                "See https://docs.litellm.ai/docs/providers for supported models.",
+            ],
+            context={
+                "category": "llm_validation",
+                "path": f"nodes[id={node_id}].params.model",
+                "model": display_model,
+                "provider": provider_name,
+                "reason": "not_in_catalog",
+            },
+            see_also=["llm"],
+            id="llm.model-not-in-catalog",
+        )
+
+    @staticmethod
+    def _decorate_llm_validator_diag(diag: Diagnostic, node_id: str) -> Diagnostic:
+        """Adapt a runtime-shaped LLMCallError diagnostic for validate-time emission.
+
+        Adjusts:
+
+        - ``source``: ``"runtime"`` -> ``"validator"`` (validate-time provenance)
+        - ``node_id``: attach (runtime exceptions don't know the node yet)
+        - ``context.category``: ``"llm_failure"`` -> ``"llm_validation"`` (the
+          model hasn't been CALLED yet; the fix lives in the workflow file)
+        - ``context.path``: add for editor click-to-source navigation
+        - ``context.provider_message``: strip (always None at validate time;
+          the suggestion text references a "provider authentication error
+          above" that doesn't apply pre-call)
+
+        ``title`` and ``suggestions`` from the exception are preserved
+        unchanged — they're more specific than category-derived alternatives,
+        and the runtime suggestions remain the right next step at validate
+        time.
+        """
+        import dataclasses
+
+        from pflow.core.diagnostic import LLM_VALIDATION_CATEGORY
+
+        new_context = dict(diag.context or {})
+        new_context["category"] = LLM_VALIDATION_CATEGORY
+        new_context["path"] = f"nodes[id={node_id}].params.model"
+        new_context.pop("provider_message", None)
+        return dataclasses.replace(
+            diag,
+            source="validator",
+            node_id=node_id,
+            context=new_context,
         )
 
     # =========================================================================

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -165,7 +165,7 @@ class WorkflowValidator:
             registry: Node registry (uses default if None)
             skip_node_types: Skip node type validation (for mock nodes in tests)
             workflow_file: Path to the workflow file being validated. Used to
-                resolve relative sub-workflow file references in step 8. When
+                resolve relative sub-workflow file references in step 10. When
                 None and a relative path is encountered, a validation error
                 is produced (relative paths are also unresolvable at runtime).
 
@@ -925,7 +925,15 @@ class WorkflowValidator:
         Matches the prefix case-insensitively (``Anthropic/`` and
         ``anthropic/`` both strip) but returns the SUFFIX with its original
         case. When the model doesn't carry the prefix, returns it unchanged.
+
+        Defensively normalizes ``provider_prefix`` to lowercase internally,
+        so the function is robust if a future caller passes a mixed-case
+        prefix. The current sole caller in ``_validate_llm_model_id_lite``
+        passes ``provider.provider_prefix`` from ``PROVIDERS`` (always
+        lowercase), but the function shouldn't silently mismatch if the
+        contract relaxes.
         """
+        provider_prefix = provider_prefix.lower()
         if model.lower().startswith(provider_prefix):
             return model[len(provider_prefix) :]
         return model
@@ -1018,15 +1026,12 @@ class WorkflowValidator:
         # runtime's case behavior (matters for users who write mixed-case
         # model identifiers).
         bare = WorkflowValidator._strip_provider_prefix_case_preserving(model, provider.provider_prefix)
-        candidate_forms = (model, normalize_model_name(model), bare)
         # De-duplicate while preserving order so the upstream-merge benefit
         # still applies when the user-written form differs from both
-        # normalized variants.
-        seen: dict[str, None] = {}
-        for form in candidate_forms:
-            if form and form not in seen:
-                seen[form] = None
-        return [], model, provider.name, tuple(seen.keys())
+        # normalized variants. ``dict.fromkeys`` is the canonical ordered-set
+        # idiom on Python 3.7+ (insertion-ordered dicts).
+        candidate_forms = tuple(dict.fromkeys(f for f in (model, normalize_model_name(model), bare) if f))
+        return [], model, provider.name, candidate_forms
 
     @staticmethod
     def _catalog_form_known_for_provider(
@@ -1048,7 +1053,14 @@ class WorkflowValidator:
         """
         entry = litellm_module.model_cost.get(form)
         if not isinstance(entry, dict):
-            return form in litellm_module.model_cost  # truthy but non-dict — best-effort
+            # Defense in depth: treat junk catalog entries as unknown rather
+            # than best-effort accept. Both upstream-fetch paths in
+            # ``litellm_runtime`` now filter malformed entries before
+            # registration (see ``_filter_well_formed_upstream_entries``), so
+            # a non-dict entry should not be reachable via normal flow.
+            # Returning False here closes the residual silent-accept window
+            # if a future code path bypasses the filter.
+            return False
         entry_provider = entry.get("litellm_provider")
         if entry_provider == expected_provider:
             return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,9 @@ def _block_upstream_cost_map_fetch(monkeypatch):
     monkeypatch.setattr(litellm_runtime, "_validator_upstream_fetch_succeeded", True)
 
 
+_FAKE_LLM_KEY_VARS = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY")
+
+
 @pytest.fixture(autouse=True, scope="function")
 def _inject_fake_llm_api_keys(monkeypatch, request):
     """Inject fake API keys for ALL canonical LLM providers under test.
@@ -65,15 +68,14 @@ def _inject_fake_llm_api_keys(monkeypatch, request):
     need the key check to pass.
 
     Skipped for tests under ``/llm/`` directories (real-API tests that need
-    actual environment-provided keys), and for any test marked
-    ``@pytest.mark.no_fake_llm_keys`` (tests that deliberately assert the
-    missing-key code path).
+    actual environment-provided keys).
 
-    **Test author warning**: this fixture auto-injects keys. Any test that
-    asserts the missing-key path WITHOUT either ``monkeypatch.delenv`` ritual
-    or the ``no_fake_llm_keys`` marker will pass for the wrong reason — the
-    diagnostic won't fire because the key is present. When in doubt, use the
-    marker to disable the fixture explicitly.
+    Tests marked ``@pytest.mark.no_fake_llm_keys`` get the OPPOSITE behavior:
+    the fixture ALSO scrubs any leaked canonical env vars (``ANTHROPIC_API_KEY``,
+    ``OPENAI_API_KEY``, ``GEMINI_API_KEY``, ``GOOGLE_API_KEY``) so tests
+    asserting the missing-key code path produce the right diagnostic without
+    needing a per-test ``monkeypatch.delenv`` loop. ``GOOGLE_API_KEY`` is
+    included because LiteLLM accepts it as a Gemini alias.
     """
     test_path = str(request.fspath)
     if "/llm/" in test_path or "\\llm\\" in test_path:
@@ -81,6 +83,13 @@ def _inject_fake_llm_api_keys(monkeypatch, request):
         return
 
     if request.node.get_closest_marker("no_fake_llm_keys"):
+        # Strengthened semantics: actively scrub. A test using this marker
+        # is asserting "no canonical key is configured" — and a developer's
+        # actual shell may leak real keys into the process env. Scrubbing
+        # here removes the trap where the test silently passes for the
+        # wrong reason because the key WAS present.
+        for var in _FAKE_LLM_KEY_VARS:
+            monkeypatch.delenv(var, raising=False)
         yield
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,10 +39,57 @@ def _block_upstream_cost_map_fetch(monkeypatch):
     ``test_litellm_runtime.py::test_ensure_model_priced_*``) opt back in
     via the local ``reset_upstream_attempted`` fixture, which monkeypatches
     the flag back to ``False`` for that test only.
+
+    The two validator-side flags (``_validator_upstream_attempted`` /
+    ``_validator_upstream_fetch_succeeded``) are independent from the
+    runtime flag — they back ``try_load_upstream_catalog`` (used by the
+    LLM model-id preflight in step 9). They're pre-set to a "successful
+    no-op" state so any test that exercises validate-time catalog checks
+    sees a usable catalog without hitting the network.
     """
     from pflow.core import litellm_runtime
 
     monkeypatch.setattr(litellm_runtime, "_upstream_attempted", True)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_attempted", True)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_fetch_succeeded", True)
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _inject_fake_llm_api_keys(monkeypatch, request):
+    """Inject fake API keys for ALL canonical LLM providers under test.
+
+    Pairs with ``mock_llm_client`` (which patches ``complete()``). The new
+    step-9 LLM model-id preflight in ``WorkflowValidator`` runs BEFORE the
+    adapter and rejects canonical-provider models when no API key is set —
+    correct behavior in production, but tests that mock the LLM call still
+    need the key check to pass.
+
+    Skipped for tests under ``/llm/`` directories (real-API tests that need
+    actual environment-provided keys), and for any test marked
+    ``@pytest.mark.no_fake_llm_keys`` (tests that deliberately assert the
+    missing-key code path).
+
+    **Test author warning**: this fixture auto-injects keys. Any test that
+    asserts the missing-key path WITHOUT either ``monkeypatch.delenv`` ritual
+    or the ``no_fake_llm_keys`` marker will pass for the wrong reason — the
+    diagnostic won't fire because the key is present. When in doubt, use the
+    marker to disable the fixture explicitly.
+    """
+    test_path = str(request.fspath)
+    if "/llm/" in test_path or "\\llm\\" in test_path:
+        yield
+        return
+
+    if request.node.get_closest_marker("no_fake_llm_keys"):
+        yield
+        return
+
+    # Set if absent — don't override a key the test deliberately scrubs or sets.
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        if not os.environ.get(var):
+            monkeypatch.setenv(var, f"test-{var}-fake")
+
+    yield
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/test_cli/test_analyze_cache.py
+++ b/tests/test_cli/test_analyze_cache.py
@@ -378,7 +378,9 @@ def test_analyze_cache_with_workflow_having_warnings_still_exits_zero(
     )
 
 
-def test_analyze_cache_renders_question_mark_for_unmeasurable_prefix(tmp_path: Path) -> None:
+def test_analyze_cache_renders_question_mark_for_unmeasurable_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """CLI integration: unresolved code-node refs make could-cache unavailable.
 
     History: ``bug-16-variant-inputs-indirection`` previously rendered a tiny
@@ -386,7 +388,19 @@ def test_analyze_cache_renders_question_mark_for_unmeasurable_prefix(tmp_path: P
     Mutation contract: route batch-prefix scans back through raw
     ``estimate_tokens(prompt[:first])``; this test fails because JSON reports a
     small integer instead of ``null`` for ``cacheable_tokens_estimated``.
+
+    Env reset: the conftest autouse ``_inject_fake_llm_api_keys`` sets fake
+    Anthropic/OpenAI/Gemini keys so step-9 LLM model-id preflight passes by
+    default. This test deliberately starts with NO API keys so the workflow's
+    omitted ``model:`` resolves to None (rather than picking up the default
+    Anthropic model) — the below-min detector then correctly returns None on
+    empty model, which is the behavior this test pins.
     """
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    from pflow.core.llm_config import clear_model_cache
+
+    clear_model_cache()
     workflow_path = _write_workflow(
         tmp_path,
         """\

--- a/tests/test_core/test_litellm_runtime.py
+++ b/tests/test_core/test_litellm_runtime.py
@@ -725,6 +725,76 @@ def test_try_load_upstream_catalog_drops_malformed_entries_keeps_well_formed(
     assert "empty-dict" not in register_calls[0]
 
 
+def test_ensure_model_priced_drops_malformed_entries(reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ensure_model_priced`` MUST apply the same shape filter as the validator path.
+
+    Without this, a runtime-side fetch landing first with malformed payload
+    would register junk entries into ``litellm.model_cost``. The validator's
+    catalog-membership check then has a residual silent-accept window for
+    those junk keys (closed in defense by tightening the non-dict fallback
+    to return False, but the registration side is the primary defense).
+    """
+    from pflow.core.litellm_runtime import ensure_model_priced, import_litellm
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    payload = {
+        "good-model": {"input_cost_per_token": 1e-6, "litellm_provider": "openai", "mode": "chat"},
+        "junk-string": "not-a-dict",
+        "empty-dict": {},
+        "no-recognized-fields": {"some_random_field": "value"},
+    }
+    _stub_httpx_get(monkeypatch, payload)
+
+    register_calls: list[dict] = []
+
+    def recording_register(upstream_map: dict) -> None:
+        register_calls.append(upstream_map)
+        for k, v in upstream_map.items():
+            litellm.model_cost.setdefault(k, {}).update(v)
+
+    monkeypatch.setattr(litellm, "register_model", recording_register)
+
+    ensure_model_priced("some/asked-for-model")
+
+    # register_model received ONLY the well-formed entry.
+    assert len(register_calls) == 1
+    assert "good-model" in register_calls[0]
+    assert "junk-string" not in register_calls[0]
+    assert "empty-dict" not in register_calls[0]
+    assert "no-recognized-fields" not in register_calls[0]
+    # Catalog ends up with only the well-formed key registered.
+    assert "good-model" in litellm.model_cost
+    assert "junk-string" not in litellm.model_cost
+    assert "empty-dict" not in litellm.model_cost
+
+
+def test_validator_catalog_check_rejects_non_dict_entry_defense_in_depth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: validator's non-dict fallback returns False.
+
+    Even if a future code path bypasses ``_filter_well_formed_upstream_entries``
+    and registers junk, the validator's ``_catalog_form_known_for_provider``
+    must NOT silently accept a non-dict catalog entry. Pins the hardened
+    fallback (changed from "best-effort accept" to "reject as unknown").
+    """
+    from pflow.core.litellm_runtime import import_litellm
+    from pflow.core.workflow.validator import WorkflowValidator
+
+    litellm = import_litellm()
+    # Manually inject a junk entry (bypassing the filter) to simulate the
+    # residual silent-accept window the fallback now closes.
+    monkeypatch.setattr(litellm, "model_cost", {"openai/gpt-fake-junk": "not-a-dict"}, raising=False)
+
+    # Function-private helper still callable for direct unit test.
+    canonical = {"openai", "anthropic", "gemini"}
+    result = WorkflowValidator._catalog_form_known_for_provider(litellm, canonical, "openai/gpt-fake-junk", "openai")
+
+    assert result is False, "non-dict catalog entry must NOT pass the membership check"
+
+
 @pytest.mark.e2e
 def test_importing_helper_module_does_not_import_litellm(
     uv_exe: str,

--- a/tests/test_core/test_litellm_runtime.py
+++ b/tests/test_core/test_litellm_runtime.py
@@ -126,10 +126,16 @@ def reset_upstream_attempted(monkeypatch: pytest.MonkeyPatch):
     Layers on top of ``tests/conftest.py::_block_upstream_cost_map_fetch``
     which pre-sets the flag to True for all tests — opting back in here
     means the helper actually enters its fetch branch.
+
+    Also resets the validator-side latch pair so tests exercising
+    ``try_load_upstream_catalog`` start with a fresh state regardless of
+    test ordering.
     """
     from pflow.core import litellm_runtime
 
     monkeypatch.setattr(litellm_runtime, "_upstream_attempted", False)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_attempted", False)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_fetch_succeeded", False)
     return litellm_runtime
 
 
@@ -432,6 +438,291 @@ def test_ensure_model_priced_thread_safe(reset_upstream_attempted, monkeypatch: 
         t.join(timeout=5)
 
     assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# try_load_upstream_catalog — validator-side membership check latch
+# ---------------------------------------------------------------------------
+
+
+def test_try_load_upstream_catalog_returns_true_on_first_successful_fetch(
+    reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A first call with a working network returns True and registers new entries."""
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    upstream = {"new/model": {"input_cost_per_token": 1e-6, "litellm_provider": "openai", "mode": "chat"}}
+    urls_called = _stub_httpx_get(monkeypatch, upstream)
+
+    register_calls: list[dict] = []
+
+    def recording_register(upstream_map: dict) -> None:
+        register_calls.append(upstream_map)
+
+    monkeypatch.setattr(litellm, "register_model", recording_register)
+
+    result = try_load_upstream_catalog()
+
+    assert result is True
+    assert urls_called == [litellm.model_cost_map_url]
+    assert register_calls == [upstream]
+
+
+def test_try_load_upstream_catalog_returns_true_when_no_new_entries_to_merge(
+    reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetch succeeds but every upstream key is already bundled.
+
+    Load-bearing: the function must return True even when there are no
+    new entries to register. The catalog is still usable for membership
+    checks. ``register_model`` MUST NOT be called (no-op fetch).
+    """
+    from pflow.core import litellm_runtime
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {"bundled/model": {"input_cost_per_token": 1.0e-7, "litellm_provider": "openai", "mode": "chat"}},
+        raising=False,
+    )
+    _stub_httpx_get(monkeypatch, {"bundled/model": {"input_cost_per_token": 9e-6}})
+
+    mock_register = MagicMock()
+    monkeypatch.setattr(litellm, "register_model", mock_register)
+
+    result = try_load_upstream_catalog()
+
+    assert result is True
+    assert mock_register.call_count == 0
+    # Latch is set + success status recorded for subsequent calls.
+    assert litellm_runtime._validator_upstream_attempted is True
+    assert litellm_runtime._validator_upstream_fetch_succeeded is True
+
+
+def test_try_load_upstream_catalog_returns_false_on_network_failure(
+    reset_upstream_attempted,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Network failure returns False, sets failure latch, does not raise."""
+    import httpx
+
+    from pflow.core import litellm_runtime
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    def failing_get(url, *args, **kwargs):
+        raise httpx.ConnectError("simulated network outage")
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+
+    mock_register = MagicMock()
+    monkeypatch.setattr(litellm, "register_model", mock_register)
+
+    caplog.set_level("DEBUG", logger="pflow.core.litellm_runtime")
+
+    result = try_load_upstream_catalog()
+
+    assert result is False
+    assert litellm_runtime._validator_upstream_attempted is True
+    assert litellm_runtime._validator_upstream_fetch_succeeded is False
+    assert mock_register.call_count == 0
+    assert any("Validator upstream catalog merge failed" in r.message for r in caplog.records)
+
+
+def test_try_load_upstream_catalog_idempotent_after_success(
+    reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second call after a successful fetch returns the cached True without re-fetching."""
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+    urls_called = _stub_httpx_get(monkeypatch, {"new/model": {"mode": "chat"}})
+
+    mock_register = MagicMock()
+    monkeypatch.setattr(litellm, "register_model", mock_register)
+
+    first = try_load_upstream_catalog()
+    second = try_load_upstream_catalog()
+    third = try_load_upstream_catalog()
+
+    assert first is True and second is True and third is True
+    assert len(urls_called) == 1
+    assert mock_register.call_count == 1
+
+
+def test_try_load_upstream_catalog_idempotent_after_failure(
+    reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second call after a failed fetch returns the cached False — no retry hammering."""
+    import httpx
+
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    call_counter = {"n": 0}
+
+    def failing_get(url, *args, **kwargs):
+        call_counter["n"] += 1
+        raise httpx.ConnectError("simulated network outage")
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+
+    first = try_load_upstream_catalog()
+    second = try_load_upstream_catalog()
+    third = try_load_upstream_catalog()
+
+    assert first is False and second is False and third is False
+    # Only ONE network attempt despite three calls.
+    assert call_counter["n"] == 1
+
+
+def test_try_load_upstream_catalog_independent_from_runtime_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime-side fetch failure does NOT disable validator-side checks.
+
+    Models the cross-coupling bug the separate latch prevents: a long-
+    running MCP server whose first ``ensure_model_priced`` call hit a
+    transient network failure must not have its validator catalog-check
+    permanently disabled for the rest of the process.
+    """
+    from pflow.core import litellm_runtime
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    # Simulate "runtime path already attempted and failed", validator path fresh.
+    monkeypatch.setattr(litellm_runtime, "_upstream_attempted", True)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_attempted", False)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_fetch_succeeded", False)
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+    urls_called = _stub_httpx_get(monkeypatch, {"new/model": {"mode": "chat"}})
+
+    mock_register = MagicMock()
+    monkeypatch.setattr(litellm, "register_model", mock_register)
+
+    result = try_load_upstream_catalog()
+
+    assert result is True
+    assert len(urls_called) == 1  # Validator path fetched fresh, independent of runtime latch.
+
+
+def test_try_load_upstream_catalog_thread_safe(reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent calls collapse to exactly one register_model invocation."""
+    import time
+
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+    _stub_httpx_get(monkeypatch, {"placeholder/model": {"mode": "chat"}})
+
+    call_count = 0
+    call_lock = threading.Lock()
+
+    def slow_register(upstream_map):
+        nonlocal call_count
+        time.sleep(0.05)
+        with call_lock:
+            call_count += 1
+
+    monkeypatch.setattr(litellm, "register_model", slow_register)
+
+    results: list[bool] = []
+    results_lock = threading.Lock()
+
+    def runner():
+        r = try_load_upstream_catalog()
+        with results_lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=runner) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert call_count == 1
+    assert all(r is True for r in results)
+
+
+def test_try_load_upstream_catalog_rejects_malformed_payload(
+    reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-entry shape validation: payloads with values that are not dicts
+    containing at least one recognized field are rejected.
+
+    Defends against silent-failure class where a malformed upstream JSON
+    (single string per key, integer values, missing fields) would still
+    register junk entries and latch the validator as "catalog merged
+    successfully" — subsequent membership checks would silently report
+    the workflow's model as known when the registered entry is garbage.
+    """
+    from pflow.core import litellm_runtime
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    # All-malformed payloads must set fetch_succeeded=False.
+    for malformed in [
+        {"gpt-4": "string-instead-of-dict"},
+        {"gpt-4": 42},
+        {"gpt-4": []},
+        {"gpt-4": {}},  # empty dict — no recognized field
+        {"gpt-4": {"random_field": "value"}},  # dict, but no recognized field
+    ]:
+        litellm_runtime._validator_upstream_attempted = False
+        litellm_runtime._validator_upstream_fetch_succeeded = False
+        _stub_httpx_get(monkeypatch, malformed)
+        mock_register = MagicMock()
+        monkeypatch.setattr(litellm, "register_model", mock_register)
+
+        result = try_load_upstream_catalog()
+        assert result is False, f"malformed payload {malformed!r} should fail"
+        assert mock_register.call_count == 0, f"register_model should not be called for {malformed!r}"
+
+
+def test_try_load_upstream_catalog_drops_malformed_entries_keeps_well_formed(
+    reset_upstream_attempted, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mixed payload: well-formed entries get registered, malformed dropped, success returned."""
+    from pflow.core.litellm_runtime import import_litellm, try_load_upstream_catalog
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    payload = {
+        "good-model": {"input_cost_per_token": 1e-6, "litellm_provider": "openai", "mode": "chat"},
+        "junk-model": "string-value",  # malformed — should be dropped
+        "empty-dict": {},  # malformed — should be dropped
+    }
+    _stub_httpx_get(monkeypatch, payload)
+    register_calls: list[dict] = []
+
+    def recording_register(upstream_map: dict) -> None:
+        register_calls.append(upstream_map)
+
+    monkeypatch.setattr(litellm, "register_model", recording_register)
+
+    result = try_load_upstream_catalog()
+
+    assert result is True
+    assert len(register_calls) == 1
+    assert "good-model" in register_calls[0]
+    assert "junk-model" not in register_calls[0]
+    assert "empty-dict" not in register_calls[0]
 
 
 @pytest.mark.e2e

--- a/tests/test_core/test_workflow_validator.py
+++ b/tests/test_core/test_workflow_validator.py
@@ -440,8 +440,12 @@ Do something.
         assert len(errors) > 0
         assert any("Circular dependency" in d.message for d in errors)
 
-    def test_valid_complex_workflow(self, registry_with_nodes):
+    def test_valid_complex_workflow(self, registry_with_nodes, monkeypatch):
         """Test that a complex valid workflow passes all checks."""
+        # OPENAI_API_KEY satisfies the new step-9 LLM model-id preflight for
+        # the ``openai/gpt-4`` node below; without it the validator would
+        # correctly flag this as a missing-key error.
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         workflow = {
             "ir_version": "0.1.0",
             "nodes": [
@@ -458,7 +462,7 @@ Do something.
                     "type": "llm",
                     "params": {
                         "prompt": "Analyze this response: ${fetch.response}",
-                        "model": "gpt-4",
+                        "model": "openai/gpt-4",
                     },
                 },
                 {

--- a/tests/test_core/test_workflow_validator_llm_model.py
+++ b/tests/test_core/test_workflow_validator_llm_model.py
@@ -179,14 +179,9 @@ def test_model_key_absent_defers_to_compiler() -> None:
 def test_canonical_provider_missing_key_emits_missing_api_key_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """``openai/gpt-4o`` with no OPENAI_API_KEY produces the validator-decorated MissingApiKeyError.
 
-    Marker disables the autouse fake-key fixture so the missing-key check fires.
-    Also scrubs settings-side keys with ``monkeypatch.delenv`` (defensive — covers
-    keys leaked into ``os.environ`` by a prior step in the same process).
+    Marker disables the autouse fake-key fixture AND actively scrubs the four
+    canonical env vars so the missing-key check fires.
     """
-    # Scrub potential env keys from the test environment so the check fires.
-    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
-        monkeypatch.delenv(var, raising=False)
-
     workflow = _llm_workflow("openai/gpt-4o")
 
     with patch("pflow.core.litellm_runtime.import_litellm") as mock_import:
@@ -413,11 +408,9 @@ def test_zero_llm_nodes_does_not_import_litellm(monkeypatch: pytest.MonkeyPatch)
 def test_sub_workflow_bad_model_surfaces_via_child_provenance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A bad model inside a sub-workflow surfaces with ``In step 'X' sub-workflow:`` prefix.
 
-    Marker disables the autouse fake-key fixture so the missing-key check fires.
+    Marker disables the autouse fake-key fixture AND actively scrubs env keys
+    so the missing-key check fires.
     """
-    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
-        monkeypatch.delenv(var, raising=False)
-
     child_path = tmp_path / "child.pflow.md"
     child_path.write_text(
         "# Child\n\n"
@@ -511,14 +504,12 @@ def test_multiple_llm_nodes_same_bad_model_emit_distinct_diagnostics(
 
 
 @pytest.mark.no_fake_llm_keys
-def test_save_path_runs_llm_model_validation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_save_path_runs_llm_model_validation(tmp_path: Path) -> None:
     """``save_workflow_with_options`` calls ``WorkflowValidator.validate`` and surfaces the same diagnostics.
 
-    Marker disables the autouse fake-key fixture so the missing-key check fires.
+    Marker disables the autouse fake-key fixture AND actively scrubs env keys
+    so the missing-key check fires.
     """
-    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
-        monkeypatch.delenv(var, raising=False)
-
     from pflow.core.exceptions import WorkflowValidationError
     from pflow.core.workflow.save_service import save_workflow_with_options
 
@@ -542,6 +533,28 @@ def test_save_path_runs_llm_model_validation(monkeypatch: pytest.MonkeyPatch, tm
         d.context.get("category") == "llm_validation" and d.context.get("error_class") == "MissingApiKeyError"
         for d in diags
     ), f"Expected llm_validation MissingApiKeyError; got {[(d.message, d.context) for d in diags]}"
+
+
+@pytest.mark.no_fake_llm_keys
+def test_no_fake_llm_keys_marker_scrubs_canonical_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pins the strengthened marker behavior: env keys ARE absent under the marker.
+
+    The marker was previously a passive disable (just skipping injection).
+    A developer's actual shell with real keys could leak through and cause
+    missing-key tests to silently pass for the wrong reason. The marker now
+    actively scrubs ``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``GEMINI_API_KEY``,
+    ``GOOGLE_API_KEY`` — proven here by manually setting them BEFORE the
+    fixture runs.
+
+    Note: the assertion runs INSIDE the test body, after the fixture has
+    applied. The monkeypatch.setenv calls inside the body are a sanity check;
+    they don't subvert the fixture (the fixture already ran).
+    """
+    import os
+
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        # Fixture scrubbed pre-test. Inside the body, confirm absence.
+        assert var not in os.environ, f"{var} should be scrubbed by no_fake_llm_keys marker, but is set"
 
 
 # =========================================================================
@@ -638,3 +651,10 @@ def test_strip_provider_prefix_case_preserving_helper() -> None:
     )
     # Case 4: model with different prefix — return unchanged (not matching).
     assert WorkflowValidator._strip_provider_prefix_case_preserving("openai/gpt-4", "anthropic/") == "openai/gpt-4"
+    # Case 5: defensive — mixed-case PREFIX argument still strips correctly.
+    # Pins the lower-internally normalization; without it the helper would
+    # silently fail to strip if a future caller passes "Anthropic/".
+    assert (
+        WorkflowValidator._strip_provider_prefix_case_preserving("anthropic/Claude-Sonnet-4-5", "Anthropic/")
+        == "Claude-Sonnet-4-5"
+    )

--- a/tests/test_core/test_workflow_validator_llm_model.py
+++ b/tests/test_core/test_workflow_validator_llm_model.py
@@ -1,0 +1,640 @@
+"""Tests for the LLM-model-id branch of validator step 9.
+
+Covers the algorithm in
+``WorkflowValidator._validate_node_param_semantics`` → LLM branch:
+
+1. Skip templated ``${...}`` model values.
+2. Skip non-canonical providers (e.g. ``openrouter/...``).
+3. Reject wrong-type ``model:`` values with ``llm.model-not-string``.
+4. Skip absent/empty ``model:`` (compiler handles default).
+5. Emit ``MissingApiKeyError`` for canonical provider + missing key.
+6. No diagnostic for bundled, valid models.
+7. Bare-name normalization handles e.g. ``claude-sonnet-4-5``.
+8. Upstream merge for unbundled-but-real models.
+9. ``UnknownModelError`` for truly unknown models.
+10. ``llm.catalog-unreachable`` INFO when upstream fetch fails.
+11. Zero-LLM-node workflows pay zero cost.
+12. Sub-workflow nodes surface child diagnostics with provenance.
+13. Multiple LLM nodes with same bad config each emit separate diagnostics.
+14. Save path runs the same validation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pflow.core.diagnostic import Severity
+from pflow.core.workflow.validator import WorkflowValidator
+
+
+@pytest.fixture
+def reset_validator_latch(monkeypatch: pytest.MonkeyPatch):
+    """Reset both validator-side flags so each catalog-check test starts fresh.
+
+    Overrides the autouse ``_block_upstream_cost_map_fetch`` fixture for tests
+    that need to exercise the actual catalog-check + ``try_load_upstream_catalog``
+    code path. Without this, every test would see the pre-latched "success"
+    state and skip the merge call entirely.
+    """
+    from pflow.core import litellm_runtime
+
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_attempted", False)
+    monkeypatch.setattr(litellm_runtime, "_validator_upstream_fetch_succeeded", False)
+    return litellm_runtime
+
+
+def _llm_workflow(model: Any, node_id: str = "n1") -> dict[str, Any]:
+    """Minimal IR with a single LLM node."""
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": node_id,
+                "type": "llm",
+                "params": {"prompt": "hello", "model": model},
+            }
+        ],
+    }
+
+
+def _validate(workflow_ir: dict[str, Any]) -> list:
+    """Run validator skipping registry-dependent steps for laser focus on step 9."""
+    return WorkflowValidator.validate(workflow_ir, skip_node_types=True)
+
+
+def _no_litellm_imported(real_import_litellm) -> bool:
+    """Helper: under the patched import_litellm, check that it was NOT called."""
+    return real_import_litellm.call_count == 0
+
+
+# =========================================================================
+# 1. Templated model — defer to runtime
+# =========================================================================
+
+
+def test_templated_model_defers_and_does_not_import_litellm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``${...}`` skips catalog check; no litellm import fired.
+
+    The data-flow validator may still complain about the template root if
+    it doesn't reference a declared input — that's orthogonal to step 9.
+    What we pin here is: no llm-validation diagnostic AND no litellm import.
+    """
+    workflow = _llm_workflow("${input.model}")
+
+    with patch("pflow.core.litellm_runtime.import_litellm") as mock_import:
+        diagnostics = _validate(workflow)
+
+    llm_validation_diags = [d for d in diagnostics if (d.context or {}).get("category") == "llm_validation"]
+    assert llm_validation_diags == []
+    mock_import.assert_not_called()
+
+
+# =========================================================================
+# 2. Non-canonical provider — trust user
+# =========================================================================
+
+
+def test_non_canonical_provider_skips_and_does_not_import_litellm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``openrouter/...`` isn't in pflow's canonical registry; skip silently."""
+    workflow = _llm_workflow("openrouter/anthropic/claude-foo")
+
+    with patch("pflow.core.litellm_runtime.import_litellm") as mock_import:
+        diagnostics = _validate(workflow)
+
+    assert diagnostics == []
+    mock_import.assert_not_called()
+
+
+# =========================================================================
+# 3. Wrong-type ``model:`` — emit ``llm.model-not-string``
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    "bad_model,expected_type",
+    [
+        (0, "int"),
+        (False, "bool"),
+        ([], "list"),
+        ({}, "dict"),
+    ],
+)
+def test_wrong_type_model_emits_typed_error(
+    monkeypatch: pytest.MonkeyPatch, bad_model: Any, expected_type: str
+) -> None:
+    """Non-string ``model:`` values fail at validate time with structured context.
+
+    Confirmed: this case bypasses both the compiler's default-injection guard
+    (``"model" not in params``) AND the bundled catalog (different type) —
+    only the new step 9 LLM branch catches it.
+    """
+    workflow = _llm_workflow(bad_model)
+
+    with patch("pflow.core.litellm_runtime.import_litellm") as mock_import:
+        diagnostics = _validate(workflow)
+
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+    assert len(errors) == 1
+    err = errors[0]
+    assert err.id == "llm.model-not-string"
+    assert err.context["value_type"] == expected_type
+    assert err.source == "validator"
+    assert err.node_id == "n1"
+    mock_import.assert_not_called()
+
+
+# =========================================================================
+# 4. Empty/absent model — treat as absent
+# =========================================================================
+
+
+@pytest.mark.parametrize("empty_value", [None, ""])
+def test_empty_model_treated_as_absent_no_diagnostic(empty_value: Any) -> None:
+    """``model: ""`` and ``model: null`` defer to the compiler default."""
+    workflow = _llm_workflow(empty_value)
+    diagnostics = _validate(workflow)
+    assert [d for d in diagnostics if d.severity == Severity.ERROR] == []
+
+
+def test_model_key_absent_defers_to_compiler() -> None:
+    """A workflow with no ``model:`` key at all skips step 9 silently."""
+    workflow = {
+        "ir_version": "0.1.0",
+        "nodes": [{"id": "n1", "type": "llm", "params": {"prompt": "hello"}}],
+    }
+    diagnostics = _validate(workflow)
+    assert [d for d in diagnostics if d.severity == Severity.ERROR] == []
+
+
+# =========================================================================
+# 5. Canonical provider + missing key — MissingApiKeyError
+# =========================================================================
+
+
+@pytest.mark.no_fake_llm_keys
+def test_canonical_provider_missing_key_emits_missing_api_key_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``openai/gpt-4o`` with no OPENAI_API_KEY produces the validator-decorated MissingApiKeyError.
+
+    Marker disables the autouse fake-key fixture so the missing-key check fires.
+    Also scrubs settings-side keys with ``monkeypatch.delenv`` (defensive — covers
+    keys leaked into ``os.environ`` by a prior step in the same process).
+    """
+    # Scrub potential env keys from the test environment so the check fires.
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    workflow = _llm_workflow("openai/gpt-4o")
+
+    with patch("pflow.core.litellm_runtime.import_litellm") as mock_import:
+        diagnostics = _validate(workflow)
+
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+    assert len(errors) == 1
+    err = errors[0]
+    assert err.source == "validator"
+    assert err.context["category"] == "llm_validation"
+    assert err.context["path"] == "nodes[id=n1].params.model"
+    # provider_message is stripped at validate-time (always None pre-call).
+    assert "provider_message" not in err.context
+    # ``MissingApiKeyError.to_diagnostics()`` carries the env-var hint.
+    assert err.context["error_class"] == "MissingApiKeyError"
+    assert err.context["kind"] == "missing_key"
+    mock_import.assert_not_called()
+
+
+# =========================================================================
+# 6 + 7. Bundled / bare-name normalization — no diagnostic, no fetch
+# =========================================================================
+
+
+def test_bundled_prefixed_model_passes_without_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``anthropic/claude-sonnet-4-5`` resolves via bundled catalog — no upstream fetch."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    workflow = _llm_workflow("anthropic/claude-sonnet-4-5")
+
+    with patch("pflow.core.litellm_runtime.try_load_upstream_catalog") as mock_load:
+        diagnostics = _validate(workflow)
+
+    assert diagnostics == []
+    mock_load.assert_not_called()
+
+
+def test_bare_name_resolves_via_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``claude-sonnet-4-5`` (bare) maps to anthropic via ``detect_provider`` + bundled lookup.
+
+    Pins the normalize-before-lookup fix: without it, bare names would be
+    flagged as Unknown Model when the bundled catalog only has the bare form.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    workflow = _llm_workflow("claude-sonnet-4-5")
+
+    with patch("pflow.core.litellm_runtime.try_load_upstream_catalog") as mock_load:
+        diagnostics = _validate(workflow)
+
+    assert diagnostics == []
+    mock_load.assert_not_called()
+
+
+# =========================================================================
+# 8. Unbundled-but-real — upstream merge succeeds, no diagnostic
+# =========================================================================
+
+
+def test_unbundled_but_real_model_passes_via_upstream_merge(
+    reset_validator_latch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Model missing from bundle but present in upstream → catalog merge fills in, no error."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    from pflow.core.litellm_runtime import import_litellm
+
+    litellm = import_litellm()
+    # Remove the bundled entry so the catalog miss forces an upstream fetch.
+    real_cost = dict(litellm.model_cost)
+    real_cost.pop("claude-sonnet-4-5", None)
+    real_cost.pop("anthropic/claude-sonnet-4-5", None)
+    monkeypatch.setattr(litellm, "model_cost", real_cost, raising=False)
+
+    fetch_count = {"n": 0}
+
+    def fake_get(url, *args, **kwargs):
+        fetch_count["n"] += 1
+        from unittest.mock import MagicMock
+
+        return MagicMock(
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "claude-sonnet-4-5": {"input_cost_per_token": 3e-6, "litellm_provider": "anthropic", "mode": "chat"},
+            },
+        )
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    # Real register_model — let it actually merge into our patched dict so
+    # subsequent membership reads see the new entry.
+    workflow = _llm_workflow("claude-sonnet-4-5")
+    diagnostics = _validate(workflow)
+
+    assert diagnostics == []
+    assert fetch_count["n"] == 1
+
+
+# =========================================================================
+# 9. Catalog-miss after upstream merge — WARNING (severity-policy choice)
+# =========================================================================
+
+
+def test_catalog_miss_after_upstream_merge_emits_warning(
+    reset_validator_latch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Upstream fetch succeeds but the model isn't there → WARNING (not ERROR).
+
+    Severity-policy choice: ``litellm.model_cost`` is a pricing catalog, not
+    a "this name is callable" registry. Fine-tunes, custom endpoints, and
+    brand-new models may be missing from the catalog but still callable at
+    runtime. Emitting WARNING preserves the original-bug fix (the warning
+    surfaces at validate time before any execution) without blocking
+    legitimate workflows on ``--validate-only`` / ``save``.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    from pflow.core.litellm_runtime import import_litellm
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    import httpx
+
+    def fake_get(url, *args, **kwargs):
+        from unittest.mock import MagicMock
+
+        return MagicMock(
+            raise_for_status=lambda: None,
+            # Well-formed entry per the new shape-validation contract.
+            json=lambda: {
+                "gpt-4o": {
+                    "input_cost_per_token": 5e-6,
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                }
+            },
+        )
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    workflow = _llm_workflow("openai/gpt-totally-made-up-9.9")
+    diagnostics = _validate(workflow)
+
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+    warnings = [d for d in diagnostics if d.severity == Severity.WARNING]
+    assert errors == []
+    assert len(warnings) == 1
+    warn = warnings[0]
+    assert warn.source == "validator"
+    assert warn.id == "llm.model-not-in-catalog"
+    assert warn.context["category"] == "llm_validation"
+    assert warn.context["model"] == "openai/gpt-totally-made-up-9.9"
+    assert warn.context["provider"] == "openai"
+    assert warn.context["reason"] == "not_in_catalog"
+
+
+# =========================================================================
+# 10. Network failure — INFO breadcrumb ``llm.catalog-unreachable``
+# =========================================================================
+
+
+def test_network_failure_emits_info_breadcrumb(reset_validator_latch, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the upstream fetch fails, defer + emit one INFO ``llm.catalog-unreachable``."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    from pflow.core.litellm_runtime import import_litellm
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    import httpx
+
+    def failing_get(url, *args, **kwargs):
+        raise httpx.ConnectError("simulated outage")
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+
+    workflow = _llm_workflow("openai/gpt-totally-made-up-9.9")
+    diagnostics = _validate(workflow)
+
+    # No ERROR diagnostic (deferred), one INFO breadcrumb.
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+    infos = [d for d in diagnostics if d.severity == Severity.INFO]
+    assert errors == []
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.id == "llm.catalog-unreachable"
+    assert info.context["deferred_node_ids"] == ["n1"]
+
+
+# =========================================================================
+# 11. Zero LLM nodes — no litellm import at all
+# =========================================================================
+
+
+def test_zero_llm_nodes_does_not_import_litellm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Workflow with only non-LLM nodes pays zero cost.
+
+    ``cache: false`` on the shell node silences the unrelated step-11 cache
+    lint warning; the assertion below targets only LLM-validation behavior.
+    """
+    workflow = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "s", "type": "shell", "cache": False, "params": {"command": "echo hi"}},
+        ],
+    }
+
+    with patch("pflow.core.litellm_runtime.import_litellm") as mock_import:
+        diagnostics = _validate(workflow)
+
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+    assert errors == []
+    mock_import.assert_not_called()
+
+
+# =========================================================================
+# 12. Sub-workflow with bad model — diagnostic propagates with provenance
+# =========================================================================
+
+
+@pytest.mark.no_fake_llm_keys
+def test_sub_workflow_bad_model_surfaces_via_child_provenance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bad model inside a sub-workflow surfaces with ``In step 'X' sub-workflow:`` prefix.
+
+    Marker disables the autouse fake-key fixture so the missing-key check fires.
+    """
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    child_path = tmp_path / "child.pflow.md"
+    child_path.write_text(
+        "# Child\n\n"
+        "Child workflow with a bad model.\n\n"
+        "## Steps\n\n"
+        "### llm-node\n\n"
+        "Calls llm.\n\n"
+        "- type: llm\n"
+        "- model: openai/gpt-4o\n"
+        "- prompt: hello\n"
+    )
+
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "child-step",
+                "type": "workflow",
+                "params": {"workflow": str(child_path)},
+            }
+        ],
+    }
+
+    diagnostics = WorkflowValidator.validate(
+        parent_ir, skip_node_types=True, workflow_file=tmp_path / "parent.pflow.md"
+    )
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+
+    # The child-step's missing-key error should propagate with provenance.
+    assert any(
+        d.context.get("sub_workflow_step") == "child-step" and d.context.get("category") == "llm_validation"
+        for d in errors
+    ), (
+        f"Expected validator-decorated llm_validation diagnostic from child; got {[(d.message, d.context) for d in errors]}"
+    )
+
+
+# =========================================================================
+# 13. Multiple LLM nodes, same bad model — distinct diagnostics
+# =========================================================================
+
+
+def test_multiple_llm_nodes_same_bad_model_emit_distinct_diagnostics(
+    reset_validator_latch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two LLM nodes using the same unknown model produce two WARNING diagnostics."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    from pflow.core.litellm_runtime import import_litellm
+
+    litellm = import_litellm()
+    monkeypatch.setattr(litellm, "model_cost", {}, raising=False)
+
+    fetch_count = {"n": 0}
+
+    def fake_get(url, *args, **kwargs):
+        fetch_count["n"] += 1
+        from unittest.mock import MagicMock
+
+        # Well-formed entry per new shape-validation contract.
+        return MagicMock(
+            raise_for_status=lambda: None,
+            json=lambda: {"some/other-model": {"mode": "chat", "litellm_provider": "openai"}},
+        )
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    workflow = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "a", "type": "llm", "params": {"prompt": "p", "model": "openai/gpt-bad-9.9"}},
+            {"id": "b", "type": "llm", "params": {"prompt": "p", "model": "openai/gpt-bad-9.9"}},
+        ],
+    }
+    diagnostics = _validate(workflow)
+    warnings = [d for d in diagnostics if d.severity == Severity.WARNING]
+
+    # Two distinct diagnostics (different node_id ⇒ different __hash__).
+    assert len(warnings) == 2
+    node_ids = sorted({d.node_id for d in warnings})
+    assert node_ids == ["a", "b"]
+    # Exactly one upstream fetch was made for all nodes combined.
+    assert fetch_count["n"] == 1
+
+
+# =========================================================================
+# 14. Save path runs the same validation
+# =========================================================================
+
+
+@pytest.mark.no_fake_llm_keys
+def test_save_path_runs_llm_model_validation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``save_workflow_with_options`` calls ``WorkflowValidator.validate`` and surfaces the same diagnostics.
+
+    Marker disables the autouse fake-key fixture so the missing-key check fires.
+    """
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    from pflow.core.exceptions import WorkflowValidationError
+    from pflow.core.workflow.save_service import save_workflow_with_options
+
+    markdown_content = (
+        "# Bad model workflow\n\n"
+        "Demo of save-time validation.\n\n"
+        "## Steps\n\n"
+        "### call-llm\n\n"
+        "Calls an LLM with a bad model.\n\n"
+        "- type: llm\n"
+        "- model: openai/gpt-4o\n"
+        "- prompt: hello\n"
+    )
+
+    with pytest.raises(WorkflowValidationError) as exc_info:
+        save_workflow_with_options("test-bad-model", markdown_content, force=False)
+
+    # The validator's missing-key error must be present in the wrapped diagnostics.
+    diags = exc_info.value.validation_errors
+    assert any(
+        d.context.get("category") == "llm_validation" and d.context.get("error_class") == "MissingApiKeyError"
+        for d in diags
+    ), f"Expected llm_validation MissingApiKeyError; got {[(d.message, d.context) for d in diags]}"
+
+
+# =========================================================================
+# 15. Cross-provider false positive guard (review finding W3)
+# =========================================================================
+
+
+def test_cross_provider_bare_name_does_not_silently_accept(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``anthropic/gpt-4`` (wrong provider for the bare-name family) MUST emit a WARNING.
+
+    Without the per-entry provider check, the bare form ``gpt-4`` is in
+    ``litellm.model_cost`` (bundled under openai) and a naive membership
+    test would silently accept the workflow. The new step 9 reads
+    ``litellm_provider`` from the catalog entry and rejects the bare-form
+    match when it explicitly names a DIFFERENT canonical provider.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    workflow = _llm_workflow("anthropic/gpt-4")
+
+    diagnostics = _validate(workflow)
+    warnings = [d for d in diagnostics if d.severity == Severity.WARNING]
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+
+    assert errors == []
+    assert len(warnings) == 1
+    warn = warnings[0]
+    assert warn.id == "llm.model-not-in-catalog"
+    assert warn.context["model"] == "anthropic/gpt-4"
+    assert warn.context["provider"] == "anthropic"
+
+
+def test_correct_provider_bare_name_accepts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``openai/gpt-4`` (correct provider for bare-name match) passes — sanity guard.
+
+    Pins that the cross-provider check is precise: it rejects ONLY the
+    canonical-mismatch case, never legitimate prefixed-name lookups that
+    resolve to a bare bundled entry.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    workflow = _llm_workflow("openai/gpt-4")
+
+    diagnostics = _validate(workflow)
+    assert [d for d in diagnostics if d.severity == Severity.WARNING] == []
+    assert [d for d in diagnostics if d.severity == Severity.ERROR] == []
+
+
+# =========================================================================
+# 16. Case-preserving bare lookup (review finding C1 validation-consistency)
+# =========================================================================
+
+
+def test_mixed_case_model_does_not_lowercase_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``Anthropic/Claude-Sonnet-4-5`` (mixed case) does NOT silently pass via lowercased lookup.
+
+    Pins the case-preserving fix: ``model_name_without_provider`` lowercases,
+    so without the validator-local ``_strip_provider_prefix_case_preserving``
+    helper the mixed-case input would match the lowercase catalog entry at
+    validate time but runtime might reject the mixed-case call. WARNING
+    surfaces (catalog-miss) rather than silent acceptance.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    workflow = _llm_workflow("Anthropic/Claude-Sonnet-4-5")
+
+    diagnostics = _validate(workflow)
+    warnings = [d for d in diagnostics if d.severity == Severity.WARNING]
+    errors = [d for d in diagnostics if d.severity == Severity.ERROR]
+
+    assert errors == []
+    # Catalog-miss WARNING (mixed-case form isn't in any catalog candidate).
+    assert any(d.id == "llm.model-not-in-catalog" for d in warnings)
+
+
+def test_strip_provider_prefix_case_preserving_helper() -> None:
+    """Unit test the case-preserving prefix stripper directly."""
+    from pflow.core.workflow.validator import WorkflowValidator
+
+    # Case 1: prefixed model — strip provider prefix, preserve suffix case.
+    assert (
+        WorkflowValidator._strip_provider_prefix_case_preserving("anthropic/Claude-Sonnet-4-5", "anthropic/")
+        == "Claude-Sonnet-4-5"
+    )
+    # Case 2: prefixed with mixed-case prefix — still recognize and strip.
+    assert (
+        WorkflowValidator._strip_provider_prefix_case_preserving("Anthropic/Claude-Sonnet-4-5", "anthropic/")
+        == "Claude-Sonnet-4-5"
+    )
+    # Case 3: bare name (no prefix) — return unchanged.
+    assert (
+        WorkflowValidator._strip_provider_prefix_case_preserving("claude-sonnet-4-5", "anthropic/")
+        == "claude-sonnet-4-5"
+    )
+    # Case 4: model with different prefix — return unchanged (not matching).
+    assert WorkflowValidator._strip_provider_prefix_case_preserving("openai/gpt-4", "anthropic/") == "openai/gpt-4"

--- a/tests/test_execution/test_executor_service_llm.py
+++ b/tests/test_execution/test_executor_service_llm.py
@@ -17,8 +17,12 @@ from pflow.runtime.node_state import FAILURE_CATEGORY_LLM
 
 
 def _llm_workflow_ir(params: dict | None = None) -> dict:
+    # Use a bundled model so the new validate-time LLM model-id preflight
+    # passes; the runtime ``fail_complete`` simulator still raises the
+    # parameterized error for the test's actual subject (runtime error
+    # propagation to the runner diagnostics).
     node_params = {
-        "model": "anthropic/foo",
+        "model": "anthropic/claude-sonnet-4-5",
         "prompt": "Reply with a short answer.",
     }
     if params:
@@ -140,7 +144,7 @@ def test_llm_response_parse_error_context_reaches_runner_diagnostics(monkeypatch
     context = result.errors[0].context or {}
     assert context["category"] == FAILURE_CATEGORY_LLM
     assert context["error_class"] == "LLMResponseParseError"
-    assert context["model"] == "anthropic/foo"
+    assert context["model"] == "anthropic/claude-sonnet-4-5"
 
     failure = result.shared_after["__failures__"]["ask"]
     assert failure["category"] == FAILURE_CATEGORY_LLM
@@ -148,7 +152,7 @@ def test_llm_response_parse_error_context_reaches_runner_diagnostics(monkeypatch
     assert node_output["response"] == "not valid json"
     assert node_output["error_class"] == "LLMResponseParseError"
     assert node_output["_diagnostic_context"]["error_class"] == "LLMResponseParseError"
-    assert node_output["_diagnostic_context"]["model"] == "anthropic/foo"
+    assert node_output["_diagnostic_context"]["model"] == "anthropic/claude-sonnet-4-5"
 
 
 def test_real_litellm_exception_provider_message_reaches_runner_diagnostics(monkeypatch):
@@ -207,7 +211,7 @@ def test_real_litellm_exception_provider_message_reaches_runner_diagnostics(monk
     assert context["category"] == FAILURE_CATEGORY_LLM
     assert context["error_class"] == "MissingApiKeyError"
     assert context["kind"] == "missing_key"
-    assert context["model"] == "anthropic/foo"
+    assert context["model"] == "anthropic/claude-sonnet-4-5"
     # The crux: provider_message preserves the raw upstream text end-to-end.
     # The whole point of the field — agents reading JSON get the WHY.
     assert raw_provider_text in context["provider_message"]

--- a/tests/test_runtime/fixtures/golden_config_hashes.json
+++ b/tests/test_runtime/fixtures/golden_config_hashes.json
@@ -96,6 +96,6 @@
     "remove_existing_worktree": "b12c05c948994d17d102e0590c757bad"
   },
   "examples/test_llm_templates.pflow.md": {
-    "generate": "64b4044c0fc4dd32f552317fe81c4db7"
+    "generate": "5486d8f3047f8de66ae7cfbf4ab72b30"
   }
 }


### PR DESCRIPTION
## Summary

Move LLM model-id diagnosis from runtime to `WorkflowValidator` step 9 so bad `model:` values fail at validate/dry-run/save **before** any upstream node burns tokens. Single insertion point in the validator covers `--validate-only`, `--dry-run`, full run, `pflow save`, `analyze-cache`, and the MCP server's validate/plan/execute/save tools.

Fixes #439

## Changes

- **`src/pflow/core/workflow/validator.py`** — extended step 9 (`_validate_node_param_semantics`) with an LLM branch (`_validate_llm_model_id_lite`, `_validate_llm_model_id_catalog`, `_decorate_llm_validator_diag`, helpers for case-preserving prefix stripping and per-entry provider check).
- **`src/pflow/core/litellm_runtime.py`** — new `try_load_upstream_catalog()` with two new module-level flags (`_validator_upstream_attempted`, `_validator_upstream_fetch_succeeded`) sharing the existing `_UPSTREAM_LOCK`. Per-entry shape validation drops malformed upstream payloads. Runtime path (`ensure_model_priced`) unchanged.
- **`tests/conftest.py`** — extended the autouse `_block_upstream_cost_map_fetch` fixture to pre-set the new validator-side latches; added a paired autouse `_inject_fake_llm_api_keys` so mocked-LLM tests satisfy the new pre-call key check.
- **`pyproject.toml`** — registered `no_fake_llm_keys` marker so tests asserting the missing-key path can opt out of the autouse fixture.
- Three existing test files updated (`test_workflow_validator.py`, `test_executor_service_llm.py`, `test_analyze_cache.py`) for the new severity policy and key-injection interaction; one example file updated to use a valid model name; one golden baseline regenerated.

## Explanation

**Severity policy** (chosen after multi-agent review):

| Class | Severity | ID |
|---|---|---|
| Wrong-type `model:` (int/bool/list/dict) | ERROR | `llm.model-not-string` |
| Missing API key for canonical-provider model | ERROR | (from `MissingApiKeyError`) |
| Catalog miss after successful upstream merge | **WARNING** | `llm.model-not-in-catalog` |
| Network failure during upstream fetch | INFO | `llm.catalog-unreachable` |

The catalog-miss case is WARNING (not ERROR) because `litellm.model_cost` is a pricing catalog, not a callability registry. Fine-tunes (`openai/ft:...`), custom endpoints, and brand-new models are legitimately absent. The original bug-report repro (missing key for wrong-provider model) still ERRORs via the missing-key path, preserving the upstream-execution block.

**Cross-provider FP guard**: `anthropic/gpt-4` previously would have silently passed any naive catalog check because bare `gpt-4` is bundled under openai. The validator now reads each catalog entry's `litellm_provider` field and rejects bare-form matches whose entry explicitly names a DIFFERENT canonical provider — while accepting matches with non-canonical or missing provider metadata (best-effort).

**Case preservation**: the existing `model_name_without_provider` lowercases its result, so `Anthropic/Claude-Sonnet-4-5` would have silently matched a lowercase catalog entry. New validator-local `_strip_provider_prefix_case_preserving` keeps user case intact, mirroring the runtime's call shape.

**Independent latch design**: a new `_validator_upstream_attempted` / `_validator_upstream_fetch_succeeded` pair is kept separate from the runtime's `_upstream_attempted` so a runtime-side network failure cannot permanently disable validator membership checks in a long-lived MCP server process. Both functions share `litellm.model_cost` so successful merges from either path benefit the other.

**Upstream payload shape validation**: each entry value must be a dict containing at least one recognized field (`litellm_provider`, `input_cost_per_token`, `mode`, etc.) before merging. Defends against silent-failure where a partial-JSON response would otherwise register junk entries and latch the validator as "catalog merged successfully".

**File stats**: 11 files changed, 1433 insertions, 12 deletions.

## Testing

### New tests (`tests/test_core/test_workflow_validator_llm_model.py` — 24 tests):
- `test_wrong_type_model_emits_typed_error` (parametrized over int/bool/list/dict)
- `test_canonical_provider_missing_key_emits_missing_api_key_error` — bug-report repro
- `test_bare_name_resolves_via_normalization`, `test_bundled_prefixed_model_passes_without_fetch`
- `test_unbundled_but_real_model_passes_via_upstream_merge`, `test_catalog_miss_after_upstream_merge_emits_warning`
- `test_network_failure_emits_info_breadcrumb`
- `test_sub_workflow_bad_model_surfaces_via_child_provenance` — propagation through step 10
- `test_save_path_runs_llm_model_validation` — save-time entry point
- `test_cross_provider_bare_name_does_not_silently_accept` — pins the W3 FP fix
- `test_mixed_case_model_does_not_lowercase_match` — pins case-preservation
- `test_strip_provider_prefix_case_preserving_helper` — unit test for the new helper

### New tests (`tests/test_core/test_litellm_runtime.py` — 9 tests):
- `test_try_load_upstream_catalog_returns_true_on_first_successful_fetch`
- `test_try_load_upstream_catalog_returns_true_when_no_new_entries_to_merge`
- `test_try_load_upstream_catalog_returns_false_on_network_failure`
- `test_try_load_upstream_catalog_idempotent_after_success` / `_after_failure`
- `test_try_load_upstream_catalog_independent_from_runtime_latch` — prevents latch cross-coupling
- `test_try_load_upstream_catalog_thread_safe` — concurrent calls collapse to one fetch
- `test_try_load_upstream_catalog_rejects_malformed_payload` (5 shapes) / `_drops_malformed_entries_keeps_well_formed`

### Manual verification:
- Original bug-report repro (`openai/gpt-totally-made-up-9.9` + only Anthropic key): validator emits `MissingApiKeyError` ERROR; upstream shell node with side-effect (`echo > /tmp/marker`) **does NOT execute**.
- Cross-provider FP (`anthropic/gpt-4`): WARNING (was silent pass).
- Fine-tune (`openai/ft:gpt-4o-2024-08-06:my-org::abc123`): WARNING (was ERROR — would have blocked valid workflows).
- Mixed-case (`Anthropic/Claude-Sonnet-4-5`): WARNING (was silent pass via lowercase lookup).
- Multi-agent code review (`review-silent-failures`, `review-validation-consistency`, `review-concurrency-safety`): 3 Critical findings folded into the implementation.

### Full suite:
- `make test`: 7205 passed, 10 skipped (no regressions; 33 new tests added).
- `make check`: ruff, ruff-format, mypy (225 files), deptry — all pass.
- Lazy-import contract (`tests/test_cli/test_lazy_imports.py`): pass.