### PR TITLE
fix: unify reasoning budget under clamp semantics (#446)

### DIFF
--- a/docs/reference/nodes/llm.mdx
+++ b/docs/reference/nodes/llm.mdx
@@ -18,7 +18,9 @@ The LLM node calls AI models using [LiteLLM](https://docs.litellm.ai/). Use it w
 | `model` | str | No | See below | Model identifier |
 | `system` | str | No | - | System prompt for behavior guidance |
 | `temperature` | float | No | `1.0` | Sampling temperature (0.0-2.0) |
-| `max_tokens` | int | No | - | Maximum response tokens |
+| `max_tokens` | int | No | - | Response-length ceiling. On reasoning models it caps thinking depth but never raises it — see [Reasoning depth](#reasoning-depth) |
+| `reasoning_effort` | str | No | - | `xhigh`/`high`/`medium`/`low`/`minimal`/`none` — how hard the model thinks |
+| `reasoning_max_tokens` | int | No | - | Explicit thinking-token budget (mutually exclusive with `reasoning_effort`) |
 | `images` | list | No | `[]` | Image URLs or file paths for vision models |
 | `output_schema` | dict | No | - | JSON Schema for structured output |
 | `prompt_cache` | list | No | `[]` | Names of `## Cache` chunks to include as a cached system prefix. See [Prompt caching](/how-it-works/prompt-caching) |
@@ -35,6 +37,16 @@ pflow settings set-env OPENAI_API_KEY "sk-..."
 ```
 
 See [LLM model settings](/reference/cli/settings#llm-model-settings) for the full resolution order and default models per provider.
+
+## Reasoning depth
+
+`reasoning_effort` controls how hard a reasoning model thinks. `max_tokens` controls how long the response may get. They're separate dials, and pflow keeps them that way: effort sets the thinking budget, and `max_tokens` only ever *caps* it — raising `max_tokens` to leave room for a longer answer never inflates reasoning spend.
+
+This matters because Anthropic counts thinking and answer against one `max_tokens` pool and rejects any request where the thinking budget isn't strictly smaller than `max_tokens`. pflow always derives the budget to sit under `max_tokens`, so that rejection can't happen — whether you set `reasoning_effort` or an explicit `reasoning_max_tokens`. If you set both `reasoning_max_tokens` and a smaller `max_tokens`, the budget is capped to fit (the explicit budget is a request, not a guarantee).
+
+One consequence on reasoning models: if you omit `max_tokens`, the provider may cap the *visible* answer low (LiteLLM defaults it to the thinking budget plus ~4096). Set `max_tokens` explicitly when you need a long answer from a reasoning model.
+
+The same `reasoning_effort` value maps to provider-specific knobs under the hood — Anthropic and Gemini 2.5 get a token budget, OpenAI and Gemini 3 get their native effort/level. Models without a reasoning knob ignore the parameter.
 
 ## Output
 

--- a/src/pflow/core/llm_client.py
+++ b/src/pflow/core/llm_client.py
@@ -52,7 +52,6 @@ from pflow.core.exceptions import (
     UnknownModelError,
 )
 from pflow.core.llm_providers import detect_provider, normalize_model_name
-from pflow.core.llm_reasoning_map import DEFAULT_MAX_TOKENS_BASE, EFFORT_RATIOS
 from pflow.core.llm_usage import normalize_litellm_usage_tokens
 
 logger = logging.getLogger(__name__)
@@ -727,26 +726,20 @@ def _translate_reasoning_for_litellm(model: str, kwargs: dict[str, Any]) -> dict
     out: dict[str, Any] = {}
     leftover = dict(kwargs)
 
-    thinking_effort = leftover.pop("thinking_effort", None)
     thinking_flag = leftover.pop("thinking", None)
     thinking_budget = leftover.pop("thinking_budget", None)
 
-    if thinking_effort is not None:
-        # Opus 4.5 path. LiteLLM's standardized ``thinking`` param uses
-        # budget_tokens, not effort_level. Derive budget from effort using
-        # the same EFFORT_RATIOS the budget-style models use, so
-        # behavior is internally consistent across Anthropic models.
-        ratio = EFFORT_RATIOS.get(thinking_effort, 0.5)
-        budget = max(min(int(DEFAULT_MAX_TOKENS_BASE * ratio), 128000), 1024)
-        out["thinking"] = {"type": "enabled", "budget_tokens": budget}
-    elif thinking_flag is True and thinking_budget is not None:
-        # Older Anthropic path (Sonnet 4.x, Opus 4.0/4.1)
+    if thinking_flag is True and thinking_budget is not None:
+        # Budget-style Anthropic models (Sonnet 4.x, Opus 4.0/4.1/4.5). The
+        # budget was already derived and fit under max_tokens by
+        # llm_reasoning_map, so it just needs reshaping to LiteLLM's native
+        # thinking dict here.
         out["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
     elif thinking_flag is True:
         raise InvalidRequestError(
             f"Invalid reasoning options for model '{model}': thinking=True requires "
-            "thinking_budget or thinking_effort. Use reasoning_effort or "
-            "reasoning_max_tokens on the LLM node instead of raw model_options.",
+            "thinking_budget. Use reasoning_effort or reasoning_max_tokens on the "
+            "LLM node instead of raw model_options.",
             model=model,
         )
     elif thinking_flag is False:

--- a/src/pflow/core/llm_reasoning_map.py
+++ b/src/pflow/core/llm_reasoning_map.py
@@ -12,10 +12,12 @@ native shape (``{"thinking": {"type": "enabled", "budget_tokens": N}}``) at
 the API boundary. Keeping the translation in the adapter localizes provider
 quirks; this map only decides "which kwargs does this model accept".
 
-CRITICAL: Anthropic Opus 4.5 supports `thinking_effort`, `thinking`, AND
-`thinking_budget`. `thinking_effort` MUST be checked first — getting this
-wrong silently degrades Opus 4.5 reasoning. This precedence is preserved
-from the previous `nodes/llm/llm.py::_map_effort` implementation.
+BUDGET LAW: `reasoning_effort` / `reasoning_max_tokens` set the thinking
+*depth*; `max_tokens` is only a *ceiling*. The thinking budget is always
+derived to sit under `max_tokens` (see `_fit_budget`), so Anthropic's hard
+constraint `budget_tokens < max_tokens` holds by construction. All
+budget-style models — Anthropic (incl. Opus 4.5) and Gemini 2.5 — share one
+derivation; there is no per-model budget branch.
 
 Anthropic Opus 4.7 is the exception to the "emit legacy shape, adapter
 translates" rule. It uses *adaptive* thinking and REJECTS the
@@ -37,9 +39,8 @@ from typing import Any
 
 from pflow.core.llm_providers import detect_provider, model_name_without_provider
 
-# OpenRouter-style effort-to-token-budget ratios. Moved verbatim from the
-# previous nodes/llm/llm.py:22-32. Five levels intentional (matches what
-# pflow accepts as `reasoning_effort` parameter input).
+# OpenRouter-style effort-to-token-budget ratios. Five levels intentional
+# (matches what pflow accepts as `reasoning_effort` parameter input).
 EFFORT_RATIOS: dict[str, float] = {
     "xhigh": 0.95,
     "high": 0.80,
@@ -48,9 +49,17 @@ EFFORT_RATIOS: dict[str, float] = {
     "minimal": 0.10,
 }
 
-# Default base for token budget calculation when max_tokens is not set.
-# Moved verbatim from the previous nodes/llm/llm.py:32.
-DEFAULT_MAX_TOKENS_BASE = 16000
+# Fixed base the effort ratios scale to produce the thinking budget — the
+# reasoning *depth* base. Used for every effort-derived budget, not just when
+# max_tokens is unset. `max_tokens` only constrains the result (see
+# `_fit_budget`); it never drives depth above this base.
+EFFORT_BUDGET_BASE = 16000
+
+# The thinking budget never exceeds this fraction of `max_tokens` (when set).
+# Guarantees Anthropic's `budget_tokens < max_tokens` and leaves headroom for
+# the visible answer (Anthropic counts thinking + answer against one
+# `max_tokens` pool).
+SAFETY_FRACTION = 0.8
 
 
 def _detect_capabilities(model: str) -> set[str]:
@@ -66,8 +75,8 @@ def _detect_capabilities(model: str) -> set[str]:
     """
     provider = detect_provider(model)
 
-    # Anthropic Opus 4.5 — supports thinking_effort (precedence!), plus
-    # thinking and thinking_budget for direct-budget callers.
+    # Anthropic — extended thinking via thinking + thinking_budget (Opus 4.7
+    # is the lone exception: adaptive thinking, handled first below).
     if provider is not None and provider.name == "anthropic":
         provider_model = model_name_without_provider(model, provider)
 
@@ -83,11 +92,11 @@ def _detect_capabilities(model: str) -> set[str]:
         if "claude-opus-4-7" in provider_model or "claude-opus-4.7" in provider_model:
             return {"reasoning_effort_adaptive"}
 
-        if "claude-opus-4-5" in provider_model or "claude-opus-4.5" in provider_model:
-            return {"thinking_effort", "thinking", "thinking_budget"}
-
-        # Other Anthropic models (Sonnet 4.x, Opus 4.0/4.1, older Sonnet,
-        # Haiku, etc.) — extended thinking via thinking + thinking_budget.
+        # All other Anthropic models (Opus 4.5/4.1/4.0, Sonnet 4.x, Haiku,
+        # etc.) — extended thinking via thinking + thinking_budget. Opus 4.5
+        # used to carry a `thinking_effort` capability, but that was a
+        # categorical relay that never reached the API (LiteLLM wants
+        # budget_tokens); it now derives a budget through the shared path.
         return {"thinking", "thinking_budget"}
 
     if provider is not None and provider.name == "gemini":
@@ -126,13 +135,30 @@ def _matches_openai_o_family(model_name: str) -> bool:
     return any(model_name == family or model_name.startswith(f"{family}-") for family in ("o1", "o3", "o4"))
 
 
-def _map_direct_budget(option_fields: set[str], reasoning_max_tokens: int) -> dict[str, Any]:
-    """Map reasoning_max_tokens to provider-specific token budget param.
+def _fit_budget(desired: int, max_tokens: int | None) -> int:
+    """Fit a thinking budget under `max_tokens` (the ceiling), bounded.
 
-    Logic ported verbatim from the previous `nodes/llm/llm.py::_map_direct_budget`.
+    The single budget law: depth is the `desired` value; `max_tokens`, when
+    set, only constrains it. Clamping here makes Anthropic's
+    `budget_tokens < max_tokens` hold by construction — no separate
+    validation step is needed.
+    """
+    if max_tokens is not None:
+        desired = min(desired, int(max_tokens * SAFETY_FRACTION))
+    return max(min(desired, 128000), 1024)
+
+
+def _map_direct_budget(option_fields: set[str], reasoning_max_tokens: int, max_tokens: int | None) -> dict[str, Any]:
+    """Map reasoning_max_tokens to a provider-specific token budget param.
+
+    The explicit budget is still fit under `max_tokens` for budget-style
+    models (Anthropic, Gemini 2.5), so the `budget_tokens < max_tokens`
+    invariant holds by construction — same law as the effort path. The
+    OpenAI `reasoning_max_tokens` knob (no hard ceiling constraint) passes
+    through unchanged.
     """
     if "thinking_budget" in option_fields:
-        kwargs: dict[str, Any] = {"thinking_budget": reasoning_max_tokens}
+        kwargs: dict[str, Any] = {"thinking_budget": _fit_budget(reasoning_max_tokens, max_tokens)}
         if "thinking" in option_fields:
             kwargs["thinking"] = True
         return kwargs
@@ -144,23 +170,18 @@ def _map_direct_budget(option_fields: set[str], reasoning_max_tokens: int) -> di
 def _map_effort(option_fields: set[str], effort: str, max_tokens: int | None) -> dict[str, Any]:
     """Map effort level string to provider-specific reasoning params.
 
-    Logic ported verbatim from the previous `nodes/llm/llm.py::_map_effort`.
-
-    Provider detection order matters — Anthropic Opus 4.5 has thinking_effort,
-    thinking, AND thinking_budget, so thinking_effort must be checked first.
+    Categorical-reasoning models (Opus 4.7 adaptive, OpenAI, Gemini 3) emit
+    their native effort string; budget-style models (Anthropic incl. Opus
+    4.5, Gemini 2.5) derive a token budget via the shared `_fit_budget`.
     """
     # Anthropic Opus 4.7 — adaptive thinking via LiteLLM's standardized
     # reasoning_effort (LiteLLM builds the native thinking.type.adaptive +
     # output_config.effort shape). Anthropic's effort vocabulary is
     # low/medium/high, so collapse pflow's extra buckets (xhigh→high,
-    # minimal→low) the same way the Opus 4.5 thinking_effort path does.
+    # minimal→low) onto it.
     if "reasoning_effort_adaptive" in option_fields:
         mapped = {"xhigh": "high", "minimal": "low"}.get(effort, effort)
         return {"reasoning_effort": mapped}
-    # Anthropic Opus 4.5 — thinking_effort natively
-    if "thinking_effort" in option_fields:
-        mapped = {"xhigh": "high", "minimal": "low"}.get(effort, effort)
-        return {"thinking_effort": mapped}
     # OpenAI / OpenRouter — reasoning_effort natively
     if "reasoning_effort" in option_fields:
         return {"reasoning_effort": effort}
@@ -168,11 +189,11 @@ def _map_effort(option_fields: set[str], effort: str, max_tokens: int | None) ->
     if "thinking_level" in option_fields:
         mapped = {"xhigh": "high"}.get(effort, effort)
         return {"thinking_level": mapped}
-    # Anthropic older / Gemini 2.5 — needs token budget calculation
+    # Anthropic (incl. Opus 4.5) / Gemini 2.5 — budget derived from effort
+    # depth, then fit under max_tokens (the ceiling).
     if "thinking_budget" in option_fields:
-        base = max_tokens or DEFAULT_MAX_TOKENS_BASE
         ratio = EFFORT_RATIOS.get(effort, 0.50)
-        budget = max(min(int(base * ratio), 128000), 1024)
+        budget = _fit_budget(int(EFFORT_BUDGET_BASE * ratio), max_tokens)
         kwargs: dict[str, Any] = {"thinking_budget": budget}
         if "thinking" in option_fields:
             kwargs["thinking"] = True
@@ -204,8 +225,10 @@ def map_reasoning_options(
             or ``None`` for default.
         reasoning_max_tokens: Direct token budget. Mutually exclusive with
             ``reasoning_effort`` — when both are set, this takes precedence.
-        max_tokens: The max response tokens, used as base for the budget
-            formula when only effort is given on a budget-style model.
+        max_tokens: The response-length ceiling. On budget-style models it
+            only *constrains* the thinking budget (kept under
+            ``max_tokens * SAFETY_FRACTION``); it never drives depth. See
+            ``_fit_budget``.
 
     Returns:
         Dict of kwargs to merge into the LLM call. Empty dict when no
@@ -221,7 +244,7 @@ def map_reasoning_options(
 
     # Direct token budget takes precedence over effort
     if reasoning_max_tokens is not None:
-        return _map_direct_budget(option_fields, reasoning_max_tokens)
+        return _map_direct_budget(option_fields, reasoning_max_tokens, max_tokens)
 
     effort = reasoning_effort.lower()  # type: ignore[union-attr]
 

--- a/src/pflow/core/llm_reasoning_map.py
+++ b/src/pflow/core/llm_reasoning_map.py
@@ -15,9 +15,12 @@ quirks; this map only decides "which kwargs does this model accept".
 BUDGET LAW: `reasoning_effort` / `reasoning_max_tokens` set the thinking
 *depth*; `max_tokens` is only a *ceiling*. The thinking budget is always
 derived to sit under `max_tokens` (see `_fit_budget`), so Anthropic's hard
-constraint `budget_tokens < max_tokens` holds by construction. All
-budget-style models — Anthropic (incl. Opus 4.5) and Gemini 2.5 — share one
-derivation; there is no per-model budget branch.
+constraint `budget_tokens < max_tokens` holds for any `max_tokens` above
+Anthropic's 1024-token minimum thinking budget (i.e. `max_tokens > 1024`).
+At or below 1024 no valid budget exists at all (you'd need `1024 <= budget <
+max_tokens <= 1024`), so the request is left to fail at the provider rather
+than special-cased. All budget-style models — Anthropic (incl. Opus 4.5) and
+Gemini 2.5 — share one derivation; there is no per-model budget branch.
 
 Anthropic Opus 4.7 is the exception to the "emit legacy shape, adapter
 translates" rule. It uses *adaptive* thinking and REJECTS the
@@ -139,9 +142,11 @@ def _fit_budget(desired: int, max_tokens: int | None) -> int:
     """Fit a thinking budget under `max_tokens` (the ceiling), bounded.
 
     The single budget law: depth is the `desired` value; `max_tokens`, when
-    set, only constrains it. Clamping here makes Anthropic's
-    `budget_tokens < max_tokens` hold by construction — no separate
-    validation step is needed.
+    set, only constrains it. The result stays under `max_tokens` for any
+    `max_tokens > 1024`, so no separate validation step is needed there. The
+    1024 floor (Anthropic's minimum thinking budget) wins for `max_tokens <=
+    1024`, where no valid budget exists at all and the contradictory request
+    is left to fail at the provider rather than special-cased.
     """
     if max_tokens is not None:
         desired = min(desired, int(max_tokens * SAFETY_FRACTION))

--- a/src/pflow/nodes/llm/llm.py
+++ b/src/pflow/nodes/llm/llm.py
@@ -17,7 +17,7 @@ from pflow.core.llm_capabilities import get_min_cache_tokens
 from pflow.core.llm_client import Attachment, TraceHook, complete
 from pflow.core.llm_providers import detect_provider
 from pflow.core.llm_reasoning_map import (
-    DEFAULT_MAX_TOKENS_BASE,
+    EFFORT_BUDGET_BASE,
     EFFORT_RATIOS,
     map_reasoning_options,
 )
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 # Re-exported for backward compatibility with code that imported these names
 # from pflow.nodes.llm.llm. The canonical home is pflow.core.llm_reasoning_map.
 __all__ = [
-    "DEFAULT_MAX_TOKENS_BASE",
+    "EFFORT_BUDGET_BASE",
     "EFFORT_RATIOS",
     "LLMNode",
 ]
@@ -903,8 +903,8 @@ class LLMNode(Node):
     - Params: system: str  # System prompt (optional)
     - Params: images: list[str]  # Image URLs or file paths (optional)
     - Params: output_schema: dict  # JSON Schema for structured output (optional)
-    - Params: reasoning_effort: str  # Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params)
-    - Params: reasoning_max_tokens: int  # Direct reasoning token budget, mutually exclusive with reasoning_effort (optional)
+    - Params: reasoning_effort: str  # Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params). Drives how hard the model thinks; max_tokens only caps it, never raises it.
+    - Params: reasoning_max_tokens: int  # Direct reasoning token budget, mutually exclusive with reasoning_effort (optional). Still capped to stay under max_tokens when both are set.
     - Params: model_options: dict  # Additional provider-specific model options passed as kwargs (optional; reasoning keys must use reasoning_effort/reasoning_max_tokens)
     - Writes: shared["response"]: str|dict  # Text (str), parsed JSON (dict) when output_schema is set, or raw text on parse failure
     - Writes: shared["error"]: str  # Error message if LLM call or JSON parsing failed
@@ -927,7 +927,7 @@ class LLMNode(Node):
         - prewarm_disabled_reason: str|None  # Trace 2.3.0 — "below_min" when pre-flight disabled batch prewarm for this node.
     - Params: model: str  # Model to use (optional - always use smart default unless user requests specific model)
     - Params: temperature: float  # Sampling temperature (default: 1.0)
-    - Params: max_tokens: int  # Max response tokens (optional)
+    - Params: max_tokens: int  # Response-length ceiling (optional). On reasoning models this is the combined thinking+answer budget and only caps thinking depth — it never increases it. Set it explicitly when you need a long visible answer from a reasoning model (otherwise the provider may cap visible output low).
     - Params: timeout: int  # Execution timeout in seconds for LLM API call (default: 120)
     - Actions: default (success), error (failure)
     """

--- a/src/pflow/nodes/llm/llm.py
+++ b/src/pflow/nodes/llm/llm.py
@@ -17,7 +17,6 @@ from pflow.core.llm_capabilities import get_min_cache_tokens
 from pflow.core.llm_client import Attachment, TraceHook, complete
 from pflow.core.llm_providers import detect_provider
 from pflow.core.llm_reasoning_map import (
-    EFFORT_BUDGET_BASE,
     EFFORT_RATIOS,
     map_reasoning_options,
 )
@@ -45,7 +44,6 @@ logger = logging.getLogger(__name__)
 # Re-exported for backward compatibility with code that imported these names
 # from pflow.nodes.llm.llm. The canonical home is pflow.core.llm_reasoning_map.
 __all__ = [
-    "EFFORT_BUDGET_BASE",
     "EFFORT_RATIOS",
     "LLMNode",
 ]
@@ -903,7 +901,7 @@ class LLMNode(Node):
     - Params: system: str  # System prompt (optional)
     - Params: images: list[str]  # Image URLs or file paths (optional)
     - Params: output_schema: dict  # JSON Schema for structured output (optional)
-    - Params: reasoning_effort: str  # Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params). Drives how hard the model thinks; max_tokens only caps it, never raises it.
+    - Params: reasoning_effort: str  # Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params). Sets reasoning depth; max_tokens only caps the budget, never raises it.
     - Params: reasoning_max_tokens: int  # Direct reasoning token budget, mutually exclusive with reasoning_effort (optional). Still capped to stay under max_tokens when both are set.
     - Params: model_options: dict  # Additional provider-specific model options passed as kwargs (optional; reasoning keys must use reasoning_effort/reasoning_max_tokens)
     - Writes: shared["response"]: str|dict  # Text (str), parsed JSON (dict) when output_schema is set, or raw text on parse failure

--- a/tests/test_core/test_llm_client.py
+++ b/tests/test_core/test_llm_client.py
@@ -223,22 +223,15 @@ class TestTranslateReasoningForAnthropic:
         )
         assert result == {"thinking": {"type": "enabled", "budget_tokens": 8000}}
 
-    def test_opus_45_thinking_effort_high(self):
-        # thinking_effort gets translated to budget_tokens via EFFORT_RATIOS.
-        # high (0.80) * DEFAULT_MAX_TOKENS_BASE (16000) = 12800
+    def test_opus_45_budget_reshaped_like_other_anthropic(self):
+        # #446: Opus 4.5 no longer takes a special thinking_effort path. The
+        # map derives a thinking_budget (e.g. high → 12800) and the adapter
+        # reshapes it identically to every other budget-style Anthropic model.
         result = _translate_reasoning_for_litellm(
             "anthropic/claude-opus-4-5",
-            {"thinking_effort": "high"},
+            {"thinking": True, "thinking_budget": 12800},
         )
         assert result == {"thinking": {"type": "enabled", "budget_tokens": 12800}}
-
-    def test_opus_45_thinking_effort_low(self):
-        # low (0.20) * 16000 = 3200
-        result = _translate_reasoning_for_litellm(
-            "anthropic/claude-opus-4-5",
-            {"thinking_effort": "low"},
-        )
-        assert result == {"thinking": {"type": "enabled", "budget_tokens": 3200}}
 
     def test_thinking_false_disables(self):
         result = _translate_reasoning_for_litellm(
@@ -254,7 +247,7 @@ class TestTranslateReasoningForAnthropic:
     def test_thinking_true_without_budget_raises(self):
         with pytest.raises(InvalidRequestError) as exc_info:
             _translate_reasoning_for_litellm("anthropic/claude-sonnet-4-5", {"thinking": True})
-        assert "thinking=True requires thinking_budget or thinking_effort" in str(exc_info.value)
+        assert "thinking=True requires thinking_budget" in str(exc_info.value)
 
     def test_opus_47_reasoning_effort_passes_through(self):
         # Opus 4.7 uses adaptive thinking: llm_reasoning_map emits LiteLLM's
@@ -634,9 +627,10 @@ class TestCompleteUsageNormalization:
         response = complete(
             model="anthropic/claude-opus-4-5",
             prompt="hi",
-            reasoning_kwargs={"thinking_effort": "medium"},
+            # #446: map_reasoning_options now emits a derived budget for Opus
+            # 4.5 (medium → 0.5 * 16000 = 8000), same shape as other Anthropic.
+            reasoning_kwargs={"thinking": True, "thinking_budget": 8000},
         )
-        # 'medium' resolves to 0.5 * 16000 = 8000 budget per the EFFORT_RATIOS map
         assert response.usage["thinking_budget"] == 8000
         assert response.usage["thinking_tokens"] == 512
 

--- a/tests/test_core/test_llm_reasoning_map.py
+++ b/tests/test_core/test_llm_reasoning_map.py
@@ -197,9 +197,9 @@ class TestMapReasoningMaxTokens:
         assert result == {"thinking": True, "thinking_budget": 8000}
 
     def test_anthropic_opus_45_thinking_budget(self):
-        # Opus 4.5 uses thinking_budget for direct budget too (the
-        # _map_direct_budget helper checks thinking_budget before
-        # thinking_effort — by design)
+        # Opus 4.5 uses the same thinking_budget shape as every other
+        # Anthropic model for direct budgets (#446 removed its thinking_effort
+        # relay, so there is no longer a separate path to dispatch).
         result = map_reasoning_options("anthropic/claude-opus-4-5", None, 8000, None)
         assert result == {"thinking": True, "thinking_budget": 8000}
 
@@ -217,15 +217,27 @@ class TestMapReasoningMaxTokens:
         assert result == {"thinking": True, "thinking_budget": 8000}
 
     def test_opus_45_max_tokens_takes_precedence_over_effort(self):
-        # Opus 4.5 is the only model with BOTH thinking_effort capability
-        # (used when only effort is provided) AND thinking_budget capability
-        # (used for direct budget). When both inputs are given, max_tokens
-        # wins per map_reasoning_options' contract — the thinking_budget
-        # shape is returned, NOT the thinking_effort shape. Easy to break
-        # by reordering the precedence dispatch in map_reasoning_options.
+        # When both reasoning_max_tokens and reasoning_effort are given, the
+        # direct budget wins per map_reasoning_options' contract — the explicit
+        # 8000 budget is returned, not an effort-derived one. Easy to break by
+        # reordering the precedence dispatch in map_reasoning_options. (The
+        # exact-equality assertion already pins that no effort shape leaks in.)
         result = map_reasoning_options("anthropic/claude-opus-4-5", "high", 8000, None)
         assert result == {"thinking": True, "thinking_budget": 8000}
-        assert "thinking_effort" not in result
+
+    def test_explicit_budget_clamped_under_max_tokens(self):
+        # #446: the explicit reasoning_max_tokens path is clamped under
+        # max_tokens too, not just the effort path. 15000 + max_tokens=4000
+        # → 4000 * 0.8 = 3200, keeping budget < max_tokens.
+        result = map_reasoning_options("anthropic/claude-sonnet-4-5", None, 15000, 4000)
+        assert result == {"thinking": True, "thinking_budget": 3200}
+
+    def test_openai_explicit_budget_not_clamped(self):
+        # OpenAI has no hard budget < max_tokens constraint, so the direct
+        # budget passes through unchanged — the deliberate asymmetry with
+        # Anthropic/Gemini that _map_direct_budget's docstring promises.
+        result = map_reasoning_options("gpt-5-mini", None, 15000, 4000)
+        assert result == {"reasoning_max_tokens": 15000}
 
 
 class TestMapReasoningEffortNone:

--- a/tests/test_core/test_llm_reasoning_map.py
+++ b/tests/test_core/test_llm_reasoning_map.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import pytest
 
 from pflow.core.llm_reasoning_map import (
-    DEFAULT_MAX_TOKENS_BASE,
+    EFFORT_BUDGET_BASE,
     EFFORT_RATIOS,
+    SAFETY_FRACTION,
     _detect_capabilities,
     map_reasoning_options,
 )
@@ -24,25 +25,23 @@ from pflow.core.llm_reasoning_map import (
 
 
 class TestDetectCapabilitiesAnthropic:
-    """Anthropic Opus 4.5 has thinking_effort precedence; older Anthropic doesn't."""
+    """Opus 4.5 collapses into the generic Anthropic budget caps (no special
+    thinking_effort relay — see #446); Opus 4.7 stays adaptive."""
 
-    def test_opus_45_has_thinking_effort(self):
-        # Order invariant: thinking_effort MUST be in the set for Opus 4.5
-        # so that map_reasoning_options dispatches to the thinking_effort
-        # branch FIRST. Getting this wrong silently degrades reasoning.
+    def test_opus_45_uses_budget_caps(self):
+        # Opus 4.5 no longer carries a `thinking_effort` capability. It uses
+        # the same thinking + thinking_budget path as every other Anthropic
+        # budget-style model; the budget is derived in llm_reasoning_map.
         caps = _detect_capabilities("anthropic/claude-opus-4-5")
-        assert "thinking_effort" in caps
-        assert "thinking" in caps
-        assert "thinking_budget" in caps
+        assert caps == {"thinking", "thinking_budget"}
 
     def test_opus_45_dotted_alias(self):
-        caps = _detect_capabilities("anthropic/claude-opus-4.5")
-        assert "thinking_effort" in caps
+        assert _detect_capabilities("anthropic/claude-opus-4.5") == {"thinking", "thinking_budget"}
 
     def test_opus_45_dated_variant(self):
         # Real Anthropic model ids include a date suffix (e.g. -20251101)
         caps = _detect_capabilities("anthropic/claude-opus-4-5-20251101")
-        assert "thinking_effort" in caps
+        assert caps == {"thinking", "thinking_budget"}
 
     def test_opus_47_uses_adaptive_reasoning_effort(self):
         # Opus 4.7 must NOT get the legacy thinking/thinking_budget caps — that
@@ -254,34 +253,49 @@ class TestMapReasoningEffortNone:
         assert result == {}
 
 
-class TestOpus45ThinkingEffortPrecedence:
-    """CRITICAL: Anthropic Opus 4.5 has BOTH thinking_effort and thinking_budget.
+class TestOpus45Effort:
+    """Opus 4.5 derives a thinking budget through the shared path (#446).
 
-    thinking_effort MUST be checked first or reasoning is silently degraded.
-    This is the highest-stakes test in the file.
+    It used to emit a categorical ``thinking_effort`` that never reached the
+    API. It now produces the SAME budget as every other Anthropic
+    budget-style model (see ``TestEffortOpusSonnetParity``). xhigh and
+    minimal are no longer collapsed to high/low — they get their own ratios.
     """
 
+    MODEL = "anthropic/claude-opus-4-5"
+
     def test_high(self):
-        result = map_reasoning_options("anthropic/claude-opus-4-5", "high", None, None)
-        # Must dispatch to thinking_effort branch — NOT thinking_budget branch
-        assert result == {"thinking_effort": "high"}
-        assert "thinking_budget" not in result
+        result = map_reasoning_options(self.MODEL, "high", None, None)
+        assert result == {"thinking": True, "thinking_budget": 12800}  # 0.80 * 16000
+        assert "thinking_effort" not in result
 
-    def test_xhigh_maps_to_high(self):
-        result = map_reasoning_options("anthropic/claude-opus-4-5", "xhigh", None, None)
-        assert result == {"thinking_effort": "high"}
+    def test_xhigh(self):
+        result = map_reasoning_options(self.MODEL, "xhigh", None, None)
+        assert result == {"thinking": True, "thinking_budget": 15200}  # 0.95 * 16000
 
-    def test_minimal_maps_to_low(self):
-        result = map_reasoning_options("anthropic/claude-opus-4-5", "minimal", None, None)
-        assert result == {"thinking_effort": "low"}
+    def test_minimal(self):
+        result = map_reasoning_options(self.MODEL, "minimal", None, None)
+        assert result == {"thinking": True, "thinking_budget": 1600}  # 0.10 * 16000
 
     def test_low(self):
-        result = map_reasoning_options("anthropic/claude-opus-4-5", "low", None, None)
-        assert result == {"thinking_effort": "low"}
+        result = map_reasoning_options(self.MODEL, "low", None, None)
+        assert result == {"thinking": True, "thinking_budget": 3200}  # 0.20 * 16000
 
     def test_medium(self):
-        result = map_reasoning_options("anthropic/claude-opus-4-5", "medium", None, None)
-        assert result == {"thinking_effort": "medium"}
+        result = map_reasoning_options(self.MODEL, "medium", None, None)
+        assert result == {"thinking": True, "thinking_budget": 8000}  # 0.50 * 16000
+
+
+class TestEffortOpusSonnetParity:
+    """#446 root fix: Opus 4.5 and Sonnet 4.5 now derive IDENTICAL budgets for
+    the same (effort, max_tokens). The old Sonnet-vs-Opus-4.5 split is gone."""
+
+    @pytest.mark.parametrize("effort", list(EFFORT_RATIOS))
+    @pytest.mark.parametrize("max_tokens", [None, 4000, 16000, 64000])
+    def test_opus_45_matches_sonnet(self, effort: str, max_tokens: int | None):
+        opus = map_reasoning_options("anthropic/claude-opus-4-5", effort, None, max_tokens)
+        sonnet = map_reasoning_options("anthropic/claude-sonnet-4-5", effort, None, max_tokens)
+        assert opus == sonnet
 
 
 class TestOpus47AdaptiveReasoning:
@@ -361,41 +375,66 @@ class TestEffortGemini3:
         assert result == {"thinking_level": "minimal"}
 
 
+def _expected_budget(effort: str, max_tokens: int | None) -> int:
+    """Mirror of llm_reasoning_map._fit_budget for the effort path (#446)."""
+    desired = int(EFFORT_BUDGET_BASE * EFFORT_RATIOS[effort])
+    if max_tokens is not None:
+        desired = min(desired, int(max_tokens * SAFETY_FRACTION))
+    return max(min(desired, 128000), 1024)
+
+
 class TestEffortTokenBudgetCalculation:
-    """Anthropic Sonnet (older), Gemini 2.5 — needs token budget formula."""
+    """Anthropic / Gemini 2.5 — clamp semantics (#446): effort drives depth
+    against a fixed base; max_tokens only constrains."""
 
-    def test_anthropic_high_with_max_tokens(self):
+    def test_anthropic_high_with_max_tokens_equal_to_base(self):
+        # max_tokens == base, so cap (0.8*16000) == desired (0.8*16000) == 12800.
         result = map_reasoning_options("anthropic/claude-sonnet-4-5", "high", None, 16000)
-        expected_budget = int(16000 * 0.80)
-        assert result == {"thinking": True, "thinking_budget": expected_budget}
+        assert result == {"thinking": True, "thinking_budget": 12800}
 
-    def test_anthropic_high_uses_default_when_max_tokens_none(self):
+    def test_anthropic_high_uses_fixed_base_when_max_tokens_none(self):
         result = map_reasoning_options("anthropic/claude-sonnet-4-5", "high", None, None)
-        expected_budget = int(DEFAULT_MAX_TOKENS_BASE * 0.80)
+        expected_budget = int(EFFORT_BUDGET_BASE * 0.80)  # 12800
         assert result == {"thinking": True, "thinking_budget": expected_budget}
 
-    def test_budget_clamped_minimum(self):
-        # minimal effort with small max_tokens → 200 tokens, clamped to 1024
-        result = map_reasoning_options("anthropic/claude-sonnet-4-5", "minimal", None, 2000)
+    def test_large_max_tokens_does_not_inflate_budget(self):
+        # The headline #446 fix: raising max_tokens for a longer answer must
+        # NOT inflate reasoning spend. high effort caps at the fixed base
+        # (12800), NOT max_tokens * ratio (which would be 51200).
+        result = map_reasoning_options("anthropic/claude-sonnet-4-5", "high", None, 64000)
+        assert result["thinking_budget"] == 12800
+
+    def test_small_max_tokens_clamps_below_ceiling(self):
+        # high effort wants 12800, but max_tokens=4000 caps it to 4000*0.8=3200.
+        result = map_reasoning_options("anthropic/claude-sonnet-4-5", "high", None, 4000)
+        assert result["thinking_budget"] == 3200
+        assert result["thinking_budget"] < 4000  # invariant: budget < max_tokens
+
+    def test_budget_floored_to_minimum(self):
+        # minimal effort with a tiny max_tokens floors to 1024.
+        result = map_reasoning_options("anthropic/claude-sonnet-4-5", "minimal", None, 1100)
         assert result["thinking_budget"] == 1024
 
-    def test_budget_clamped_maximum(self):
-        # xhigh with huge max_tokens → 190000, clamped to 128000
+    def test_huge_max_tokens_caps_at_fixed_base_not_128k(self):
+        # Under clamp the effort budget tops out at the fixed base (xhigh →
+        # 15200), so the 128k ceiling no longer binds via the effort path.
         result = map_reasoning_options("anthropic/claude-sonnet-4-5", "xhigh", None, 200000)
-        assert result["thinking_budget"] == 128000
+        assert result["thinking_budget"] == 15200
 
     def test_gemini_25_has_no_thinking_flag(self):
         # Gemini lacks the `thinking` capability — only thinking_budget
         result = map_reasoning_options("gemini-2.5-pro", "medium", None, 16000)
-        expected_budget = int(16000 * 0.50)
-        assert result == {"thinking_budget": expected_budget}
+        assert result == {"thinking_budget": 8000}  # 0.50 * 16000
 
-    @pytest.mark.parametrize("effort,ratio", EFFORT_RATIOS.items())
-    def test_all_effort_levels_anthropic(self, effort: str, ratio: float):
-        result = map_reasoning_options("anthropic/claude-sonnet-4-5", effort, None, 16000)
-        expected = max(min(int(16000 * ratio), 128000), 1024)
-        assert result["thinking_budget"] == expected
+    @pytest.mark.parametrize("effort", list(EFFORT_RATIOS))
+    @pytest.mark.parametrize("max_tokens", [None, 2000, 4000, 16000, 64000, 200000])
+    def test_budget_always_under_ceiling(self, effort: str, max_tokens: int | None):
+        result = map_reasoning_options("anthropic/claude-sonnet-4-5", effort, None, max_tokens)
+        assert result["thinking_budget"] == _expected_budget(effort, max_tokens)
         assert result["thinking"] is True
+        if max_tokens is not None:
+            # The invariant the whole issue is about.
+            assert result["thinking_budget"] < max_tokens
 
 
 class TestUnsupportedModel:


### PR DESCRIPTION
## Summary
pflow derived an LLM thinking budget from `reasoning_effort` in two different places with two different bases — Sonnet/Gemini scaled by `max_tokens` (multiplier), while Opus 4.5 used a fixed `16000` base and ignored `max_tokens`. The same effort produced different budgets per model, and a small explicit `max_tokens` could fall below the derived budget and be rejected by Anthropic (`budget_tokens < max_tokens`).

This adopts **clamp semantics** in a single derivation site: `reasoning_effort` sets depth against a fixed base; `max_tokens` only *constrains* it. The Anthropic invariant then holds by construction.

Fixes #446

## Changes
- `_fit_budget(desired, max_tokens)` in `llm_reasoning_map.py` — the one budget law (`min(desired, max_tokens * SAFETY_FRACTION)`, bounded). Used by both the effort path and the explicit `reasoning_max_tokens` path.
- Opus 4.5 collapses into the generic Anthropic `{thinking, thinking_budget}` path — its `thinking_effort` capability was a categorical relay that never reached the API.
- Removed the `thinking_effort` branch + the false "internally consistent across Anthropic models" comment + the now-unused import from `llm_client.py`.
- Renamed `DEFAULT_MAX_TOKENS_BASE` → `EFFORT_BUDGET_BASE` (it's now the depth base used always, not a fallback) and added `SAFETY_FRACTION`.
- Node docstring documents the depth-vs-ceiling relationship; this flows into `pflow guide llm` automatically via the registry. New "Reasoning depth" section in `docs/reference/nodes/llm.mdx`.

## Explanation
`max_tokens` and the thinking budget answer different questions: `max_tokens` is a ceiling, `reasoning_effort` is a depth dial. Multiplier semantics conflated them — bumping `max_tokens` for a longer answer silently multiplied reasoning spend (high effort: `8000 → 64000` max_tokens took thinking from ~6.4k to ~51k). Clamp keeps them orthogonal.

The decision deliberately *drops* the pre-call validation the issue proposed: because the budget is always clamped to fit, there is no illegal state left to validate — an invariant enforced by construction rather than by a guard. The multiplier convention (OpenRouter/LiteLLM) was considered and rejected for the cost-coupling reason above; the fixed-base clamp is a deliberate deviation, noted in the code comments. Net effect is negative LOC (182 insertions / 121 deletions) while fixing the bug.

Verified empirically against LiteLLM 1.86.1: omitting `max_tokens` auto-injects `budget + 4096` (no crash, documented as a UX note), while an explicit small `max_tokens` is passed unclamped by LiteLLM (the 400 this PR prevents).

## Testing
- `TestEffortOpusSonnetParity::test_opus_45_matches_sonnet` — parametrized over effort × max_tokens; Opus 4.5 and Sonnet now derive identical budgets (the root-cause split is gone).
- `TestEffortTokenBudgetCalculation::test_large_max_tokens_does_not_inflate_budget` — `high` + `max_tokens=64000` caps at 12800, not 51200 (the headline fix).
- `TestEffortTokenBudgetCalculation::test_budget_always_under_ceiling` — parametrized invariant guard: derived budget is always `< max_tokens`.
- `test_small_max_tokens_clamps_below_ceiling`, `test_huge_max_tokens_caps_at_fixed_base_not_128k` — clamp bounds.
- `TestOpus45Effort` — Opus 4.5 effort now maps to budgets (high→12800, xhigh→15200, etc.), no `thinking_effort`.
- `make check` (ruff, ruff-format, mypy on 226 files, deptry) and `make test` (7276 passed, 1 skipped) both green.
- Manual: `litellm.utils.get_optional_params` probe confirming clamped budgets assemble into valid Anthropic payloads (`budget < max_tokens`).