### PR TITLE
fix: empty-input batch is a non-degrading advisory, not a DEGRADED warning (#450)

### DIFF
--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -799,6 +799,13 @@ def _display_execution_summary(
     warning_diagnostics: list[Diagnostic] | None = None,
 ) -> None:
     """Display one-line execution summary with supplementary info."""
+    from pflow.execution.formatters.success_formatter import partition_surfaced_diagnostics
+
+    # INFO advisories (e.g. an empty batch) are not warnings: only WARNING/ERROR
+    # diagnostics drive the "completed with N warnings" header. Advisories get
+    # their own section so a fully correct run still reads "✓ Workflow completed".
+    warnings_list, advisories_list = partition_surfaced_diagnostics(warning_diagnostics)
+
     duration_ms = formatted_result.get("duration_ms")
     total_cost = formatted_result.get("total_cost_usd")
     execution = formatted_result.get("execution", {})
@@ -814,7 +821,7 @@ def _display_execution_summary(
         has_stderr_warnings = any(step.get("has_stderr") for step in steps)
         cache_hits = execution.get("cache_hits", 0)
         completed_count = execution.get("nodes_executed", 0)
-        warning_count = len(formatted_result.get("warnings", []))
+        warning_count = len(warnings_list)
         _display_workflow_completion_status(
             duration_s,
             status,
@@ -837,11 +844,16 @@ def _display_execution_summary(
 
     _display_cost_summary(total_cost, formatted_result)
 
-    if warning_diagnostics:
+    if warnings_list:
         click.echo("", err=True)
         click.echo("⚠️ Warnings:", err=True)
-        for warning in warning_diagnostics:
+        for warning in warnings_list:
             click.echo(format_diagnostic(warning), err=True)
+    if advisories_list:
+        click.echo("", err=True)
+        click.echo("\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} Advisories:", err=True)
+        for advisory in advisories_list:
+            click.echo(format_diagnostic(advisory), err=True)
 
 
 def _handle_json_output(

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -372,6 +372,11 @@ def format_success_as_text(  # noqa: C901
         lines.append("⚠️ Warnings:")
         for warning in warnings_list:
             lines.append(format_diagnostic(warning))
+    # Unreachable today: the only production caller is MCP, which passes
+    # WARNING-only diagnostics (see the filter in
+    # mcp_server/services/execution_service.py). Kept for symmetry with the CLI
+    # renderer (workflow_output.py) and exercised by unit tests — a future
+    # caller passing the full diagnostics list exercises it for real.
     if advisories_list:
         lines.append("")
         lines.append("\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} Advisories:")

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -7,7 +7,7 @@ ensuring CLI and MCP return identical output structures.
 import json
 from typing import Any, Optional
 
-from pflow.core.diagnostic import Diagnostic
+from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.core.diagnostic_render import format_diagnostic
 from pflow.core.workflow.status import WorkflowStatus
 from pflow.execution.formatters.batch_errors import (
@@ -66,9 +66,15 @@ def format_execution_success(
     # Add workflow metadata (default to unsaved if not provided)
     result["workflow"] = workflow_metadata if workflow_metadata else {"action": "unsaved"}
 
-    warning_diagnostics = warnings or []
-    result["warnings"] = [warning.to_display_dict() for warning in warning_diagnostics]
-    result["diagnostics"] = [warning.to_dict() for warning in warning_diagnostics]
+    # Split by severity so INFO advisories (e.g. an empty batch) don't appear
+    # under `warnings` — an agent parsing JSON would otherwise read a clean run
+    # as warned. `diagnostics` keeps the full severity-tagged list. Mirrors the
+    # text renderer's Warnings/Advisories split (CLI/JSON parity).
+    all_diagnostics = warnings or []
+    warnings_list, advisories_list = partition_surfaced_diagnostics(all_diagnostics)
+    result["warnings"] = [d.to_display_dict() for d in warnings_list]
+    result["advisories"] = [d.to_display_dict() for d in advisories_list]
+    result["diagnostics"] = [d.to_dict() for d in all_diagnostics]
 
     # Add metrics from collector
     if metrics_collector:
@@ -235,6 +241,24 @@ def _collect_outputs(
     return result
 
 
+def partition_surfaced_diagnostics(
+    diagnostics: list[Diagnostic] | None,
+) -> tuple[list[Diagnostic], list[Diagnostic]]:
+    """Split surfaced diagnostics into ``(warnings, advisories)``.
+
+    Warnings (``WARNING``/``ERROR`` severity) drive the "completed with N
+    warnings" header. Advisories (``INFO`` severity) are non-degrading notes —
+    e.g. an empty batch (a drained iteration loop or a filter that matched
+    nothing) or a cache advisory — rendered under their own heading so a fully
+    correct run still reads "✓ Workflow completed". Single source of truth for
+    both the CLI text renderer and this MCP/success formatter.
+    """
+    diags = diagnostics or []
+    warnings = [d for d in diags if d.severity is not Severity.INFO]
+    advisories = [d for d in diags if d.severity is Severity.INFO]
+    return warnings, advisories
+
+
 def format_success_as_text(  # noqa: C901
     success_dict: dict[str, Any],
     warning_diagnostics: list[Diagnostic] | None = None,
@@ -257,7 +281,11 @@ def format_success_as_text(  # noqa: C901
     workflow_name = workflow_metadata.get("name", "workflow")
     workflow_action = workflow_metadata.get("action", "executed")
     status = success_dict.get("status", "success")
-    warning_count = len(success_dict.get("warnings", []))
+    # INFO advisories (e.g. an empty batch) must not be counted as warnings:
+    # only WARNING/ERROR diagnostics drive the "completed with N warnings"
+    # header. Advisories render in their own section below.
+    warnings_list, advisories_list = partition_surfaced_diagnostics(warning_diagnostics)
+    warning_count = len(warnings_list)
 
     # Show workflow name and action (matches CLI)
     if workflow_action == "reused":
@@ -337,12 +365,18 @@ def format_success_as_text(  # noqa: C901
         else:
             lines.append(f"💰 Cost: ${total_cost:.4f}")
 
-    # Show warnings if present (matches CLI format with proper indentation)
-    if warning_diagnostics:
+    # Show warnings and advisories in separate sections (matches CLI format).
+    # Warnings are regressions; advisories are non-degrading notes.
+    if warnings_list:
         lines.append("")
         lines.append("⚠️ Warnings:")
-        for warning in warning_diagnostics:
+        for warning in warnings_list:
             lines.append(format_diagnostic(warning))
+    if advisories_list:
+        lines.append("")
+        lines.append("\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} Advisories:")
+        for advisory in advisories_list:
+            lines.append(format_diagnostic(advisory))
 
     # Show outputs if present (matches CLI "Workflow output:" section)
     result = success_dict.get("result", {})

--- a/src/pflow/guide/features/branching.md
+++ b/src/pflow/guide/features/branching.md
@@ -203,37 +203,7 @@ falls through `${checker.result ?? 0}` to `0`, and later visits read the int
 
 **Visit guard:** each node may be visited at most 100 times per run (loop-runaway protection). Override with the `PFLOW_MAX_NODE_VISITS=200` environment variable.
 
-**The worker can be any node type.** Make it a `workflow` node and the loop body becomes an entire sub-workflow that repeats until the checker's condition is met — the checker branches on one of the sub-workflow's `## Outputs`. This is how you get a heavyweight per-iteration body that still stops the moment the work is done:
-
-````markdown
-### process-chunk
-
-The loop body — a whole sub-workflow run as one node. It handles the next chunk
-of pending work and exposes a `remaining` output (a declared `## Output` of the
-child). As a loop target it declares an explicit successor.
-
-- type: workflow
-- workflow: ./process-chunk.pflow.md
-- next: check-remaining
-
-### check-remaining
-
-Loop while work is left; stop the instant it drains. There is no iteration
-count — the loop exits on the condition, which the batch pattern cannot.
-
-- type: code
-- inputs: { remaining: "${process-chunk.remaining}" }
-- next: process-chunk, end
-
-```python code
-remaining: int
-result: int = remaining
-if remaining > 0:
-    next: str = "process-chunk"
-else:
-    next: str = "end"
-```
-````
+**The worker can be any node type.** Make the worker a `workflow` node and the loop body becomes an entire sub-workflow that repeats until the condition is met — the checker just branches on one of the child's declared `## Outputs` (e.g. `${worker.remaining}`) instead of a counter. That gives a heavyweight per-iteration body — a whole sub-workflow — that still exits the moment the work is done, which the fixed-count batch pattern cannot.
 
 **Choosing the loop style:** the deciding question is whether the number of iterations is known up front — not how heavy each iteration is. Use the sub-workflow batch pattern (`parallel: false`) for a fixed iteration count; it always runs all N. Use this backward-edge loop when iterations continue until a condition is met, since only it can stop early. Both can carry a substantial per-iteration body and read state from disk. See `pflow guide sub-workflows` → Bounded iteration.
 

--- a/src/pflow/mcp_server/services/execution_service.py
+++ b/src/pflow/mcp_server/services/execution_service.py
@@ -74,6 +74,13 @@ def _format_success_result(
         workflow_metadata=workflow_metadata,
         trace_path=trace_path,
         status=result.status,
+        # INTENTIONAL: MCP surfaces WARNING/ERROR only, never INFO advisories
+        # (e.g. an empty-batch note). MCP agents already see an empty result via
+        # `shared_after` + `batch_metadata.count: 0`, so the advisory would be
+        # redundant noise. This asymmetry with the CLI (which DOES show an
+        # `advisories` section/key) is deliberate — do not "fix" it by passing
+        # the full diagnostics list without a decision. Mirror at the text path
+        # below (`format_success_as_text(..., warning_diagnostics=result.warnings)`).
         warnings=[
             diagnostic for diagnostic in getattr(result, "diagnostics", []) if diagnostic.severity == Severity.WARNING
         ],
@@ -259,6 +266,10 @@ class ExecutionService(BaseService):
                 success_dict = _format_success_result(result, resolved, str(workflow))
                 from pflow.execution.formatters.success_formatter import format_success_as_text
 
+                # `result.warnings` is WARNING-only by design — see the comment at
+                # the `_format_success_result` filter above. INFO advisories are
+                # intentionally not surfaced to MCP, so the formatter's
+                # "Advisories:" branch never fires on this path.
                 return format_success_as_text(success_dict, warning_diagnostics=result.warnings)
             else:
                 error_diagnostics = [d for d in result.diagnostics if d.severity == Severity.ERROR]

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -16,6 +16,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.core.exceptions import CompilationError
 from pflow.core.json_utils import try_parse_json
 
@@ -971,7 +972,39 @@ def _push_batch_warnings(
     node_id: str,
     batch_config: BatchConfig,
 ) -> None:
-    """Push warnings for DEGRADED status when batch had issues."""
+    """Push warnings for DEGRADED status when batch had issues.
+
+    The empty-INPUT case is treated differently from the other two. An empty
+    input list is a legitimate terminal state for the iteration patterns the
+    guide teaches (a drained queue loop, a filter that matched nothing), so it
+    is emitted as a non-degrading ``Severity.INFO`` advisory — visible in
+    ``--report`` / CLI output but not flipping the workflow to DEGRADED. The
+    runtime cannot tell "empty because the work is done" from "empty because
+    upstream broke" (there is no loop construct), so it surfaces the fact
+    without asserting wrongdoing. The genuinely anomalous cases — items that
+    ran but produced empty output, or per-item errors — stay degrading.
+    """
+    # Empty input is mutually exclusive with the other two cases: no items
+    # means no per-item errors and no per-item empty output. Handle it as a
+    # standalone advisory and return.
+    if not exec_res:
+        if "__warnings__" not in shared:
+            shared["__warnings__"] = {}
+        shared["__warnings__"][node_id] = Diagnostic(
+            severity=Severity.INFO,
+            title="Empty batch",
+            message=f"Batch '{node_id}' ran with 0 items (input list was empty).",
+            suggestions=[
+                "Expected when iterating a drained queue or a filter that "
+                "matched nothing. If items were expected, check the node that "
+                "produces this batch's list.",
+            ],
+            node_id=node_id,
+            source="runtime",
+            id="batch.empty-input",
+        )
+        return
+
     empty_indices = _detect_empty_output_items(exec_res, errors)
 
     # Under --only, suppress empty-output warnings workflow-wide. The common
@@ -986,8 +1019,6 @@ def _push_batch_warnings(
         empty_indices = []
 
     warning_parts: list[str] = []
-    if not exec_res:
-        warning_parts.append("0 items to process (input list was empty)")
     if batch_config.error_handling == "continue" and errors:
         warning_parts.append(f"{len(errors)} error(s) out of {len(exec_res)} items")
     if empty_indices:

--- a/tests/test_cli/test_direct_execution_helpers.py
+++ b/tests/test_cli/test_direct_execution_helpers.py
@@ -403,3 +403,30 @@ class TestDisplayExecutionSummaryAdvisories:
         assert "Workflow completed with 1 warnings" in cli_result.output
         assert "⚠️ Warnings:" in cli_result.output
         assert "Advisories:" not in cli_result.output
+
+    def test_legacy_warnings_dict_key_does_not_resurrect_old_count(self) -> None:
+        """The completion-header count derives from the partitioned
+        ``warning_diagnostics``, NOT the legacy ``formatted_result['warnings']``
+        list. A stray INFO entry in that key must not re-trigger the pre-fix
+        '⚠️ completed with N warnings' header — pins the regression against the
+        old ``len(formatted_result.get('warnings', []))`` source.
+        """
+        formatted = self._formatted()
+        advisory = Diagnostic(
+            severity=Severity.INFO,
+            message="Batch 'consume' ran with 0 items (input list was empty).",
+            node_id="consume",
+            source="runtime",
+        )
+        # Simulate the legacy data source still carrying the advisory: the
+        # pre-fix code counted this list, so a regression to that source would
+        # mis-render the header.
+        formatted["warnings"] = [advisory.to_display_dict()]
+
+        @click.command()
+        def cmd() -> None:
+            _display_execution_summary(formatted, verbose=False, warning_diagnostics=[advisory])
+
+        cli_result = click.testing.CliRunner().invoke(cmd)
+        assert "✓ Workflow completed" in cli_result.output
+        assert "with 1 warnings" not in cli_result.output

--- a/tests/test_cli/test_direct_execution_helpers.py
+++ b/tests/test_cli/test_direct_execution_helpers.py
@@ -4,8 +4,9 @@ import click
 import click.testing
 
 from pflow.cli.param_parsing import infer_type, parse_workflow_params
-from pflow.cli.workflow_output import _display_cost_summary
+from pflow.cli.workflow_output import _display_cost_summary, _display_execution_summary
 from pflow.cli.workflow_resolution import is_likely_workflow_name
+from pflow.core.diagnostic import Diagnostic, Severity
 
 
 class TestInferType:
@@ -341,3 +342,64 @@ class TestDisplayCostSummary:
         # Locked wording from F#17 deferred spec
         assert "my-custom-model (3 calls); 2 calls without recorded model" in cli_result.output
         assert "   Total LLM calls: 5" in cli_result.output
+
+
+class TestDisplayExecutionSummaryAdvisories:
+    """CLI default summary splits INFO advisories from WARNING-severity
+    diagnostics (``cli/workflow_output.py::_display_execution_summary``).
+
+    Guards the CLI half of the empty-batch advisory fix: an INFO advisory must
+    render under 'Advisories' with a clean '✓ Workflow completed' header, while
+    a real WARNING still degrades the header under 'Warnings'.
+    """
+
+    @staticmethod
+    def _formatted() -> dict:
+        """Minimal synthetic shape mirroring format_execution_success output."""
+        return {
+            "duration_ms": 100,
+            "total_cost_usd": None,
+            "status": "success",
+            "workflow": {"name": "wf", "action": "unsaved"},
+            "execution": {"steps": [], "cache_hits": 0, "nodes_executed": 1},
+        }
+
+    def test_info_advisory_renders_under_advisories_not_warnings(self) -> None:
+        formatted = self._formatted()
+        advisory = Diagnostic(
+            severity=Severity.INFO,
+            message="Batch 'consume' ran with 0 items (input list was empty).",
+            node_id="consume",
+            source="runtime",
+        )
+
+        @click.command()
+        def cmd() -> None:
+            _display_execution_summary(formatted, verbose=False, warning_diagnostics=[advisory])
+
+        cli_result = click.testing.CliRunner().invoke(cmd)
+        assert cli_result.exit_code == 0, cli_result.output
+        assert "✓ Workflow completed" in cli_result.output
+        assert "with 1 warnings" not in cli_result.output
+        assert "⚠️ Warnings:" not in cli_result.output
+        assert "Advisories:" in cli_result.output
+        assert "ran with 0 items" in cli_result.output
+
+    def test_real_warning_still_degrades_under_warnings(self) -> None:
+        """Contrast: a WARNING keeps the degraded header and the Warnings section."""
+        formatted = self._formatted()
+        warning = Diagnostic(
+            severity=Severity.WARNING,
+            message="something genuinely off",
+            node_id="n",
+            source="runtime",
+        )
+
+        @click.command()
+        def cmd() -> None:
+            _display_execution_summary(formatted, verbose=False, warning_diagnostics=[warning])
+
+        cli_result = click.testing.CliRunner().invoke(cmd)
+        assert "Workflow completed with 1 warnings" in cli_result.output
+        assert "⚠️ Warnings:" in cli_result.output
+        assert "Advisories:" not in cli_result.output

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -400,6 +400,35 @@ class TestFormatSuccessAsText:
         assert "[send-alert] API error: Rate limit exceeded" in text
         assert "API error: Rate limit exceeded" in text
 
+    def test_info_advisory_does_not_count_as_warning(self):
+        """INFO advisories render under 'Advisories', not 'Warnings', and do not
+        trigger the 'completed with N warnings' header.
+
+        Guards ``partition_surfaced_diagnostics``: an empty-batch advisory (and
+        other INFO notes like cache advisories) must not make a fully-correct
+        run read as warned.
+        """
+        result_dict = {
+            "success": True,
+            "status": "success",
+            "duration_ms": 100,
+            "execution": {"nodes_executed": 1, "steps": []},
+        }
+        advisory = Diagnostic(
+            severity=Severity.INFO,
+            message="Batch 'consume' ran with 0 items (input list was empty).",
+            node_id="consume",
+            source="runtime",
+        )
+
+        text = format_success_as_text(result_dict, warning_diagnostics=[advisory])
+
+        assert "\u2713 Workflow completed in" in text  # clean \u2713 header
+        assert "with 1 warnings" not in text
+        assert "\u26a0\ufe0f Warnings:" not in text
+        assert "Advisories:" in text
+        assert "ran with 0 items" in text
+
     def test_format_execution_success_serializes_warning_diagnostics_for_json(self):
         """REGRESSION: Warning diagnostics stay structured in success JSON output.
 
@@ -446,6 +475,40 @@ class TestFormatSuccessAsText:
                 "node_id": "run-shell",
             }
         ]
+
+    def test_info_advisory_goes_to_advisories_not_warnings_in_json(self):
+        """REGRESSION: INFO advisories must not appear under ``warnings`` in the
+        success dict — JSON/MCP consumers count ``warnings``. They belong under
+        ``advisories``; ``diagnostics`` keeps the full severity-tagged list.
+
+        This is the JSON-surface half of the empty-batch advisory fix: the text
+        renderer already splits Warnings vs Advisories; the structured output
+        must match (CLI/JSON parity).
+        """
+        result = format_execution_success(
+            shared_storage={"stdout": "ok"},
+            workflow_ir={},
+            metrics_collector=None,
+            warnings=[
+                Diagnostic(
+                    severity=Severity.WARNING,
+                    message="a real warning",
+                    node_id="w",
+                    source="runtime",
+                ),
+                Diagnostic(
+                    severity=Severity.INFO,
+                    message="Batch 'b' ran with 0 items (input list was empty).",
+                    node_id="b",
+                    source="runtime",
+                ),
+            ],
+        )
+
+        assert [w["message"] for w in result["warnings"]] == ["a real warning"]
+        assert [a["message"] for a in result["advisories"]] == ["Batch 'b' ran with 0 items (input list was empty)."]
+        # Full list (both severities) stays under diagnostics.
+        assert [d["severity"] for d in result["diagnostics"]] == ["warning", "info"]
 
     def test_format_execution_success_compacts_degraded_batch_error_details_for_json(self):
         """Degraded success JSON must not expose full failed batch items."""

--- a/tests/test_integration/test_cli_mcp_parity.py
+++ b/tests/test_integration/test_cli_mcp_parity.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import pytest
 
-from pflow.execution.result import RunnerConfig
+from pflow.execution.result import RunnerConfig, WorkflowStatus
 from pflow.execution.runner import WorkflowRunner
 
 
@@ -146,6 +146,10 @@ def test_only_batch_node_runtime_empty_items_emits_compact_summary(capsys):
 
     result = WorkflowRunner().run(ir, {}, RunnerConfig(only_node="consume"))
     assert result.success, [d.message for d in result.diagnostics]
+    # An empty-input batch is a legitimate terminal state (drained loop / empty
+    # filter), so it must NOT degrade the workflow — it emits a non-degrading
+    # INFO advisory instead. Regression guard for the empty-input advisory.
+    assert result.status == WorkflowStatus.SUCCESS
 
     aggregate = result.shared_after.get("consume")
     assert isinstance(aggregate, dict)
@@ -160,3 +164,50 @@ def test_only_batch_node_runtime_empty_items_emits_compact_summary(capsys):
     assert "batch consume: ran with no items" in captured.out
     # The undefined '0/0 succeeded' wording must NOT appear.
     assert "0/0" not in captured.out
+
+
+def test_empty_input_batch_emits_non_degrading_info_advisory():
+    """End-to-end: a runtime-empty batch surfaces an INFO advisory in
+    ``result.diagnostics`` but NOT in ``result.warnings``, and the workflow
+    stays SUCCESS (cross-layer guard per tests/CLAUDE.md #20).
+
+    The advisory rides the ``__warnings__`` channel as a ``Severity.INFO``
+    Diagnostic; ``result.warnings`` is WARNING-only, so it must be absent there
+    while present in the full ``result.diagnostics`` list.
+    """
+    from pflow.core.diagnostic import Severity
+
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "produce-empty",
+                "type": "code",
+                "purpose": "Emit an empty list so the downstream batch has nothing to do.",
+                "params": {"code": "result: list = []"},
+            },
+            {
+                "id": "consume",
+                "type": "shell",
+                "purpose": "Batch over the runtime-empty upstream list.",
+                "params": {"command": "echo ${item}"},
+                "batch": {"items": "${produce-empty.result}", "parallel": False},
+            },
+        ],
+        "edges": [{"from": "produce-empty", "to": "consume", "action": "default"}],
+        "start_node": "produce-empty",
+    }
+
+    result = WorkflowRunner().run(ir, {}, RunnerConfig())
+
+    assert result.success
+    assert result.status == WorkflowStatus.SUCCESS
+    # No WARNING-severity diagnostics (the advisory is INFO).
+    assert result.warnings == []
+    # The INFO advisory IS present in the full diagnostics list.
+    advisories = [
+        d
+        for d in result.diagnostics
+        if d.severity == Severity.INFO and d.node_id == "consume" and "0 items" in d.message
+    ]
+    assert len(advisories) == 1, [(d.severity, d.message) for d in result.diagnostics]

--- a/tests/test_integration/test_loop_example.py
+++ b/tests/test_integration/test_loop_example.py
@@ -1,0 +1,97 @@
+"""Regression guard for the Loops worked example in the branching guide.
+
+This reproduces **Example A** (the self-contained int-counter worker/checker
+loop) from ``src/pflow/guide/features/branching.md`` (lines ~152-195) and runs
+it end-to-end. It guards that the documented loop actually executes and
+terminates — closing the "verify the example itself runs" gap (a guide example
+that silently rots to something broken misleads agents who copy it).
+
+Maintenance contract: this is a hand-copied reproduction. If you edit the Loops
+example in ``branching.md``, update the workflow string below to match. The test
+runs a copy, so it guards the runtime capability the doc claims — it cannot
+detect that the doc text itself drifted.
+
+Note: the section also carries a prose note that the worker can be a
+``workflow`` node (the loop body becomes a whole sub-workflow). That's a
+one-line variation on this same structure, not a separate runnable example, so
+there's nothing additional to guard here.
+
+Pattern: mirrors ``tests/test_integration/test_iteration_pattern.py`` — write an
+inline ``.pflow.md`` to ``tmp_path`` and run via ``WorkflowRunner``.
+"""
+
+from pflow.execution.result import RunnerConfig
+from pflow.execution.runner import WorkflowRunner
+
+# Example A verbatim (branching.md ~152-195), wrapped in a workflow title +
+# `## Steps` heading so the step fragment becomes a complete workflow.
+LOOP_EXAMPLE_WORKFLOW = """\
+# Loop Example (branching guide)
+
+Reproduces the int-counter worker/checker loop from the branching guide's
+Loops section, used as an execution regression guard.
+
+## Steps
+
+### worker
+
+Increment the running count. `worker` is a branch target of `checker`'s
+loop-back edge, so it needs an explicit `- next:`.
+
+- type: code
+- inputs:
+    prior: ${checker.result ?? 0}
+- next: checker
+
+```python code
+prior: int
+result: int = prior + 1
+```
+
+### checker
+
+Decide whether to loop or finish.
+
+- type: code
+- inputs: { count: "${worker.result}" }
+- next: worker, done
+
+```python code
+count: int
+result: int = count
+if count >= 3:
+    next: str = "done"
+else:
+    next: str = "worker"
+```
+
+### done
+
+Report the final count.
+
+- type: shell
+- next: end
+
+```shell command
+echo "Looped ${worker.result} times"
+```
+"""
+
+
+def test_branching_guide_loop_example_runs_and_terminates(tmp_path):
+    """The documented worker/checker loop runs, loops exactly 3 times, exits."""
+    workflow_path = tmp_path / "loop-example.pflow.md"
+    workflow_path.write_text(LOOP_EXAMPLE_WORKFLOW, encoding="utf-8")
+
+    result = WorkflowRunner().run(str(workflow_path), {}, RunnerConfig())
+    assert result.success, f"Loop example failed: {[d.message for d in result.errors]}"
+
+    # The loop must terminate at the documented threshold: worker runs on visits
+    # 1→2→3, checker exits when count reaches 3. Pins the loop behavior rather
+    # than just "it didn't crash" (same technique as
+    # test_conditional_branching.py::test_loop_with_exit_condition).
+    visit_counts = result.shared_after["__execution__"]["node_visit_counts"]
+    assert visit_counts["worker"] == 3, visit_counts
+
+    # The `done` node reports the final count via stdout.
+    assert "Looped 3 times" in result.shared_after["done"]["stdout"]

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -2944,15 +2944,25 @@ class TestEmptyOutputWarnings:
         assert "error" in warning.lower()
         assert "empty output" in warning
 
-    def test_empty_input_list_pushes_warning(self):
-        """When batch receives an empty input list, a warning about 0 items is pushed."""
+    def test_empty_input_list_pushes_info_advisory(self):
+        """Empty input list emits a non-degrading INFO advisory, not a warning.
+
+        An empty list is the normal terminal state of iteration loops (drained
+        queue) and filters that matched nothing, so it must NOT degrade the
+        workflow. The value is a ``Severity.INFO`` Diagnostic (not a plain
+        string), which ``_is_degrading_warning`` treats as advisory-only.
+        """
+        from pflow.core.diagnostic import Diagnostic, Severity
+
         inner = MockInnerNode("test_node")
         shared: dict = {"data": []}
 
         _run_batch(inner, shared, error_handling="continue")
 
-        assert "test_node" in shared.get("__warnings__", {})
-        assert "0 items" in shared["__warnings__"]["test_node"]
+        advisory = shared.get("__warnings__", {}).get("test_node")
+        assert isinstance(advisory, Diagnostic)
+        assert advisory.severity is Severity.INFO
+        assert "0 items" in advisory.message
 
     def test_only_node_suppresses_empty_output_warning(self):
         """Under --only, empty output is expected and should not trigger a warning."""


### PR DESCRIPTION
## Summary

An empty batch input list is the normal terminal state of the iteration patterns the guide teaches — a backward-edge loop draining a queue, or a batch over a filter that matched nothing. Previously such a run reported **DEGRADED** and told the agent to "fix the upstream data," mis-signalling on exactly the patterns we recommend. This makes an empty-input batch a **non-degrading INFO advisory** instead, keeps genuine batch anomalies degrading, and makes the text and JSON surfaces agree.

Fixes #450

## Changes

- **`batch_executor.py`** — the empty-input case now emits a `Severity.INFO` Diagnostic via an early branch (the case is mutually exclusive with the other two: empty input ⇒ no per-item errors, no per-item empty-output). The errors / empty-output paths are unchanged and still degrade.
- **Warnings vs Advisories split** — new shared SSoT helper `partition_surfaced_diagnostics()` in `success_formatter.py`. INFO advisories no longer count toward the "completed with N warnings" header and render under their own "Advisories:" section. Applied to **both** the CLI text renderer (`workflow_output.py`) and the JSON/MCP success formatter:
  - `result["warnings"]` → WARNING/ERROR only
  - `result["advisories"]` → new key, INFO only
  - `result["diagnostics"]` → unchanged (full severity-tagged list)
- **`branching.md`** — collapsed the Loops "worker can be a `workflow` node" example (which referenced a non-existent `./process-chunk.pflow.md`) into a one-line note. The example was ~90% a duplicate of the int-counter example; its only unique point was a single changed line, which is now prose. Removes the dangling file reference.

## Explanation

The root cause: the memo/runtime layer can't tell *why* a batch list is empty — drained loop (success) vs broken upstream (bug) — because there's no loop construct to consult. So the right behavior is a non-degrading advisory: visible if you look, never alarming, with wording that names the legitimate case instead of asserting wrongdoing. Genuine anomalies (items that ran but produced empty output; per-item errors) remain degrading warnings.

The text fix alone would have left a parity gap: the JSON/MCP `warnings` array still counted the INFO advisory, so an agent doing `len(warnings)` would still read a clean run as warned. The shared `partition_surfaced_diagnostics()` helper closes that — text and JSON now treat advisories identically. MCP already filters to WARNING-only before the shared formatter, so its behavior is unchanged (it gets an empty `advisories` list).

Diffstat: 9 files, +284 / -51 (4 source, 5 test).

## Testing

- `test_batch_node.py::test_empty_input_list_pushes_info_advisory` — empty input emits an INFO `Diagnostic` (not a degrading string).
- `test_cli_mcp_parity.py::test_only_batch_node_runtime_empty_items_emits_compact_summary` — strengthened with `result.status == SUCCESS` (was DEGRADED).
- `test_cli_mcp_parity.py::test_empty_input_batch_emits_non_degrading_info_advisory` — end-to-end: SUCCESS, advisory present in `result.diagnostics`, absent from `result.warnings`.
- `test_success_formatter.py::test_info_advisory_does_not_count_as_warning` — INFO ⇒ "✓ Workflow completed" header + "Advisories" section, not counted as a warning.
- `test_success_formatter.py::test_info_advisory_goes_to_advisories_not_warnings_in_json` — JSON split: `warnings` WARNING-only, `advisories` INFO-only, `diagnostics` full list.
- `test_direct_execution_helpers.py::TestDisplayExecutionSummaryAdvisories` — CLI summary renders advisories under "Advisories:" (clean header) and a real WARNING still degrades under "Warnings:".
- `test_loop_example.py` — reproduces the branching-guide runnable Loops example; asserts it runs, loops exactly 3 times, exits, prints "Looped 3 times".
- Full suite: 7236 passed, 1 skipped. `make check` clean.
- Manual: `pflow <empty-batch>.pflow.md` → exit 0, `✓ Workflow completed`, advisory under `ℹ️ Advisories:`; `--output-format json` → `status: success`, `warnings: []`, advisory under `advisories`.