### PR TITLE
fix: reject stray `--flag` args after workflow instead of silently dropping them (#454)

### DIFF
--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -250,7 +250,7 @@ See `core/CLAUDE.md` (shell_integration section) for FIFO detection, StdinData m
 - **Use lazy imports** in command files and `commands/run.py` to avoid circular dependencies
 - **Don't mix output streams** — errors→stderr, results→stdout. This makes piping work.
 - **Don't mix routing and rendering** — stdout/stderr routing is TTY-agnostic; the stderr header in `_output_with_header` and the `\r` batch counter are the only TTY-sensitive writes
-- **`ignore_unknown_options=True` tradeoff** — typos like `--output-formt` silently pass through. `_validate_workflow_flags` in `commands/run.py` catches common misplaced flags.
+- **`ignore_unknown_options=True` is load-bearing, not lax** — it lets `--help` and any unknown dash token reach the `workflow` tuple instead of erroring at parse time; the per-workflow `--help` passthrough depends on it, so don't remove it. `_validate_workflow_flags` (`commands/run.py`) then rejects *every* stray leading-dash token after the workflow with a "use key=value" error (`--help` is the one whitelist; `-h` points to `--help`). This is what stops unknown flags like `--scenario x` from being silently dropped (GH #454). Note: `=`-bearing dash tokens (`--scenario=x`) skip this guard and fail later via the undeclared-input validator instead.
 
 ## Test Mapping
 

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -545,7 +545,7 @@ def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
         ),
         suggestions=[
             f"Did you mean '{_suggest_key_value(bad, workflow)}'?",
-            f"See this workflow's inputs:  pflow {target} --help",
+            f"See this workflow's inputs: pflow {target} --help",
         ],
     )
 

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -455,41 +455,99 @@ def _preprocess_run_prefix(workflow: tuple[str, ...]) -> tuple[str, ...]:
     return workflow
 
 
-def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
-    """Validate that CLI flags are not misplaced in workflow arguments."""
-    misplaced_flags = [
-        arg
-        for arg in workflow
-        if arg
-        in (
-            "--no-trace",
-            "--verbose",
-            "-v",
-            "--output-key",
-            "-o",
-            "--output-format",
-            "--print",
-            "-p",
-            "--report",
-            "--report-dir",
-            "--validate-only",
-            "--dry-run",
-            "--cache",
-            "--no-cache",
-            "--only",
-        )
-    ]
-    if misplaced_flags:
-        from pflow.core.user_errors import UserFriendlyError
+# pflow's own flags. They configure the run; they belong BEFORE the workflow,
+# not after it. Click consumes most of these positionally (so they rarely reach
+# the workflow tuple), but group-level flags like --verbose/-v land here when
+# misplaced — and listing them keeps the "move it before" guidance precise.
+_PFLOW_FLAGS = frozenset({
+    "--no-trace",
+    "--verbose",
+    "-v",
+    "--output-key",
+    "-o",
+    "--output-format",
+    "--print",
+    "-p",
+    "--report",
+    "--report-dir",
+    "--validate-only",
+    "--dry-run",
+    "--cache",
+    "--no-cache",
+    "--only",
+})
 
+
+def _suggest_key_value(flag: str, workflow: tuple[str, ...]) -> str:
+    """Build the canonical ``key=value`` suggestion for a stray ``--flag`` token.
+
+    Pairs the flag with the token that follows it (``--scenario fail-mid`` →
+    ``scenario=fail-mid``) when that token looks like a value; otherwise falls
+    back to a ``key=<value>`` placeholder.
+    """
+    key = flag.lstrip("-")
+    idx = workflow.index(flag)
+    following = workflow[idx + 1] if idx + 1 < len(workflow) else None
+    if following is not None and not following.startswith("-") and "=" not in following:
+        return f"{key}={following}"
+    return f"{key}=<value>"
+
+
+def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
+    """Reject option-like tokens left after the workflow name.
+
+    After Click parses the run command, the only legal tokens are the workflow
+    name/path and ``key=value`` params. Any remaining leading-dash token is an
+    error — either a pflow flag placed after the workflow (move it before), or
+    an unknown option (agents reflexively type ``--flag``; redirect them to
+    ``key=value``). Silent-dropping these is the worst failure for an agent-first
+    CLI: a green run on the wrong inputs (GH #454).
+
+    ``--help`` is whitelisted — it routes to per-workflow help downstream
+    (``_handle_named_workflow``). ``=``-bearing tokens (e.g. ``--scenario=x``)
+    are left alone: those already fail loudly via the undeclared-input validator.
+    """
+    from pflow.core.user_errors import UserFriendlyError
+
+    stray = [arg for arg in workflow if arg.startswith("-") and "=" not in arg and arg != "--help"]
+    if not stray:
+        return
+
+    # The name/path the user typed, so suggestions are concrete and copy-pasteable.
+    # `<workflow>` only when the name was omitted (workflow[0] is itself a dash).
+    # Per-workflow `--help` (not `pflow describe`) is used to list inputs because
+    # it accepts BOTH file paths and saved names; `describe` only takes saved names.
+    target = workflow[0] if workflow and not workflow[0].startswith("-") else "<workflow>"
+
+    misplaced = [arg for arg in stray if arg in _PFLOW_FLAGS]
+    if misplaced:
         raise UserFriendlyError(
-            title="CLI flags must come BEFORE the workflow text",
-            explanation=f"Found misplaced flags: {', '.join(misplaced_flags)}",
-            suggestions=[
-                'pflow --verbose "analyze this data"',
-                'pflow --no-trace "run without tracing"',
-            ],
+            title="CLI flags must come BEFORE the workflow",
+            explanation=(
+                f"pflow flags configure the run and must precede the workflow. Found after it: {', '.join(misplaced)}"
+            ),
+            suggestions=[f"pflow {misplaced[0]} {target}"],
         )
+
+    bad = stray[0]
+    if bad == "-h":
+        raise UserFriendlyError(
+            title="Unknown option '-h'",
+            explanation="pflow uses '--help' to show a workflow's inputs and outputs.",
+            suggestions=[f"pflow {target} --help"],
+        )
+
+    raise UserFriendlyError(
+        title=f"Unknown option '{bad}'",
+        explanation=(
+            f"pflow passes workflow inputs as key=value, not --flags. "
+            f"'{bad}' was not recognized and would be silently ignored."
+        ),
+        suggestions=[
+            f"Did you mean '{_suggest_key_value(bad, workflow)}'?",
+            f"See this workflow's inputs:  pflow {target} --help",
+        ],
+    )
 
 
 def _find_stdin_input(workflow_ir: dict[str, Any]) -> str | None:
@@ -903,8 +961,10 @@ def run(
         stdin_content, enhanced_stdin = _read_stdin_data()
         stdin_data = enhanced_stdin if enhanced_stdin else stdin_content
 
-        _validate_workflow_flags(workflow)
+        # Normalize the optional leading "run" token first so the flag guard
+        # sees the real workflow name at workflow[0] (concrete suggestions).
         workflow = _preprocess_run_prefix(workflow)
+        _validate_workflow_flags(workflow)
 
         raw_input = " ".join(workflow) if workflow else ""
         ctx.obj["workflow_text"] = raw_input

--- a/tests/test_cli/test_unknown_flag_handling.py
+++ b/tests/test_cli/test_unknown_flag_handling.py
@@ -1,0 +1,206 @@
+"""Regression tests for GH #454: stray ``--flag`` tokens after a workflow name.
+
+Before the fix, ``pflow wf.pflow.md --scenario fail-mid`` silently dropped the
+``--scenario`` token (it has no ``=``) and ran with defaults — exit 0, no
+warning. For an agent-first CLI that is the worst failure class: a green run on
+the wrong inputs. The run command now rejects any stray leading-dash token with
+a tailored "use key=value" error, while leaving the ``--help`` passthrough, the
+``key=value`` form, and pflow's own flags untouched.
+
+The guard lives in ``pflow.cli.commands.run._validate_workflow_flags`` (called
+before workflow resolution) and inspects the post-Click ``workflow`` tuple.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from pflow.cli.commands.run import _suggest_key_value, _validate_workflow_flags
+from pflow.cli.main import main
+from pflow.core.user_errors import UserFriendlyError
+from tests.shared.markdown_utils import write_workflow_file
+
+_WF_IR = {
+    "inputs": {
+        "scenario": {
+            "type": "string",
+            "required": False,
+            "default": "happy",
+            "description": "The scenario to run.",
+        }
+    },
+    "nodes": [
+        {
+            "id": "echo",
+            "type": "shell",
+            "purpose": "Echo the scenario value back out.",
+            "params": {"command": 'echo "scenario=${scenario}"'},
+        }
+    ],
+}
+
+
+@pytest.fixture
+def workflow_file(tmp_path: Path) -> Path:
+    """A minimal valid workflow declaring one optional input ``scenario``."""
+    path = tmp_path / "wf454.pflow.md"
+    write_workflow_file(_WF_IR, path, title="WF 454", description="Unknown-flag test workflow.")
+    return path
+
+
+class TestValidateWorkflowFlagsGuard:
+    """Unit coverage of the guard's decision logic (no workflow file needed)."""
+
+    def test_unknown_long_flag_rejected_with_key_value_suggestion(self):
+        """The headline bug: ``--scenario fail-mid`` must raise, not vanish, and
+        the suggestion must teach the canonical ``scenario=fail-mid`` form."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", "--scenario", "fail-mid"))
+        err = exc_info.value
+        assert err.title == "Unknown option '--scenario'"
+        assert "key=value" in err.explanation
+        assert any("scenario=fail-mid" in s for s in err.suggestions)
+        # Inputs are listed via per-workflow --help (accepts file paths), using the
+        # concrete name — NOT `pflow describe`, which only resolves saved names.
+        assert any("pflow wf.pflow.md --help" in s for s in err.suggestions)
+        assert not any("describe" in s for s in err.suggestions)
+
+    def test_unknown_flag_pairs_its_following_value(self):
+        """An unknown flag pairs with the token that follows it for the hint."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", "--nonsense-flag", "xyz"))
+        assert any("nonsense-flag=xyz" in s for s in exc_info.value.suggestions)
+
+    def test_unknown_flag_without_value_suggests_placeholder(self):
+        """A trailing flag with no value falls back to ``key=<value>``."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", "--scenario"))
+        assert any("scenario=<value>" in s for s in exc_info.value.suggestions)
+
+    def test_forgot_workflow_name_first_token_is_dash(self):
+        """When the name is omitted entirely, ``workflow[0]`` is itself a dash
+        token — it must still be caught, not treated as a workflow name."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("--scenario", "x"))
+        assert exc_info.value.title == "Unknown option '--scenario'"
+
+    @pytest.mark.parametrize("flag", ["--verbose", "-v"])
+    def test_misplaced_pflow_flag_says_move_before(self, flag):
+        """A real pflow flag in the wrong place keeps the precise "move it
+        before the workflow" message — distinct from the unknown-option path.
+        The suggestion is a concrete, runnable command (flag before the name),
+        never the removed natural-language form (``pflow --verbose "..."``)."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", flag))
+        err = exc_info.value
+        assert err.title == "CLI flags must come BEFORE the workflow"
+        assert flag in err.explanation
+        assert err.suggestions == [f"pflow {flag} wf.pflow.md"]
+        # Guard against re-introducing the stale natural-language suggestion.
+        assert all('"' not in s for s in err.suggestions)
+
+    def test_short_help_flag_points_to_double_dash_help(self):
+        """``-h`` (currently unwired) is rejected loudly with a pointer to the
+        real ``--help`` rather than a nonsensical ``h=<value>`` suggestion. The
+        pointer is concrete (uses the typed name) and uses ``--help``, which
+        accepts file paths (unlike ``pflow describe``)."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", "-h"))
+        err = exc_info.value
+        assert err.title == "Unknown option '-h'"
+        assert "--help" in err.explanation
+        assert err.suggestions == ["pflow wf.pflow.md --help"]
+
+    def test_first_unknown_flag_reported_when_several(self):
+        """Only the first stray token is surfaced; fixing it re-runs to the next."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", "--foo", "a", "--bar", "b"))
+        assert exc_info.value.title == "Unknown option '--foo'"
+
+    @pytest.mark.parametrize(
+        "workflow",
+        [
+            (),
+            ("wf.pflow.md",),
+            ("wf.pflow.md", "scenario=fail-mid"),
+            ("my-workflow", "scenario=fail-mid"),
+            ("wf.pflow.md", "--help"),
+            ("wf.pflow.md", "--help", "scenario=x"),
+        ],
+    )
+    def test_valid_invocations_do_not_raise(self, workflow):
+        """Names, ``key=value`` params, and ``--help`` must all pass cleanly."""
+        assert _validate_workflow_flags(workflow) is None
+
+    def test_equals_dash_form_left_to_downstream_validator(self):
+        """``--scenario=fail-mid`` has an ``=`` and is intentionally NOT caught
+        here — it already fails loudly via the undeclared-input validator
+        ("Unknown input '--scenario', did you mean 'scenario'?"). Keeping the
+        guard scoped to the dash-WITHOUT-``=`` form avoids changing that path."""
+        assert _validate_workflow_flags(("wf.pflow.md", "--scenario=fail-mid")) is None
+
+
+class TestSuggestKeyValue:
+    """Unit coverage of the ``key=value`` suggestion builder."""
+
+    @pytest.mark.parametrize(
+        ("flag", "workflow", "expected"),
+        [
+            ("--scenario", ("wf.pflow.md", "--scenario", "fail-mid"), "scenario=fail-mid"),
+            ("--nonsense-flag", ("--nonsense-flag", "xyz"), "nonsense-flag=xyz"),
+            ("--scenario", ("wf.pflow.md", "--scenario"), "scenario=<value>"),
+            ("--scenario", ("wf.pflow.md", "--scenario", "--other"), "scenario=<value>"),
+            ("--scenario", ("wf.pflow.md", "--scenario", "k=v"), "scenario=<value>"),
+        ],
+    )
+    def test_suggestion(self, flag, workflow, expected):
+        assert _suggest_key_value(flag, workflow) == expected
+
+
+class TestUnknownFlagCLI:
+    """End-to-end coverage through the real CLI surface (CliRunner)."""
+
+    def test_stray_flag_no_longer_silently_dropped(self, workflow_file):
+        """The exact repro from #454: exit 1 (was 0) with an actionable error."""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, [str(workflow_file), "--scenario", "fail-mid"])
+        assert result.exit_code == 1
+        assert "Unknown option '--scenario'" in result.stderr
+        assert "scenario=fail-mid" in result.stderr
+
+    def test_workflow_help_still_works(self, workflow_file):
+        """Regression pin: ``--help`` is whitelisted and reaches per-workflow
+        help instead of being rejected by the guard."""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, [str(workflow_file), "--help"])
+        assert result.exit_code == 0
+        assert "Inputs:" in result.output
+        assert "scenario" in result.output
+
+    def test_misplaced_verbose_flag_after_workflow(self, workflow_file):
+        """``--verbose`` (a group flag) lands in the tuple and keeps its
+        tailored "must come BEFORE" message end-to-end."""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, [str(workflow_file), "--verbose"])
+        assert result.exit_code == 1
+        assert "CLI flags must come BEFORE the workflow" in result.stderr
+        assert "--verbose" in result.stderr
+
+    def test_key_value_param_not_rejected(self, workflow_file):
+        """No false positive: a legitimate ``key=value`` param validates fine."""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, ["--validate-only", str(workflow_file), "scenario=fail-mid"])
+        assert result.exit_code == 0, result.stderr
+
+    def test_json_mode_error_is_parseable(self, workflow_file):
+        """Agent surface: in JSON mode the rejection is a parseable error
+        object on stdout with exit 1 (not a silent success)."""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(main, ["--output-format", "json", str(workflow_file), "--scenario", "fail-mid"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"] == "Unknown option '--scenario'"
+        assert any("scenario=fail-mid" in s for s in payload["errors"][0]["suggestions"])

--- a/tests/test_cli/test_unknown_flag_handling.py
+++ b/tests/test_cli/test_unknown_flag_handling.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from pflow.cli.commands.run import _suggest_key_value, _validate_workflow_flags
+from pflow.cli.commands.run import _PFLOW_FLAGS, _suggest_key_value, _validate_workflow_flags, run
 from pflow.cli.main import main
 from pflow.core.user_errors import UserFriendlyError
 from tests.shared.markdown_utils import write_workflow_file
@@ -119,6 +119,33 @@ class TestValidateWorkflowFlagsGuard:
             _validate_workflow_flags(("wf.pflow.md", "--foo", "a", "--bar", "b"))
         assert exc_info.value.title == "Unknown option '--foo'"
 
+    def test_misplaced_pflow_flag_wins_over_unknown_flag(self):
+        """When a misplaced pflow flag AND an unknown flag are both present, the
+        pflow-flag diagnosis surfaces first — it's the more confident call. The
+        unknown flag re-surfaces on the next run. Pins the precedence so a future
+        refactor can't silently flip it."""
+        with pytest.raises(UserFriendlyError) as exc_info:
+            _validate_workflow_flags(("wf.pflow.md", "--scenario", "x", "--verbose"))
+        assert exc_info.value.title == "CLI flags must come BEFORE the workflow"
+
+    def test_pflow_flags_mirrors_run_command_options(self):
+        """`_PFLOW_FLAGS` must list every run-command option (plus the group-level
+        flags that land in the workflow tuple when misplaced) so the "move it
+        before the workflow" message stays precise instead of degrading to the
+        generic "Unknown option" path.
+
+        This is primarily a consistency/documentation invariant: declared run
+        options are consumed by Click regardless of position (`allow_interspersed_args`),
+        so they rarely reach the guard — drift mostly costs the wrong suggestion in
+        the degenerate `-- <flag>` case. Limitation: `group_flags` is hardcoded, so
+        a NEWLY added group-level flag won't be auto-detected here.
+        """
+        declared = {opt for p in run.params for opt in getattr(p, "opts", []) + getattr(p, "secondary_opts", [])}
+        run_flags = {f for f in declared if f.startswith("-") and f != "--help"}
+        group_flags = {"--verbose", "-v"}
+        missing = (run_flags | group_flags) - _PFLOW_FLAGS
+        assert not missing, f"_PFLOW_FLAGS drifted from run options; missing: {missing}"
+
     @pytest.mark.parametrize(
         "workflow",
         [
@@ -128,6 +155,10 @@ class TestValidateWorkflowFlagsGuard:
             ("my-workflow", "scenario=fail-mid"),
             ("wf.pflow.md", "--help"),
             ("wf.pflow.md", "--help", "scenario=x"),
+            # Standalone --help is consumed at the group level and normally never
+            # reaches this guard; included so the whitelist is pinned even if that
+            # routing ever changes.
+            ("--help",),
         ],
     )
     def test_valid_invocations_do_not_raise(self, workflow):


### PR DESCRIPTION
## Summary
`pflow wf.pflow.md --scenario fail-mid` (a space-separated leading-dash arg after the workflow) was **silently discarded** — the run proceeded with defaults, exit 0, no warning. For an agent-first CLI this is the worst failure class: a green run on the wrong inputs. This PR makes those tokens fail loudly with a tailored, copy-pasteable fix suggestion.

Fixes #454

## Changes
- Generalized `_validate_workflow_flags` (`cli/commands/run.py`) from a hardcoded misplaced-flag list into one rule: after Click parsing, the only legal tokens are the workflow name and `key=value` params; any stray leading-dash token is rejected.
  - unknown option → `Unknown option '--scenario'` + `Did you mean 'scenario=fail-mid'?`
  - misplaced pflow flag → `CLI flags must come BEFORE the workflow` + `pflow --verbose <workflow>`
  - `-h` → `pflow <workflow> --help`
- Added `_suggest_key_value()` helper to build the `key=value` hint from the flag + its following token.
- Suggestions are **concrete/copy-pasteable** (use the name the user typed) and point at `pflow <wf> --help` to list inputs — not `pflow describe`, which only resolves saved names, not file paths.
- Reordered the guard to run *after* the `run`-prefix strip so `workflow[0]` is always the real name.
- Updated `cli/CLAUDE.md` gotcha (the old note claimed typos "silently pass through" — no longer true).
- New regression suite `tests/test_cli/test_unknown_flag_handling.py` (25 tests).

## Explanation
Root cause: the `run` command sets `ignore_unknown_options=True`, so unknown `--flags` are collected into the variadic `workflow` tuple instead of erroring; `parse_workflow_params` then keeps only tokens containing `=` and drops the rest.

I kept `ignore_unknown_options=True` rather than removing it — investigation showed it's **load-bearing for the per-workflow `--help` passthrough** (without it, `pflow wf --help` errors at parse time). The real defect was the *absence of a guard*, not the permissive parser. `--help` is whitelisted; `=`-bearing dash tokens (`--scenario=x`) are intentionally left to the existing undeclared-input validator (already a good "did you mean 'scenario'?" error), keeping this change scoped exactly to the silently-dropped space form.

Considered and rejected: supporting `--key value` as an input syntax. It collides with pflow's own flag namespace (a workflow input named `report`/`cache`/`only` could never be set, since Click claims the flag first) and introduces boolean/value parse ambiguity — which is why `key=value` is the idiomatic choice (make/docker `-e`/terraform `-var`).

Scope verified: the bug is unique to `run`. `probe`/`analyze-cache` already reject unknown flags via Click (exit 2, not silent); the MCP server takes structured dicts and never calls `parse_workflow_params`.

`cli/commands/run.py` +122/−32 · `cli/CLAUDE.md` +1/−1 · new test file +208.

## Testing
- `test_unknown_long_flag_rejected_with_key_value_suggestion` — `--scenario fail-mid` raises with `scenario=fail-mid` + a concrete `--help` pointer (asserts NOT `describe`)
- `test_misplaced_pflow_flag_says_move_before` — `--verbose`/`-v` keep the "move before" message with a runnable suggestion; guards against re-introducing the removed natural-language `pflow --verbose "..."` form
- `test_short_help_flag_points_to_double_dash_help` — `-h` → `pflow <wf> --help`
- `test_equals_dash_form_left_to_downstream_validator` — `--scenario=x` is NOT caught by the guard (scope pin)
- `test_valid_invocations_do_not_raise` (parametrized) — names, `key=value`, `--help`, `--help param=x` all pass
- `TestSuggestKeyValue` — value pairing incl. placeholder fallbacks
- `test_workflow_help_still_works` — regression pin: `pflow <wf> --help` still renders the interface
- `test_json_mode_error_is_parseable` — `--output-format json` returns a parseable error object, exit 1
- Manual adversarial matrix on real workflows: negative/dash-leading values via `=` (`offset=-5`, `name=-weird`) succeed; flags before/after/interspersed succeed; `probe --foo` errors natively; stdin routing intact; required-input errors not masked; `--` separator behaves
- Suites: full `make test` 7394 passed/1 skipped · `make test-e2e` 43 passed · `make check` (ruff + mypy + deptry) clean