### PR TITLE
fix: claude-code defaults to subscription, opt into API billing via use_api_key (#455)

### DIFF
--- a/context/adr/0002-455-claude-code-subscription-default.md
+++ b/context/adr/0002-455-claude-code-subscription-default.md
@@ -43,8 +43,16 @@ untouched, so a sibling `llm` node still reads the real key.
 - **Scope is `ANTHROPIC_API_KEY` only.** `CLAUDE_CODE_OAUTH_TOKEN` (the subscription
   path) is deliberately left intact; Bedrock/Vertex vars are not referenced by pflow
   or the SDK and are out of scope.
-- **Auth detection is heuristic string-matching.** The common auth failure arrives as
-  a bare `Exception` carrying the CLI's error text (the SDK rewrites the result-level
-  error before re-raising) and `ProcessError.stderr` is a useless placeholder, so a
-  multi-marker OR on the message is the most robust signal available; the exact
-  markers may need tuning as CLI wording drifts.
+- **Auth detection had to work around an SDK quirk (found by real-CLI verification,
+  not the unit tests).** The SDK does *not* surface the CLI's real error text: when the
+  CLI returns an error result it forwards only the result *subtype*, so an invalid key
+  arrives as the useless bare `Exception("...returned an error result: success")` —
+  dropping both the real `result` text ("Invalid API key · Fix external API key") and
+  the structured `api_error_status` (401). `_run_claude_session` therefore captures
+  `result`/`api_error_status` off the `ResultMessage` (which the SDK *does* yield before
+  raising) and re-builds the exception, so `exec_fallback` can detect auth via a
+  multi-marker string OR *and* the structured `api_error_status=401/403`. Enrichment is
+  scoped to the bare-`Exception` injection path only — typed SDK errors
+  (`CLIConnectionError`, ...) keep their type so their dedicated branches still match.
+  The original unit tests passed by feeding the detector synthetic strings the CLI never
+  actually emits; the regression is now pinned by `test_invalid_api_key_surfaces_real_error_text_and_status`.

--- a/context/adr/0002-455-claude-code-subscription-default.md
+++ b/context/adr/0002-455-claude-code-subscription-default.md
@@ -1,0 +1,50 @@
+# claude-code defaults to subscription billing by blanking ANTHROPIC_API_KEY
+
+Status: accepted
+
+The Claude CLI prefers an ambient `ANTHROPIC_API_KEY` over a logged-in Pro/Max
+subscription, silently billing the Anthropic Console per token (issue #455). pflow
+makes this worse: it injects settings-stored keys into `os.environ` at startup
+(`inject_settings_env_vars`, for the `llm` node's LiteLLM path), and the claude-code
+SDK subprocess inherits that key. We decided the claude-code node should **default to
+subscription billing** and only use the key when the author opts in with
+`use_api_key: true` (default `false`). It enforces this by setting
+`options.env = {"ANTHROPIC_API_KEY": ""}` for its subprocess only — `os.environ` is
+untouched, so a sibling `llm` node still reads the real key.
+
+## Considered options
+
+1. **Omit the key from a rebuilt env dict** (the issue's proposed fix). Does not
+   work: the SDK merges `{**os.environ, ..., **options.env}`, so `os.environ` is the
+   base and a dict merge cannot delete an inherited key by leaving it out. The
+   subprocess would still receive the key — and the proposed unit test (asserting on
+   `options.env`) would pass while the bug survived. Rejected.
+2. **Pop `ANTHROPIC_API_KEY` from `os.environ` around the query.** Process-global and
+   not thread-safe: it would race with parallel batch items and starve a concurrent
+   `llm` node of the key it needs for LiteLLM. Rejected.
+3. **Override the key with an empty string in `options.env`** (chosen). The only
+   in-process, subprocess-scoped, thread-safe mechanism. The CLI treats an empty key
+   as "no key" and falls back to subscription — verified against `claude` v2.1.159
+   with `claude auth status` (empty `ANTHROPIC_API_KEY` → `subscriptionType: "max"`,
+   no `apiKeySource`; a present key → `apiKeySource: "ANTHROPIC_API_KEY"`).
+
+## Consequences
+
+- **Billing-affecting default change.** Anyone who relied on an ambient key + the
+  claude-code node now gets subscription billing unless they set `use_api_key: true`.
+  A user with *only* a key and *no* subscription login will see an auth failure until
+  they opt in; `exec_fallback` detects auth-marker error text and emits guidance
+  (subscription setup first, `use_api_key: true` second). Acceptable: pflow has no
+  users yet, and the alternative is silent overcharging.
+- **`use_api_key` fails closed.** Node params are not coerced to bool at runtime, and
+  a templated string `"false"` is truthy in Python — so the validator accepts only
+  real bools / canonical string literals and raises on anything else, rather than
+  risk silently re-enabling per-token billing.
+- **Scope is `ANTHROPIC_API_KEY` only.** `CLAUDE_CODE_OAUTH_TOKEN` (the subscription
+  path) is deliberately left intact; Bedrock/Vertex vars are not referenced by pflow
+  or the SDK and are out of scope.
+- **Auth detection is heuristic string-matching.** The common auth failure arrives as
+  a bare `Exception` carrying the CLI's error text (the SDK rewrites the result-level
+  error before re-raising) and `ProcessError.stderr` is a useless placeholder, so a
+  multi-marker OR on the message is the most robust signal available; the exact
+  markers may need tuning as CLI wording drifts.

--- a/docs/reference/nodes/claude-code.mdx
+++ b/docs/reference/nodes/claude-code.mdx
@@ -41,6 +41,7 @@ The claude-code node runs agentic tasks using Claude Code's capabilities. It can
 | `system_prompt` | str | No | - | Custom system instructions |
 | `resume` | str | No | - | Session ID to resume a previous conversation |
 | `sandbox` | dict | No | - | Sandbox configuration for command isolation |
+| `use_api_key` | bool | No | `false` | Bill to `ANTHROPIC_API_KEY` (Anthropic Console). Default uses your Claude Pro/Max subscription |
 
 ### Sandbox configuration
 
@@ -87,21 +88,29 @@ The node always returns `default` from `post()` — schema soft-failures and SDK
 
 ## Authentication
 
+By default the claude-code node uses your **Claude Pro/Max subscription** and blanks `ANTHROPIC_API_KEY` for the Claude subprocess — so an ambient key (including one stored with `pflow settings set-env` for the `llm` node) never silently bills your Anthropic Console per token. Set `use_api_key: true` on the node to opt into Console billing.
+
 <Tabs>
-  <Tab title="CLI authentication (recommended)">
-    Install and authenticate Claude Code CLI:
+  <Tab title="Subscription (default)">
+    Install and authenticate the Claude Code CLI:
     ```bash
     npm install -g @anthropic-ai/claude-code
-    claude auth login
+    claude auth login          # or: claude setup-token (non-interactive/CI)
     ```
-    Uses your Claude Pro/Max subscription with no additional API charges.
+    Uses your Claude Pro/Max subscription with no per-token charges. Check status any time with `claude auth status`.
   </Tab>
-  <Tab title="API key">
-    Set the `ANTHROPIC_API_KEY` environment variable:
+  <Tab title="API key (opt in)">
+    Set `use_api_key: true` on the node, with `ANTHROPIC_API_KEY` available in the environment:
+    ```yaml
+    ### agent
+    - type: claude-code
+    - prompt: Refactor this module
+    - use_api_key: true
+    ```
     ```bash
     pflow settings set-env ANTHROPIC_API_KEY "sk-ant-..."
     ```
-    Bills to your Anthropic Console account. Works in CI/CD and servers.
+    Bills to your Anthropic Console account (pay per token). Useful for CI/CD or when you have no subscription.
   </Tab>
 </Tabs>
 
@@ -256,7 +265,7 @@ For read-only analysis, use `["Read", "Glob", "Grep", "LS"]`. For full capabilit
 | Error | Cause | Solution |
 |-------|-------|----------|
 | CLI not found | Claude Code not installed | `npm install -g @anthropic-ai/claude-code` |
-| Connection error | Auth issue | Run `claude auth login` or set API key |
+| Connection / auth error | Not logged in (default subscription mode) | Run `claude auth login`, or set `use_api_key: true` with `ANTHROPIC_API_KEY` for Console billing |
 | Timeout | Task too complex | Increase `timeout` or simplify prompt |
 | Rate limit | Too many requests | Wait and retry |
 

--- a/examples/nodes/claude-code/README.md
+++ b/examples/nodes/claude-code/README.md
@@ -7,7 +7,7 @@ Features:
 - Native JSON Schema structured output
 - Metadata capture (cost, duration, token usage) in `llm_usage`
 - Tool use (Read, Write, Edit, Bash, Glob, Grep, LS, WebFetch, WebSearch)
-- Dual authentication: API key or Claude Pro/Max CLI
+- Subscription-first auth: Claude Pro/Max by default; opt into API-key billing with `use_api_key: true`
 
 ## Examples
 
@@ -130,8 +130,10 @@ ${node.llm_usage.session_id}                    # Resumable session ID
 
 ## Authentication
 
-- **API key**: `export ANTHROPIC_API_KEY=sk-ant-...` - billed to your Anthropic Console account.
-- **Claude Pro/Max subscription**: `claude setup-token` (or `claude auth login`) - uses subscription entitlements.
+By default this node uses your **Claude Pro/Max subscription** and blanks `ANTHROPIC_API_KEY` for the Claude subprocess, so an ambient key (including one stored via `pflow settings set-env` for the `llm` node) never silently bills your Anthropic Console per token.
+
+- **Subscription (default)**: `claude auth login` (or `claude setup-token` for non-interactive/CI) - no per-token charges. Check with `claude auth status`.
+- **API key (opt in)**: set `- use_api_key: true` on the node, with `ANTHROPIC_API_KEY` in the environment (e.g. `pflow settings set-env ANTHROPIC_API_KEY "sk-ant-..."`) - bills your Anthropic Console per token.
 
 ## Parameters
 
@@ -149,6 +151,7 @@ ${node.llm_usage.session_id}                    # Resumable session ID
 | `system_prompt`       | None                | System instructions                                         |
 | `resume`              | None                | Session ID to resume a previous conversation                |
 | `sandbox`             | None                | Sandbox configuration (see node docstring for full schema)  |
+| `use_api_key`         | `false`             | Bill to `ANTHROPIC_API_KEY` (Console); default uses subscription |
 
 ## Best practices
 
@@ -164,7 +167,7 @@ ${node.llm_usage.session_id}                    # Resumable session ID
 - **Top-level array schema rejected** - wrap arrays or primitives inside a top-level object property.
 - **High cost** - reduce `max_turns`, tighten the prompt, or restrict `allowed_tools`.
 - **Timeouts** - break complex tasks into smaller steps or raise `timeout`.
-- **Authentication failed** - run `claude doctor` or verify `ANTHROPIC_API_KEY`.
+- **Authentication failed** - by default this node uses your subscription; run `claude auth login` (check with `claude auth status`), or set `- use_api_key: true` to bill `ANTHROPIC_API_KEY` to your Anthropic Console.
 
 ## See also
 

--- a/src/pflow/nodes/claude/AUTHENTICATION.md
+++ b/src/pflow/nodes/claude/AUTHENTICATION.md
@@ -2,194 +2,119 @@
 
 ## Overview
 
-The Claude Code SDK supports **two distinct authentication methods**, each with different billing implications:
+The `claude-code` node spawns the Claude CLI through the Claude Agent SDK. The CLI
+supports two authentication methods with different billing implications:
 
-1. **API Key Authentication** - Bills to your Anthropic Console account
-2. **CLI Authentication** - Uses your Claude Pro/Max subscription entitlements
+1. **Subscription (default)** — uses your Claude Pro/Max entitlements. No per-token charges.
+2. **API key (opt in)** — bills your Anthropic Console account per token.
 
-## Authentication Methods
+**By default the node uses your subscription.** It does this by blanking
+`ANTHROPIC_API_KEY` for the Claude subprocess (`options.env = {"ANTHROPIC_API_KEY": ""}`
+in `_build_claude_options`). Set `- use_api_key: true` on the node to bill to your
+Console instead.
 
-### Method 1: API Key (Recommended for Production)
+## Why the node blanks `ANTHROPIC_API_KEY` by default
 
-Use an Anthropic API key from your Console account:
+The Claude CLI prefers an `ANTHROPIC_API_KEY` over a logged-in subscription: if the
+key is present, it bills your Anthropic Console **even when you are logged into a
+Pro/Max subscription**. This is a silent cost footgun, because the key is easy to
+have in the environment without realising it:
+
+- you `export ANTHROPIC_API_KEY=...` in your shell, **or**
+- you ran `pflow settings set-env ANTHROPIC_API_KEY ...` for the `llm` node — pflow
+  injects stored settings keys into `os.environ` at startup
+  (`inject_settings_env_vars`, `src/pflow/core/llm_config.py`) so LiteLLM can find
+  them. The Claude SDK subprocess then inherits that key too.
+
+To protect subscription users, the node overrides the key with an empty string for
+**its subprocess only**. `os.environ` is left untouched, so a sibling `llm` node in
+the same workflow still reads the real key for LiteLLM.
+
+### Mechanism note (why empty string, not "omit the key")
+
+The SDK builds the subprocess environment as
+`{**os.environ, ..., **options.env, ...}` (`claude_agent_sdk` subprocess transport).
+`os.environ` is the **base** of that merge, so it always carries an ambient
+`ANTHROPIC_API_KEY`. A dict merge can only add or overwrite keys — it cannot delete
+an inherited key by leaving it out of `options.env`. The node therefore sets
+`ANTHROPIC_API_KEY` to an empty string, which **overrides** the inherited value. The
+CLI treats an empty key as "no key" and falls back to subscription auth (verified
+with `claude auth status`: an empty `ANTHROPIC_API_KEY` reports
+`subscriptionType: "max"` with no `apiKeySource`).
+
+## Using your subscription (default)
+
+Install and authenticate the CLI once:
 
 ```bash
-# macOS/Linux
-export ANTHROPIC_API_KEY=sk-ant-...
-
-# Windows PowerShell
-$env:ANTHROPIC_API_KEY="sk-ant-..."
-
-# Windows Command Prompt
-set ANTHROPIC_API_KEY=sk-ant-...
-```
-
-**Advantages:**
-- No CLI installation required
-- Works immediately after setting environment variable
-- Ideal for CI/CD, Docker, and server deployments
-- Standard API usage billing through Console
-
-**Billing:** Usage is charged to your Anthropic Console account at standard API rates.
-
-### Method 2: CLI Authentication (For Development/Personal Use)
-
-Authenticate through the Claude Code CLI:
-
-```bash
-# Install CLI first
 npm install -g @anthropic-ai/claude-code
-
-# Then authenticate (choose one):
-claude auth login      # Interactive OAuth login
-claude setup-token     # Long-lived token (requires subscription)
+claude auth login          # interactive OAuth
+# or, for non-interactive / CI:
+claude setup-token         # long-lived token (requires a subscription)
 ```
 
-**Advantages:**
-- Uses your Claude Pro/Max subscription entitlements
-- No additional API charges
-- Good for personal development
+Check your current auth without making a billed call:
 
-**Billing:** Uses your Claude Pro/Max subscription - no additional API charges.
-
-## How the Node Detects Authentication
-
-The node checks for authentication in this order:
-
-1. **Checks for `ANTHROPIC_API_KEY`** - If found, uses API key authentication
-2. **Falls back to CLI authentication** - Requires CLI to be installed and authenticated
-
-```python
-# The node automatically detects which method you're using:
-if os.getenv("ANTHROPIC_API_KEY"):
-    # Uses API key authentication
-else:
-    # Uses CLI authentication (requires CLI installed)
-```
-
-## Usage in Workflows
-
-Both authentication methods work identically in workflows:
-
-```json
-{
-  "nodes": [
-    {
-      "id": "claude",
-      "type": "claude-code",
-      "params": {
-        "prompt": "Write a function to parse JSON",
-        "cwd": "./src"
-      }
-    }
-  ]
-}
-```
-
-## Environment Variables
-
-### ANTHROPIC_API_KEY
-Your Anthropic API key for Console billing:
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-api03-...
+claude auth status
 ```
 
-### CLAUDE_CODE_PATH
-Custom path to Claude CLI executable (optional):
+No node configuration is required — subscription is the default.
+
+## Using an API key (opt in)
+
+Set `use_api_key: true` on the node and make `ANTHROPIC_API_KEY` available:
+
+```markdown
+### agent
+- type: claude-code
+- prompt: Refactor this module
+- use_api_key: true
+```
+
 ```bash
-export CLAUDE_CODE_PATH="/custom/path/to/claude"
+# either of these provides the key:
+export ANTHROPIC_API_KEY=sk-ant-...
+pflow settings set-env ANTHROPIC_API_KEY "sk-ant-..."
 ```
 
-## Platform Support
+With `use_api_key: true` the node does not blank the key, so the CLI uses it and
+bills your Anthropic Console per token. This is the right choice for CI/CD, servers,
+or when you have no subscription.
 
-The SDK also supports alternative AI platforms through environment variables:
+`use_api_key` accepts a real boolean (`true`/`false`) or the canonical string
+literals (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`). Any other value raises a
+`TypeError` — the node fails closed rather than guess and risk silent per-token
+billing (e.g. the string `"false"` would otherwise be truthy).
 
-### AWS Bedrock
-```bash
-export ANTHROPIC_BEDROCK_REGION=us-east-1
-export ANTHROPIC_BEDROCK_AUTH=profile  # or 'keys'
-# Additional AWS credentials as needed
-```
+## Billing comparison
 
-### Google Vertex AI
-```bash
-export ANTHROPIC_VERTEX_REGION=us-central1
-export ANTHROPIC_VERTEX_PROJECT_ID=your-project
-# Additional Google Cloud credentials as needed
-```
-
-## Common Scenarios
-
-### CI/CD Pipeline
-Use API key authentication for automated workflows:
-```yaml
-env:
-  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-```
-
-### Docker Container
-```dockerfile
-ENV ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-```
-
-### Local Development
-Choose based on your billing preference:
-- API key if you want to bill to Console
-- CLI auth if you have Claude Pro/Max subscription
-
-### Team Development
-- Each developer can use their preferred authentication method
-- API keys can be shared (with caution) or individual
-- CLI auth is always individual
+| Mode | `use_api_key` | Billing | Best for |
+|------|---------------|---------|----------|
+| Subscription (default) | `false` | Claude Pro/Max — no per-token charge | Personal use, development |
+| API key | `true` | Anthropic Console — pay per token | CI/CD, servers, no subscription |
 
 ## Troubleshooting
 
+### "Claude Code could not authenticate" (default mode)
+You are not logged into a subscription and the key is intentionally not used.
+- Recommended: `claude auth login` (or `claude setup-token` for non-interactive/CI),
+  then `claude auth status` to confirm.
+- Or set `- use_api_key: true` to bill `ANTHROPIC_API_KEY` to your Anthropic Console.
+
+### Authentication failed while `use_api_key: true`
+The key may be invalid or out of credit.
+- Check/replace `ANTHROPIC_API_KEY` in your Anthropic Console, or
+- Remove `- use_api_key: true` to use your subscription instead.
+
 ### "Claude Code CLI not installed"
-**Solution:** Either:
-1. Set `ANTHROPIC_API_KEY` environment variable, OR
-2. Install the CLI: `npm install -g @anthropic-ai/claude-code`
+Install it: `npm install -g @anthropic-ai/claude-code`.
 
-### "Not authenticated with Claude Code"
-**Solution:** Either:
-1. Set `ANTHROPIC_API_KEY` environment variable, OR
-2. Run `claude auth login` to authenticate via CLI
+### `CLAUDE_CODE_PATH`
+Set a custom path to the Claude CLI executable if it is not on `PATH`.
 
-### "Rate limit exceeded"
-- **API Key:** Check your Console usage limits
-- **CLI Auth:** Check your subscription tier limits
+## Security best practices
 
-## Security Best Practices
-
-1. **Never commit API keys** to version control
-2. **Use environment variables** or secret management systems
-3. **Rotate API keys** regularly
-4. **Use separate keys** for development and production
-5. **Set appropriate rate limits** in Console
-
-## Billing Comparison
-
-| Method | Billing | Best For |
-|--------|---------|----------|
-| API Key | Anthropic Console (pay per token) | Production, CI/CD, team projects |
-| CLI Auth | Claude Pro/Max subscription | Personal use, development, testing |
-
-## Skip Authentication Check
-
-For testing or when you know authentication is configured:
-
-```json
-{
-  "params": {
-    "skip_auth_check": true
-  }
-}
-```
-
-## Summary
-
-The Claude Code node provides flexible authentication to suit different use cases:
-- **Production/CI/CD**: Use API keys for predictable billing
-- **Development**: Use CLI auth with your subscription
-- **Both methods** work seamlessly with the same code
-
-The node automatically detects which authentication method you're using based on environment variables, making it easy to switch between them as needed.
+1. Never commit API keys to version control.
+2. Store keys via `pflow settings set-env` or your secret manager, not in workflow files.
+3. Rotate keys regularly and use separate keys for development and production.

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -118,11 +118,12 @@ _AUTH_ERROR_MARKERS = (
     "invalid api key",
     "authentication_error",
     "authentication error",
-    "please run /login",
-    "/login",
+    # "run /login" matches the real not-logged-in result ("Not logged in · Please
+    # run /login") without the broad bare "/login" substring, which could match an
+    # unrelated /login path mentioned in agent output.
+    "run /login",
     "unauthorized",
     "credit balance",
-    "oauth",
     # Structured HTTP status surfaced by _run_claude_session from the
     # ResultMessage (the SDK drops it from its own exception text). Specific
     # `key=value` form, so no false positives on stray numbers.
@@ -444,12 +445,18 @@ class ClaudeCodeNode(Node):
         Console. A templated value may arrive as a string (node params are not
         coerced to bool at runtime) — never trust truthiness, since the string
         "false" is truthy and would silently re-enable per-token billing. Accept
-        only canonical bool literals and fail closed on anything else.
+        real bools, integer 0/1, and canonical bool-string literals; fail closed
+        on anything else.
         """
         if value is None:
             return False
         if isinstance(value, bool):
             return value
+        # Accept integer 0/1 (YAML coerces `- use_api_key: 1` to int, and "1"/"0"
+        # strings are already accepted). Safe: bool(0)/bool(1) is unambiguous —
+        # no truthiness footgun — and 2+ still falls through to fail closed.
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
         if isinstance(value, str):
             normalized = value.strip().lower()
             if normalized in ("true", "1", "yes"):

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -35,6 +35,7 @@ Interface:
     - excludedCommands: list  # Commands that bypass sandbox (e.g., ["docker"])
     - allowUnsandboxedCommands: bool  # Allow model to request unsandboxed execution
     - network: dict  # Network settings (allowLocalBinding, allowUnixSockets, etc.)
+- Params: use_api_key: bool  # Bill to ANTHROPIC_API_KEY (Anthropic Console) when true. Default false uses your Claude Pro/Max subscription.
 
 Note: When output_schema is provided, the result is the SDK's parsed structured_output.
 Access object values as shared["result"]["key"] in templates: ${node.result.key}
@@ -107,6 +108,23 @@ DANGEROUS_BASH_PATTERNS = [
 # Restricted directories that should not be used as working directories
 RESTRICTED_DIRECTORIES = ["/", "/etc", "/usr", "/bin", "/sbin", "/lib", "/sys", "/proc"]
 
+# Substrings (lowercased) that mark a Claude CLI authentication/billing failure.
+# The common auth failure surfaces as a bare Exception whose message carries the
+# CLI's error text, so exec_fallback matches on the message to attach
+# subscription-vs-API-key remediation (issue #455). A multi-marker OR keeps this
+# robust to CLI wording drift; bare numeric codes (401/403) are intentionally
+# excluded to avoid false positives on unrelated numbers.
+_AUTH_ERROR_MARKERS = (
+    "invalid api key",
+    "authentication_error",
+    "authentication error",
+    "please run /login",
+    "/login",
+    "unauthorized",
+    "credit balance",
+    "oauth",
+)
+
 
 class ClaudeCodeNode(Node):
     """Claude Code agentic super node for AI-assisted development tasks.
@@ -153,18 +171,22 @@ class ClaudeCodeNode(Node):
         - excludedCommands: list  # Commands that bypass sandbox (e.g., ["docker"])
         - allowUnsandboxedCommands: bool  # Allow model to request unsandboxed execution
         - network: dict  # Network settings (allowLocalBinding, allowUnixSockets, etc.)
+    - Params: use_api_key: bool  # Bill to ANTHROPIC_API_KEY (Anthropic Console) when true. Default false uses your Claude Pro/Max subscription.
 
     Authentication:
-        The Claude Code SDK supports two authentication methods:
+        By default this node uses your Claude Pro/Max subscription and blanks
+        ANTHROPIC_API_KEY for the Claude subprocess, so an ambient key (including
+        one stored via `pflow settings set-env`) never silently bills your
+        Anthropic Console. os.environ is left untouched, so a sibling llm node
+        still reads the key for LiteLLM.
 
-        1. API Key (Console billing):
-           export ANTHROPIC_API_KEY=sk-ant-...
-           Uses your Anthropic Console account for billing
-
-        2. CLI Authentication (Claude Pro/Max subscription):
+        1. Subscription (default — no per-token charges):
            claude auth login      # Interactive OAuth
-           claude setup-token     # Long-lived token (requires subscription)
-           Uses your Claude Pro/Max subscription entitlements
+           claude setup-token     # Long-lived token for non-interactive/CI
+
+        2. API key (opt in — bills your Anthropic Console per token):
+           Set `- use_api_key: true` on the node, with ANTHROPIC_API_KEY in the
+           environment (or via `pflow settings set-env ANTHROPIC_API_KEY ...`).
 
         The SDK automatically runs in headless mode using --output-format json
         and bypasses all permission prompts since workflows run autonomously.
@@ -409,6 +431,32 @@ class ClaudeCodeNode(Node):
             raise TypeError(f"resume must be a string (session ID), got {type(resume).__name__}")
         return resume
 
+    def _validate_use_api_key(self, value: Any) -> bool:
+        """Resolve the use_api_key billing flag to a strict bool.
+
+        Default False blanks ANTHROPIC_API_KEY for the Claude subprocess so it
+        uses the Pro/Max subscription; True lets the ambient key bill to Anthropic
+        Console. A templated value may arrive as a string (node params are not
+        coerced to bool at runtime) — never trust truthiness, since the string
+        "false" is truthy and would silently re-enable per-token billing. Accept
+        only canonical bool literals and fail closed on anything else.
+        """
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in ("true", "1", "yes"):
+                return True
+            if normalized in ("false", "0", "no"):
+                return False
+        raise TypeError(
+            f"use_api_key must be true or false, got {value!r}. Use "
+            "'- use_api_key: true' to bill ANTHROPIC_API_KEY to your Anthropic "
+            "Console, or omit it to use your Claude Pro/Max subscription."
+        )
+
     def _validate_sandbox(self, sandbox: Any) -> Optional[dict]:
         """Validate sandbox configuration parameter.
 
@@ -505,6 +553,10 @@ class ClaudeCodeNode(Node):
         # Sandbox configuration for command isolation
         sandbox = self._validate_sandbox(self.params.get("sandbox"))
 
+        # Billing/auth: default False blanks ANTHROPIC_API_KEY so Claude uses the
+        # Pro/Max subscription; True lets the ambient key bill to Anthropic Console.
+        use_api_key = self._validate_use_api_key(self.params.get("use_api_key"))
+
         logger.info(f"Prepared Claude Code execution for prompt: {prompt[:100]}...")
 
         return {
@@ -520,6 +572,7 @@ class ClaudeCodeNode(Node):
             "resume": resume,
             "timeout": timeout,
             "sandbox": sandbox,
+            "use_api_key": use_api_key,
         }
 
     def exec(self, prep_res: dict[str, Any]) -> dict[str, Any]:
@@ -608,6 +661,16 @@ class ClaudeCodeNode(Node):
         # Add sandbox configuration if provided
         if prep_res.get("sandbox") is not None:
             options_kwargs["sandbox"] = prep_res["sandbox"]
+
+        # Default (use_api_key=False): blank ANTHROPIC_API_KEY for THIS subprocess
+        # only, so the Claude CLI uses the Pro/Max subscription instead of API/
+        # Console billing. The SDK merges options.env OVER the inherited os.environ
+        # (subprocess_cli.py), so we must OVERRIDE the key with an empty string —
+        # omitting it leaves the inherited (or pflow settings-injected) key intact,
+        # since a dict merge cannot delete an inherited key. os.environ is untouched,
+        # so a sibling llm node still reads the real key for LiteLLM. See issue #455.
+        if not prep_res.get("use_api_key"):
+            options_kwargs["env"] = {"ANTHROPIC_API_KEY": ""}
 
         return ClaudeAgentOptions(**options_kwargs)
 
@@ -859,8 +922,8 @@ class ClaudeCodeNode(Node):
 
         if (CLIConnectionError is not None and isinstance(exc, CLIConnectionError)) or "CLIConnectionError" in exc_type:
             raise ValueError(
-                "Failed to connect to Claude Code. Check authentication with: claude doctor\n"
-                "If not authenticated, run: claude auth login\n"
+                "Failed to connect to Claude Code. Check health with: claude doctor\n"
+                f"{self._auth_failure_guidance(bool(prep_res.get('use_api_key')))}\n"
                 f"Original error: {error_msg}"
             ) from None
 
@@ -889,8 +952,50 @@ class ClaudeCodeNode(Node):
                 f"Claude API rate limit exceeded. Please wait a moment and try again.\nOriginal error: {error_msg}"
             ) from None
 
+        # Authentication/billing failure. The common case arrives as a bare
+        # Exception whose message carries the CLI's error text (the SDK rewrites
+        # the result-level error before re-raising), so it falls through the typed
+        # branches to here. Attach subscription-vs-API-key remediation tailored to
+        # the node's billing mode. See issue #455.
+        if self._is_auth_error(exc):
+            raise ValueError(self._auth_failure_guidance(bool(prep_res.get("use_api_key")))) from None
+
         # Generic error — pass through the SDK error message directly
         raise ValueError(f"Claude Code execution failed after {self.max_retries} attempts: {error_msg}") from None
+
+    @staticmethod
+    def _is_auth_error(exc: Exception) -> bool:
+        """Heuristically detect a Claude CLI authentication/billing failure.
+
+        The common auth failure surfaces as a bare ``Exception`` whose message
+        carries the CLI's error text (the SDK rewrites the result-level error
+        before re-raising), so we match on the message string, not the exception
+        type. A multi-marker OR keeps this robust to CLI wording drift.
+        """
+        text = str(exc).lower()
+        return any(marker in text for marker in _AUTH_ERROR_MARKERS)
+
+    @staticmethod
+    def _auth_failure_guidance(use_api_key: bool) -> str:
+        """Build remediation text for an auth failure, tailored to the billing mode."""
+        if use_api_key:
+            return (
+                "Claude Code authentication failed using ANTHROPIC_API_KEY "
+                "(use_api_key: true) — the key may be invalid or out of credit.\n"
+                "  - Correct ANTHROPIC_API_KEY in your Anthropic Console, or\n"
+                "  - Remove `- use_api_key: true` to use your Claude Pro/Max "
+                "subscription instead (no per-token charges)."
+            )
+        return (
+            "Claude Code could not authenticate. This node uses your Claude "
+            "Pro/Max subscription by default and ignores ANTHROPIC_API_KEY "
+            "unless you opt in.\n"
+            "  - Recommended: run `claude auth login` (or `claude setup-token` "
+            "for non-interactive/CI) to authenticate with your subscription — no "
+            "per-token charges.\n"
+            "  - Or add `- use_api_key: true` to this node to bill "
+            "ANTHROPIC_API_KEY to your Anthropic Console (pay per token)."
+        )
 
     def _store_results(
         self,

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -123,6 +123,11 @@ _AUTH_ERROR_MARKERS = (
     "unauthorized",
     "credit balance",
     "oauth",
+    # Structured HTTP status surfaced by _run_claude_session from the
+    # ResultMessage (the SDK drops it from its own exception text). Specific
+    # `key=value` form, so no false positives on stray numbers.
+    "api_error_status=401",
+    "api_error_status=403",
 )
 
 
@@ -721,6 +726,7 @@ class ClaudeCodeNode(Node):
         structured_output: Any = None
         is_error_from_sdk = False
         sdk_exception_text: str | None = None
+        api_error_status: int | None = None
 
         try:
             async for message in query(prompt=prompt, options=options):
@@ -740,6 +746,10 @@ class ClaudeCodeNode(Node):
                         result_text = message.result
                     structured_output = message.structured_output
                     is_error_from_sdk = is_error_from_sdk or message.is_error
+                    # HTTP status of an API-level error (e.g. 401/403 auth). The
+                    # SDK drops this from the exception it raises, so capture it
+                    # here while the ResultMessage is in scope (#455).
+                    api_error_status = getattr(message, "api_error_status", None) or api_error_status
         except Exception as exc:
             # The SDK pairs ``ResultMessage(is_error=True)`` with a non-zero CLI
             # exit raised as ``ProcessError``. That single class of exception is
@@ -754,6 +764,11 @@ class ClaudeCodeNode(Node):
                 ProcessError is not None and isinstance(exc, ProcessError)
             ) or exc_type_name == "ProcessError"
             if not is_error_from_sdk or not is_process_error:
+                enriched = self._enrich_error_result_exception(
+                    exc, exc_type_name, is_error_from_sdk, result_text, api_error_status
+                )
+                if enriched is not None:
+                    raise enriched from exc
                 raise
             sdk_exception_text = str(exc)
             logger.warning("Claude Code SDK raised after an error ResultMessage: %s", sdk_exception_text)
@@ -962,6 +977,34 @@ class ClaudeCodeNode(Node):
 
         # Generic error — pass through the SDK error message directly
         raise ValueError(f"Claude Code execution failed after {self.max_retries} attempts: {error_msg}") from None
+
+    @staticmethod
+    def _enrich_error_result_exception(
+        exc: Exception,
+        exc_type_name: str,
+        is_error_from_sdk: bool,
+        result_text: str,
+        api_error_status: Optional[int],
+    ) -> Optional[Exception]:
+        """Recover the real error detail the SDK drops from an error-result.
+
+        When the CLI reports an error result then exits, the SDK raises a *bare*
+        Exception whose text is only the result subtype — e.g. an invalid key
+        surfaces as "...returned an error result: success" instead of "Invalid
+        API key" (#455). Rebuild the message from the real result text / HTTP
+        status captured off the ResultMessage so exec_fallback can detect auth
+        failures. Returns an enriched exception to raise, or None to re-raise the
+        original unchanged. Typed SDK errors (CLIConnectionError, ...) are left
+        alone so exec_fallback's typed branches still match.
+        """
+        if not (is_error_from_sdk and exc_type_name == "Exception"):
+            return None
+        detail = str(exc)
+        if result_text and result_text not in detail:
+            detail = f"{detail}: {result_text}"
+        if api_error_status is not None:
+            detail = f"{detail} [api_error_status={api_error_status}]"
+        return RuntimeError(detail) if detail != str(exc) else None
 
     @staticmethod
     def _is_auth_error(exc: Exception) -> bool:

--- a/tests/test_core/test_unknown_param_validation.py
+++ b/tests/test_core/test_unknown_param_validation.py
@@ -69,6 +69,32 @@ class TestValidateUnknownParams:
 
         assert len(errors) == 0
 
+    def test_no_error_for_claude_code_use_api_key(self, registry: Registry) -> None:
+        """Issue #455: use_api_key is a recognized claude-code param.
+
+        Guards the docstring → metadata → validator allow-list chain end-to-end:
+        if the `- Params: use_api_key:` line is dropped from the node docstring,
+        every workflow using the param would fail validation as "unknown".
+        """
+        workflow_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "agent",
+                    "type": "claude-code",
+                    "params": {
+                        "prompt": "do a thing",
+                        "use_api_key": True,
+                    },
+                }
+            ],
+            "edges": [],
+        }
+
+        errors = WorkflowValidator._validate_unknown_params(workflow_ir, registry)
+
+        assert errors == []
+
     def test_suggests_similar_param(self, registry: Registry) -> None:
         """Should suggest similar params when a typo is detected."""
         workflow_ir = {

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -69,6 +69,7 @@ class ResultMessage:
     usage: dict | None = None
     result: str | None = None
     structured_output: Any = None
+    api_error_status: int | None = None
 
 
 class CLINotFoundError(Exception):
@@ -1675,3 +1676,87 @@ def test_exec_fallback_non_auth_error_has_no_auth_guidance(claude_node):
     msg = str(exc_info.value)
     assert "claude auth login" not in msg
     assert "disk full" in msg
+
+
+# --- Regression: the SDK mangles the real auth error (found by real-CLI verify) ---
+#
+# The real CLI reports an invalid key as a result with is_error=True,
+# api_error_status=401, result="Invalid API key · Fix external API key" — but the
+# SDK forwards only the result SUBTYPE ("success"), raising a bare Exception
+# "Claude Code returned an error result: success". The useful text + status are
+# dropped. _run_claude_session must surface them from the ResultMessage so
+# exec_fallback can recognize the auth failure. The original mock tests passed by
+# feeding _is_auth_error synthetic strings the CLI never actually emits (#455).
+
+
+def test_invalid_api_key_surfaces_real_error_text_and_status(claude_node):
+    """The real "Invalid API key" text + api_error_status are surfaced on re-raise,
+    not the SDK's useless "...error result: success"."""
+    claude_node.params = {"prompt": "do a thing", "use_api_key": True}
+
+    async def mock_response(*args, **kwargs):
+        # Mirrors the real CLI: error result carrying the real text + 401 is
+        # yielded first, then the SDK raises a bare Exception with the subtype.
+        yield ResultMessage(
+            is_error=True,
+            result="Invalid API key · Fix external API key",
+            api_error_status=401,
+        )
+        raise Exception("Claude Code returned an error result: success")  # noqa: TRY002 - mirror SDK bare raise
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep({})
+        with pytest.raises(RuntimeError) as exc_info:
+            claude_node.exec(prep_res)
+
+    assert "Invalid API key" in str(exc_info.value)
+    assert "api_error_status=401" in str(exc_info.value)
+    # The enriched exception is now recognized as auth, and exec_fallback gives the
+    # use_api_key=True remediation (the key, not subscription setup).
+    assert ClaudeCodeNode._is_auth_error(exc_info.value)
+    with pytest.raises(ValueError) as fb:
+        claude_node.exec_fallback(prep_res, exc_info.value)
+    assert "Anthropic Console" in str(fb.value)
+    assert "Remove `- use_api_key: true`" in str(fb.value)
+
+
+def test_api_error_status_detected_even_without_text(claude_node):
+    """A 401 with no usable result text is still recognized as auth via the
+    structured status alone."""
+    claude_node.params = {"prompt": "do a thing", "use_api_key": True}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(is_error=True, result=None, api_error_status=401)
+        raise Exception("Claude Code returned an error result: success")  # noqa: TRY002 - mirror SDK bare raise
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep({})
+        with pytest.raises(RuntimeError) as exc_info:
+            claude_node.exec(prep_res)
+
+    assert "api_error_status=401" in str(exc_info.value)
+    assert ClaudeCodeNode._is_auth_error(exc_info.value)
+
+
+def test_non_auth_error_result_stays_generic(claude_node):
+    """A non-auth error result (no 401, no auth text) must NOT trigger auth
+    guidance — surfaced detail is preserved but routed to the generic message."""
+    claude_node.params = {"prompt": "do a thing"}
+
+    async def mock_response(*args, **kwargs):
+        yield ResultMessage(is_error=True, result="Tool failed: disk full", api_error_status=None)
+        raise Exception("Claude Code returned an error result: error_during_execution")  # noqa: TRY002 - mirror SDK bare raise
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+        prep_res = claude_node.prep({})
+        with pytest.raises(RuntimeError) as exc_info:
+            claude_node.exec(prep_res)
+
+    assert not ClaudeCodeNode._is_auth_error(exc_info.value)
+    with pytest.raises(ValueError) as fb:
+        claude_node.exec_fallback(prep_res, exc_info.value)
+    assert "claude auth login" not in str(fb.value)
+    assert "disk full" in str(fb.value)

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -30,6 +30,7 @@ Tests criteria from the specification:
 """
 
 import asyncio
+import os
 import sys
 from dataclasses import dataclass
 from typing import Any
@@ -1631,6 +1632,32 @@ def test_use_api_key_invalid_value_raises(claude_node):
     assert "use_api_key must be true or false" in str(exc_info.value)
 
 
+def test_use_api_key_accepts_int_0_and_1(claude_node):
+    """Integer 0/1 is accepted (YAML coerces `- use_api_key: 1` to int, and the
+    string forms "1"/"0" are already accepted). 2+ still fails closed."""
+    v = claude_node._validate_use_api_key
+    assert v(1) is True
+    assert v(0) is False
+    for bad in (2, -1, 42):
+        with pytest.raises(TypeError):
+            v(bad)
+
+
+def test_default_does_not_mutate_os_environ(monkeypatch, claude_node):
+    """The empty-string override must NOT touch os.environ — a sibling llm node
+    in the same workflow keeps reading the real key for LiteLLM. This pins the
+    decision so a future switch to os.environ.pop fails loudly (#455 review)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real")
+    claude_node.params = {"prompt": "test prompt"}
+    prep_res = claude_node.prep({})
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+    # The subprocess env blanks the key...
+    assert mock_options.call_args.kwargs["env"] == {"ANTHROPIC_API_KEY": ""}
+    # ...but the process environment is untouched.
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-real"
+
+
 def test_use_api_key_registered_as_bool_param():
     """use_api_key is a declared bool param — this drives the validator allow-list."""
     md = PflowMetadataExtractor().extract_metadata(ClaudeCodeNode)
@@ -1643,11 +1670,19 @@ def test_use_api_key_registered_as_bool_param():
 
 def test_is_auth_error_matches_only_auth_markers():
     """_is_auth_error matches CLI auth/billing markers, not generic failures."""
-    assert ClaudeCodeNode._is_auth_error(Exception("Invalid API key · Please run /login"))
+    assert ClaudeCodeNode._is_auth_error(Exception("Invalid API key · Fix external API key"))
     assert ClaudeCodeNode._is_auth_error(Exception("authentication_error: bad token"))
     assert ClaudeCodeNode._is_auth_error(Exception("Your credit balance is too low"))
+    # Real not-logged-in result text — pins the narrowed "run /login" marker.
+    assert ClaudeCodeNode._is_auth_error(Exception("Not logged in · Please run /login"))
     assert not ClaudeCodeNode._is_auth_error(Exception("Tool 'Bash' failed: exit 1"))
     assert not ClaudeCodeNode._is_auth_error(Exception("connection reset by peer"))
+    # "oauth" marker was dropped: an MCP OAuth error surfaced inside a claude
+    # subprocess must NOT be misclassified as a Claude billing failure (#455 review).
+    assert not ClaudeCodeNode._is_auth_error(Exception("MCP server oauth flow failed"))
+    # The bare "/login" substring was narrowed to "run /login" — an unrelated
+    # /login path in agent output must no longer false-match.
+    assert not ClaudeCodeNode._is_auth_error(Exception("POST /login returned 500"))
 
 
 def test_exec_fallback_auth_default_suggests_subscription(claude_node):

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -1538,3 +1538,140 @@ def test_runtime_and_validator_agree_on_max_turns_with_schema(claude_node: Any) 
         f"max_turns parity drift: validator={validator_rejected}, runtime={runtime_rejected}"
     )
     assert validator_rejected
+
+
+# ---------------------------------------------------------------------------
+# Issue #455: use_api_key billing flag.
+# The node blanks ANTHROPIC_API_KEY for the Claude subprocess by default so an
+# ambient (or `pflow settings set-env`-injected) key cannot silently override
+# the user's Pro/Max subscription with per-token Console billing.
+# ---------------------------------------------------------------------------
+
+
+def test_use_api_key_defaults_false(claude_node):
+    """Param absent → False → subscription billing."""
+    claude_node.params = {"prompt": "test prompt"}
+    prep_res = claude_node.prep({})
+    assert prep_res["use_api_key"] is False
+
+
+def test_default_blanks_api_key_in_options(claude_node):
+    """Default mode sets options.env = {ANTHROPIC_API_KEY: ""}.
+
+    The SDK merges options.env OVER os.environ, so the empty-string override is
+    what actually neutralizes an inherited key — omitting it would leave the
+    inherited key intact (a dict merge cannot delete a base key).
+    """
+    claude_node.params = {"prompt": "test prompt"}
+    prep_res = claude_node.prep({})
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert mock_options.call_args.kwargs["env"] == {"ANTHROPIC_API_KEY": ""}
+
+
+def test_default_scrub_only_touches_anthropic_key(claude_node):
+    """Only ANTHROPIC_API_KEY is overridden; every other var still inherits."""
+    claude_node.params = {"prompt": "test prompt"}
+    prep_res = claude_node.prep({})
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert list(mock_options.call_args.kwargs["env"].keys()) == ["ANTHROPIC_API_KEY"]
+
+
+def test_use_api_key_true_does_not_scrub(claude_node):
+    """Opt-in (True) leaves env untouched so the ambient key bills to Console."""
+    claude_node.params = {"prompt": "test prompt", "use_api_key": True}
+    prep_res = claude_node.prep({})
+    assert prep_res["use_api_key"] is True
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert "env" not in mock_options.call_args.kwargs
+
+
+def test_string_false_still_scrubs(claude_node):
+    """Footgun guard: a templated string "false" must NOT enable API billing.
+
+    Node params aren't coerced to bool at runtime and the string "false" is
+    truthy in Python — a naive bool(value) would silently bill per token.
+    """
+    claude_node.params = {"prompt": "test prompt", "use_api_key": "false"}
+    prep_res = claude_node.prep({})
+    assert prep_res["use_api_key"] is False
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert mock_options.call_args.kwargs["env"] == {"ANTHROPIC_API_KEY": ""}
+
+
+def test_string_true_opts_in(claude_node):
+    """Templated string "true" opts into API billing (no scrub)."""
+    claude_node.params = {"prompt": "test prompt", "use_api_key": "true"}
+    prep_res = claude_node.prep({})
+    assert prep_res["use_api_key"] is True
+
+    with patch("pflow.nodes.claude.claude_code.ClaudeAgentOptions") as mock_options:
+        claude_node._build_claude_options(prep_res, "")
+
+    assert "env" not in mock_options.call_args.kwargs
+
+
+def test_use_api_key_invalid_value_raises(claude_node):
+    """A non-bool, non-canonical value fails closed with a TypeError."""
+    claude_node.params = {"prompt": "test prompt", "use_api_key": "maybe"}
+    with pytest.raises(TypeError) as exc_info:
+        claude_node.prep({})
+    assert "use_api_key must be true or false" in str(exc_info.value)
+
+
+def test_use_api_key_registered_as_bool_param():
+    """use_api_key is a declared bool param — this drives the validator allow-list."""
+    md = PflowMetadataExtractor().extract_metadata(ClaudeCodeNode)
+    params = {p["key"]: p["type"] for p in md["params"]}
+    assert params.get("use_api_key") == "bool"
+
+
+# --- Auth-failure guidance (exec_fallback) ---
+
+
+def test_is_auth_error_matches_only_auth_markers():
+    """_is_auth_error matches CLI auth/billing markers, not generic failures."""
+    assert ClaudeCodeNode._is_auth_error(Exception("Invalid API key · Please run /login"))
+    assert ClaudeCodeNode._is_auth_error(Exception("authentication_error: bad token"))
+    assert ClaudeCodeNode._is_auth_error(Exception("Your credit balance is too low"))
+    assert not ClaudeCodeNode._is_auth_error(Exception("Tool 'Bash' failed: exit 1"))
+    assert not ClaudeCodeNode._is_auth_error(Exception("connection reset by peer"))
+
+
+def test_exec_fallback_auth_default_suggests_subscription(claude_node):
+    """Default-mode auth failure points to subscription first, API key second."""
+    with pytest.raises(ValueError) as exc_info:
+        claude_node.exec_fallback({"use_api_key": False}, Exception("authentication_error"))
+    msg = str(exc_info.value)
+    assert "claude auth login" in msg
+    assert "- use_api_key: true" in msg
+
+
+def test_exec_fallback_auth_with_api_key_suggests_fixing_key(claude_node):
+    """Opt-in auth failure points to the Console key, not subscription setup."""
+    with pytest.raises(ValueError) as exc_info:
+        claude_node.exec_fallback({"use_api_key": True}, Exception("Your credit balance is too low"))
+    msg = str(exc_info.value)
+    assert "Anthropic Console" in msg
+    assert "Remove `- use_api_key: true`" in msg
+    assert "claude auth login" not in msg
+
+
+def test_exec_fallback_non_auth_error_has_no_auth_guidance(claude_node):
+    """Non-auth failures fall through to the generic message (no auth hint)."""
+    with pytest.raises(ValueError) as exc_info:
+        claude_node.exec_fallback({"use_api_key": False}, Exception("disk full"))
+    msg = str(exc_info.value)
+    assert "claude auth login" not in msg
+    assert "disk full" in msg


### PR DESCRIPTION
## Summary
The `claude-code` node leaked an ambient `ANTHROPIC_API_KEY` straight through to the Claude CLI subprocess, so the CLI billed Anthropic **Console per token even when the user was logged into a Pro/Max subscription** — a silent cost footgun. pflow amplifies it: it injects settings-stored keys into `os.environ` at startup (for the `llm` node's LiteLLM path), and the SDK subprocess inherits them.

This makes the node **default to subscription billing** and adds an explicit `use_api_key` opt-in for Console billing.

Fixes #455

## Changes
- **`use_api_key: bool` param (default `false`)** on the claude-code node. Strict-bool validation that **fails closed** — accepts real bools / canonical string literals (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`) and raises `TypeError` on anything else (a templated string `"false"` is truthy in Python and would otherwise silently re-enable per-token billing).
- **Subscription-by-default scrub** in `_build_claude_options`: sets `options.env = {"ANTHROPIC_API_KEY": ""}` for the Claude subprocess only. `os.environ` is untouched, so a sibling `llm` node still reads the real key for LiteLLM.
- **Direction-aware auth-failure guidance** in `exec_fallback`: on an auth error, points to subscription setup first (`claude auth login`), `use_api_key: true` second; if already opted in, points at the Console key instead.
- **Docs**: full rewrite of stale `AUTHENTICATION.md` (dropped the phantom `skip_auth_check` param and a detection snippet the node never had), plus `claude-code.mdx` and example `README.md` (param row, auth sections, error tables).
- **ADR 0002** recording the decision and rejected alternatives.

## Explanation
The issue's proposed fix (rebuild `env` without the key) does **not** work: the SDK merges `{**os.environ, ..., **options.env}`, so `os.environ` is the merge base and a dict merge cannot *delete* an inherited key by omitting it — the subprocess would still receive it, and a unit test asserting on `options.env` would pass while the bug survived. The empty-string **override** is the only in-process, subprocess-scoped, thread-safe mechanism (popping `os.environ` would race with parallel batch items and starve a concurrent `llm` node).

Verified empirically against `claude` v2.1.159 with `claude auth status`: an empty `ANTHROPIC_API_KEY` reports `subscriptionType: "max"` with no `apiKeySource`, while a present key reports `apiKeySource: "ANTHROPIC_API_KEY"`.

Trade-off (in the ADR): a user with only a key and no subscription login now gets an auth error (with guidance) until they set `use_api_key: true` — acceptable since pflow has no users yet, and the alternative is silent overcharging.

Diff: 6 files changed, +380/-175, plus the new ADR.

## Created Docs
- `context/adr/0002-455-claude-code-subscription-default.md` — why empty-string-override (not omission), rejected alternatives, consequences
- Updated user docs: `docs/reference/nodes/claude-code.mdx` (Authentication tabs + `use_api_key` param row + error table), `examples/nodes/claude-code/README.md`, and a full rewrite of `src/pflow/nodes/claude/AUTHENTICATION.md`

## Testing
New unit tests in `tests/test_nodes/test_claude/test_claude_code.py`:
- `test_default_blanks_api_key_in_options` — default sets `env == {"ANTHROPIC_API_KEY": ""}`
- `test_default_scrub_only_touches_anthropic_key` — no other env var is overridden
- `test_use_api_key_true_does_not_scrub` / `test_string_true_opts_in` — opt-in leaves `env` untouched
- `test_string_false_still_scrubs` — **footgun guard**: templated string `"false"` must NOT enable API billing
- `test_use_api_key_invalid_value_raises` — non-coercible value fails closed with `TypeError`
- `test_is_auth_error_matches_only_auth_markers` — auth/billing markers match, generic failures don't
- `test_exec_fallback_auth_default_suggests_subscription` / `_with_api_key_suggests_fixing_key` / `_non_auth_error_has_no_auth_guidance`
- `test_use_api_key_registered_as_bool_param` — param is registered in node metadata

End-to-end validation guard in `tests/test_core/test_unknown_param_validation.py`:
- `test_no_error_for_claude_code_use_api_key` — the real registry/validator accepts `use_api_key` (guards the docstring → metadata → allow-list chain)

Gates: `make test` → 7382 passed, 1 skipped. `make check` → pre-commit, mypy (227 files), deptry all clean. Manual smoke test against real `claude` v2.1.159 confirmed empty-key → subscription.