### PR TITLE
fix: code-node `list[T]` output can satisfy a `list[str]` param (#460)

### DIFF
--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -336,6 +336,8 @@ Detects file path references in node params and batch items, reads the files, an
 
 Single source of truth for the workflow-IR `type:` vocabulary. `CANONICAL_TYPES` = the 7 valid names (`string | number | integer | boolean | array | object | any`). `TypeSpec.parse(raw)` is the only entry point — raises `TypeVocabularyError` with structured context (fuzzy suggestions, Python-alias replacements) for the diagnostic pipeline. `TypeSpec.accepts(value)` is reserved for Task 120 (strict runtime enforcement); no production callers yet. Python annotations in code blocks use Python names, not these — see the S1↔S2 bridge in `src/pflow/guide/core.md`.
 
+`outer_base_type(type_str)` strips a parameterized generic to its outer base name (`list[str]` → `list`, discarding the element type). It's the shared home for the `split("[")[0]` pattern; `is_type_compatible` (template validation) uses it so a canonical `array` source can satisfy a verbatim `list[str]` registry param (issue #460). Element types are never compared — consistent with code-node outputs, which also collapse to the bare collection type.
+
 ### param_coercion.py
 
 **Two functions for different pipeline stages** — easy to confuse:

--- a/src/pflow/core/types.py
+++ b/src/pflow/core/types.py
@@ -33,6 +33,16 @@ PYTHON_ALIASES_AT_S1: Final[dict[str, str]] = {
 }
 
 
+def outer_base_type(type_str: str) -> str:
+    """Strip a parameterized generic to its outer base name (``list[str]`` -> ``list``).
+
+    The element type is discarded: ``dict[str, int]`` -> ``dict``,
+    ``list[dict]`` -> ``list``. Bare names pass through unchanged. Used wherever a
+    type string must be compared against the bare type vocabulary.
+    """
+    return type_str.split("[", 1)[0].strip()
+
+
 @dataclass
 class TypeVocabularyError(ValueError):
     """Raised when an authored workflow uses an invalid S1 type name."""
@@ -136,7 +146,7 @@ class TypeSpec:
 
 def _raise_parameterized_generic_error(raw: str, stripped: str) -> NoReturn:
     """Raise the canonical error for unsupported parameterized generics."""
-    base = stripped.split("[", 1)[0].strip()
+    base = outer_base_type(stripped)
     if base in PYTHON_ALIASES_AT_S1:
         canonical = PYTHON_ALIASES_AT_S1[base]
         suggestion = (

--- a/src/pflow/runtime/engine/template_resolution.py
+++ b/src/pflow/runtime/engine/template_resolution.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 
 from pflow.core.json_utils import try_parse_json
 from pflow.core.param_coercion import coerce_param_for_node
+from pflow.core.types import outer_base_type
 from pflow.runtime.template_resolver import TemplateResolver
 
 from .template_errors import (
@@ -26,8 +27,29 @@ from .types import TemplateConfig
 logger = logging.getLogger(__name__)
 
 
+def _runtime_base_type(type_str: str) -> str:
+    """Normalize a declared type for runtime comparison against bare type names.
+
+    The runtime type machinery (the JSON auto-parse gate in ``resolve_templates``
+    and ``validate_resolved_type``) compares against bare names — ``dict``/``list``/
+    ``object``/``array``/``str``. Strip a parameterized generic to its outer base so
+    ``list[str]`` is recognized as ``list``. Without this, a code/shell value wired
+    into a ``list[str]`` param would pass validation (the validator already strips
+    generics — see ``type_checker.is_type_compatible``) but silently fail to
+    JSON-auto-parse at runtime (issue #460 / PR #461).
+
+    Unions are left intact — they are never auto-parsed, and collapsing
+    ``list[str]|str`` to ``list`` would wrongly start parsing them.
+    """
+    return type_str if "|" in type_str else outer_base_type(type_str)
+
+
 def build_type_cache(interface_metadata: Optional[dict[str, Any]]) -> dict[str, str]:
     """Extract param_key -> expected_type from registry interface metadata.
+
+    Declared types are normalized to their outer base via ``_runtime_base_type``
+    (``list[str]`` -> ``list``) so the runtime type machinery, which only speaks
+    bare type names, stays in sync with the generic-aware validation layer.
 
     Args:
         interface_metadata: Node interface metadata from registry
@@ -49,7 +71,7 @@ def build_type_cache(interface_metadata: Optional[dict[str, Any]]) -> dict[str, 
                 key = input_spec.get("key")
                 type_str = input_spec.get("type")
                 if key and type_str:
-                    types[key] = type_str
+                    types[key] = _runtime_base_type(type_str)
 
     # Extract types from params
     params = interface_metadata.get("params", [])
@@ -59,7 +81,7 @@ def build_type_cache(interface_metadata: Optional[dict[str, Any]]) -> dict[str, 
                 key = param_spec.get("key")
                 type_str = param_spec.get("type")
                 if key and type_str:
-                    types[key] = type_str
+                    types[key] = _runtime_base_type(type_str)
 
     return types
 

--- a/src/pflow/runtime/template_validation/type_checker.py
+++ b/src/pflow/runtime/template_validation/type_checker.py
@@ -103,9 +103,13 @@ def is_type_compatible(source_type: str, target_type: str) -> bool:
     # but registry param types keep generics verbatim (list[str]); without this an
     # array source could never satisfy a list[str] param. Element types are not
     # compared — consistent with code-node outputs, which also collapse to the
-    # bare collection type. (issue #460)
+    # bare collection type. A future strict pass (Task 120) could add element-type
+    # checking here. (issue #460)
     source_base = outer_base_type(source_type)
     target_base = outer_base_type(target_type)
+    # Identity short-circuit: covers unknown-but-equal bracketed types (e.g. a
+    # user-named generic `foo[bar]` outside the canonical vocabulary). For
+    # canonical names this is redundant — every matrix entry already lists itself.
     if source_base == target_base:
         return True
     return target_base in TYPE_COMPATIBILITY_MATRIX.get(source_base, [])

--- a/src/pflow/runtime/template_validation/type_checker.py
+++ b/src/pflow/runtime/template_validation/type_checker.py
@@ -7,6 +7,7 @@ ensuring that resolved values match expected parameter types.
 import re
 from typing import Any, Optional
 
+from pflow.core.types import outer_base_type
 from pflow.registry.registry import Registry
 
 # Type compatibility matrix
@@ -97,8 +98,17 @@ def is_type_compatible(source_type: str, target_type: str) -> bool:
         target_types = [t.strip() for t in target_type.split("|")]
         return any(is_type_compatible(source_type, tt) for tt in target_types)
 
-    # Check compatibility matrix
-    return target_type in TYPE_COMPATIBILITY_MATRIX.get(source_type, [])
+    # Strip parameterized generics to their outer collection type before the
+    # matrix lookup. The producer side already canonicalizes (list[str] -> array),
+    # but registry param types keep generics verbatim (list[str]); without this an
+    # array source could never satisfy a list[str] param. Element types are not
+    # compared — consistent with code-node outputs, which also collapse to the
+    # bare collection type. (issue #460)
+    source_base = outer_base_type(source_type)
+    target_base = outer_base_type(target_type)
+    if source_base == target_base:
+        return True
+    return target_base in TYPE_COMPATIBILITY_MATRIX.get(source_base, [])
 
 
 def infer_template_type(  # noqa: C901

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -9,6 +9,7 @@ import re
 from typing import Any, Optional
 
 from pflow.core.diagnostic import Diagnostic, Severity
+from pflow.core.types import outer_base_type
 from pflow.registry import Registry
 from pflow.runtime.template_resolver import TemplateResolver
 from pflow.runtime.template_validation.type_checker import (
@@ -32,27 +33,6 @@ _QUOTED_TEMPLATE_PATTERN = re.compile(r"'\$\{([^}]+)\}'")
 _SHELL_SAFE_TYPES = {"str", "string", "any"}
 
 
-def _extract_base_type(type_str: str) -> str:
-    """Extract base type from generic type string.
-
-    Generic types like list[dict] or dict[str, any] have a base type
-    (list, dict) that determines their shell command compatibility.
-
-    Examples:
-        list[dict] -> list
-        dict[str, any] -> dict
-        str -> str
-        list -> list
-
-    Args:
-        type_str: Type string, possibly with generic parameters
-
-    Returns:
-        Base type without generic parameters
-    """
-    return type_str.split("[")[0]
-
-
 def _is_shell_safe_type(inferred_type: str, blocked_types: set[str]) -> tuple[bool, str | None]:
     """Check if a type is safe for shell command embedding.
 
@@ -67,7 +47,7 @@ def _is_shell_safe_type(inferred_type: str, blocked_types: set[str]) -> tuple[bo
     """
     # Split union and get base type for each component
     type_parts = [t.strip() for t in inferred_type.split("|")]
-    base_types = [_extract_base_type(t) for t in type_parts]
+    base_types = [outer_base_type(t) for t in type_parts]
 
     # Tier 1: If union contains a safe base type (str, string, any), allow it
     if any(t in _SHELL_SAFE_TYPES for t in base_types):

--- a/tests/test_core/test_types.py
+++ b/tests/test_core/test_types.py
@@ -2,7 +2,23 @@
 
 import pytest
 
-from pflow.core.types import CANONICAL_TYPES, TypeSpec, TypeVocabularyError
+from pflow.core.types import CANONICAL_TYPES, TypeSpec, TypeVocabularyError, outer_base_type
+
+
+class TestOuterBaseType:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("list[str]", "list"),
+            ("dict[str, int]", "dict"),
+            ("list[dict[str, int]]", "list"),  # only the outermost generic matters
+            ("list", "list"),  # bare names pass through
+            ("array", "array"),
+            ("  list[str]  ", "list"),  # surrounding whitespace stripped
+        ],
+    )
+    def test_strips_outer_generic(self, raw: str, expected: str) -> None:
+        assert outer_base_type(raw) == expected
 
 
 class TestTypeSpecParse:

--- a/tests/test_integration/test_code_annotation_validation.py
+++ b/tests/test_integration/test_code_annotation_validation.py
@@ -117,6 +117,76 @@ def test_valid_workflow_passes_validation_and_runs(tmp_path: Path) -> None:
     assert result.success, [diagnostic.message for diagnostic in result.diagnostics]
 
 
+def _write_images_workflow(tmp_path: Path, annotation: str) -> Path:
+    """Code node `result: <annotation>` feeding the llm `images: list[str]` param.
+
+    Exercises the node-parameter path (Pass 6) end-to-end against the real llm
+    node — distinct from the code-input path (Pass 9) covered above. The llm
+    `images` param keeps its generic verbatim (``list[str]``), while the code
+    output canonicalizes to ``array``.
+    """
+    path = tmp_path / "images.pflow.md"
+    path.write_text(
+        f"""# Issue 460
+Code node produces image paths consumed by the llm images param.
+
+## Steps
+
+### make-images
+
+Build a list of image paths.
+
+- type: code
+
+```python code
+result: {annotation} = ["a.png", "b.png"]
+```
+
+### use-images
+
+Consume the list of image paths.
+
+- type: llm
+- images: ${{make-images.result}}
+
+```prompt
+Describe these images.
+```
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.parametrize("annotation", ["list[str]", "list", "list[int]"])
+def test_issue_460_generic_code_output_satisfies_generic_param(tmp_path: Path, annotation: str) -> None:
+    """A code `result: list[...]` (or bare `list`) must satisfy the llm `images: list[str]` param.
+
+    Regression for issue #460: the producer canonicalizes ``list[str]`` -> ``array``,
+    but the registry param stays verbatim ``list[str]`` and the matrix only knew bare
+    names, so validation spuriously failed. ``list[int]`` also passes — generics
+    collapse to their outer collection type (no element check).
+    """
+    path = _write_images_workflow(tmp_path, annotation)
+    validation = WorkflowRunner().validate(str(path), params={})
+    assert validation.valid, [diagnostic.message for diagnostic in validation.errors]
+
+
+def test_issue_460_dict_output_still_rejected_by_list_param(tmp_path: Path) -> None:
+    """A code `result: dict[...]` must STILL fail the llm `images: list[str]` param.
+
+    The fix collapses generics to the outer collection type; it must not let a
+    genuinely-wrong outer type (object vs array) through.
+    """
+    path = _write_images_workflow(tmp_path, "dict[str, int]")
+    validation = WorkflowRunner().validate(str(path), params={})
+
+    assert not validation.valid
+    assert any("images" in diagnostic.message for diagnostic in validation.errors), [
+        diagnostic.message for diagnostic in validation.errors
+    ]
+
+
 def test_runtime_still_defends_when_validation_bypassed() -> None:
     """Direct compile+run still fails at runtime when validation is skipped."""
     from pflow.runtime import WorkflowEngine, compile_workflow

--- a/tests/test_runtime/test_node_wrapper_json_parsing.py
+++ b/tests/test_runtime/test_node_wrapper_json_parsing.py
@@ -165,6 +165,41 @@ class TestSimpleTemplateJsonParsing:
         assert result["array_param"] == ["item1", "item2"]
 
 
+class TestParameterizedGenericJsonParsing:
+    """Auto-parse must fire for parameterized-generic params, not just bare ones.
+
+    Regression for issue #460 / PR #461: the validator accepts a value wired into a
+    ``list[str]`` / ``dict[str, int]`` param (it strips the generic), but the runtime
+    auto-parse gate only knew bare names — so a JSON string fed into ``images:
+    list[str]`` validated clean then stayed an un-parsed string at runtime. The fix
+    normalizes declared types to their outer base in ``build_type_cache``.
+    """
+
+    def test_json_array_string_parses_for_list_str_param(self):
+        """JSON-array string -> list for a ``list[str]`` param (the issue #460 case)."""
+        interface = {"params": [{"key": "images", "type": "list[str]"}]}
+        result = _resolve({"images": "${x}"}, {"x": '["a.png", "b.png"]'}, interface)
+
+        assert isinstance(result["images"], list)
+        assert result["images"] == ["a.png", "b.png"]
+
+    def test_json_object_string_parses_for_dict_generic_param(self):
+        """JSON-object string -> dict for a ``dict[str, int]`` param."""
+        interface = {"params": [{"key": "cfg", "type": "dict[str, int]"}]}
+        result = _resolve({"cfg": "${x}"}, {"x": '{"a": 1, "b": 2}'}, interface)
+
+        assert isinstance(result["cfg"], dict)
+        assert result["cfg"] == {"a": 1, "b": 2}
+
+    def test_union_with_generic_is_not_collapsed(self):
+        """A union containing a generic stays a union (no auto-parse) — not collapsed to list."""
+        interface = {"params": [{"key": "p", "type": "list[str]|str"}]}
+        # The runtime never auto-parses unions; the value must pass through unchanged.
+        result = _resolve({"p": "${x}"}, {"x": '["a", "b"]'}, interface)
+
+        assert result["p"] == '["a", "b"]'
+
+
 class TestComplexTemplateNoParsing:
     """Test that complex templates are NOT auto-parsed (escape hatch)."""
 

--- a/tests/test_runtime/test_node_wrapper_type_validation.py
+++ b/tests/test_runtime/test_node_wrapper_type_validation.py
@@ -329,7 +329,9 @@ class TestPerformance:
         assert len(expected_types) == 5
         assert expected_types["prompt"] == "str"
         assert expected_types["model"] == "str"
-        assert expected_types["images"] == "list[str]"
+        # Parameterized generics are normalized to their outer base so the runtime
+        # type machinery (which speaks bare names) recognizes them (issue #460).
+        assert expected_types["images"] == "list"
 
     def test_type_cache_reusable(self):
         """build_type_cache can be called once and reused across multiple resolutions."""

--- a/tests/test_runtime/test_template_validation/test_type_checker.py
+++ b/tests/test_runtime/test_template_validation/test_type_checker.py
@@ -104,6 +104,51 @@ class TestTypeCompatibility:
         assert is_type_compatible("dict|list", "int|float") is False
 
 
+class TestTypeCompatibilityGenerics:
+    """Parameterized generics in is_type_compatible (issue #460).
+
+    Registry param types keep generics verbatim (``list[str]``); the producer side
+    canonicalizes to the bare collection type (``array``). Compatibility compares
+    the OUTER collection type only — element types are not checked, consistent with
+    how code-node outputs already collapse ``list[str]`` -> ``array``.
+    """
+
+    def test_canonical_array_satisfies_generic_list_param(self):
+        # The exact issue #460 case: code result (array) -> llm images (list[str]).
+        assert is_type_compatible("array", "list[str]") is True
+
+    def test_bare_list_satisfies_generic_list_param(self):
+        assert is_type_compatible("list", "list[str]") is True
+
+    def test_element_type_is_not_checked(self):
+        # list[int] satisfies list[str]; generics collapse to the outer type.
+        assert is_type_compatible("array", "list[int]") is True
+        assert is_type_compatible("list[str]", "list[dict]") is True
+
+    def test_generic_source_satisfies_canonical_target(self):
+        # Symmetric: a generic on the source side strips too.
+        assert is_type_compatible("list[str]", "array") is True
+        assert is_type_compatible("list[str]", "list") is True
+
+    def test_generic_dict_and_object_interchangeable(self):
+        assert is_type_compatible("object", "dict[str, int]") is True
+        assert is_type_compatible("dict[str, int]", "object") is True
+
+    def test_mismatched_outer_type_still_rejected(self):
+        # The fix must NOT let a genuinely-wrong outer type through.
+        assert is_type_compatible("object", "list[str]") is False
+        assert is_type_compatible("array", "dict[str, int]") is False
+
+    def test_generic_in_union_target(self):
+        assert is_type_compatible("array", "list[str]|str") is True
+        assert is_type_compatible("array", "int|list[str]") is True
+
+    def test_generic_in_union_source(self):
+        # Source union: ALL members must be compatible with the target.
+        assert is_type_compatible("list[str]|array", "list") is True
+        assert is_type_compatible("list[str]|object", "list") is False
+
+
 class TestTemplateTypeInference:
     """Tests for infer_template_type()."""
 

--- a/tests/test_runtime/test_template_validation/test_type_checker.py
+++ b/tests/test_runtime/test_template_validation/test_type_checker.py
@@ -148,6 +148,13 @@ class TestTypeCompatibilityGenerics:
         assert is_type_compatible("list[str]|array", "list") is True
         assert is_type_compatible("list[str]|object", "list") is False
 
+    def test_unknown_bracketed_type_does_not_become_compatible(self):
+        # An unknown generic base must not be promoted to any-compatible: it has no
+        # matrix entry, so only an identical base matches.
+        assert is_type_compatible("weirdtype[x]", "str") is False
+        assert is_type_compatible("str", "weirdtype[x]") is False
+        assert is_type_compatible("weirdtype[x]", "weirdtype[y]") is True  # equal outer base
+
 
 class TestTemplateTypeInference:
     """Tests for infer_template_type()."""


### PR DESCRIPTION
## Summary
A `code` node whose `result` is annotated with a parameterized generic (e.g. `list[str]`) could not be passed into a node parameter expecting that same generic (e.g. the `llm` node's `images: list[str]`). Validation failed with a spurious type mismatch, and the only workaround was annotating the output as `result: Any` — which opts out of type checking entirely.

Fixes #460

## Changes
**Validation fix (commit 1)**
- **`src/pflow/core/types.py`** — add `outer_base_type(type_str)`, the shared home for the `split("[")[0]` generic-stripping pattern.
- **`type_checker.py`** — `is_type_compatible` strips parameterized generics to their outer collection type on **both** operands, at the leaf level (after the union branches), before the matrix lookup.

**Runtime consistency + cleanups (commit 2 — addresses code review)**
- **`runtime/engine/template_resolution.py`** — normalize declared types to their outer base in `build_type_cache` (`_runtime_base_type`), so the runtime JSON auto-parse stays in sync with the generic-aware validator (see Explanation).
- **`type_validation.py`** — fold the lone remaining hand-rolled `split("[")[0]` (`_extract_base_type`) into `outer_base_type` (behavior-preserving).
- Tests across unit / matrix / runtime / end-to-end layers + CLAUDE.md note.

## Explanation
Root cause was a vocabulary asymmetry. The **producer** side canonicalizes code-node output types with the generic stripped (`list[str]` → `array`), but the **consumer** side keeps registry param types verbatim (`list[str]`). The compatibility matrix only understands bare names, so `is_type_compatible("array", "list[str]")` fell through to a matrix miss and returned `False`. The fix adds generic stripping — the one missing operation — at the single chokepoint, symmetric on both operands, after the union branches so `list[str]|str` still splits correctly.

**Runtime drift caught in review (Codex P1):** the validation fix alone created a validation/runtime mismatch. The runtime JSON auto-parse gate (`resolve_templates`) and `validate_resolved_type` only matched **bare** type names, so a JSON-array string wired into `images: list[str]` would *pass validation* but stay an un-parsed string at runtime, failing with a confusing `Image file not found`. Commit 2 closes this by normalizing types to their outer base in `build_type_cache` — the single boundary where registry types enter runtime resolution. Unions are left intact (they are never auto-parsed; collapsing `list[str]|str` → `list` would wrongly start parsing them). Verified directly: a JSON-array string now resolves to a real list for a `list[str]` param.

**Intentional limitation:** generics collapse to their outer collection type, so `list[int]` satisfies `list[str]`. This matches how code-node outputs already discard the element type, and is consistent with the rest of the system (no element checking exists anywhere). Element-level checking is noted as future work (Task 120). A genuinely mismatched **outer** type (e.g. `dict[str,int]` → `list[str]`) is still correctly rejected, at both validation and runtime.

## Testing
- `test_type_checker.py::TestTypeCompatibilityGenerics` — pins the validation fix: `array`/`list`/`list[str]` satisfy `list[str]`; symmetric generic-on-source; generics inside unions; regression guards that `object`↔`array` and `array`↔`dict[...]` stay incompatible; unknown bracketed types are not promoted to any-compatible.
- `test_types.py::TestOuterBaseType` — `outer_base_type` strips the outer generic (incl. nested + whitespace), passes bare names through.
- `test_node_wrapper_json_parsing.py::TestParameterizedGenericJsonParsing` — **runtime** auto-parse now fires for `list[str]` / `dict[str,int]` params; a union containing a generic is *not* collapsed.
- `test_node_wrapper_type_validation.py` — `build_type_cache` normalizes generics to their outer base.
- `test_code_annotation_validation.py` — end-to-end via `WorkflowRunner().validate()` against the real `llm` node: `list[str]`/`list`/`list[int]` → `images` validate clean; `dict[str,int]` → `images` still fails. Covers the node-parameter path (Pass 6) the issue actually hits.
- Full suite: 7463 passed, 1 skipped. `make check` clean (ruff + mypy 227 files + deptry).
- **Manual CLI verification** (before/after stash-confirmed): exact repro `list[str]` → `images` flips ✗→✓; `Optional[list[str]]`, nested `list[dict[str,int]]`, forward-ref `"list[str]"` also flip ✗→✓; `dict[str,int]` → `images` stays ✗. Ran end-to-end: code→code generic passthrough, batch over a code-produced `list[str]`, sub-workflow feeding code `list[str]` into a child `type: array`, and a shell-JSON→code-list pipeline — all execute correctly. Runtime auto-parse for `list[str]` proven directly via `resolve_templates`.