### PR TITLE
fix: `--report` shows true input tokens + Agent-calls label (#463)

### DIFF
--- a/src/pflow/core/trace_report.py
+++ b/src/pflow/core/trace_report.py
@@ -346,6 +346,47 @@ def _format_cost(cost: float | None) -> str:
     return f"${cost:.4f}"
 
 
+def _input_token_total(llm_call: dict[str, Any]) -> tuple[int, int]:
+    """Return ``(total_input_tokens, cache_read_tokens)`` for one LLM call.
+
+    LLM input is billed in three tiers that SUM to the true input the model
+    processed: uncached (``input_tokens``) + cache-write
+    (``cache_creation_input_tokens``) + cache-read (``cache_read_input_tokens``).
+    The report headlines that total and surfaces the cache-read share as a
+    cache-hit %, rather than showing the uncached slice alone \u2014 which made
+    cache-heavy agent runs look like ``in`` << ``out`` and divorced the cache
+    numbers from the token line.
+    """
+    uncached = llm_call.get("input_tokens", llm_call.get("prompt_tokens", 0)) or 0
+    cache_write = llm_call.get("cache_creation_input_tokens", 0) or 0
+    cache_read = llm_call.get("cache_read_input_tokens", 0) or 0
+    return uncached + cache_write + cache_read, cache_read
+
+
+def _format_tokens(total_in: int, tokens_out: int, cache_read: int, *, with_cache_pct: bool) -> str:
+    """``<total_in> in / <out> out`` with an optional ``\u00b7 N% of input cached``."""
+    cell = f"{total_in:,} in / {tokens_out:,} out"
+    if with_cache_pct and cache_read > 0 and total_in > 0:
+        cell += f"  \u00b7  {round(cache_read / total_in * 100)}% of input cached"
+    return cell
+
+
+def _format_call_count_line(total_calls: int, agent_calls: int, total_turns: int) -> str:
+    """Summary line for LLM/agent invocations.
+
+    ``claude-code`` nodes are agentic \u2014 one invocation spans many internal
+    turns \u2014 so they're labelled "Agent calls" with the turn total, distinct
+    from single-shot "LLM calls". A mixed run surfaces both counts.
+    """
+    turns = f" ({total_turns:,} turns)" if total_turns else ""
+    llm_calls = total_calls - agent_calls
+    if agent_calls and llm_calls:
+        return f"- Agent calls: {agent_calls}{turns} \u00b7 LLM calls: {llm_calls}"
+    if agent_calls:
+        return f"- Agent calls: {agent_calls}{turns}"
+    return f"- LLM calls: {total_calls}"
+
+
 def _format_llm_call_metadata(
     llm_call: dict[str, Any],
     lines: list[str],
@@ -367,9 +408,9 @@ def _format_llm_call_metadata(
     turns_label = "Source turns" if cached else "Turns"
     session_label = "Source session" if cached else "Session"
     lines.append(f"- {model_label}: {llm_call.get('model', '?')}")
-    tokens_in = llm_call.get("input_tokens", llm_call.get("prompt_tokens", 0))
-    tokens_out = llm_call.get("output_tokens", llm_call.get("completion_tokens", 0))
-    lines.append(f"- {tokens_label}: {tokens_in:,} in / {tokens_out:,} out")
+    total_in, cache_read = _input_token_total(llm_call)
+    tokens_out = llm_call.get("output_tokens", llm_call.get("completion_tokens", 0)) or 0
+    lines.append(f"- {tokens_label}: {_format_tokens(total_in, tokens_out, cache_read, with_cache_pct=True)}")
     thinking_tokens = llm_call.get("thinking_tokens")
     if isinstance(thinking_tokens, int) and thinking_tokens > 0:
         lines.append(f"- {thinking_label}: {thinking_tokens:,} tokens")
@@ -750,14 +791,20 @@ def _build_summary(
 
     llm = trace.get("llm_summary")
     if llm and llm.get("total_calls", 0) > 0:
-        lines.append(f"- LLM calls: {llm.get('total_calls', 0)}")
-        tokens_in = llm.get("total_input_tokens", 0)
+        lines.append(
+            _format_call_count_line(
+                llm.get("total_calls", 0),
+                llm.get("agent_calls", 0),
+                llm.get("total_num_turns", 0),
+            )
+        )
+        # `in` is the TRUE total: uncached + cache-write + cache-read (the three
+        # billing tiers). total_input_tokens alone is just the uncached slice.
+        cache_read = llm.get("total_cache_read_tokens", 0)
+        total_in = llm.get("total_input_tokens", 0) + llm.get("total_cache_creation_tokens", 0) + cache_read
         tokens_out = llm.get("total_output_tokens", 0)
-        if tokens_in or tokens_out:
-            lines.append(f"- Tokens: {tokens_in:,} in / {tokens_out:,} out")
-        elif llm.get("total_tokens", 0):
-            # Fallback for traces generated before input/output breakdown was added
-            lines.append(f"- Tokens: {llm['total_tokens']:,}")
+        if total_in or tokens_out:
+            lines.append(f"- Tokens: {_format_tokens(total_in, tokens_out, cache_read, with_cache_pct=True)}")
         cost = llm.get("total_cost_usd")
         if cost is not None and cost > 0:
             lines.append(f"- Total cost: ${cost:.4f}")
@@ -971,9 +1018,10 @@ def _row_tokens(event_or_item: dict[str, Any]) -> str:
     llm_call = event_or_item.get("llm_call")
     if not isinstance(llm_call, dict):
         return "—"
-    tokens_in = llm_call.get("input_tokens", llm_call.get("prompt_tokens", 0)) or 0
+    total_in, cache_read = _input_token_total(llm_call)
     tokens_out = llm_call.get("output_tokens", llm_call.get("completion_tokens", 0)) or 0
-    return f"{tokens_in:,} in / {tokens_out:,} out"
+    # Compact table cell: total in/out, no cache-% (that lives on the per-node line).
+    return _format_tokens(total_in, tokens_out, cache_read, with_cache_pct=False)
 
 
 def _format_pipeline_table(events: list[dict[str, Any]], lines: list[str]) -> None:
@@ -1156,17 +1204,18 @@ def _format_cache_telemetry(event: dict[str, Any], lines: list[str]) -> None:
     cache_age_sec = llm_call.get("cache_age_sec")
     chunks_skipped = llm_call.get("cache_chunks_skipped") or []
     is_cached_replay = bool(llm_call.get("cache_source"))
+    # llm nodes that opted into prompt caching carry the effective system in
+    # `llm_system`; claude-code's prompt-cache tiers come from the SDK and have
+    # no `llm_system`.
+    declared_cache = bool(event.get("llm_system"))
 
-    # When llm_system is present the workflow opted into caching — render the
-    # section even with all-zero tokens so agents see "declared cache, didn't
-    # fire" instead of silent suppression.
-    has_signal = (
-        is_cached_replay
-        or (isinstance(cache_creation, int) and cache_creation > 0)
-        or (isinstance(cache_read, int) and cache_read > 0)
-        or bool(chunks_skipped)
-        or bool(event.get("llm_system"))
-    )
+    # Live prompt-cache tiers (write/read) are now folded into the "- Tokens:"
+    # line as the input total + "% of input cached". This section remains ONLY
+    # for what that line can't carry: a memo/result REPLAY (cache_key + age), or
+    # an llm node that DECLARED caching — so "declared but didn't fire" stays
+    # visible even at zero tokens. A live claude-code call (cache fired, no
+    # declaration, not a replay) no longer emits a divorced section.
+    has_signal = is_cached_replay or declared_cache or bool(chunks_skipped)
     if not has_signal:
         return
 
@@ -1178,10 +1227,13 @@ def _format_cache_telemetry(event: dict[str, Any], lines: list[str]) -> None:
         lines.append("## Cache telemetry")
     lines.append("")
 
-    if isinstance(cache_creation, int):
-        lines.append(f"- Cache write: {cache_creation:,} tokens")
-    if isinstance(cache_read, int):
-        lines.append(f"- Cache read: {cache_read:,} tokens")
+    # Token tiers only answer "did the DECLARED cache fire?" — show them for the
+    # declared/replay cases; for live claude-code they're already on the Tokens line.
+    if declared_cache or is_cached_replay:
+        if isinstance(cache_creation, int):
+            lines.append(f"- Cache write: {cache_creation:,} tokens")
+        if isinstance(cache_read, int):
+            lines.append(f"- Cache read: {cache_read:,} tokens")
     if cache_key:
         lines.append(f"- Cache key: {cache_key}")
     if is_cached_replay and isinstance(cache_age_sec, (int, float)):

--- a/src/pflow/core/trace_report.py
+++ b/src/pflow/core/trace_report.py
@@ -364,6 +364,8 @@ def _format_llm_call_metadata(
     model_label = "Source model" if cached else "Model"
     tokens_label = "Source tokens" if cached else "Tokens"
     thinking_label = "Source thinking" if cached else "Thinking"
+    turns_label = "Source turns" if cached else "Turns"
+    session_label = "Source session" if cached else "Session"
     lines.append(f"- {model_label}: {llm_call.get('model', '?')}")
     tokens_in = llm_call.get("input_tokens", llm_call.get("prompt_tokens", 0))
     tokens_out = llm_call.get("output_tokens", llm_call.get("completion_tokens", 0))
@@ -371,6 +373,16 @@ def _format_llm_call_metadata(
     thinking_tokens = llm_call.get("thinking_tokens")
     if isinstance(thinking_tokens, int) and thinking_tokens > 0:
         lines.append(f"- {thinking_label}: {thinking_tokens:,} tokens")
+    # num_turns / session_id are claude-code-only; llm-node calls omit them and
+    # the guards skip the lines. num_turns counts the main agent's loop only —
+    # subagent turns are not included (a lens-deploying review node can show a
+    # low count despite heavy subagent work).
+    num_turns = llm_call.get("num_turns")
+    if isinstance(num_turns, int) and num_turns > 0:
+        lines.append(f"- {turns_label}: {num_turns:,}")
+    session_id = llm_call.get("session_id")
+    if isinstance(session_id, str) and session_id:
+        lines.append(f"- {session_label}: {session_id}")
     lines.append(f"- Paid this run: {_format_cost(paid_cost)}")
 
     historical_cost = llm_call.get("cost_usd")

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -232,6 +232,10 @@ class _LLMSummaryAccumulator:
     total_tokens: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_num_turns: int = 0
+    agent_calls: int = 0
     priced_cost: float = 0.0
     models: set[str] = field(default_factory=set)
     unavailable_models: Counter[str] = field(default_factory=Counter)
@@ -244,6 +248,15 @@ class _LLMSummaryAccumulator:
         self.total_tokens += call.get("total_tokens", 0)
         self.total_input_tokens += call.get("input_tokens", 0)
         self.total_output_tokens += call.get("output_tokens", 0)
+        self.total_cache_creation_tokens += call.get("cache_creation_input_tokens", 0) or 0
+        self.total_cache_read_tokens += call.get("cache_read_input_tokens", 0) or 0
+        # num_turns is claude-code-only — its presence marks an AGENT call (one
+        # invocation = many internal turns), distinct from a single-shot llm call.
+        turns = call.get("num_turns")
+        if turns is not None and not is_warmup:
+            self.agent_calls += 1
+            if isinstance(turns, int) and turns > 0:
+                self.total_num_turns += turns
         cost = call.get("cost_usd")
         model = call.get("model") or ""
         is_real_model = bool(model) and model != VALIDATION_PLACEHOLDER
@@ -265,6 +278,17 @@ class _LLMSummaryAccumulator:
             "total_output_tokens": self.total_output_tokens,
             "models_used": sorted(self.models),
         }
+        # Additive within trace 2.x — omitted when zero so older readers and
+        # non-caching/non-agent runs stay unchanged. ``total_input_tokens`` is
+        # the UNCACHED slice; renderers add the two cache tiers for the true total.
+        if self.total_cache_creation_tokens:
+            result["total_cache_creation_tokens"] = self.total_cache_creation_tokens
+        if self.total_cache_read_tokens:
+            result["total_cache_read_tokens"] = self.total_cache_read_tokens
+        if self.agent_calls:
+            result["agent_calls"] = self.agent_calls
+        if self.total_num_turns:
+            result["total_num_turns"] = self.total_num_turns
         if self.unavailable_models or self.unavailable_models_unnamed_count:
             result["total_cost_usd"] = None
             result["partial_cost_usd"] = round(self.priced_cost, 6) if self.priced_cost > 0 else None

--- a/tests/test_core/test_trace_report.py
+++ b/tests/test_core/test_trace_report.py
@@ -649,6 +649,47 @@ class TestBuildNodeFile:
         assert "- Tokens: 1,000 in / 200 out" in md
         assert "- Paid this run: $0.0420" in md
 
+    def test_llm_metadata_shows_turns_and_session(self) -> None:
+        # claude-code nodes carry num_turns (agent loop effort) and session_id.
+        event = _make_event(
+            llm_call={
+                "model": "claude-sonnet-4-5",
+                "input_tokens": 93,
+                "output_tokens": 3477,
+                "cost_usd": 0.1957,
+                "num_turns": 18,
+                "session_id": "7e81004e-5ba2-4c9f",
+            }
+        )
+        md = _build_node_file(event)
+        assert "- Turns: 18" in md
+        assert "- Session: 7e81004e-5ba2-4c9f" in md
+
+    def test_llm_metadata_omits_turns_and_session_when_absent(self) -> None:
+        # llm-node (LiteLLM) calls carry neither field — the lines must not appear.
+        event = _make_event(
+            llm_call={
+                "model": "gpt-4",
+                "input_tokens": 1000,
+                "output_tokens": 200,
+                "cost_usd": 0.042,
+            }
+        )
+        md = _build_node_file(event)
+        assert "- Turns:" not in md
+        assert "- Session:" not in md
+
+    def test_cached_llm_metadata_uses_source_turns_and_session_labels(self) -> None:
+        builder = TraceFixtureBuilder()
+        event = builder.cached_llm_event_with_call("draft", cost_usd=0.07)
+        event["llm_call"]["num_turns"] = 5
+        event["llm_call"]["session_id"] = "cached-session-id"
+
+        md = _build_node_file(event)
+
+        assert "- Source turns: 5" in md
+        assert "- Source session: cached-session-id" in md
+
     def test_cached_llm_metadata_splits_paid_and_historical_cost(self) -> None:
         builder = TraceFixtureBuilder()
         event = builder.cached_llm_event_with_call("draft", cost_usd=0.07)

--- a/tests/test_core/test_trace_report.py
+++ b/tests/test_core/test_trace_report.py
@@ -558,6 +558,42 @@ class TestBuildSummary:
         assert "gpt-4" in md
         assert "claude" in md
 
+    def test_agent_calls_label_with_turns_and_cache(self) -> None:
+        """claude-code runs render 'Agent calls: N (T turns)', and `in` is the
+        true total (uncached + cache-write + cache-read) with a cache-% suffix."""
+        trace = _make_trace(
+            llm_summary={
+                "total_calls": 9,
+                "agent_calls": 9,
+                "total_num_turns": 104,
+                "total_input_tokens": 1743,
+                "total_cache_creation_tokens": 153248,
+                "total_cache_read_tokens": 1982131,
+                "total_output_tokens": 41733,
+                "models_used": ["claude-sonnet-4-5"],
+            }
+        )
+        md = _build_summary(trace, source_path="test")
+        assert "- Agent calls: 9 (104 turns)" in md
+        # 1,743 + 153,248 + 1,982,131 = 2,137,122 in; 1,982,131 / 2,137,122 ≈ 93%
+        assert "- Tokens: 2,137,122 in / 41,733 out  ·  93% of input cached" in md
+        assert "LLM calls" not in md
+
+    def test_mixed_agent_and_llm_calls_label(self) -> None:
+        """A run with both claude-code and llm nodes surfaces both counts."""
+        trace = _make_trace(
+            llm_summary={
+                "total_calls": 5,
+                "agent_calls": 2,
+                "total_num_turns": 30,
+                "total_input_tokens": 1000,
+                "total_output_tokens": 500,
+                "models_used": ["claude-sonnet-4-5", "gpt-4"],
+            }
+        )
+        md = _build_summary(trace, source_path="test")
+        assert "- Agent calls: 2 (30 turns) · LLM calls: 3" in md
+
     def test_empty_llm_summary_omitted(self) -> None:
         """LLM summary with zero calls should not render models/tokens lines."""
         trace = _make_trace(
@@ -585,19 +621,6 @@ class TestBuildSummary:
         assert "- LLM calls: 1" in md
         assert "Tokens" not in md
         assert "- Models: gpt-4" in md
-
-    def test_llm_summary_fallback_total_tokens(self) -> None:
-        """Old traces without input/output breakdown fall back to total_tokens."""
-        trace = _make_trace(
-            llm_summary={
-                "total_calls": 2,
-                "total_tokens": 500,
-                "models_used": ["gpt-4"],
-            }
-        )
-        md = _build_summary(trace, source_path="test")
-        assert "- Tokens: 500" in md
-        assert "in /" not in md
 
     def test_pipeline_table(self) -> None:
         trace = _make_trace(
@@ -698,7 +721,8 @@ class TestBuildNodeFile:
 
         assert "- Status: success [cached]" in md
         assert "- Source model: anthropic/claude-sonnet-4-5" in md
-        assert "- Source tokens: 1,000 in / 100 out" in md
+        # `in` is the true total: 1,000 uncached + 950 cache-read = 1,950 (49% cached).
+        assert "- Source tokens: 1,950 in / 100 out  ·  49% of input cached" in md
         assert "- Paid this run: $0.0000" in md
         assert "- Historical source cost: $0.0700" in md
         assert "- Cost: $0.0700" not in md
@@ -940,33 +964,34 @@ class TestBuildNodeFile:
 class TestCacheTelemetrySection:
     """Trace report per-call cache telemetry rendering."""
 
-    def test_renders_section_when_cache_creation_nonzero(self) -> None:
+    def test_live_cache_write_folds_into_tokens_line_no_section(self) -> None:
+        """A live (non-replay, non-declared) cache no longer emits a divorced
+        ``## Cache telemetry`` section — the tiers are part of the input total
+        on the Tokens line. cache-write only (0 read) ⇒ no cache-% suffix."""
         event = _make_event(
             llm_call={
                 "cache_creation_input_tokens": 1500,
                 "cache_read_input_tokens": 0,
-                "cache_key": "abc123",
             },
         )
         md = _build_node_file(event)
 
-        assert "## Cache telemetry" in md
-        assert "Cache write: 1,500 tokens" in md
-        assert "Cache read: 0 tokens" in md
-        assert "Cache key: abc123" in md
+        assert "## Cache telemetry" not in md
+        assert "- Tokens: 1,500 in / 0 out" in md
 
-    def test_renders_section_when_cache_read_nonzero(self) -> None:
+    def test_live_cache_read_folds_into_tokens_line_with_pct(self) -> None:
+        """A live cache-read fold: ``in`` is the total and the cache-read share
+        shows as ``% of input cached`` — no separate section."""
         event = _make_event(
             llm_call={
                 "cache_creation_input_tokens": 0,
                 "cache_read_input_tokens": 8062,
-                "cache_key": "def456",
             },
         )
         md = _build_node_file(event)
 
-        assert "## Cache telemetry" in md
-        assert "Cache read: 8,062 tokens" in md
+        assert "## Cache telemetry" not in md
+        assert "- Tokens: 8,062 in / 0 out  ·  100% of input cached" in md
 
     def test_omitted_when_no_cache_signal(self) -> None:
         """Plain LLM call without cache activity suppresses the section."""
@@ -1083,10 +1108,11 @@ class TestCacheTelemetrySection:
         assert "Cache write: 0 tokens" in md
         assert "Cache read: 0 tokens" in md
 
-    def test_renders_in_batch_item_file(self) -> None:
-        """Batch items reuse _format_resolutions; cache telemetry must
-        propagate to per-item .md files. Pins the contract against future
-        refactors that move batch-item rendering off the shared helper."""
+    def test_cache_tiers_fold_into_tokens_line_in_batch_item_file(self) -> None:
+        """Batch per-item files reuse the shared metadata helper, so a live
+        cache's tiers land on the item's Tokens line (input total), not in a
+        separate section. Pins the contract against future refactors that move
+        batch-item rendering off the shared helper."""
         from pflow.core.trace_report import _build_batch_item_file
 
         parent_event = _make_event(node_id="batch-parent", node_type="LLMNode")
@@ -1097,13 +1123,12 @@ class TestCacheTelemetrySection:
             "llm_call": {
                 "cache_creation_input_tokens": 1500,
                 "cache_read_input_tokens": 0,
-                "cache_key": "item-0",
             },
         }
         md = _build_batch_item_file(item, parent_event)
 
-        assert "## Cache telemetry" in md
-        assert "Cache write: 1,500 tokens" in md
+        assert "## Cache telemetry" not in md
+        assert "- Tokens: 1,500 in / 0 out" in md
 
     def test_thinking_tokens_renders_in_metadata_when_nonzero(self) -> None:
         event = _make_event(


### PR DESCRIPTION
## Summary
`pflow report` undercounted input tokens and mislabeled agentic `claude-code` nodes. This makes the report reflect real token usage and agent effort.

Fixes #463

## Changes
- **Token line `in` = the true total** (uncached + cache-write + cache-read) with a `· N% of input cached` suffix — in the summary, per-node files, and pipeline rows. Shared `_input_token_total` / `_format_tokens` helpers keep the three render sites consistent.
- **`Agent calls: N (T turns)`** label for `claude-code` (one invocation = many internal turns; discriminator = `num_turns` present); `llm` nodes stay `LLM calls`; a mixed run shows both.
- `_LLMSummaryAccumulator` now sums cache-write/read + `num_turns` and counts `agent_calls` (additive to `llm_summary`, omitted when zero).
- `## Cache telemetry` section suppressed for **live claude-code** (tiers now on the token line); **kept** for the memo/replay case and the `llm`-node "declared cache didn't fire" signal.
- Dropped the legacy `total_tokens`-only summary fallback.

## Explanation
LLM input is billed in three tiers that **sum** to the true input: uncached (`input_tokens`) + cache-write (`cache_creation_input_tokens`) + cache-read (`cache_read_input_tokens`). The report headlined only the uncached tier, so a cache-heavy agent run showed e.g. `1,743 in / 41,733 out` (input < output, looks broken) while the model actually processed ~2.1M input tokens — and the prompt-cache numbers sat in a `## Cache telemetry` section divorced from the token line, conflating Anthropic's prompt cache with pflow's memo cache. Likewise, `claude-code` nodes are multi-turn agents, so counting 9 nodes as "9 LLM calls" hid the ~104 actual agent turns.

`trace_report.py` (+106/−~30), `workflow_trace.py` (+24), `test_trace_report.py` (+87/−~30).

## Testing
- `test_agent_calls_label_with_turns_and_cache` — summary renders `Agent calls: 9 (104 turns)` and `2,137,122 in / 41,733 out · 93% of input cached`.
- `test_mixed_agent_and_llm_calls_label` — mixed run shows `Agent calls: 2 (30 turns) · LLM calls: 3`.
- `test_live_cache_write_folds_into_tokens_line_no_section` / `test_live_cache_read_folds_into_tokens_line_with_pct` — live cache tiers fold into the token line; no divorced section.
- `test_cache_tiers_fold_into_tokens_line_in_batch_item_file` — same for batch per-item files.
- `test_cached_llm_metadata_splits_paid_and_historical_cost` — memo replay totals input correctly (1,950 in · 49% cached).
- Existing memo/replay + "declared cache didn't fire" telemetry tests stay green (behavior preserved).
- Full `test_core` + `test_runtime` + `test_execution`: 5215 passed, 1 skipped; ruff/format/mypy clean.
- Manual: regenerated a real run's report — per-node `implement` shows `232,676 in / 3,477 out · 91% of input cached`, `Turns: 18`, no cache-telemetry section; a fresh-trace summary renders the corrected `Agent calls` + total-input line.