### PR TITLE
fix(cli): readable run summary — meta above data, airy spacing, agent-visible output label (#469)

### DIFF
--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -103,13 +103,14 @@ This split is critical: `pflow workflow.pflow.md | jq` works because progress no
 
 ### Output routing (`_output_with_header` in workflow_output.py)
 
-Routing is TTY-agnostic: data always goes to stdout, diagnostics always go to stderr. The stderr header (`Workflow output (<desc>):`) is the only TTY-sensitive element — suppressed when stdout is non-TTY because a naked label with the value elsewhere reads as "empty output" to both humans and agents.
+Routing is TTY-agnostic: data always goes to stdout, diagnostics always go to stderr. The stderr header (`Workflow output (<desc>):`) is the only TTY-sensitive element — shown when stdout is a TTY **or** stderr is non-TTY, and suppressed ONLY when stdout is redirected to a file/pipe while stderr is a terminal (`pflow wf > out.json` watched in a shell), where a naked label with the value elsewhere reads as "empty output". Agents capturing both streams (e.g. `2>&1`) see the label as a result delimiter. This is the Option B refinement of the Task 149 suppression — see `_show_output_header` in `workflow_output.py`.
 
 | Mode | When | Header | Data | Summary |
 |------|------|--------|------|---------|
 | `--print` (`-p`) | Explicitly requested | None | stdout | None |
-| TTY stdout | Interactive terminal | stderr | stdout | stderr |
-| Non-TTY stdout | Pipe / redirect / CI / agent subprocess | None | stdout | stderr |
+| stdout TTY | Interactive terminal | stderr | stdout | stderr |
+| stdout non-TTY, stderr non-TTY | Pipe / CI / agent (`2>&1`, both captured) | stderr | stdout | stderr |
+| stdout non-TTY, stderr TTY | Redirect to file while watching terminal (`pflow wf > out`) | None | stdout | stderr |
 
 `--print` suppresses header, summary, and warnings on stderr. Data still goes to stdout.
 

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -108,6 +108,15 @@ def _handle_workflow_success(
         if diagnostic.severity in {Severity.WARNING, Severity.INFO}
     ]
 
+    # Text mode renders the trace path in the summary's meta block (above the
+    # data), so save it now and thread the path down. JSON leaves it None — its
+    # ``set_json_output`` mutates the trace during output handling, so the file
+    # must be saved afterward (in the finally block), where the line is echoed.
+    trace_path = None
+    if output_format == "text" and workflow_trace and ctx.obj.get("trace"):
+        trace_file = _save_trace_file(ctx, workflow_trace)
+        trace_path = str(trace_file) if trace_file else None
+
     # Writes data to stdout, summary/advice to stderr; rationale in docstring.
     _handle_workflow_output(
         shared_storage,
@@ -121,26 +130,43 @@ def _handle_workflow_success(
         workflow_trace=workflow_trace,
         status=status,
         warnings=result_warnings,
+        trace_path=trace_path,
     )
 
 
-def _save_trace_and_report(ctx: click.Context, workflow_trace: Any | None) -> None:
-    """Save trace to file and generate report if requested."""
-    if not workflow_trace:
-        return
-    if not ctx.obj.get("trace", False):
-        return
-    try:
-        trace_file = workflow_trace.save_to_file()
-    except Exception as trace_err:
-        logger.error("Failed to save trace: %s", trace_err, exc_info=True)
-        return
+def _save_trace_file(ctx: click.Context, workflow_trace: Any) -> Any | None:
+    """Save the trace to disk once; cache and return its path.
 
-    if trace_file:
-        _echo_trace(ctx, f"📊 Workflow trace saved: {trace_file}")
-        report = ctx.obj.get("report")
-        if report:
-            _generate_and_echo_report(ctx, trace_file, report, workflow_trace)
+    Idempotent across the two callers — the text-success path (which renders the
+    path in the summary's meta block above the data) and the ``finally`` block
+    (report generation + the failure/JSON-path trace echo) — so the file is
+    written exactly once. Returns ``None`` if the save fails.
+    """
+    if "trace_file" not in ctx.obj:
+        try:
+            ctx.obj["trace_file"] = workflow_trace.save_to_file()
+        except Exception as trace_err:
+            logger.error("Failed to save trace: %s", trace_err, exc_info=True)
+            ctx.obj["trace_file"] = None
+    return ctx.obj["trace_file"]
+
+
+def _finalize_trace_and_report(ctx: click.Context, workflow_trace: Any, *, echo_trace_line: bool) -> None:
+    """Save the trace, optionally echo its path, and generate the report.
+
+    ``echo_trace_line`` is False on the text-success path — there the path is
+    already rendered in the summary's meta block (above the data). It's True for
+    JSON and failure paths, which have no such meta block, so the line is echoed
+    here (after the payload / error output), matching the prior behavior.
+    """
+    trace_file = _save_trace_file(ctx, workflow_trace)
+    if not trace_file:
+        return
+    if echo_trace_line:
+        _echo_trace(ctx, f"Workflow trace saved: {trace_file}")
+    report = ctx.obj.get("report")
+    if report:
+        _generate_and_echo_report(ctx, trace_file, report, workflow_trace)
 
 
 def _generate_and_echo_report(ctx: click.Context, trace_file: Any, report: Any, workflow_trace: Any) -> None:
@@ -294,7 +320,10 @@ def execute_json_workflow(  # noqa: C901
     finally:
         trace = result.trace if result else None
         if trace and config.trace_enabled:
-            _save_trace_and_report(ctx, trace)
+            # Text-success already rendered the trace line in the summary's meta
+            # block (above the data); JSON and failure paths echo it here.
+            text_success = bool(result and result.success and output_format == "text")
+            _finalize_trace_and_report(ctx, trace, echo_trace_line=not text_success)
         _cleanup_temp_files(stdin_data, effective_verbose)
 
 

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -62,13 +62,14 @@ def safe_output(value: Any) -> bool:
         raise
 
 
-def _stdout_is_tty() -> bool:
-    """Return whether stdout is a TTY, preferring OutputController's captured state.
+def _stream_is_tty(stream_name: str) -> bool:
+    """Return whether ``stdout``/``stderr`` is a TTY.
 
-    Falls back to ``sys.stdout.isatty()`` when no Click context / OutputController
-    is available — matches what ``OutputController.__init__`` does itself, so the
-    TTY decision stays consistent for any caller of ``_output_with_header``
-    (including non-CLI entry points that don't thread through ``_initialize_context``).
+    Prefers ``OutputController``'s captured state (set once at CLI startup) and
+    falls back to ``sys.<stream>.isatty()`` when no Click context /
+    OutputController is available — so the TTY decision stays consistent for any
+    caller of ``_output_with_header`` (including non-CLI entry points that don't
+    thread through ``_initialize_context``).
     """
     import sys
 
@@ -77,24 +78,41 @@ def _stdout_is_tty() -> bool:
     except RuntimeError:
         ctx = None
     if ctx is not None and ctx.obj and "output_controller" in ctx.obj:
-        return bool(ctx.obj["output_controller"].stdout_tty)
-    return sys.stdout.isatty() if sys.stdout is not None else False
+        return bool(getattr(ctx.obj["output_controller"], f"{stream_name}_tty"))
+    stream = getattr(sys, stream_name, None)
+    return stream.isatty() if stream is not None else False
+
+
+def _show_output_header() -> bool:
+    """Whether to emit the ``Workflow output:`` label before the data.
+
+    Show it whenever stdout is interactive OR stderr is captured. The label is
+    suppressed in exactly one case — stdout redirected to a file/pipe WHILE
+    stderr is a terminal (``pflow wf > out.json`` watched in a shell) — where a
+    naked label on stderr with the data elsewhere reads as empty output.
+
+    For the agent case (both streams captured, non-TTY) the label IS shown: it
+    delimits where the result begins in a merged ``2>&1`` capture. This is the
+    Option B refinement of the Task 149 suppression, which only ever needed to
+    fire for the human-redirect case.
+    """
+    return _stream_is_tty("stdout") or not _stream_is_tty("stderr")
 
 
 def _output_with_header(value: Any, print_flag: bool, description: str | None = None) -> None:
     """Output value with Unix-convention routing.
 
     - ``--print`` mode: data to stdout, no header.
-    - Non-TTY stdout (pipe/redirect): data to stdout, no header — the naked
-      stderr label would otherwise look like empty output when the terminal
-      has nothing to render below it.
-    - TTY stdout: header to stderr, data to stdout — the description is
-      useful interactive context.
+    - stdout redirected while stderr is a terminal: data to stdout, no header —
+      the naked stderr label would look like empty output (see
+      ``_show_output_header``).
+    - Otherwise (interactive, or both streams captured by an agent): header to
+      stderr, data to stdout — the label delimits the result.
     """
     from pflow.execution.formatters.batch_errors import compact_batch_output_value
 
     value = compact_batch_output_value(value)
-    if print_flag or not _stdout_is_tty():
+    if print_flag or not _show_output_header():
         safe_output(value)
         return
 
@@ -113,6 +131,7 @@ def _handle_text_output(
     workflow_metadata: dict[str, Any] | None = None,
     status: Any = None,
     warnings: list[Any] | None = None,
+    trace_path: str | None = None,
 ) -> None:
     """Handle text formatted output with execution summary.
 
@@ -136,6 +155,10 @@ def _handle_text_output(
         print_flag: Whether -p flag is set (suppress warnings)
         metrics_collector: Optional MetricsCollector for execution metrics
         workflow_metadata: Optional workflow metadata
+        status: Optional tri-state workflow status
+        warnings: Optional list of warning diagnostics
+        trace_path: Optional trace file path, rendered in the meta block above
+            the data (text-success path only)
     """
     # Display execution summary or --only mode indicator (dispatch in helper)
     _emit_summary_or_only_indicator(
@@ -148,6 +171,7 @@ def _handle_text_output(
         warnings=warnings,
         verbose=verbose,
         print_flag=print_flag,
+        trace_path=trace_path,
     )
 
     # User-specified key takes priority. Supports dotted paths (e.g.
@@ -160,6 +184,9 @@ def _handle_text_output(
             _output_with_header(value, print_flag)
         elif not print_flag:
             hint = _diagnose_path_failure(shared_storage, output_key)
+            # Blank line separates this advisory from the summary block above,
+            # matching the other output-section advisories (airy layout).
+            click.echo("", err=True)
             click.echo(
                 f"cli: Warning - output key '{output_key}' not found. {hint}",
                 err=True,
@@ -226,6 +253,8 @@ def _emit_only_output(shared_storage: dict[str, Any], print_flag: bool) -> bool:
         return True
 
     if not print_flag:
+        # Blank line separates this advisory from the summary block above (airy).
+        click.echo("", err=True)
         click.echo(
             f"cli: --only active — streaming auto-detected key '{key_found}' from target '{only_node}' to stdout.",
             err=True,
@@ -412,6 +441,9 @@ def _emit_auto_detected_output(
     if not key_found:
         return False
     if message_template and not print_flag:
+        # Blank line separates this output advisory from the summary block above
+        # (airy layout); the header below carries its own leading blank.
+        click.echo("", err=True)
         click.echo(message_template.format(key=key_found), err=True)
     _output_with_header(value, print_flag)
     return True
@@ -478,6 +510,8 @@ def _warn_multi_output_ambiguity(chosen: str, dropped: list[str]) -> None:
     """
     total = 1 + len(dropped)
     names = ", ".join([chosen, *dropped])
+    # Blank line separates this advisory from the summary block above (airy).
+    click.echo("", err=True)
     click.echo(
         f"cli: Workflow declares {total} outputs ({names}). "
         f"Streaming '{chosen}' to stdout. Mark one output with `- stdout: true`, "
@@ -567,64 +601,50 @@ def _truncate_error_message(message: str, max_length: int = 200) -> str:
     return shared_truncate_error_message(message, max_length)
 
 
-def _display_batch_errors(steps: list[dict[str, Any]]) -> None:
-    """Display batch errors section for all batch nodes with failures.
+def _as_block(lines: list[str]) -> list[str]:
+    """Normalize a formatter's output into a clean block.
 
-    Args:
-        steps: List of execution step dicts
+    Drops leading/trailing blank lines and a newline baked into the first line,
+    so ``_echo_summary_blocks`` is the single owner of inter-block spacing.
+    ``format_stderr_warnings`` leads with a ``""`` element;
+    ``format_batch_errors_section`` bakes a ``\\n`` into its first line — this
+    flattens both to bare content.
     """
-    from pflow.execution.formatters.batch_errors import format_batch_errors_section
+    block = list(lines)
+    while block and block[0] == "":
+        block.pop(0)
+    while block and block[-1] == "":
+        block.pop()
+    if block:
+        block[0] = block[0].lstrip("\n")
+    return block
 
-    for line in format_batch_errors_section(steps):
-        click.echo(line, err=True)
 
+def _echo_summary_blocks(blocks: list[list[str]]) -> None:
+    """Echo summary blocks to stderr with one blank line before each (airy).
 
-def _display_stderr_warnings(steps: list[dict[str, Any]]) -> None:
-    """Display stderr warnings for shell nodes that succeeded but produced stderr.
-
-    This helps surface hidden errors from shell pipeline failures where
-    intermediate commands fail but the overall exit code is 0.
-
-    Delegates to ``format_stderr_warnings`` in ``success_formatter.py`` so CLI
-    and MCP text output stay in lockstep (same bullet shape, same truncation,
-    same ⚠️ header). MCP consumers of this block are in
-    ``success_formatter.format_success_as_text``; any change to the block
-    shape must be made in the shared helper, not here.
-
-    Args:
-        steps: List of execution step dicts (may contain has_stderr and stderr fields)
+    The leading blank before the first block separates the summary from the
+    progress stream above it (replacing the old per-action blank line). Empty
+    blocks are skipped so absent sections leave no dangling separators.
     """
-    from pflow.execution.formatters.success_formatter import format_stderr_warnings
-
-    for line in format_stderr_warnings(steps):
-        click.echo(line, err=True)
-
-
-def _display_workflow_action(workflow_name: str, workflow_action: str) -> None:
-    """Display workflow name and action message.
-
-    Args:
-        workflow_name: Name of the workflow
-        workflow_action: Action type (reused, created, unsaved)
-    """
-    click.echo("", err=True)
-    if workflow_action == "reused":
-        click.echo(f"{workflow_name} was executed", err=True)
-    elif workflow_action == "created":
-        click.echo(f"{workflow_name} was created and executed", err=True)
-    # Skip showing workflow line for "unsaved" workflows
+    for block in blocks:
+        if not block:
+            continue
+        click.echo("", err=True)
+        for line in block:
+            click.echo(line, err=True)
 
 
-def _display_cost_summary(total_cost: float | None, formatted_result: dict[str, Any]) -> None:
-    """Display LLM cost and token usage summary.
+def _format_cost_summary_lines(total_cost: float | None, formatted_result: dict[str, Any]) -> list[str]:
+    """Build the LLM cost / token usage summary lines.
 
-    Renders ``💰 Cost: ...`` (priced) or ``⚠️  Cost unavailable — ...``
-    (unpriced) on the first line, followed by a ``   Total LLM calls: N``
+    Returns ``💰 Cost: ...`` (priced) or ``⚠️  Cost unavailable — ...``
+    (unpriced) as the first line, followed by a ``   Total LLM calls: N``
     sibling line (3-space indent) whenever the run actually made any LLM
     calls. The sibling line is intentionally suppressed when no LLM calls
     happened so workflows that never touch an LLM don't see ``Total LLM
     calls: 0`` (mirrors the "honest unmeasurable" precedent in
-    ``format_dry_run_nudge``).
+    ``format_dry_run_nudge``). Returns ``[]`` when there is no cost to show.
 
     Args:
         total_cost: Total cost in USD
@@ -643,18 +663,15 @@ def _display_cost_summary(total_cost: float | None, formatted_result: dict[str, 
         models_phrase = format_unavailable_models_phrase(unavailable_counts, unavailable_unnamed_count)
         partial = total_metrics.get("partial_cost_usd")
         if partial is not None:
-            click.echo(
-                f"💰 Cost: ${partial:.4f}+ (partial — pricing unavailable for: {models_phrase})",
-                err=True,
-            )
+            lines = [f"💰 Cost: ${partial:.4f}+ (partial — pricing unavailable for: {models_phrase})"]
         else:
-            click.echo(f"⚠️  Cost unavailable — pricing data missing for: {models_phrase}", err=True)
+            lines = [f"⚠️  Cost unavailable — pricing data missing for: {models_phrase}"]
         if total_llm_calls > 0:
-            click.echo(f"   Total LLM calls: {total_llm_calls}", err=True)
-        return
+            lines.append(f"   Total LLM calls: {total_llm_calls}")
+        return lines
 
     if total_cost is None or total_cost <= 0:
-        return
+        return []
 
     # Get token count for context
     workflow_metrics = metrics.get("workflow", {})
@@ -667,20 +684,19 @@ def _display_cost_summary(total_cost: float | None, formatted_result: dict[str, 
         detail_parts.append(f"{total_tokens:,} tokens")
 
     if detail_parts:
-        click.echo(f"💰 Cost: ${total_cost:.4f} ({', '.join(detail_parts)})", err=True)
-    else:
-        click.echo(f"💰 Cost: ${total_cost:.4f}", err=True)
+        return [f"💰 Cost: ${total_cost:.4f} ({', '.join(detail_parts)})"]
+    return [f"💰 Cost: ${total_cost:.4f}"]
 
 
-def _display_workflow_completion_status(
+def _format_workflow_completion_status(
     duration_s: float,
     status: str,
     has_stderr_warnings: bool,
     cache_hits: int = 0,
     nodes_executed: int = 0,
     warning_count: int = 0,
-) -> None:
-    """Display workflow completion status with appropriate indicator.
+) -> str:
+    """Build the workflow completion status line with the appropriate indicator.
 
     Args:
         duration_s: Execution duration in seconds
@@ -696,18 +712,16 @@ def _display_workflow_completion_status(
         cache_suffix = f" ({cache_hits} cached, {executed_fresh} executed)"
 
     if status == "degraded":
-        click.echo(f"⚠️ Workflow completed with warnings in {duration_s:.3f}s{cache_suffix}", err=True)
-    elif status == "failed":
+        return f"⚠️ Workflow completed with warnings in {duration_s:.3f}s{cache_suffix}"
+    if status == "failed":
         if warning_count:
-            click.echo(f"❌ Workflow failed ({warning_count} warnings) after {duration_s:.3f}s{cache_suffix}", err=True)
-        else:
-            click.echo(f"❌ Workflow failed after {duration_s:.3f}s{cache_suffix}", err=True)
-    elif warning_count:
-        click.echo(f"⚠️ Workflow completed with {warning_count} warnings in {duration_s:.3f}s{cache_suffix}", err=True)
-    elif has_stderr_warnings:
-        click.echo(f"⚠️ Workflow completed in {duration_s:.3f}s{cache_suffix}", err=True)
-    else:
-        click.echo(f"✓ Workflow completed in {duration_s:.3f}s{cache_suffix}", err=True)
+            return f"❌ Workflow failed ({warning_count} warnings) after {duration_s:.3f}s{cache_suffix}"
+        return f"❌ Workflow failed after {duration_s:.3f}s{cache_suffix}"
+    if warning_count:
+        return f"⚠️ Workflow completed with {warning_count} warnings in {duration_s:.3f}s{cache_suffix}"
+    if has_stderr_warnings:
+        return f"⚠️ Workflow completed in {duration_s:.3f}s{cache_suffix}"
+    return f"✓ Workflow completed in {duration_s:.3f}s{cache_suffix}"
 
 
 def _emit_summary_or_only_indicator(
@@ -721,17 +735,21 @@ def _emit_summary_or_only_indicator(
     warnings: list[Any] | None,
     verbose: bool,
     print_flag: bool,
+    trace_path: str | None = None,
 ) -> None:
     """Dispatch between full summary, --only-only emission, or nothing.
 
-    The full summary (workflow action + completion tag + batch errors +
-    cost + warnings + --only line) is suppressed in ``-p`` mode because
-    the user explicitly asked for minimal stderr. The ``--only`` mode
-    confirmation is a mode signal (not a suppressible detail) and is
-    emitted even in ``-p`` mode when ``--only`` is active. Verbosity
-    flags hide details; mode flags survive verbosity. Matches the
-    convention of ``make -k``, ``pytest --maxfail``, ``rsync --dry-run``,
-    ``apt-get --simulate``, ``kubectl --dry-run``, etc.
+    The full summary (completion tag + batch errors + cost + trace path +
+    warnings + --only line) is suppressed in ``-p`` mode because the user
+    explicitly asked for minimal stderr. The ``--only`` mode confirmation is a
+    mode signal (not a suppressible detail) and is emitted even in ``-p`` mode
+    when ``--only`` is active. Verbosity flags hide details; mode flags survive
+    verbosity. Matches the convention of ``make -k``, ``pytest --maxfail``,
+    ``rsync --dry-run``, ``apt-get --simulate``, ``kubectl --dry-run``, etc.
+
+    ``trace_path``, when given, rides into the summary so the "Workflow trace
+    saved" line renders in the meta block above the data (text mode). JSON and
+    failure paths leave it ``None`` and echo the trace line from ``run.py``.
 
     No-op when there's no metrics collector OR when neither path applies.
     """
@@ -750,7 +768,7 @@ def _emit_summary_or_only_indicator(
         metrics_collector=metrics_collector,
         workflow_metadata=workflow_metadata,
         output_key=output_key,
-        trace_path=None,
+        trace_path=trace_path,
         status=status,
         warnings=warnings,
     )
@@ -766,14 +784,24 @@ def _emit_summary_or_only_indicator(
     _display_execution_summary(formatted, verbose, warning_diagnostics=warning_diags or None)
 
 
-def _emit_only_indicator(formatted_result: dict[str, Any]) -> None:
-    """Emit the ``--only`` mode confirmation line to stderr.
+def _only_indicator_line(formatted_result: dict[str, Any]) -> str | None:
+    """Build the ``--only`` mode confirmation line, or ``None`` if not active.
 
-    Used by ``_handle_text_output`` in ``-p`` mode (where the full summary
-    is suppressed). The full default-mode summary path
-    (``_display_execution_summary``) emits the same line via the same
-    shared formatter — see ``format_only_indicator`` in
-    ``success_formatter.py``.
+    Shared by ``_emit_only_indicator`` (the ``-p`` path) and the default
+    summary block so the indicator text has one source — see
+    ``format_only_indicator`` in ``success_formatter.py``.
+    """
+    from pflow.execution.formatters.success_formatter import format_only_indicator
+
+    execution = formatted_result.get("execution", {})
+    only_node = execution.get("only_node")
+    if not only_node:
+        return None
+    return format_only_indicator(only_node, execution.get("nodes_skipped", 0))
+
+
+def _emit_only_indicator(formatted_result: dict[str, Any]) -> None:
+    """Emit the ``--only`` mode confirmation line to stderr (``-p`` path).
 
     Why this exists: ``--only`` is a mode signal, not a summary detail.
     Without this emission, ``pflow -p foo --only target`` produces zero
@@ -783,14 +811,9 @@ def _emit_only_indicator(formatted_result: dict[str, Any]) -> None:
     ``rsync --dry-run``, ``apt-get --simulate``, ``kubectl --dry-run``,
     etc.).
     """
-    from pflow.execution.formatters.success_formatter import format_only_indicator
-
-    execution = formatted_result.get("execution", {})
-    only_node = execution.get("only_node")
-    if not only_node:
-        return
-    nodes_skipped = execution.get("nodes_skipped", 0)
-    click.echo(format_only_indicator(only_node, nodes_skipped), err=True)
+    line = _only_indicator_line(formatted_result)
+    if line:
+        click.echo(line, err=True)
 
 
 def _display_execution_summary(
@@ -798,8 +821,20 @@ def _display_execution_summary(
     verbose: bool,
     warning_diagnostics: list[Diagnostic] | None = None,
 ) -> None:
-    """Display one-line execution summary with supplementary info."""
-    from pflow.execution.formatters.success_formatter import partition_surfaced_diagnostics
+    """Display the execution summary as airy blocks (one blank line between).
+
+    Order: completion · --only · batch errors · shell-stderr · cost · warnings ·
+    advisories · trace path. The trace path is read from
+    ``formatted_result["trace_path"]`` (populated only on the text-success path)
+    so the "Workflow trace saved" line lands in the meta block above the data,
+    de-emoji'd. Sections are collected first and emitted with a single blank
+    line before each present one — absent sections leave no dangling separators.
+    """
+    from pflow.execution.formatters.batch_errors import format_batch_errors_section
+    from pflow.execution.formatters.success_formatter import (
+        format_stderr_warnings,
+        partition_surfaced_diagnostics,
+    )
 
     # INFO advisories (e.g. an empty batch) are not warnings: only WARNING/ERROR
     # diagnostics drive the "completed with N warnings" header. Advisories get
@@ -810,50 +845,47 @@ def _display_execution_summary(
     total_cost = formatted_result.get("total_cost_usd")
     execution = formatted_result.get("execution", {})
     steps = execution.get("steps", []) if execution else []
-    workflow_metadata = formatted_result.get("workflow", {})
-    workflow_name = workflow_metadata.get("name", "workflow")
-    workflow_action = workflow_metadata.get("action", "executed")
-    _display_workflow_action(workflow_name, workflow_action)
+
+    blocks: list[list[str]] = []
 
     if duration_ms is not None:
-        duration_s = duration_ms / 1000.0
-        status = formatted_result.get("status", "success")
-        has_stderr_warnings = any(step.get("has_stderr") for step in steps)
-        cache_hits = execution.get("cache_hits", 0)
-        completed_count = execution.get("nodes_executed", 0)
         warning_count = len(warnings_list)
-        _display_workflow_completion_status(
-            duration_s,
-            status,
-            has_stderr_warnings,
-            cache_hits=cache_hits,
-            nodes_executed=completed_count,
-            warning_count=warning_count,
-        )
+        blocks.append([
+            _format_workflow_completion_status(
+                duration_ms / 1000.0,
+                formatted_result.get("status", "success"),
+                any(step.get("has_stderr") for step in steps),
+                cache_hits=execution.get("cache_hits", 0),
+                nodes_executed=execution.get("nodes_executed", 0),
+                warning_count=warning_count,
+            )
+        ])
 
-    # --only mode confirmation: always emit when --only is active, even
-    # when no downstream nodes were skipped (e.g., --only targeted the
-    # last node). Delegated to _emit_only_indicator so there's ONE call
-    # site for the indicator — the -p path (_emit_summary_or_only_indicator)
-    # and the default path (here) share this function, preventing drift.
-    _emit_only_indicator(formatted_result)
+    # --only mode confirmation: always emit when --only is active, even when no
+    # downstream nodes were skipped (e.g. --only targeted the last node).
+    only_line = _only_indicator_line(formatted_result)
+    if only_line:
+        blocks.append([only_line])
 
     if steps:
-        _display_batch_errors(steps)
-        _display_stderr_warnings(steps)
+        blocks.append(_as_block(format_batch_errors_section(steps)))
+        blocks.append(_as_block(format_stderr_warnings(steps)))
 
-    _display_cost_summary(total_cost, formatted_result)
+    blocks.append(_format_cost_summary_lines(total_cost, formatted_result))
 
     if warnings_list:
-        click.echo("", err=True)
-        click.echo("⚠️ Warnings:", err=True)
-        for warning in warnings_list:
-            click.echo(format_diagnostic(warning), err=True)
+        blocks.append(["⚠️ Warnings:", *(format_diagnostic(w) for w in warnings_list)])
     if advisories_list:
-        click.echo("", err=True)
-        click.echo("\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} Advisories:", err=True)
-        for advisory in advisories_list:
-            click.echo(format_diagnostic(advisory), err=True)
+        blocks.append([
+            "\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} Advisories:",
+            *(format_diagnostic(a) for a in advisories_list),
+        ])
+
+    trace_path = formatted_result.get("trace_path")
+    if trace_path:
+        blocks.append([f"Workflow trace saved: {trace_path}"])
+
+    _echo_summary_blocks(blocks)
 
 
 def _handle_json_output(
@@ -971,6 +1003,7 @@ def _handle_workflow_output(
     workflow_trace: Any | None = None,
     status: Any = None,
     warnings: list[Any] | None = None,
+    trace_path: str | None = None,
 ) -> None:
     """Handle output from workflow execution.
 
@@ -987,6 +1020,11 @@ def _handle_workflow_output(
         print_flag: Whether -p flag is set (suppress warnings)
         workflow_metadata: Optional workflow metadata for JSON output
         workflow_trace: Optional workflow trace collector for saving JSON output
+        status: Optional tri-state workflow status
+        warnings: Optional list of warning diagnostics
+        trace_path: Optional trace file path. In text mode it renders in the
+            meta block above the data; JSON leaves it ``None`` (the trace line
+            is echoed from ``run.py`` after the JSON payload).
     """
     if output_format == "json":
         _handle_json_output(
@@ -1013,4 +1051,5 @@ def _handle_workflow_output(
         workflow_metadata,
         status=status,
         warnings=warnings,
+        trace_path=trace_path,
     )

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -316,7 +316,7 @@ directories for migration.
 
 **Per-node files include**: metadata (type, timing, status, LLM model/tokens/cost, error), resolved inputs (`## Command` for shell, `## Prompt` for LLM, `## Code` + `## Inputs` for python), outputs (`## stdout`, `## stderr`, `## Result`, `## Response`), and a catch-all for remaining output keys.
 
-**Consumer**: `cli/main.py:_save_trace_and_report()` (CLI `--report` flag), `cli/commands/trace.py` (trace subcommand).
+**Consumer**: `cli/commands/run.py:_finalize_trace_and_report()` (CLI `--report` flag), `cli/commands/report.py` (`pflow report` command).
 
 **Binary encoding convention**: `{"__type": "base64", "data": "..."}` — used project-wide for binary data in JSON. Sensitive params auto-masked before caching.
 

--- a/src/pflow/core/output_controller.py
+++ b/src/pflow/core/output_controller.py
@@ -61,6 +61,7 @@ class OutputController:
         print_flag: bool = False,
         stdin_tty: Optional[bool] = None,
         stdout_tty: Optional[bool] = None,
+        stderr_tty: Optional[bool] = None,
     ):
         """Initialize output controller with execution mode parameters.
 
@@ -68,6 +69,7 @@ class OutputController:
             print_flag: CLI flag -p/--print to force non-interactive mode
             stdin_tty: Override for sys.stdin.isatty() (for testing)
             stdout_tty: Override for sys.stdout.isatty() (for testing)
+            stderr_tty: Override for sys.stderr.isatty() (for testing)
         """
         self.print_flag = print_flag
 
@@ -85,6 +87,18 @@ class OutputController:
             self.stdout_tty = False
         else:
             self.stdout_tty = sys.stdout.isatty()
+
+        # Whether stderr is a terminal. Distinguishes the agent case (stderr
+        # captured/piped → non-TTY) from the human-redirect case (stderr is a
+        # terminal while stdout is a file). The ``Workflow output:`` label is
+        # suppressed ONLY in the latter — see ``_show_output_header`` in
+        # ``cli/workflow_output.py``.
+        if stderr_tty is not None:
+            self.stderr_tty = stderr_tty
+        elif sys.stderr is None:
+            self.stderr_tty = False
+        else:
+            self.stderr_tty = sys.stderr.isatty()
 
         # Tracks whether _handle_node_start left a partial line open (nl=False).
         # Required so that anything else writing to stderr — nested-workflow

--- a/src/pflow/execution/formatters/CLAUDE.md
+++ b/src/pflow/execution/formatters/CLAUDE.md
@@ -68,8 +68,8 @@ Parity gaps have shipped before — e.g. adding `status`/`warnings` to `format_e
 
 **Shared SSoT helpers in `success_formatter.py`** enforce text-rendering parity structurally for the tricky parts:
 - `format_only_indicator(only_node, nodes_skipped)` — `--only` mode confirmation line. Called from CLI default summary (`_display_execution_summary`), CLI `-p` mode emission (`_emit_only_indicator`), and MCP text (`_append_execution_steps`).
-- `format_stderr_warnings(steps)` — shell-stderr warning block (`⚠️  Shell stderr (exit code 0):` + per-node bullets with 300-char truncation). Called from CLI `_display_stderr_warnings` and MCP `format_success_as_text`.
+- `format_stderr_warnings(steps)` — shell-stderr warning block (`⚠️  Shell stderr (exit code 0):` + per-node bullets with 300-char truncation). Consumed directly by the CLI summary block (`_display_execution_summary` in `workflow_output.py`) and MCP `format_success_as_text`.
 - `_append_outputs` (MCP text) and `cli/workflow_output.py::safe_output` (CLI stdout) both JSON-encode non-string output values with `ensure_ascii=False, allow_nan=False, default=str` and fall back to `repr(value)` on serialization failure. MCP can't emit a side-channel warning on failure, so the divergence is the warning emission only; the fallback VALUE is aligned.
-- `format_success_as_text` upgrades the ✓ completion glyph to ⚠️ when any step has `has_stderr` — mirroring CLI `_display_workflow_completion_status`.
+- `format_success_as_text` upgrades the ✓ completion glyph to ⚠️ when any step has `has_stderr` — mirroring CLI `_format_workflow_completion_status`.
 
 Parity tests: `TestAppendOutputsCliMcpParity` and `TestStderrWarningsCliMcpParity` in `tests/test_execution/formatters/test_success_formatter.py`. Add to these when expanding the shared helpers rather than documenting the parity contract by comment.

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -287,7 +287,11 @@ def format_success_as_text(  # noqa: C901
     warnings_list, advisories_list = partition_surfaced_diagnostics(warning_diagnostics)
     warning_count = len(warnings_list)
 
-    # Show workflow name and action (matches CLI)
+    # Show workflow name and action (MCP text only). The CLI summary
+    # deliberately dropped this line as redundant with the completion line
+    # below (PR #470); MCP keeps it because agents calling the tool have no
+    # command-line context for which workflow ran. Do NOT "restore parity" by
+    # re-adding it to the CLI.
     if workflow_action == "reused":
         lines.append(f"{workflow_name} was executed")
     elif workflow_action == "created":

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -325,10 +325,11 @@ def format_success_as_text(  # noqa: C901
     # Show node execution details (matches CLI lines 646-655)
     _append_execution_steps(lines, execution_data)
 
-    # Shell-stderr warnings (CLI/MCP parity — mirrors CLI _display_stderr_warnings)
+    # Shell-stderr warnings (CLI/MCP parity — same `format_stderr_warnings`
+    # the CLI summary block calls in `_display_execution_summary`)
     lines.extend(format_stderr_warnings(steps))
 
-    # Show cost (matches CLI _display_cost_summary). The "Total LLM calls: N"
+    # Show cost (matches CLI `_format_cost_summary_lines`). The "Total LLM calls: N"
     # sibling line below the cost line keeps the call tally visible at all
     # three surfaces (CLI text, success formatter, trace report); call counts
     # are also now interpolated into the priced cost line and per-model in
@@ -465,7 +466,7 @@ def format_stderr_warnings(steps: list[dict[str, Any]]) -> list[str]:
     """Format shell-stderr warning block for nodes that exited 0 with non-empty stderr.
 
     Single source of truth used by both:
-    - CLI ``cli/workflow_output.py::_display_stderr_warnings`` (emits via ``click.echo`` in a loop)
+    - CLI ``cli/workflow_output.py::_display_execution_summary`` (as a summary block)
     - MCP ``format_success_as_text`` below (extends the lines list)
 
     Mirrors the CLI/MCP parity pattern established by ``format_only_indicator`` and

--- a/tests/test_cli/test_direct_execution_helpers.py
+++ b/tests/test_cli/test_direct_execution_helpers.py
@@ -4,7 +4,7 @@ import click
 import click.testing
 
 from pflow.cli.param_parsing import infer_type, parse_workflow_params
-from pflow.cli.workflow_output import _display_cost_summary, _display_execution_summary
+from pflow.cli.workflow_output import _display_execution_summary, _format_cost_summary_lines
 from pflow.cli.workflow_resolution import is_likely_workflow_name
 from pflow.core.diagnostic import Diagnostic, Severity
 
@@ -176,7 +176,7 @@ class TestIsLikelyWorkflowName:
 
 
 class TestDisplayCostSummary:
-    """Tests for _display_cost_summary pricing warning display."""
+    """Tests for _format_cost_summary_lines pricing warning display."""
 
     @staticmethod
     def _make_formatted_result(
@@ -190,7 +190,7 @@ class TestDisplayCostSummary:
 
         ``unavailable_models`` uses the F#17-deferred shape
         ``list[{name, calls}]`` consumed by the helper-normalizer in
-        ``cli/workflow_output.py::_display_cost_summary``.
+        ``cli/workflow_output.py::_format_cost_summary_lines``.
         """
         total: dict = {
             "tokens_input": 10,
@@ -214,18 +214,12 @@ class TestDisplayCostSummary:
             unavailable_models=[{"name": "my-custom-model", "calls": 4}],
             total_calls=4,
         )
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(None, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
-        assert "Cost unavailable" in cli_result.output
+        out = "\n".join(_format_cost_summary_lines(None, result))
+        assert "Cost unavailable" in out
         # F#17 deferred: per-model call count in parenthetical
-        assert "my-custom-model (4 calls)" in cli_result.output
+        assert "my-custom-model (4 calls)" in out
         # F#17 deferred: total LLM calls sibling line (3-space indent)
-        assert "   Total LLM calls: 4" in cli_result.output
+        assert "   Total LLM calls: 4" in out
 
     def test_partial_cost_shows_partial_with_models(self) -> None:
         """When some models have pricing, show partial cost."""
@@ -235,72 +229,41 @@ class TestDisplayCostSummary:
             partial_cost_usd=0.03,
             total_calls=2,
         )
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(None, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
-        assert "$0.0300+" in cli_result.output
-        assert "unknown-model (1 call)" in cli_result.output
-        assert "   Total LLM calls: 2" in cli_result.output
+        out = "\n".join(_format_cost_summary_lines(None, result))
+        assert "$0.0300+" in out
+        assert "unknown-model (1 call)" in out
+        assert "   Total LLM calls: 2" in out
 
     def test_known_model_shows_normal_cost(self) -> None:
         """When pricing is available, show normal cost."""
         result = self._make_formatted_result(total_calls=3)
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(0.05, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
-        assert "$0.0500" in cli_result.output
-        assert "unavailable" not in cli_result.output.lower()
+        out = "\n".join(_format_cost_summary_lines(0.05, result))
+        assert "$0.0500" in out
+        assert "unavailable" not in out.lower()
         # F#17 deferred: priced multi-call line carries the call count
-        assert "3 calls" in cli_result.output
+        assert "3 calls" in out
 
     def test_known_model_singular_call_uses_singular_noun(self) -> None:
         """F#17 wording lock: single LLM call renders as ``1 call``."""
         result = self._make_formatted_result(total_calls=1)
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(0.05, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
-        assert "$0.0500" in cli_result.output
-        assert "1 call" in cli_result.output
-        assert "1 calls" not in cli_result.output
+        out = "\n".join(_format_cost_summary_lines(0.05, result))
+        assert "$0.0500" in out
+        assert "1 call" in out
+        assert "1 calls" not in out
 
     def test_zero_cost_shows_nothing(self) -> None:
-        """When cost is zero, show nothing."""
+        """When cost is zero, produce no lines."""
         result = self._make_formatted_result()
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(0.0, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
-        assert cli_result.output.strip() == ""
+        assert _format_cost_summary_lines(0.0, result) == []
 
     def test_total_llm_calls_suppressed_when_zero(self) -> None:
         """Honest unmeasurable: workflows with no LLM calls must NOT show
         ``Total LLM calls: 0``."""
         result = self._make_formatted_result(total_calls=0)
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(0.05, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
+        out = "\n".join(_format_cost_summary_lines(0.05, result))
         # Cost line shows but no sibling line for zero calls.
-        assert "$0.0500" in cli_result.output
-        assert "Total LLM calls" not in cli_result.output
+        assert "$0.0500" in out
+        assert "Total LLM calls" not in out
 
     def test_unnamed_only_shows_count_not_unknown(self) -> None:
         """Regression: genuinely-unrecorded calls render as a clear count
@@ -311,16 +274,10 @@ class TestDisplayCostSummary:
             unavailable_models_unnamed_count=3,
             total_calls=3,
         )
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(None, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
-        assert "3 calls without recorded model" in cli_result.output
-        assert "unknown" not in cli_result.output
-        assert "   Total LLM calls: 3" in cli_result.output
+        out = "\n".join(_format_cost_summary_lines(None, result))
+        assert "3 calls without recorded model" in out
+        assert "unknown" not in out
+        assert "   Total LLM calls: 3" in out
 
     def test_named_plus_unnamed_shows_both(self) -> None:
         """A mix surfaces both real model names and the unnamed-count
@@ -332,16 +289,10 @@ class TestDisplayCostSummary:
             partial_cost_usd=0.01,
             total_calls=5,
         )
-
-        @click.command()
-        def cmd() -> None:
-            _display_cost_summary(None, result)
-
-        runner = click.testing.CliRunner()
-        cli_result = runner.invoke(cmd)
+        out = "\n".join(_format_cost_summary_lines(None, result))
         # Locked wording from F#17 deferred spec
-        assert "my-custom-model (3 calls); 2 calls without recorded model" in cli_result.output
-        assert "   Total LLM calls: 5" in cli_result.output
+        assert "my-custom-model (3 calls); 2 calls without recorded model" in out
+        assert "   Total LLM calls: 5" in out
 
 
 class TestDisplayExecutionSummaryAdvisories:

--- a/tests/test_cli/test_dual_mode_stdout.py
+++ b/tests/test_cli/test_dual_mode_stdout.py
@@ -1,19 +1,22 @@
 """Integration tests for stdout output routing (`stdout: true` marker + TTY-gated label).
 
-Mirrors ``test_dual_mode_stdin.py``. Covers the redirect UX bug (naked
-``Workflow output (desc):`` label when stdout is redirected) and the
+Mirrors ``test_dual_mode_stdin.py``. Covers the ``Workflow output (desc):``
+label routing (Option B: shown when both streams are captured — the agent case;
+suppressed only when stdout is redirected while stderr is a terminal) and the
 multi-output silent-drop bug (declared outputs vanishing without warning).
 
 These tests use real subprocesses because:
 - ``CliRunner`` always reports ``isatty() = False``, which can't distinguish
   "stdout is a pipe" from "stdout is a file" from "stdout is a terminal".
-- Subprocess pipes let us verify that the label is suppressed on redirect
-  while the payload is intact on stdout.
+- Subprocess pipes let us verify the payload reaches stdout while the label and
+  summary reach stderr.
 - The ambiguity error path goes through the full CLI exit-code and stderr
   rendering pipeline, which ``CliRunner`` handles but fragilely.
 
-See `tests/test_cli/test_workflow_output_handling.py` for in-process unit
-tests of the selection logic itself.
+The header heuristic's four TTY combinations (including the genuine-suppression
+case) are unit-tested in ``test_workflow_output_handling.py`` —
+``capture_output=True`` captures BOTH streams as pipes, so a subprocess can
+only exercise the both-non-TTY (agent) branch.
 """
 
 from __future__ import annotations
@@ -50,10 +53,13 @@ def _run_pflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProc
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
 @pytest.mark.e2e
 class TestStdoutRedirectLabel:
-    """When stdout is not a TTY, the ``Workflow output (desc):`` label is suppressed."""
+    """Both streams captured (the agent case) → the ``Workflow output (desc):``
+    label IS shown on stderr so a merged ``2>&1`` capture is delimited; the data
+    still goes to stdout only. (Suppression fires only when stderr is a terminal
+    — unit-tested separately.)"""
 
-    def test_single_output_label_suppressed_when_stdout_redirected(self, tmp_path, prepared_subprocess_env):
-        """Single declared output + pipe/redirect → no label, value on stdout."""
+    def test_label_shown_on_stderr_when_both_streams_captured(self, tmp_path, prepared_subprocess_env):
+        """Single declared output + both streams captured → label on stderr, value on stdout."""
         workflow = {
             "ir_version": "0.1.0",
             "outputs": {"greeting": {"description": "The greeting", "source": "${hello.stdout}"}},
@@ -72,13 +78,14 @@ class TestStdoutRedirectLabel:
         _skip_uv_sandbox_panic(result)
 
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        # Data on stdout only; label/summary delimit it on stderr (Option B).
         assert "CANARY_REDIRECT_VALUE" in result.stdout
-        # The naked label must not appear on stderr when stdout is captured
-        assert "Workflow output" not in result.stderr, (
-            f"Label should be TTY-gated; stderr still has it:\n{result.stderr}"
+        assert "CANARY_REDIRECT_VALUE" not in result.stderr
+        assert "Workflow output" in result.stderr, (
+            f"Label should be shown when stderr is captured (agent case); stderr:\n{result.stderr}"
         )
 
-    def test_stdout_marker_routes_to_stdout_on_redirect(self, tmp_path, prepared_subprocess_env):
+    def test_stdout_marker_routes_to_stdout(self, tmp_path, prepared_subprocess_env):
         """Multi-output with ``stdout: true`` on one → only that one on stdout."""
         workflow = {
             "ir_version": "0.1.0",
@@ -115,8 +122,8 @@ class TestStdoutRedirectLabel:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert "PRIMARY_MARKED_VALUE" in result.stdout
         assert "METADATA_VALUE" not in result.stdout, "Only the marked output should stream to stdout; metadata leaked"
-        # And no label on stderr (redirected stdout)
-        assert "Workflow output" not in result.stderr
+        # Label on stderr (agent case), data clean on stdout
+        assert "Workflow output" in result.stderr
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")

--- a/tests/test_cli/test_progress_streaming_subprocess.py
+++ b/tests/test_cli/test_progress_streaming_subprocess.py
@@ -1148,8 +1148,8 @@ class TestRealSubprocessProgressRendering:
         2. ``stderr`` contains the header line AND the completion summary
            (verifies both diagnostic components reach stderr)
         3. ``stdout`` contains NO stderr markers (``Executing workflow``,
-           ``Workflow completed``, ``📊``) — catches the Mode 3 regression
-           where diagnostics bleed onto stdout
+           ``Workflow completed``, ``Workflow trace saved``) — catches the
+           Mode 3 regression where diagnostics bleed onto stdout
         4. ``stderr`` does NOT contain the declared canary value — catches
            the original #194 bug where data landed on stderr
 
@@ -1207,7 +1207,7 @@ class TestRealSubprocessProgressRendering:
 
         # 3. Stderr markers must NOT appear on stdout (the #194 Mode 3 regression
         #    would route them to stdout alongside data, breaking `pflow foo | jq`)
-        for marker in ("Executing workflow", "Workflow completed", "📊"):
+        for marker in ("Executing workflow", "Workflow completed", "Workflow trace saved"):
             assert marker not in result.stdout, (
                 f"Diagnostic marker {marker!r} leaked onto stdout — this is the "
                 f"#194 Mode 3 regression where diagnostics contaminate the data "

--- a/tests/test_cli/test_shell_stderr_warnings.py
+++ b/tests/test_cli/test_shell_stderr_warnings.py
@@ -11,7 +11,7 @@ import json
 from click.testing import CliRunner
 
 from pflow.cli.main import main
-from pflow.cli.workflow_output import _display_stderr_warnings
+from pflow.execution.formatters.success_formatter import format_stderr_warnings
 from tests.shared.markdown_utils import write_workflow_file
 
 
@@ -349,10 +349,10 @@ class TestPipelineFailureScenario:
 
 
 class TestDisplayStderrWarnings:
-    """Unit tests for _display_stderr_warnings function."""
+    """Unit tests for the ``format_stderr_warnings`` SSoT the CLI summary renders."""
 
-    def test_displays_stderr_for_steps_with_has_stderr(self, capsys):
-        """Should display stderr for steps with has_stderr=True."""
+    def test_displays_stderr_for_steps_with_has_stderr(self):
+        """Should produce stderr lines for steps with has_stderr=True."""
         steps = [
             {
                 "node_id": "test-node",
@@ -362,26 +362,21 @@ class TestDisplayStderrWarnings:
             }
         ]
 
-        _display_stderr_warnings(steps)
+        out = "\n".join(format_stderr_warnings(steps))
+        assert "Shell stderr (exit code 0):" in out
+        assert "test-node:" in out
+        assert "Some error message" in out
 
-        captured = capsys.readouterr()
-        assert "Shell stderr (exit code 0):" in captured.err
-        assert "test-node:" in captured.err
-        assert "Some error message" in captured.err
-
-    def test_no_output_when_no_stderr_steps(self, capsys):
-        """Should not display anything when no steps have stderr."""
+    def test_no_output_when_no_stderr_steps(self):
+        """Should produce no lines when no steps have stderr."""
         steps = [
             {"node_id": "node1", "status": "completed"},
             {"node_id": "node2", "status": "completed"},
         ]
 
-        _display_stderr_warnings(steps)
+        assert format_stderr_warnings(steps) == []
 
-        captured = capsys.readouterr()
-        assert captured.err == ""
-
-    def test_truncates_long_stderr(self, capsys):
+    def test_truncates_long_stderr(self):
         """Long stderr should be truncated to 300 chars."""
         long_stderr = "X" * 400
 
@@ -394,14 +389,12 @@ class TestDisplayStderrWarnings:
             }
         ]
 
-        _display_stderr_warnings(steps)
-
-        captured = capsys.readouterr()
-        assert "..." in captured.err
+        out = "\n".join(format_stderr_warnings(steps))
+        assert "..." in out
         # Should have truncated to 300 + "..."
-        assert "X" * 301 not in captured.err
+        assert "X" * 301 not in out
 
-    def test_multiline_stderr_indented(self, capsys):
+    def test_multiline_stderr_indented(self):
         """Multiline stderr should be properly indented."""
         multiline_stderr = "Line 1\nLine 2\nLine 3"
 
@@ -414,9 +407,7 @@ class TestDisplayStderrWarnings:
             }
         ]
 
-        _display_stderr_warnings(steps)
-
-        captured = capsys.readouterr()
+        out = "\n".join(format_stderr_warnings(steps))
         # Check that newlines are replaced with indented newlines
-        assert "Line 1" in captured.err
-        assert "Line 2" in captured.err
+        assert "Line 1" in out
+        assert "Line 2" in out

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -280,11 +280,10 @@ class TestWorkflowOutputHandling:
             )
             assert "HELLO_STDOUT_CANARY_GH194" in result.stdout
             assert "HELLO_STDOUT_CANARY_GH194" not in result.stderr
-            # The "Workflow output (desc):" label is TTY-gated. CliRunner reports
-            # stdout_tty=False, so the label must be suppressed — this is the
-            # redirect-UX fix. For the gh194 invariant (data stream correctness)
-            # the relevant assertions are the two above.
-            assert "Workflow output" not in result.stderr
+            # GH194 invariant: the DATA lives on stdout only (the two asserts
+            # above). The "Workflow output (desc):" label is a stderr delimiter —
+            # CliRunner captures both streams (the agent case), so under Option B
+            # it IS shown on stderr; it just must never carry the data value.
         finally:
             Path(workflow_file).unlink()
 
@@ -728,12 +727,12 @@ class TestWorkflowOutputHandling:
         finally:
             Path(workflow_file).unlink()
 
-    def test_non_tty_mode_suppresses_output_header(self, mock_registry_instance, mock_compile, mock_validate_ir):
-        """When stdout is not a TTY (pipe/redirect), the label is suppressed.
+    def test_both_streams_captured_shows_header(self, mock_registry_instance, mock_compile, mock_validate_ir):
+        """Both streams captured (the agent case) → the label IS shown on stderr.
 
-        A naked ``Workflow output (description):`` header on stderr with the
-        value elsewhere (in the file/pipe) reads as "empty output" to both
-        humans and agents. The fix: skip the label on non-TTY stdout.
+        CliRunner reports isatty()=False for BOTH stdout and stderr, so this is
+        the agent/merged-capture branch of Option B: the label delimits where the
+        result begins. Data still goes to stdout only.
         """
         runner = click.testing.CliRunner(mix_stderr=False)
 
@@ -754,10 +753,58 @@ class TestWorkflowOutputHandling:
             workflow_file = f.name
 
         try:
-            # CliRunner already reports isatty()=False — this is the redirect case.
             result = runner.invoke(main, [workflow_file])
 
             assert result.exit_code == 0
+            assert "Workflow output (The final processed result):" in result.stderr
+            assert "Processing complete" in result.stdout
+            assert "Processing complete" not in result.stderr
+        finally:
+            Path(workflow_file).unlink()
+
+    def test_stdout_redirected_stderr_terminal_suppresses_header(
+        self, mock_registry_instance, mock_compile, mock_validate_ir
+    ):
+        """stdout redirected to a file WHILE stderr is a terminal → label suppressed.
+
+        This is the only case the suppression fires in (Option B): a naked
+        ``Workflow output (...)`` label on the terminal with the value in the
+        redirected file reads as "empty output". Forced via ``stderr_tty=True``
+        + ``stdout_tty=False`` since CliRunner reports both as non-TTY.
+        """
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        workflow = {
+            "ir_version": "0.1.0",
+            "outputs": {"final_result": {"description": "The final processed result", "type": "string"}},
+            "nodes": [
+                {
+                    "id": "test",
+                    "type": "test-node",
+                    "params": {"output_key": "final_result", "output_value": "Processing complete"},
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pflow.md", delete=False) as f:
+            f.write(ir_to_markdown(workflow))
+            workflow_file = f.name
+
+        from pflow.core.output_controller import OutputController
+
+        original_init = OutputController.__init__
+
+        def redirect_init(self, *args, **kwargs):
+            kwargs.setdefault("stdout_tty", False)
+            kwargs.setdefault("stderr_tty", True)
+            original_init(self, *args, **kwargs)
+
+        try:
+            with patch.object(OutputController, "__init__", redirect_init):
+                result = runner.invoke(main, [workflow_file])
+
+            assert result.exit_code == 0
+            # Label suppressed because stderr is a terminal; data still on stdout.
             assert "Workflow output" not in result.stderr
             assert "Processing complete" in result.stdout
         finally:

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -1196,9 +1196,9 @@ class TestStderrWarningsCliMcpParity:
     """Tests for ``format_stderr_warnings`` shared helper + MCP rendering parity.
 
     PARITY GUARDRAIL — shell nodes that exit 0 but wrote to stderr are an
-    important agent signal (hidden pipeline failures). CLI ``_display_stderr_warnings``
-    has emitted a ``⚠️  Shell stderr (exit code 0):`` block and upgraded the
-    completion glyph from ``✓`` to ``⚠️`` since GH #194 shipped. The MCP side
+    important agent signal (hidden pipeline failures). The CLI summary (via the
+    shared ``format_stderr_warnings``) emits a ``⚠️  Shell stderr (exit code 0):``
+    block and upgrades the completion glyph from ``✓`` to ``⚠️`` since GH #194 shipped. The MCP side
     (``format_success_as_text``) was silently missing both behaviors, so an
     agent calling the MCP ``workflow_execute`` tool on a workflow with a
     failing grep pipeline would see ``✓ Workflow completed`` with no visibility.


### PR DESCRIPTION
## Summary

Makes the `pflow <workflow>` run summary readable and agent-parseable: run
metadata (completion, cost, trace path) now reads as one coherent block above the
result, the result is clearly delimited and separated, and stdout stays clean for
piping. Four reported symptoms fixed.

Fixes #469

## Changes

- **Output-label heuristic ("Option B").** Show the `Workflow output:` /
  `Workflow output (<desc>):` label whenever stdout is a TTY **or** stderr is
  captured; suppress it only when stdout is redirected while stderr is a terminal
  (`pflow wf > out.txt`). Restores the result delimiter for agents capturing both
  streams while preserving the original "naked label looks empty" suppression for
  the human-redirect case. New `OutputController.stderr_tty`; new
  `_show_output_header()` / `_stream_is_tty()` in `workflow_output.py`.
- **Trace line moved into the meta block + de-emoji'd.** `Workflow trace saved: …`
  (was `📊 …`, printed *after* the data) now renders in the stderr summary above
  the data in text mode. Saved exactly once via a memoized `_save_trace_file`;
  echoed in the summary on text success, or in the `finally` for JSON/failure
  (JSON's `set_json_output` must mutate the trace before it's written). The `📊`
  is gone everywhere.
- **Airy summary.** `_display_execution_summary` now builds a list of blocks and
  emits one blank line between each present section (completion · `--only` ·
  batch errors · shell-stderr · cost · warnings · advisories · trace), and each
  output-section advisory gets a leading blank. The riskiest piece, `_as_block`,
  normalizes the SSoT formatters' baked-in `\n` / leading `""` so spacing is
  uniform.
- **Dropped the redundant action line.** `{name} was executed` is removed from the
  CLI summary (the MCP text renderer, `format_success_as_text`, is intentionally
  left unchanged).

## Explanation

The three core issues all stemmed from two roots: the trace line was emitted in
`execute_json_workflow`'s `finally` (after the data), and the output label was
suppressed on *any* non-TTY stdout — which optimized for `pflow wf > file` typed in
a terminal but backfired for the primary consumer, an agent capturing both streams
in a merged `2>&1`. The label suppression now keys on stderr's TTY-ness (the only
case where a naked label genuinely "looks empty"), and the trace path rides into
the summary through `format_execution_success`'s existing `trace_path` field so it
sits in the meta block. Spacing moved from scattered conditional `click.echo("")`
calls to a single block-list + emitter, which is both simpler and correct for the
absent-section cases. Net: `+384 / -305` across 9 files (4 src, 5 test).

stdout routing is unchanged — data still goes to stdout only; everything added is
stderr. `--print` (clean data-only), `--output-format json` (shape unchanged, no
`trace_path` key), and `--no-trace` are all preserved.

## Testing

- `test_workflow_output_handling.py::test_both_streams_captured_shows_header` /
  `::test_stdout_redirected_stderr_terminal_suppresses_header` — the two new
  Option-B branches (agent case shows the label; the genuine redirect case
  suppresses it), the latter forcing `stdout_tty=False, stderr_tty=True`.
- `test_direct_execution_helpers.py::TestDisplayCostSummary` — rewritten to test
  the pure `_format_cost_summary_lines` producer (priced / partial / unavailable /
  zero-cost / singular-vs-plural call counts).
- `test_shell_stderr_warnings.py::TestDisplayStderrWarnings` — retargeted to the
  shared `format_stderr_warnings` SSoT.
- `test_dual_mode_stdout.py` / `test_progress_streaming_subprocess.py` — updated to
  the new label semantics and the de-emoji'd trace marker; GH#194 stdout-byte
  separation still pinned.
- Full suite: 7535 passed, 1 skipped; e2e: 43 passed; `make check` clean.
- **Adversarial manual verification** via a dual-pty harness (independent
  TTY/pipe/file control of each stream): all four TTY combinations of the label;
  trace file written exactly once per run across text/JSON/`--report`/`-p`/failure/
  `--only` (no double-write from the memoization); byte-exact airy spacing
  including the hard `_as_block` cases (shell-stderr block adjacent to the cost
  block, and a batch-errors block); pipe-cleanliness (`| jq` valid, no label/trace
  leak to stdout); dropped action line on a saved workflow; and the LLM cost line
  in-position via a real Gemini call. The one inconsistency it surfaced — the
  `-o <key>`-miss warning lacking the airy blank its siblings got — was fixed in
  this PR.