### PR TITLE
feat: settable node retry+backoff and status-model consistency (#471)

### DIFF
--- a/context/CONTEXT.md
+++ b/context/CONTEXT.md
@@ -30,6 +30,28 @@ feedback, recurrence, state-threading.
 produced output. From round 2 on, the Carry supplies the value. A role, not a separate field —
 a carried input's ordinary input value *is* its Seed. _Avoid_: initial, default, base.
 
+**Retry** — re-running a *single step's own work* after a **transient** failure, capped by a
+maximum attempt count, same inputs each time. A *deterministic* failure (e.g. bad config) is
+not retried. A retry that eventually succeeds leaves no trace — the run is a clean Success.
+_Avoid_: loop (advances across iterations), fallback, recursion.
+
+**Backoff** — the growing wait between Retry attempts, either *fixed* (constant) or
+*exponential* (doubling), clamped to a ceiling. _Avoid_: delay, sleep, cooldown.
+
+**Fallback (on-error)** — routing to a *different* step when one fails, instead of re-running
+it. The original step genuinely failed, so the run is Degraded (data may be lost) — distinct
+from a Retry that makes the same step succeed. pflow recovery is forward-only: no rollback of
+side effects already done. _Avoid_: catch, rescue, compensation.
+
+**Degraded** — a run that *finished its work but flagged a non-fatal problem* (a Fallback
+fired, a batch dropped failed items, output was salvaged). Completes successfully. Distinct
+from **Failed** (a fatal error halted the run) and from a clean **Success**.
+_Avoid_: partial, warning-state.
+
+**Advisory** — information surfaced about a run that does **not**, on its own, mark it
+Degraded (an empty batch, a Loop hitting its cap, a section typo parsed around). Contrast
+with a degrading warning. _Avoid_: note, hint, info.
+
 **Snapshot** — the frozen prior-run state that `--only <step>` runs a single step against:
 every *other* step's output reused from the most recent full run, so only the target
 re-executes and upstream side effects never re-fire. Requires a prior full run.
@@ -39,6 +61,14 @@ _Avoid_: replay, restore, checkpoint.
 
 **Batch vs Loop** — both repeat a step. Discriminator: can you write the list of runs
 before starting (Batch), or only know you're done by inspecting what just happened (Loop).
+
+**Retry vs Loop** — both re-run a step. Retry re-runs the *same attempt* after a transient
+failure (same inputs, capped, invisible once it succeeds). Loop re-runs across *iterations*,
+each building on the last, until a condition goes falsy.
+
+**Retry vs Fallback** — both are failure responses. Retry re-runs the *same* step hoping it
+succeeds (→ Success). Fallback routes to a *different* step because the original failed
+(→ Degraded).
 
 **Snapshot vs Cache** — both reuse prior output. Cache reuses a step's *own* output when
 its declared inputs are unchanged (correctness-gated, per-step, can still re-run the step).

--- a/docs/how-it-works/batch-processing.mdx
+++ b/docs/how-it-works/batch-processing.mdx
@@ -56,8 +56,8 @@ This runs the `classify` node once for each issue. The `as: "issue"` creates a t
 | `parallel` | bool | No | `false` | Run items concurrently instead of sequentially |
 | `max_concurrent` | int | No | `10` | Maximum parallel items (1-100) |
 | `error_handling` | string | No | `"fail_fast"` | `"fail_fast"` or `"continue"` |
-| `max_retries` | int | No | `0` | Retry failed items this many times |
-| `retry_wait` | int | No | `1` | Seconds to wait between retries |
+| `max_retries` | int | No | `1` | Batch item total attempts after an exception escapes the node (`1` = no batch retry) |
+| `retry_wait` | number | No | `0` | Seconds to wait between batch item attempts |
 
 ## Sequential vs parallel
 
@@ -189,10 +189,31 @@ Process each API call with retries and error tolerance.
     error_handling: continue
 ```
 
-This configuration retries each failed item up to 3 times, waiting 2 seconds between attempts. Common in scenarios involving:
+This configuration gives each failed item up to 3 total batch attempts, waiting 2 seconds between attempts. Common in scenarios involving:
 - Transient API errors
 - Rate limit recovery
 - Network timeouts
+
+Node-level `retry:` is separate from batch retry and applies inside each node attempt:
+
+```markdown
+### fetch
+
+Fetch each API call with exponential node backoff.
+
+- type: http
+- url: ${call.url}
+- retry:
+    max: 3
+    wait: 0.5
+    backoff: exponential
+- batch:
+    items: ${api_calls}
+    as: call
+    parallel: true
+```
+
+For nodes that return an `"error"` action when exhausted (`llm`, `shell`, `mcp`, `code`, file nodes), batch does not run another item attempt. Attempts multiply only for nodes that re-raise after node retries are exhausted, such as `http`, `claude-code`, or custom nodes using the default fallback.
 
 ## What you'll see
 

--- a/examples/error-handling/README.md
+++ b/examples/error-handling/README.md
@@ -18,6 +18,8 @@ These workflows double as regression fixtures for the Task 148 failed-node invar
 | `typo-on-failed-node.pflow.md` | When you typo a field on a failed node (`${primary.stddout}`), the error surfaces BOTH the failure (primary signal) AND the typo correction (secondary hint), and the paste-able fix uses the corrected field |
 | `coalesce-mixed-absent-failed.pflow.md` | A coalesce `${never_run.x ?? fails.y}` with one absent operand and one failed operand errors loudly with the "All coalesce operands are unavailable" summary block — it does NOT silently skip (that was the Task 128 bug class) |
 | `loop-recovery.pflow.md` | A node fails on visit 1, succeeds on visit 2. The loop guard clears the stale `__failures__` entry, the workflow reports success, and downstream references see the visit-2 data |
+| `retry-with-backoff.pflow.md` | A file node uses `retry:` with exponential backoff before exhausting into its `on-error` path |
+| `non-retriable-file-error.pflow.md` | A file-node validation error skips retry sleeps even with `retry:` configured, then routes to `on-error` |
 | `source-line-multi-output.pflow.md` | Multiple output declarations at different lines — the diagnostic's `At:` line points at the exact failing output, not the last output or the top of the file |
 | `source-line-heavy-offsets.pflow.md` | Heavy blank-line padding and prose before the Outputs section — the parser's line tracker handles real-world offsets without off-by-N errors |
 
@@ -29,4 +31,6 @@ These workflows double as regression fixtures for the Task 148 failed-node invar
 pflow examples/error-handling/failed-node-direct-reference.pflow.md --no-cache --no-trace
 pflow examples/error-handling/typo-on-failed-node.pflow.md --no-cache --no-trace
 pflow examples/error-handling/loop-recovery.pflow.md --no-cache --no-trace
+pflow examples/error-handling/retry-with-backoff.pflow.md --no-cache --no-trace
+pflow examples/error-handling/non-retriable-file-error.pflow.md --no-cache --no-trace
 ```

--- a/examples/error-handling/non-retriable-file-error.pflow.md
+++ b/examples/error-handling/non-retriable-file-error.pflow.md
@@ -1,0 +1,52 @@
+# Non-Retriable File Error
+
+Demonstrates that deterministic file validation errors skip the retry wait and route to `on-error`.
+
+## Steps
+
+### prepare-directory
+
+Creates a directory where the copy node expects a file.
+
+- type: shell
+
+```shell command
+mkdir -p /private/tmp/pflow-non-retriable-example
+rm -f /private/tmp/pflow-non-retriable-example/dest.txt
+mkdir -p /private/tmp/pflow-non-retriable-example/source-dir
+```
+
+### copy-directory
+
+Attempts to copy a directory as if it were a file; this is deterministic and should not retry.
+
+- type: copy-file
+- source_path: /private/tmp/pflow-non-retriable-example/source-dir
+- dest_path: /private/tmp/pflow-non-retriable-example/dest.txt
+- retry:
+    max: 3
+    wait: 0.5
+    backoff: exponential
+- on-error: report-error
+- next: done
+
+### report-error
+
+Reports the expected deterministic failure path.
+
+- type: shell
+- next: done
+
+```shell command
+echo "copy-directory failed without retrying deterministic validation"
+```
+
+### done
+
+Marks the end of the recovery path.
+
+- type: shell
+
+```shell command
+echo "non-retriable example complete"
+```

--- a/examples/error-handling/non-retriable-file-error.pflow.md
+++ b/examples/error-handling/non-retriable-file-error.pflow.md
@@ -11,9 +11,9 @@ Creates a directory where the copy node expects a file.
 - type: shell
 
 ```shell command
-mkdir -p /private/tmp/pflow-non-retriable-example
-rm -f /private/tmp/pflow-non-retriable-example/dest.txt
-mkdir -p /private/tmp/pflow-non-retriable-example/source-dir
+mkdir -p /tmp/pflow-non-retriable-example
+rm -f /tmp/pflow-non-retriable-example/dest.txt
+mkdir -p /tmp/pflow-non-retriable-example/source-dir
 ```
 
 ### copy-directory
@@ -21,8 +21,8 @@ mkdir -p /private/tmp/pflow-non-retriable-example/source-dir
 Attempts to copy a directory as if it were a file; this is deterministic and should not retry.
 
 - type: copy-file
-- source_path: /private/tmp/pflow-non-retriable-example/source-dir
-- dest_path: /private/tmp/pflow-non-retriable-example/dest.txt
+- source_path: /tmp/pflow-non-retriable-example/source-dir
+- dest_path: /tmp/pflow-non-retriable-example/dest.txt
 - retry:
     max: 3
     wait: 0.5

--- a/examples/error-handling/retry-with-backoff.pflow.md
+++ b/examples/error-handling/retry-with-backoff.pflow.md
@@ -1,0 +1,52 @@
+# Retry With Backoff
+
+Demonstrates node-level retry with exponential backoff before an `on-error` recovery route.
+
+## Steps
+
+### prepare-path
+
+Ensures the destination path is clear while leaving the source file absent.
+
+- type: shell
+
+```shell command
+mkdir -p /private/tmp/pflow-retry-with-backoff-example
+rm -f /private/tmp/pflow-retry-with-backoff-example/source.txt
+rm -f /private/tmp/pflow-retry-with-backoff-example/dest.txt
+```
+
+### copy-missing-file
+
+Attempts to copy a missing file, exhausts retry attempts, then routes to recovery.
+
+- type: copy-file
+- source_path: /private/tmp/pflow-retry-with-backoff-example/source.txt
+- dest_path: /private/tmp/pflow-retry-with-backoff-example/dest.txt
+- retry:
+    max: 2
+    wait: 0.1
+    backoff: exponential
+- on-error: retry-exhausted
+- next: done
+
+### retry-exhausted
+
+Runs after the copy retry budget is exhausted.
+
+- type: shell
+- next: done
+
+```shell command
+echo "retry budget exhausted" >&2
+```
+
+### done
+
+Marks the end of the recovery path.
+
+- type: shell
+
+```shell command
+echo "retry example complete"
+```

--- a/examples/error-handling/retry-with-backoff.pflow.md
+++ b/examples/error-handling/retry-with-backoff.pflow.md
@@ -11,9 +11,9 @@ Ensures the destination path is clear while leaving the source file absent.
 - type: shell
 
 ```shell command
-mkdir -p /private/tmp/pflow-retry-with-backoff-example
-rm -f /private/tmp/pflow-retry-with-backoff-example/source.txt
-rm -f /private/tmp/pflow-retry-with-backoff-example/dest.txt
+mkdir -p /tmp/pflow-retry-with-backoff-example
+rm -f /tmp/pflow-retry-with-backoff-example/source.txt
+rm -f /tmp/pflow-retry-with-backoff-example/dest.txt
 ```
 
 ### copy-missing-file
@@ -21,8 +21,8 @@ rm -f /private/tmp/pflow-retry-with-backoff-example/dest.txt
 Attempts to copy a missing file, exhausts retry attempts, then routes to recovery.
 
 - type: copy-file
-- source_path: /private/tmp/pflow-retry-with-backoff-example/source.txt
-- dest_path: /private/tmp/pflow-retry-with-backoff-example/dest.txt
+- source_path: /tmp/pflow-retry-with-backoff-example/source.txt
+- dest_path: /tmp/pflow-retry-with-backoff-example/dest.txt
 - retry:
     max: 2
     wait: 0.1

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -397,6 +397,11 @@ def _display_validation_result(
             if vresult.warnings:
                 for diagnostic in vresult.warnings:
                     click.echo(format_diagnostic(diagnostic), err=True)
+            info_diagnostics = [d for d in vresult.diagnostics if d.severity is Severity.INFO]
+            if info_diagnostics:
+                click.echo("", err=True)
+                for diagnostic in info_diagnostics:
+                    click.echo(format_diagnostic(diagnostic), err=True)
         else:
             from pflow.execution.formatters.validation_formatter import format_validation_failure
 

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -374,6 +374,20 @@ def _display_execution_result(
         ctx.exit(1)
 
 
+def _echo_diagnostic_group(diagnostics: list[Any], *, blank_line: bool) -> None:
+    """Render a group of diagnostics to stderr, optionally preceded by a blank line.
+
+    Shared by the validation success and failure paths so warnings and INFO
+    advisories are grouped and spaced consistently on both.
+    """
+    if not diagnostics:
+        return
+    if blank_line:
+        click.echo("", err=True)
+    for diagnostic in diagnostics:
+        click.echo(format_diagnostic(diagnostic), err=True)
+
+
 def _display_validation_result(
     ctx: click.Context,
     vresult: Any,
@@ -394,23 +408,16 @@ def _display_validation_result(
             from pflow.execution.formatters.validation_formatter import format_validation_success
 
             click.echo(format_validation_success())
-            if vresult.warnings:
-                for diagnostic in vresult.warnings:
-                    click.echo(format_diagnostic(diagnostic), err=True)
-            info_diagnostics = [d for d in vresult.diagnostics if d.severity is Severity.INFO]
-            if info_diagnostics:
-                click.echo("", err=True)
-                for diagnostic in info_diagnostics:
-                    click.echo(format_diagnostic(diagnostic), err=True)
+            _echo_diagnostic_group(list(vresult.warnings), blank_line=False)
+            _echo_diagnostic_group([d for d in vresult.diagnostics if d.severity is Severity.INFO], blank_line=True)
         else:
             from pflow.execution.formatters.validation_formatter import format_validation_failure
 
             click.echo(format_validation_failure(vresult.errors))
-            extra_diagnostics = [d for d in vresult.diagnostics if d.severity in {Severity.WARNING, Severity.INFO}]
-            if extra_diagnostics:
-                click.echo("", err=True)
-                for diagnostic in extra_diagnostics:
-                    click.echo(format_diagnostic(diagnostic), err=True)
+            # Separate warnings from INFO advisories with a blank line, matching the
+            # success branch above (so advisories read consistently on both paths).
+            _echo_diagnostic_group([d for d in vresult.diagnostics if d.severity is Severity.WARNING], blank_line=True)
+            _echo_diagnostic_group([d for d in vresult.diagnostics if d.severity is Severity.INFO], blank_line=True)
 
     ctx.exit(0 if vresult.valid else 1)
 

--- a/src/pflow/cli/workflow_errors.py
+++ b/src/pflow/cli/workflow_errors.py
@@ -12,6 +12,7 @@ import click
 
 from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.core.diagnostic_render import format_diagnostic
+from pflow.execution.formatters.success_formatter import partition_surfaced_diagnostics
 
 
 def _display_single_error(
@@ -62,11 +63,12 @@ def _display_text_error_details(
     # `result.warnings` property filters to WARNING-only by name; pull from
     # diagnostics directly to include INFO too. Matches the parallel filter
     # in `cli/commands/run.py` on the success path.
-    warnings = [
+    surfaced_diagnostics = [
         diagnostic
         for diagnostic in getattr(result, "diagnostics", [])
         if diagnostic.severity in {Severity.WARNING, Severity.INFO}
     ]
+    warnings, advisories = partition_surfaced_diagnostics(surfaced_diagnostics)
     errors = result.errors
 
     if len(errors) > 1:
@@ -94,3 +96,8 @@ def _display_text_error_details(
         click.echo("⚠️ Warnings:", err=True)
         for warning in warnings:
             click.echo(format_diagnostic(warning), err=True)
+    if advisories:
+        click.echo("", err=True)
+        click.echo("\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} Advisories:", err=True)
+        for advisory in advisories:
+            click.echo(format_diagnostic(advisory), err=True)

--- a/src/pflow/core/diagnostic.py
+++ b/src/pflow/core/diagnostic.py
@@ -124,6 +124,21 @@ class Diagnostic:
             result["see_also"] = list(self.see_also)
         return result
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Diagnostic:
+        """Deserialize the structured JSON shape produced by ``to_dict()``."""
+        return cls(
+            severity=Severity(data["severity"]),
+            message=data["message"],
+            title=data.get("title"),
+            suggestions=data.get("suggestions"),
+            node_id=data.get("node_id"),
+            source=data.get("source", ""),
+            context=data.get("context"),
+            see_also=data.get("see_also"),
+            id=data.get("id"),
+        )
+
     def to_display_dict(self) -> dict[str, Any]:
         """Serialize with context merged into top-level keys for display consumers."""
         result = self.to_dict()
@@ -196,6 +211,24 @@ def normalize_runtime_warning(warning: Any) -> tuple[str, dict[str, Any]]:
         return message, context
 
     return str(warning), {}
+
+
+_NON_DEGRADING_SOURCES = frozenset({"parser", "validator"})
+
+
+def warning_degrades_status(entry: Any) -> bool:
+    """Whether a warning entry flips the run/trace status to DEGRADED.
+
+    Shared predicate for live ``__warnings__`` entries and trace
+    ``execution_warnings`` dictionaries. Parser/validator warnings describe
+    definition quality, not runtime data loss, and INFO diagnostics are
+    advisories. Legacy severity-less shapes fail closed as degrading.
+    """
+    if isinstance(entry, Diagnostic):
+        return entry.severity is not Severity.INFO and entry.source not in _NON_DEGRADING_SOURCES
+    if isinstance(entry, dict):
+        return str(entry.get("severity", "")).lower() != "info" and entry.get("source") not in _NON_DEGRADING_SOURCES
+    return True
 
 
 # LLM failure category — single source of truth for the string used by both

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -44,6 +44,8 @@ def copy_pflow_annotations(source: BaseException, target: BaseException) -> None
 class PflowError(Exception):
     """Base exception for all pflow errors."""
 
+    retriable: bool = True
+
     def to_diagnostics(self) -> list[Diagnostic]:
         """Convert to diagnostic representation. Override in subclasses for rich output."""
         return [
@@ -781,6 +783,8 @@ class CompilationError(PflowError):
             ``compile_validation.py`` to carry the ``validate_data_flow()`` list
             through the compiler boundary without flattening it to a string.
     """
+
+    retriable = False
 
     def __init__(
         self,

--- a/src/pflow/core/ir_schema.py
+++ b/src/pflow/core/ir_schema.py
@@ -63,6 +63,7 @@ For comprehensive examples, see the examples/ directory.
 """
 
 import json
+import math
 from typing import Any, Union
 
 import jsonschema
@@ -195,6 +196,31 @@ LOOP_CONFIG_SCHEMA: dict[str, Any] = {
 }
 
 
+RETRY_CONFIG_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Per-node retry on transient failure (overrides the node-type default). No effect on `workflow` nodes.",
+    "properties": {
+        "max": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Max total attempts (1 = no retry).",
+        },
+        # Keep retry bounds in lockstep with runtime.compilation.compiler's
+        # direct-compile retry validation; the compiler is the safety net for
+        # schema-bypassing dict IR and also rejects non-finite Python floats.
+        "wait": {"type": "number", "minimum": 0, "description": "Base finite seconds between attempts."},
+        "backoff": {
+            "type": "string",
+            "enum": ["fixed", "exponential"],
+            "default": "fixed",
+            "description": "Delay growth mode; exponential waits are clamped at 60s.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
 # JSON Schema for workflow IR (minimal MVP version)
 FLOW_IR_SCHEMA: dict[str, Any] = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -224,6 +250,7 @@ FLOW_IR_SCHEMA: dict[str, Any] = {
                     },
                     "batch": BATCH_CONFIG_SCHEMA,
                     "loop": LOOP_CONFIG_SCHEMA,
+                    "retry": RETRY_CONFIG_SCHEMA,
                     "_source_lines": {
                         "type": "object",
                         "description": "Markdown source line offsets for code block params (injected by parser)",
@@ -654,6 +681,7 @@ def validate_ir(data: Union[dict[str, Any], str]) -> None:
     if not errors:
         # Additional custom validations
         if isinstance(data, dict):
+            _validate_retry_waits_finite(data)
             _validate_node_references(data)
             _validate_duplicate_node_ids(data)
         return
@@ -669,6 +697,28 @@ def validate_ir(data: Union[dict[str, Any], str]) -> None:
         suggestion=suggestion,
         **context_kwargs,
     )
+
+
+def _validate_retry_waits_finite(data: dict[str, Any]) -> None:
+    """Reject non-finite retry waits that jsonschema's number type admits for Python floats."""
+    nodes = data.get("nodes")
+    if not isinstance(nodes, list):
+        return
+    for index, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            continue
+        retry = node.get("retry")
+        if not isinstance(retry, dict) or "wait" not in retry:
+            continue
+        wait = retry["wait"]
+        if isinstance(wait, bool) or not isinstance(wait, (int, float)):
+            continue
+        if not math.isfinite(float(wait)):
+            raise ValidationError(
+                message=f"{wait!r} is not a finite number",
+                path=f"nodes[{index}].retry.wait",
+                suggestion="Set retry.wait to a finite non-negative number of seconds.",
+            )
 
 
 def _validate_node_references(data: dict[str, Any]) -> None:

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -582,7 +582,7 @@ def parse_markdown(content: str) -> MarkdownParseResult:  # noqa: C901
         else:
             warnings.append(
                 Diagnostic(
-                    severity=Severity.WARNING,
+                    severity=Severity.INFO,
                     message=(
                         f"Unparsed content in '{section_name}' section ({line_ref}). "
                         "Content before the first ### heading is not captured."
@@ -747,7 +747,7 @@ def _resolve_section(section_name: str, line_num: int) -> tuple[_SectionType, bo
     if section_lower in _NEAR_MISS_SECTIONS:
         expected = _NEAR_MISS_SECTIONS[section_lower]
         warning = Diagnostic(
-            severity=Severity.WARNING,
+            severity=Severity.INFO,
             message=f"Line {line_num}: '## {section_name}' looks like a typo for '## {expected}'.",
             suggestions=[f"Rename to '## {expected}'."],
             source="parser",
@@ -1592,12 +1592,12 @@ def _build_node_dict(entity: _Entity) -> tuple[dict[str, Any], dict[str, Any]]:
     # Hoist top-level node fields out of params (they are NOT params). Each must
     # be a top-level key so the params-only unknown-key walk never sees it and the
     # IR-schema check + data-flow carve-outs can inspect ``node[field]`` directly:
-    #   batch / loop — fan-out vs condition-terminated iteration (siblings)
+    #   batch / loop / retry — fan-out, condition-terminated iteration, retry policy
     #   cache        — per-node memoization toggle
     #   prompt_cache / prewarm — Task 159 LLM cache opt-ins; top-level so the
     #     ``cache.invalid-on-non-llm`` rule and IR-schema check (B2.2/B2.3) see them
     #     and validator step 8 doesn't silently allow them on non-LLM nodes.
-    for top_level_field in ("batch", "loop", "cache", "prompt_cache", "prewarm"):
+    for top_level_field in ("batch", "loop", "retry", "cache", "prompt_cache", "prewarm"):
         if top_level_field in all_params:
             node[top_level_field] = all_params.pop(top_level_field)
 

--- a/src/pflow/core/node.py
+++ b/src/pflow/core/node.py
@@ -12,6 +12,8 @@ import time
 import warnings
 from typing import Any, Optional
 
+_MAX_RETRY_BACKOFF_SECONDS: float = 60.0
+
 
 class BaseNode:
     def __init__(self) -> None:
@@ -73,19 +75,30 @@ class Node(BaseNode):
     (2) parallel batch deep-copies the node per thread.
     """
 
-    def __init__(self, max_retries: int = 1, wait: float = 0) -> None:
+    def __init__(self, max_retries: int = 1, wait: float = 0, backoff: str = "fixed") -> None:
         super().__init__()
-        self.max_retries, self.wait = max_retries, wait
+        self.max_retries: int = max_retries
+        self.wait: float = wait
+        self.backoff: str = backoff
 
     def exec_fallback(self, prep_res: Any, exc: Exception) -> Any:
         raise exc
+
+    def _retry_delay(self) -> float:
+        wait = float(self.wait)
+        if self.backoff == "exponential":
+            retry_index = int(getattr(self, "cur_retry", 0))
+            delay: float = wait * (2**retry_index)
+            return min(delay, _MAX_RETRY_BACKOFF_SECONDS)
+        return wait
 
     def _exec(self, prep_res: Any) -> Any:
         for self.cur_retry in range(self.max_retries):  # noqa: B020
             try:
                 return self.exec(prep_res)
             except Exception as e:
-                if self.cur_retry == self.max_retries - 1:
+                if not getattr(e, "retriable", True) or self.cur_retry == self.max_retries - 1:
                     return self.exec_fallback(prep_res, e)
-                if self.wait > 0:
-                    time.sleep(self.wait)
+                delay = self._retry_delay()
+                if delay > 0:
+                    time.sleep(delay)

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -822,11 +822,44 @@ class WorkflowValidator:
                 diagnostics.extend(llm_diags)
                 if forms is not None and display_model is not None and provider_name is not None:
                     catalog_check_list.append((node_id, display_model, provider_name, forms))
+            elif node_type == "workflow" and node.get("retry") is not None:
+                diagnostics.append(WorkflowValidator._retry_on_workflow_node_advisory(node_id))
 
         if catalog_check_list:
             diagnostics.extend(WorkflowValidator._validate_llm_model_id_catalog(catalog_check_list))
 
         return diagnostics
+
+    @staticmethod
+    def _retry_on_workflow_node_advisory(node_id: str) -> Diagnostic:
+        """Advisory: a ``retry:`` block on a ``workflow`` (sub-workflow) node is inert.
+
+        ``WorkflowExecutor`` returns child failures as an action rather than
+        raising, so the node-level retry loop never fires. Surface this as an
+        INFO advisory (``source="validator"`` → non-degrading) so an agent that
+        wrote ``retry:`` there learns it has no effect instead of hitting a
+        silent no-op.
+        """
+        return Diagnostic(
+            severity=Severity.INFO,
+            source="validator",
+            title="Retry on Sub-Workflow Node",
+            node_id=node_id,
+            message=(
+                "`retry:` has no effect on a `workflow` (sub-workflow) node — a failing "
+                "sub-workflow is not retried. Put `retry:` on the child workflow's own steps, "
+                "or use `- on-error:` to route a failed sub-workflow elsewhere."
+            ),
+            suggestions=[
+                "Move `retry:` onto the relevant step inside the child workflow.",
+                "Or add `- on-error: <node>` to handle a failed sub-workflow.",
+            ],
+            context={
+                "category": "node_semantics",
+                "node_type": "workflow",
+                "path": f"nodes[id={node_id}].retry",
+            },
+        )
 
     @staticmethod
     def _validate_claude_code_params(node_id: str, params: dict[str, Any]) -> list[Diagnostic]:

--- a/src/pflow/execution/CLAUDE.md
+++ b/src/pflow/execution/CLAUDE.md
@@ -180,7 +180,7 @@ class WorkflowRunner:
 
 **Resource lifecycle**: Resources created in `run()` scope (not inside helpers) so `finally` always has them for cleanup. This prevents MCP server subprocess leaks.
 
-**On-error recovery status** (GH #246 fix): When a node fails and has an `on-error` handler, engine step 17.5 passes `warning=` to `mark_node_failed`, which populates `__warnings__`. This naturally triggers DEGRADED status via the existing `_determine_status` check on `__warnings__`. The `_extract_runtime_warnings` method distinguishes recovery warnings from api_warnings by checking the `__failures__` record's `warning` field and `category`.
+**On-error recovery status** (GH #246 fix): When a node fails and has an `on-error` handler, engine step 17.5 builds a structured runtime `Diagnostic` with `context["type"] == "on_error_recovery"` and passes it as `warning=` to `mark_node_failed`, which preserves it in `__warnings__`. This naturally triggers DEGRADED status via the shared warning predicate. `_extract_runtime_warnings` passes existing `Diagnostic` values through unchanged; legacy string/dict warnings still use the generic runtime-warning path.
 
 ## Result Types (result.py)
 

--- a/src/pflow/execution/runner.py
+++ b/src/pflow/execution/runner.py
@@ -14,6 +14,7 @@ from pflow.core.diagnostic import (
     deduplicate_diagnostics,
     exception_to_diagnostics,
     normalize_runtime_warning,
+    warning_degrades_status,
 )
 from pflow.core.exceptions import (
     CompilationError,
@@ -35,14 +36,11 @@ logger = logging.getLogger(__name__)
 def _is_degrading_warning(value: Any) -> bool:
     """Return True when a ``__warnings__`` entry should flip workflow status to DEGRADED.
 
-    ``Severity.INFO`` Diagnostics are advisories — they surface in reports but
-    don't represent a regression. Everything else (WARNING/ERROR diagnostics
-    and the legacy string/dict warning shapes used by the LLM adapter and
-    on-error recovery) flips DEGRADED.
+    Parser/validator diagnostics are definition-quality signals, not runtime
+    degradation. ``Severity.INFO`` entries are advisories. Legacy string/dict
+    shapes without severity/source fail closed as degrading.
     """
-    if isinstance(value, Diagnostic):
-        return value.severity is not Severity.INFO
-    return True
+    return warning_degrades_status(value)
 
 
 # Backward-compat alias: the helper moved to ``core/workflow_id.py`` so the
@@ -374,10 +372,9 @@ class WorkflowRunner:
             )
             diagnostics = [*resolved.diagnostics, *validator_diagnostics]
             # Compute ``valid`` from the combined list, not only ``validator_diagnostics``.
-            # ``resolved.diagnostics`` only carries parser WARNINGs today, but the type
-            # system permits ERROR severity there, so checking the combined list makes
-            # the invariant explicit and hardens against future parser changes that add
-            # error-severity diagnostics at resolution time.
+            # ``resolved.diagnostics`` carries parser advisories as well as any future
+            # parser errors, so checking the combined list keeps validity tied to
+            # severity rather than whichever phase produced the diagnostic.
             errors = [diagnostic for diagnostic in diagnostics if diagnostic.severity == Severity.ERROR]
 
             return ValidationResult(
@@ -503,7 +500,7 @@ class WorkflowRunner:
         return resolve_workflow(workflow)
 
     def _validate(self, ir: dict[str, Any], params: dict[str, Any]) -> list[Diagnostic]:
-        """Run WorkflowValidator once. Returns validation warnings."""
+        """Run WorkflowValidator once. Returns non-error validation diagnostics."""
         from pflow.core.workflow.validator import WorkflowValidator
         from pflow.registry import Registry
 
@@ -517,15 +514,17 @@ class WorkflowRunner:
             workflow_file=Path(wf_path) if wf_path else None,
         )
         errors = [diagnostic for diagnostic in validator_diagnostics if diagnostic.severity == Severity.ERROR]
-        warnings = [diagnostic for diagnostic in validator_diagnostics if diagnostic.severity == Severity.WARNING]
+        non_error_diagnostics = [
+            diagnostic for diagnostic in validator_diagnostics if diagnostic.severity is not Severity.ERROR
+        ]
 
         if errors:
             raise WorkflowValidationError(
                 validation_errors=errors,
-                validation_warnings=list(warnings),
+                validation_warnings=list(non_error_diagnostics),
             )
 
-        return warnings
+        return non_error_diagnostics
 
     def _initialize_shared_store(
         self,
@@ -587,13 +586,10 @@ class WorkflowRunner:
         """Map action result + store state to (success, status).
 
         DEGRADED fires when ``__template_errors__`` is non-empty OR
-        ``__warnings__`` contains at least one entry the catalog tags as a
-        regression signal (``Severity.WARNING`` or ``Severity.ERROR``).
-        ``Severity.INFO`` entries are advisories — they surface in the
-        diagnostics list and reports but do not flip workflow status.
-        Legacy string/dict warning shapes (pre-catalog producers like the LLM
-        adapter and on-error recovery) default to degrading since they don't
-        carry a typed severity.
+        ``__warnings__`` contains at least one runtime-degrading warning.
+        Parser/validator diagnostics and ``Severity.INFO`` advisories surface
+        in diagnostics/reports but do not flip workflow status. Legacy
+        severity-less warning shapes fail closed as degrading.
         """
         if action_result and isinstance(action_result, str) and action_result.startswith("error"):
             return False, WorkflowStatus.FAILED
@@ -613,57 +609,33 @@ class WorkflowRunner:
     def _extract_runtime_warnings(self, shared_store: dict[str, Any]) -> list[Diagnostic]:
         """Extract runtime warnings from shared store."""
         warnings: list[Diagnostic] = []
-        failures = shared_store.get("__failures__", {})
         for node_id, raw_message in shared_store.get("__warnings__", {}).items():
             if isinstance(raw_message, Diagnostic):
                 # Catalog-emitted Diagnostic. Preserve as-is and bypass the
-                # recovery/api_warning classifier plus canned suggestions:
+                # api_warning classifier plus canned suggestions:
                 # the Diagnostic already carries id, severity, category,
                 # suggestions, and path context end-to-end.
                 warnings.append(raw_message if raw_message.node_id else replace(raw_message, node_id=node_id))
                 continue
 
             message, warning_context = normalize_runtime_warning(raw_message)
-            failure = failures.get(node_id)
-            is_recovery = (
-                failure is not None
-                and failure.get("warning") is not None
-                and failure.get("category") not in ("api_warning", "routing_error")
-            ) or (
-                # Sub-workflow recovery: __warnings__ propagates to parent
-                # but __failures__ stays in child scope. Fall back to the
-                # message pattern written by engine step 17.5.
-                failure is None and "\u2014 on-error \u2192" in message
+            context = {"type": "api_warning"}
+            context.update(warning_context)
+            if "kind" in warning_context:
+                context.setdefault("category", LLM_WARNING_CATEGORY)
+            warnings.append(
+                Diagnostic(
+                    severity=Severity.WARNING,
+                    message=message,
+                    suggestions=[
+                        f"Inspect '{node_id}' upstream inputs and output to verify the warning is expected.",
+                        "If unintended, fix the upstream data or add error handling to this node.",
+                    ],
+                    node_id=node_id,
+                    source="runtime",
+                    context=context,
+                )
             )
-            if is_recovery:
-                category = failure.get("category") if failure else None
-                warnings.append(
-                    Diagnostic(
-                        severity=Severity.WARNING,
-                        message=message,
-                        node_id=node_id,
-                        source="runtime",
-                        context={"type": "on_error_recovery", "category": category},
-                    )
-                )
-            else:
-                context = {"type": "api_warning"}
-                context.update(warning_context)
-                if "kind" in warning_context:
-                    context.setdefault("category", LLM_WARNING_CATEGORY)
-                warnings.append(
-                    Diagnostic(
-                        severity=Severity.WARNING,
-                        message=message,
-                        suggestions=[
-                            f"Inspect '{node_id}' upstream inputs and output to verify the warning is expected.",
-                            "If unintended, fix the upstream data or add error handling to this node.",
-                        ],
-                        node_id=node_id,
-                        source="runtime",
-                        context=context,
-                    )
-                )
         for node_id, error_data in shared_store.get("__template_errors__", {}).items():
             # Every entry in __template_errors__ carries a structured
             # Diagnostic built at the source site (see

--- a/src/pflow/guide/core.md
+++ b/src/pflow/guide/core.md
@@ -303,7 +303,7 @@ Parsed record array from the fetch response.
 
 **Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false — at most one output may set this; marks the output that streams to stdout in text mode), description as prose.
 
-**Node fields**: `type` (required), all other params as `- key: value`. Code/prompts/batch go in tagged code blocks.
+**Node fields**: `type` (required), top-level controls like `batch`, `loop`, `retry`, `cache`, `prompt_cache`, and `prewarm`, then node params as `- key: value`. Code/prompts/batch go in tagged code blocks.
 
 **Execution order**: Top to bottom in `## Steps`. No explicit edges.
 
@@ -315,6 +315,7 @@ Parsed record array from the fetch response.
 - Use `-` for parameters, `*` for documentation bullets.
 - Code blocks require a tag: `shell command`, `python code`, `prompt`, `yaml batch`, `yaml output_schema`
 - Batch config: inline `- batch:` for simple cases, `yaml batch` code block for complex arrays
+- Retry config: `- retry: {max: 3, wait: 0.5, backoff: exponential}`; `max` is total attempts (`1` = no retry), `wait` is finite seconds, and `backoff` is `fixed` or `exponential`. Exponential waits are clamped to 60s per wait; fixed waits use `wait` as declared. `retry:` overrides node-type defaults and is best for transient/idempotent failures raised during node execution. It does not re-run ordinary `"error"` actions returned from `post()` (for example, a shell command that exits non-zero). On side-effecting nodes, use it only when repeating the attempted operation is acceptable. On `workflow` nodes it is ignored; put retry policies inside the child workflow instead.
 - Any code block parameter can reference an external file instead: `- prompt: ./prompts/system.md`, `- code: ./scripts/transform.py`. Paths are relative to the workflow file. Use for long prompts or reusable scripts.
 
 **Description shapes** — match the shape to the content:
@@ -397,7 +398,7 @@ state. Use this:
 - **`cache: false` on a node** — explicit opt-out (redundant for non-`llm` nodes under the default; useful for documenting intent).
 - `pflow report` — when errors aren't enough, inspect per-node resolved inputs and outputs
 
-**What the memo cache models:** a node's cache key is computed from its node type, its static params (`- key: value`), raw template strings (the `${foo.bar}` *string*, not the resolved value), batch configuration, prompt-cache content, and resolved input values. It does NOT model filesystem state, environment variables, current time, or external API responses — anything a node reads from the world outside its declared inputs. This is why non-`llm` nodes don't cache by default: a `shell` node running `cat queue.txt` has a stable cache key even as the file changes, so caching it would silently re-serve stale output in an iteration loop. (A literal string inside a `??` fallback cannot contain the `??` sequence itself — see `pflow guide branching` → Loops for fallback patterns.)
+**What the memo cache models:** a node's cache key is computed from its node type, its static params (`- key: value`), raw template strings (the `${foo.bar}` *string*, not the resolved value), batch configuration, prompt-cache content, and resolved input values. It does NOT model retry settings, filesystem state, environment variables, current time, or external API responses — anything that affects how an attempt is scheduled or what a node reads from the world outside its declared inputs. This is why non-`llm` nodes don't cache by default: a `shell` node running `cat queue.txt` has a stable cache key even as the file changes, so caching it would silently re-serve stale output in an iteration loop. (A literal string inside a `??` fallback cannot contain the `??` sequence itself — see `pflow guide branching` → Loops for fallback patterns.)
 
 **How to diagnose stale cache:** if a node returns the same output across runs when you expect change, the cache is hitting because all of the above inputs are stable. Either (a) the input genuinely hasn't changed (cache is correct); (b) the node reads external state — under the defaults this is auto-uncached for non-`llm` nodes, so check you don't have an explicit `cache: true`; or (c) upstream produced identical output — check the upstream node via `pflow report` or `--only <node>`.
 

--- a/src/pflow/guide/features/batch.md
+++ b/src/pflow/guide/features/batch.md
@@ -37,6 +37,8 @@ Current item: `${item}` (or custom `as`). Index: `${__index__}` (0-based). Resul
 | `parallel` | `false` | Concurrent execution |
 | `max_concurrent` | `10` | 1-100; use 30-50 for LLM APIs (rate limits) |
 | `error_handling` | `"fail_fast"` | `"continue"` = process all despite errors |
+| `max_retries` | `1` | Batch item total attempts after an exception escapes the node (`1` = no batch retry) |
+| `retry_wait` | `0` | Seconds between batch item attempts |
 
 **`parallel: false` is the default** — items run sequentially, in order. Use sequential when items must run in a specific order, when each item depends on side effects from the previous one (e.g. reading filesystem state a prior item wrote), or when you're using batch for bounded iteration. Sequential iteration over a sub-workflow is the cleanest loop-with-disk-state pattern — see `pflow guide sub-workflows` → Bounded iteration.
 
@@ -183,3 +185,26 @@ the normal output shape.
 ```
 
 **Common mistake: missing explicit prompt wiring on batch LLM.** Batch items may have `prompt:` fields in the data, but the LLM node ignores them unless you wire it explicitly: `- prompt: ${item.prompt}`. Batch provides data; the node still needs explicit parameter references.
+
+**Retry interaction:** `batch.max_retries` and node-level `retry:` are separate loops. Node-level retry handles transient failures inside the node attempt:
+
+````markdown
+### fetch-each
+
+Fetch each URL with node-level exponential backoff.
+
+- type: http
+- url: ${url}
+- retry:
+    max: 3
+    wait: 0.5
+    backoff: exponential
+- batch:
+    items: ${urls}
+    as: url
+    parallel: true
+````
+
+For common nodes that convert exhausted failures into an `"error"` action (`llm`, `shell`, `mcp`, `code`, file nodes), the batch item finishes with that action and `batch.max_retries` does not run another item attempt. Multiplication happens only for nodes whose fallback re-raises after node retries are exhausted (`http`, `claude-code`, or custom nodes using the default fallback). In those cases the upper bound is `batch.max_retries * retry.max` total node attempts per item.
+
+Parallel batch workers inherit the configured node retry budget. A `fail_fast` batch cannot interrupt a worker that is already sleeping in backoff; exponential node backoff is clamped to 60 seconds per wait.

--- a/src/pflow/mcp_server/services/CLAUDE.md
+++ b/src/pflow/mcp_server/services/CLAUDE.md
@@ -90,6 +90,8 @@ Every shared formatter has two call sites: CLI (`cli/main.py`) and MCP (`executi
 
 Same rule for rendering exceptions: the MCP `save_workflow` path relies on `save_workflow_with_options()` for parse + validation + save, then catches `WorkflowValidationError` and renders it via `format_validation_failure(e.validation_errors)` — parity with the CLI save/validate paths. `WorkflowValidationError.validation_warnings` is a constructor kwarg (not a dynamic attribute), so warnings survive the exception boundary without special plumbing.
 
+MCP validation/execution responses intentionally surface parser/validator INFO diagnostics as `advisories` alongside warnings/errors. This preserves agent-visible definition advisories after parser near-miss diagnostics were reclassified from WARNING to INFO; runtime INFO diagnostics remain suppressed unless a formatter explicitly opts into them.
+
 ## Testing
 
 Mock at service layer (service methods return predictable results). Integration tests use real Registry/WorkflowManager. See `mcp_server/CLAUDE.md` for test file listing.

--- a/src/pflow/mcp_server/services/execution_service.py
+++ b/src/pflow/mcp_server/services/execution_service.py
@@ -339,9 +339,9 @@ class ExecutionService(BaseService):
             from pflow.execution.formatters.validation_formatter import format_validation_failure
 
             msg = format_validation_failure(vresult.errors)
-            extra_diagnostics = [d for d in vresult.diagnostics if d.severity in {Severity.WARNING, Severity.INFO}]
-            if extra_diagnostics:
-                msg += "\n\n" + "\n".join(format_diagnostic(diagnostic) for diagnostic in extra_diagnostics)
+            surfaced_diagnostics = _mcp_surfaced_diagnostics(vresult.diagnostics)
+            if surfaced_diagnostics:
+                msg += "\n\n" + _format_mcp_diagnostic_sections(surfaced_diagnostics)
             return msg
 
     @classmethod

--- a/src/pflow/mcp_server/services/execution_service.py
+++ b/src/pflow/mcp_server/services/execution_service.py
@@ -74,19 +74,36 @@ def _format_success_result(
         workflow_metadata=workflow_metadata,
         trace_path=trace_path,
         status=result.status,
-        # INTENTIONAL: MCP surfaces WARNING/ERROR only, never INFO advisories
-        # (e.g. an empty-batch note). MCP agents already see an empty result via
-        # `shared_after` + `batch_metadata.count: 0`, so the advisory would be
-        # redundant noise. This asymmetry with the CLI (which DOES show an
-        # `advisories` section/key) is deliberate — do not "fix" it by passing
-        # the full diagnostics list without a decision. Mirror at the text path
-        # below (`format_success_as_text(..., warning_diagnostics=result.warnings)`).
-        warnings=[
-            diagnostic for diagnostic in getattr(result, "diagnostics", []) if diagnostic.severity == Severity.WARNING
-        ],
+        warnings=_mcp_surfaced_diagnostics(getattr(result, "diagnostics", [])),
     )
 
     return formatted
+
+
+def _mcp_surfaced_diagnostics(diagnostics: list[Diagnostic]) -> list[Diagnostic]:
+    """Diagnostics worth surfacing on MCP text/structured responses.
+
+    MCP suppresses runtime INFO notes that duplicate structured data agents can
+    inspect directly (for example empty-batch metadata), but parser/validator
+    INFO diagnostics are definition-quality advisories with no other surface.
+    """
+    return [
+        diagnostic
+        for diagnostic in diagnostics
+        if diagnostic.severity is Severity.WARNING
+        or (diagnostic.severity is Severity.INFO and diagnostic.source in {"parser", "validator"})
+    ]
+
+
+def _format_mcp_diagnostic_sections(diagnostics: list[Diagnostic]) -> str:
+    warning_diagnostics = [diagnostic for diagnostic in diagnostics if diagnostic.severity is Severity.WARNING]
+    advisory_diagnostics = [diagnostic for diagnostic in diagnostics if diagnostic.severity is Severity.INFO]
+    sections: list[str] = []
+    if warning_diagnostics:
+        sections.append("Warnings:\n" + "\n".join(format_diagnostic(warning) for warning in warning_diagnostics))
+    if advisory_diagnostics:
+        sections.append("Advisories:\n" + "\n".join(format_diagnostic(advisory) for advisory in advisory_diagnostics))
+    return "\n\n".join(sections)
 
 
 def _format_error_result(
@@ -147,6 +164,11 @@ def _format_error_result(
             for diagnostic in getattr(result, "diagnostics", [])
             if diagnostic.severity == Severity.WARNING
         ],
+        "advisories": [
+            diagnostic.to_display_dict()
+            for diagnostic in getattr(result, "diagnostics", [])
+            if diagnostic.severity == Severity.INFO and diagnostic.source in {"parser", "validator"}
+        ],
     }
 
 
@@ -190,9 +212,7 @@ def _build_error_text(
         lines.extend(format_batch_errors_section(steps))
 
     if warnings:
-        lines.append("\nWarnings:")
-        for warning in warnings:
-            lines.append(format_diagnostic(warning))
+        lines.append("\n" + _format_mcp_diagnostic_sections(warnings))
 
     if trace_path and Path(trace_path).exists():
         lines.append(f"\nTrace: {trace_path}")
@@ -266,14 +286,13 @@ class ExecutionService(BaseService):
                 success_dict = _format_success_result(result, resolved, str(workflow))
                 from pflow.execution.formatters.success_formatter import format_success_as_text
 
-                # `result.warnings` is WARNING-only by design — see the comment at
-                # the `_format_success_result` filter above. INFO advisories are
-                # intentionally not surfaced to MCP, so the formatter's
-                # "Advisories:" branch never fires on this path.
-                return format_success_as_text(success_dict, warning_diagnostics=result.warnings)
+                return format_success_as_text(
+                    success_dict,
+                    warning_diagnostics=_mcp_surfaced_diagnostics(result.diagnostics),
+                )
             else:
                 error_diagnostics = [d for d in result.diagnostics if d.severity == Severity.ERROR]
-                warning_diagnostics = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+                warning_diagnostics = _mcp_surfaced_diagnostics(result.diagnostics)
                 trace_path = (
                     str(result.trace.trace_path) if result.trace and hasattr(result.trace, "trace_path") else ""
                 )
@@ -312,9 +331,9 @@ class ExecutionService(BaseService):
             from pflow.execution.formatters.validation_formatter import format_validation_success
 
             msg = format_validation_success()
-            if vresult.warnings:
-                warning_text = "\n".join(format_diagnostic(warning) for warning in vresult.warnings)
-                msg += f"\n\nWarnings:\n{warning_text}"
+            surfaced_diagnostics = _mcp_surfaced_diagnostics(vresult.diagnostics)
+            if surfaced_diagnostics:
+                msg += "\n\n" + _format_mcp_diagnostic_sections(surfaced_diagnostics)
             return msg
         else:
             from pflow.execution.formatters.validation_formatter import format_validation_failure
@@ -712,7 +731,7 @@ class ExecutionService(BaseService):
                 # Use diagnostic pipeline directly
 
                 error_diagnostics = result.errors
-                warning_diagnostics = result.warnings
+                warning_diagnostics = _mcp_surfaced_diagnostics(result.diagnostics)
                 trace_path = (
                     str(result.trace.trace_path) if result.trace and hasattr(result.trace, "trace_path") else ""
                 )

--- a/src/pflow/nodes/file/copy_file.py
+++ b/src/pflow/nodes/file/copy_file.py
@@ -193,7 +193,7 @@ class CopyFileNode(Node):
         failure_message = (
             "Failed to copy file without retrying deterministic error"
             if isinstance(exc, NonRetriableError)
-            else f"Failed to copy file after {self.max_retries} retries"
+            else f"Failed to copy file after {self.max_retries} attempts"
         )
         logger.error(
             failure_message,
@@ -213,7 +213,7 @@ class CopyFileNode(Node):
         elif isinstance(exc, OSError) and ("No space left" in str(exc) or "disk full" in str(exc).lower()):
             error_msg = f"Error: No space left on device when copying to '{dest_path}'."
         else:
-            error_msg = f"Error: Could not copy '{source_path}' to '{dest_path}' after {self.max_retries} retries. {exc!s}. Check if files are locked or if there are system issues."
+            error_msg = f"Error: Could not copy '{source_path}' to '{dest_path}' after {self.max_retries} attempts. {exc!s}. Check if files are locked or if there are system issues."
 
         return error_msg
 

--- a/src/pflow/nodes/file/copy_file.py
+++ b/src/pflow/nodes/file/copy_file.py
@@ -190,8 +190,13 @@ class CopyFileNode(Node):
         """Handle final failure after all retries with user-friendly messages."""
         source_path, dest_path, _ = prep_res
 
+        failure_message = (
+            "Failed to copy file without retrying deterministic error"
+            if isinstance(exc, NonRetriableError)
+            else f"Failed to copy file after {self.max_retries} retries"
+        )
         logger.error(
-            f"Failed to copy file after {self.max_retries} retries",
+            failure_message,
             extra={"source_path": source_path, "dest_path": dest_path, "error": str(exc), "phase": "fallback"},
         )
 

--- a/src/pflow/nodes/file/delete_file.py
+++ b/src/pflow/nodes/file/delete_file.py
@@ -142,7 +142,7 @@ class DeleteFileNode(Node):
         failure_message = (
             "Failed to delete file without retrying deterministic error"
             if isinstance(exc, NonRetriableError)
-            else f"Failed to delete file after {self.max_retries} retries"
+            else f"Failed to delete file after {self.max_retries} attempts"
         )
         logger.error(
             failure_message,
@@ -158,7 +158,7 @@ class DeleteFileNode(Node):
         elif isinstance(exc, OSError) and hasattr(exc, "errno") and exc.errno == errno.EBUSY:
             error_msg = f"Error: File '{file_path}' is in use and cannot be deleted."
         else:
-            error_msg = f"Error: Could not delete '{file_path}' after {self.max_retries} retries. {exc!s}. Check if the file is locked or if there are system issues."
+            error_msg = f"Error: Could not delete '{file_path}' after {self.max_retries} attempts. {exc!s}. Check if the file is locked or if there are system issues."
 
         return error_msg
 

--- a/src/pflow/nodes/file/delete_file.py
+++ b/src/pflow/nodes/file/delete_file.py
@@ -139,8 +139,13 @@ class DeleteFileNode(Node):
         """Handle final failure after all retries with user-friendly messages."""
         file_path, _ = prep_res
 
+        failure_message = (
+            "Failed to delete file without retrying deterministic error"
+            if isinstance(exc, NonRetriableError)
+            else f"Failed to delete file after {self.max_retries} retries"
+        )
         logger.error(
-            f"Failed to delete file after {self.max_retries} retries",
+            failure_message,
             extra={"file_path": file_path, "error": str(exc), "phase": "fallback"},
         )
 

--- a/src/pflow/nodes/file/exceptions.py
+++ b/src/pflow/nodes/file/exceptions.py
@@ -8,4 +8,4 @@ class NonRetriableError(Exception):
     change with retries (e.g., wrong file type, invalid parameters).
     """
 
-    pass
+    retriable = False

--- a/src/pflow/nodes/file/move_file.py
+++ b/src/pflow/nodes/file/move_file.py
@@ -201,7 +201,7 @@ class MoveFileNode(Node):
         failure_message = (
             "Failed to move file without retrying deterministic error"
             if isinstance(exc, NonRetriableError)
-            else f"Failed to move file after {self.max_retries} retries"
+            else f"Failed to move file after {self.max_retries} attempts"
         )
         logger.error(
             failure_message,
@@ -221,7 +221,7 @@ class MoveFileNode(Node):
         elif isinstance(exc, OSError) and ("No space left" in str(exc) or "disk full" in str(exc).lower()):
             error_msg = f"Error: No space left on device when moving to '{dest_path}'."
         else:
-            error_msg = f"Error: Could not move '{source_path}' to '{dest_path}' after {self.max_retries} retries. {exc!s}. Check if files are locked or if there are system issues."
+            error_msg = f"Error: Could not move '{source_path}' to '{dest_path}' after {self.max_retries} attempts. {exc!s}. Check if files are locked or if there are system issues."
 
         return error_msg
 

--- a/src/pflow/nodes/file/move_file.py
+++ b/src/pflow/nodes/file/move_file.py
@@ -198,8 +198,13 @@ class MoveFileNode(Node):
         """Handle final failure after all retries with user-friendly messages."""
         source_path, dest_path, _ = prep_res
 
+        failure_message = (
+            "Failed to move file without retrying deterministic error"
+            if isinstance(exc, NonRetriableError)
+            else f"Failed to move file after {self.max_retries} retries"
+        )
         logger.error(
-            f"Failed to move file after {self.max_retries} retries",
+            failure_message,
             extra={"source_path": source_path, "dest_path": dest_path, "error": str(exc), "phase": "fallback"},
         )
 

--- a/src/pflow/nodes/file/read_file.py
+++ b/src/pflow/nodes/file/read_file.py
@@ -174,7 +174,7 @@ class ReadFileNode(Node):
         file_path, encoding = prep_res
 
         logger.error(
-            f"Failed to read file after {self.max_retries} retries",
+            f"Failed to read file after {self.max_retries} attempts",
             extra={"file_path": file_path, "error": str(exc), "phase": "fallback"},
         )
 
@@ -188,7 +188,7 @@ class ReadFileNode(Node):
         elif isinstance(exc, IsADirectoryError):
             error_msg = f"Error: '{file_path}' is a directory, not a file."
         else:
-            error_msg = f"Error: Could not read '{file_path}' after {self.max_retries} retries. {exc!s}. Please check if the file is locked or if there are system issues."
+            error_msg = f"Error: Could not read '{file_path}' after {self.max_retries} attempts. {exc!s}. Please check if the file is locked or if there are system issues."
 
         # Return error message that will be stored in shared["error"]
         return error_msg

--- a/src/pflow/nodes/file/write_file.py
+++ b/src/pflow/nodes/file/write_file.py
@@ -279,7 +279,7 @@ class WriteFileNode(Node):
         _, file_path, _, _append, _ = prep_res
 
         logger.error(
-            f"Failed to write file after {self.max_retries} retries",
+            f"Failed to write file after {self.max_retries} attempts",
             extra={"file_path": file_path, "error": str(exc), "phase": "fallback"},
         )
 
@@ -293,7 +293,7 @@ class WriteFileNode(Node):
         elif isinstance(exc, FileNotFoundError):
             error_msg = f"Error: Parent directory for '{file_path}' does not exist and could not be created."
         else:
-            error_msg = f"Error: Could not write to '{file_path}' after {self.max_retries} retries. {exc!s}. Check if the directory is writable or if there are system issues."
+            error_msg = f"Error: Could not write to '{file_path}' after {self.max_retries} attempts. {exc!s}. Check if the directory is writable or if there are system issues."
 
         return error_msg
 

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -173,7 +173,8 @@ shared["__failures__"] = {
         "data": {...},        # what was at shared[node_id] before the move (may be {})
         "category": "shell_failure" | "node_action_error" | "api_warning" | "routing_error" | "exception" | "template_error",
         "error": "...",       # human-readable error (optional)
-        "warning": "...",     # set for api_warning and on-error recovery (optional)
+        # NOTE: warning text is NOT stored here — structured warnings (api_warning
+        # + on-error recovery) live only in shared["__warnings__"][node_id].
     }
 }
 

--- a/src/pflow/runtime/compilation/compiler.py
+++ b/src/pflow/runtime/compilation/compiler.py
@@ -13,10 +13,12 @@ Supporting concerns are in sibling modules:
 
 import json
 import logging
+import math
 from typing import Any, Optional, Union
 
 from pflow.core.exceptions import CompilationError
 from pflow.core.llm_config import get_default_workflow_model, get_model_not_configured_help
+from pflow.core.node import Node
 from pflow.core.prompt_cache import CacheBlockIR, CacheChunkIR
 from pflow.core.workflow.loop_validation import check_loop_polarity
 from pflow.registry import Registry
@@ -29,6 +31,10 @@ from .node_loader import import_node_class
 
 # Set up module logger
 logger = logging.getLogger(__name__)
+
+# Keep direct-compile retry validation in lockstep with core.ir_schema's
+# RETRY_CONFIG_SCHEMA; this path protects callers that bypass schema validation.
+_RETRY_CONFIG_KEYS = frozenset({"max", "wait", "backoff"})
 
 
 def _parse_ir_input(ir_json: Union[str, dict[str, Any]]) -> dict[str, Any]:
@@ -325,6 +331,14 @@ def _create_node_and_config(
     if static_params:
         node_instance.set_params(static_params)
 
+    retry_data = _validate_retry_config(node_data.get("retry"), node_id, node_type)
+    if retry_data and isinstance(node_instance, Node):
+        node_instance.max_retries = _coerce_retry_int(
+            retry_data.get("max", node_instance.max_retries), "max", node_id, node_type
+        )
+        node_instance.wait = _coerce_retry_float(retry_data.get("wait", node_instance.wait), "wait", node_id, node_type)
+        node_instance.backoff = _coerce_retry_backoff(retry_data.get("backoff", "fixed"), node_id, node_type)
+
     # Build batch config (None if not a batch node)
     batch_config = None
     batch_data = node_data.get("batch")
@@ -540,6 +554,88 @@ def _validate_loop_cap(value: int, node_id: Optional[str], node_type: Optional[s
             ),
         )
     return value
+
+
+def _validate_retry_config(value: Any, node_id: str, node_type: str) -> dict[str, Any] | None:
+    """Validate direct-compile retry config before optional application to Node instances."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise CompilationError(
+            f"Node '{node_id}' `retry:` must be a mapping.",
+            phase="retry_config",
+            node_id=node_id,
+            node_type=node_type,
+            suggestion="Declare `- retry:` with optional `max:`, `wait:`, and `backoff:` fields.",
+        )
+
+    unknown_keys = sorted(str(key) for key in value if key not in _RETRY_CONFIG_KEYS)
+    if unknown_keys:
+        keys = ", ".join(repr(key) for key in unknown_keys)
+        raise CompilationError(
+            f"Node '{node_id}' `retry:` contains unknown field(s): {keys}.",
+            phase="retry_config",
+            node_id=node_id,
+            node_type=node_type,
+            suggestion="Use only `max`, `wait`, and `backoff` under `retry:`.",
+        )
+
+    if "max" in value:
+        _coerce_retry_int(value["max"], "max", node_id, node_type)
+    if "wait" in value:
+        _coerce_retry_float(value["wait"], "wait", node_id, node_type)
+    if "backoff" in value:
+        _coerce_retry_backoff(value["backoff"], node_id, node_type)
+    return value
+
+
+def _coerce_retry_int(value: Any, field: str, node_id: str, node_type: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CompilationError(
+            f"Invalid retry config '{field}': expected an integer, got {value!r}",
+            phase="retry_config",
+            node_id=node_id,
+            node_type=node_type,
+        )
+    coerced: int = value
+    if coerced < 1 or coerced > 10:
+        raise CompilationError(
+            f"Invalid retry config '{field}': expected an integer from 1 to 10, got {value!r}",
+            phase="retry_config",
+            node_id=node_id,
+            node_type=node_type,
+        )
+    return coerced
+
+
+def _coerce_retry_float(value: Any, field: str, node_id: str, node_type: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CompilationError(
+            f"Invalid retry config '{field}': expected a number, got {value!r}",
+            phase="retry_config",
+            node_id=node_id,
+            node_type=node_type,
+        )
+    coerced = float(value)
+    if coerced < 0 or not math.isfinite(coerced):
+        raise CompilationError(
+            f"Invalid retry config '{field}': expected a finite non-negative number, got {value!r}",
+            phase="retry_config",
+            node_id=node_id,
+            node_type=node_type,
+        )
+    return coerced
+
+
+def _coerce_retry_backoff(value: Any, node_id: str, node_type: str) -> str:
+    if value in ("fixed", "exponential"):
+        return str(value)
+    raise CompilationError(
+        f"Invalid retry config 'backoff': expected 'fixed' or 'exponential', got {value!r}",
+        phase="retry_config",
+        node_id=node_id,
+        node_type=node_type,
+    )
 
 
 def _default_cache_for_node_type(node_type: str) -> bool:

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -290,7 +290,7 @@ def execute_batch(
     return action
 
 
-def _execute_batch_item(  # noqa: C901
+def _execute_batch_item(
     idx: int,
     item: Any,
     node: Any,
@@ -325,72 +325,9 @@ def _execute_batch_item(  # noqa: C901
 
     for retry in range(batch_config.max_retries):
         try:
-            # Reset namespace for this attempt
-            item_shared[config.node_id] = {}
-            item_shared[batch_config.item_alias] = item
-            item_shared["__index__"] = idx
-            item_shared["_pflow_child_workflow_paths"] = {}
-
-            # Execute via callback
-            action, last_resolutions, template_errors = execute_single_fn(node, config, item_shared)
-
-            # Extract child trace events from WorkflowExecutor (sub-workflow in batch)
-            item_child_trace_events: list[dict[str, Any]] | None = getattr(node, "_child_trace_events", None)
-            item_child_workflow_path = _pop_child_workflow_path(item_shared, config.node_id)
-
-            # Normalize result
-            raw_result = item_shared.get(config.node_id)
-            result = _normalize_result(raw_result)
-
-            # Include original item
-            if "item" in result:
-                logger.warning(
-                    "Batch result already has 'item' key, overwriting with original batch item",
-                    extra={"node_id": config.node_id, "existing_item": result["item"]},
-                )
-            result["item"] = item
-            result["original_index"] = idx
-
-            # Check for error in result dict
-            error_msg = _extract_error(result)
-
-            # Fallback: detect error via action string
-            if not error_msg and isinstance(action, str) and action.startswith("error"):
-                error_msg = "Node returned error action"
-
-            duration_ms = (time.perf_counter() - start_time) * 1000
-            if error_msg:
-                error_info = _build_batch_error(idx, item, error_msg, None)
-                _capture_item_trace(
-                    parent_shared,
-                    config.node_id,
-                    config.node_type_name,
-                    item_shared,
-                    idx,
-                    item,
-                    duration_ms,
-                    error_info,
-                    last_resolutions,
-                    child_trace_events=item_child_trace_events,
-                    child_workflow_path=item_child_workflow_path,
-                )
-                return result, error_info, duration_ms, last_resolutions, template_errors
-
-            _capture_item_trace(
-                parent_shared,
-                config.node_id,
-                config.node_type_name,
-                item_shared,
-                idx,
-                item,
-                duration_ms,
-                None,
-                last_resolutions,
-                child_trace_events=item_child_trace_events,
-                child_workflow_path=item_child_workflow_path,
+            return _run_batch_item_once(
+                idx, item, node, config, parent_shared, execute_single_fn, batch_config, item_shared, start_time
             )
-            return result, None, duration_ms, last_resolutions, template_errors
-
         except CompilationError:
             raise  # Workflow definition is broken — never swallow, never retry
         except Exception as e:
@@ -420,6 +357,72 @@ def _execute_batch_item(  # noqa: C901
         child_workflow_path=_pop_child_workflow_path(item_shared, config.node_id),
     )
     return None, error_info, duration_ms, last_resolutions, template_errors
+
+
+def _run_batch_item_once(
+    idx: int,
+    item: Any,
+    node: Any,
+    config: NodeConfig,
+    parent_shared: dict[str, Any],
+    execute_single_fn: Callable,
+    batch_config: BatchConfig,
+    item_shared: dict[str, Any],
+    start_time: float,
+) -> tuple[dict | None, dict | None, float, dict, list]:
+    """Run one batch-item attempt: execute, normalize, capture the per-item trace.
+
+    Returns the standard ``_execute_batch_item`` result tuple (with ``error_info``
+    set when the item produced an error action, else ``None``). Raises on an exec
+    exception so the caller's retry loop owns retry/exhaustion handling.
+    """
+    # Reset namespace for this attempt
+    item_shared[config.node_id] = {}
+    item_shared[batch_config.item_alias] = item
+    item_shared["__index__"] = idx
+    item_shared["_pflow_child_workflow_paths"] = {}
+
+    # Execute via callback
+    action, last_resolutions, template_errors = execute_single_fn(node, config, item_shared)
+
+    # Extract child trace events from WorkflowExecutor (sub-workflow in batch)
+    item_child_trace_events: list[dict[str, Any]] | None = getattr(node, "_child_trace_events", None)
+    item_child_workflow_path = _pop_child_workflow_path(item_shared, config.node_id)
+
+    # Normalize result
+    raw_result = item_shared.get(config.node_id)
+    result = _normalize_result(raw_result)
+
+    # Include original item
+    if "item" in result:
+        logger.warning(
+            "Batch result already has 'item' key, overwriting with original batch item",
+            extra={"node_id": config.node_id, "existing_item": result["item"]},
+        )
+    result["item"] = item
+    result["original_index"] = idx
+
+    # Check for error in result dict, then fall back to detecting it via the action string
+    error_msg = _extract_error(result)
+    if not error_msg and isinstance(action, str) and action.startswith("error"):
+        error_msg = "Node returned error action"
+
+    duration_ms = (time.perf_counter() - start_time) * 1000
+    error_info = _build_batch_error(idx, item, error_msg, None) if error_msg else None
+    _capture_item_trace(
+        parent_shared,
+        config.node_id,
+        config.node_type_name,
+        item_shared,
+        idx,
+        item,
+        duration_ms,
+        error_info,
+        last_resolutions,
+        child_trace_events=item_child_trace_events,
+        child_workflow_path=item_child_workflow_path,
+    )
+    return result, error_info, duration_ms, last_resolutions, template_errors
 
 
 def _pop_child_workflow_path(shared: dict[str, Any], node_id: str) -> str | None:
@@ -603,7 +606,7 @@ def _execute_synthetic_warmup(
         return None
 
 
-def _collect_parallel_results(  # noqa: C901
+def _collect_parallel_results(
     future_to_idx: dict,
     items: list[Any],
     results: list,
@@ -635,36 +638,66 @@ def _collect_parallel_results(  # noqa: C901
         total = len(future_to_idx)
 
     for future in as_completed(future_to_idx):
-        try:
-            idx, result, error, duration_ms, buffered_events = future.result()
-            results[idx] = result
-            timings[idx] = duration_ms
-            completed_count += 1
+        completed_count += 1
+        had_error = _collect_one_future(
+            future,
+            future_to_idx,
+            items,
+            results,
+            timings,
+            pending_errors,
+            config,
+            callback,
+            depth,
+            completed_count,
+            total,
+        )
+        if had_error and batch_config.error_handling == "fail_fast" and not should_stop:
+            should_stop = True
+            for f in future_to_idx:
+                f.cancel()
 
-            _drain_worker_buffer(callback, buffered_events)
-            _report_batch_progress(callback, config.node_id, duration_ms, depth, completed_count, total, error is None)
 
-            if error:
-                pending_errors.append(error)
-                if batch_config.error_handling == "fail_fast" and not should_stop:
-                    should_stop = True
-                    for f in future_to_idx:
-                        f.cancel()
+def _collect_one_future(
+    future: Any,
+    future_to_idx: dict,
+    items: list[Any],
+    results: list,
+    timings: list,
+    pending_errors: list,
+    config: NodeConfig,
+    callback: Any,
+    depth: int,
+    completed_count: int,
+    total: int,
+) -> bool:
+    """Record one completed future into the shared result lists.
 
-        except CompilationError:
+    Returns True when the item produced an error (so the caller can trigger
+    fail-fast cancellation). Re-raises ``CompilationError`` and non-retriable
+    executor exceptions so the whole batch aborts.
+    """
+    try:
+        idx, result, error, duration_ms, buffered_events = future.result()
+    except CompilationError:
+        raise
+    except Exception as e:
+        if not getattr(e, "retriable", True):
             raise
-        except Exception as e:
-            if not getattr(e, "retriable", True):
-                raise
-            idx = future_to_idx[future]
-            pending_errors.append(_build_batch_error(idx, items[idx], f"Executor error: {e}", e))
-            timings[idx] = 0.0
-            completed_count += 1
-            _report_batch_progress(callback, config.node_id, 0.0, depth, completed_count, total, False)
-            if batch_config.error_handling == "fail_fast" and not should_stop:
-                should_stop = True
-                for f in future_to_idx:
-                    f.cancel()
+        idx = future_to_idx[future]
+        pending_errors.append(_build_batch_error(idx, items[idx], f"Executor error: {e}", e))
+        timings[idx] = 0.0
+        _report_batch_progress(callback, config.node_id, 0.0, depth, completed_count, total, False)
+        return True
+
+    results[idx] = result
+    timings[idx] = duration_ms
+    _drain_worker_buffer(callback, buffered_events)
+    _report_batch_progress(callback, config.node_id, duration_ms, depth, completed_count, total, error is None)
+    if error:
+        pending_errors.append(error)
+        return True
+    return False
 
 
 def _execute_parallel(

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -290,7 +290,7 @@ def execute_batch(
     return action
 
 
-def _execute_batch_item(
+def _execute_batch_item(  # noqa: C901
     idx: int,
     item: Any,
     node: Any,
@@ -394,6 +394,8 @@ def _execute_batch_item(
         except CompilationError:
             raise  # Workflow definition is broken — never swallow, never retry
         except Exception as e:
+            if not getattr(e, "retriable", True):
+                raise  # Deterministic/fatal errors should not burn batch retries
             last_exception = e
             if retry < batch_config.max_retries - 1:
                 if batch_config.retry_wait > 0:
@@ -601,7 +603,7 @@ def _execute_synthetic_warmup(
         return None
 
 
-def _collect_parallel_results(
+def _collect_parallel_results(  # noqa: C901
     future_to_idx: dict,
     items: list[Any],
     results: list,
@@ -652,6 +654,8 @@ def _collect_parallel_results(
         except CompilationError:
             raise
         except Exception as e:
+            if not getattr(e, "retriable", True):
+                raise
             idx = future_to_idx[future]
             pending_errors.append(_build_batch_error(idx, items[idx], f"Executor error: {e}", e))
             timings[idx] = 0.0

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -1116,16 +1116,30 @@ class WorkflowEngine:
             # returns DEGRADED instead of SUCCESS. Without this, recovered
             # workflows silently report SUCCESS (GH #246).
             if str(action).startswith("error"):
+                from pflow.core.diagnostic import Diagnostic, Severity
+
                 node_data = shared.get(config.node_id, {})
                 node_error = node_data.get("error") if isinstance(node_data, dict) else None
                 error_handler = node.successors.get("error")
                 handler_id = getattr(error_handler, "node_id", None) if error_handler else None
+                category = _NODE_TYPE_FAILURE_CATEGORY.get(config.node_type_name, FAILURE_CATEGORY_NODE_ERROR)
+                recovery_warning = (
+                    Diagnostic(
+                        severity=Severity.WARNING,
+                        message=f"Node '{config.node_id}' failed — on-error → '{handler_id}'",
+                        node_id=config.node_id,
+                        source="runtime",
+                        context={"type": "on_error_recovery", "category": category},
+                    )
+                    if handler_id
+                    else None
+                )
                 mark_node_failed(
                     shared,
                     config.node_id,
-                    category=_NODE_TYPE_FAILURE_CATEGORY.get(config.node_type_name, FAILURE_CATEGORY_NODE_ERROR),
+                    category=category,
                     error=node_error,
-                    warning=f"Node '{config.node_id}' failed — on-error → '{handler_id}'" if handler_id else None,
+                    warning=recovery_warning,
                 )
 
             return action

--- a/src/pflow/runtime/engine/instrumentation.py
+++ b/src/pflow/runtime/engine/instrumentation.py
@@ -13,6 +13,7 @@ import os
 import time
 from typing import Any, Optional
 
+from pflow.core.diagnostic import Diagnostic
 from pflow.core.exceptions import MaxNodeVisitsError
 from pflow.core.node_type_display import is_llm_node_type
 
@@ -396,6 +397,8 @@ def apply_memo_hit(
     restored = {k: v for k, v in cached_output.items() if k not in reserved_keys}
     cached_warning = cached_output.get("__pflow_warnings__")
     if cached_warning is not None:
+        if isinstance(cached_warning, dict) and "severity" in cached_warning and "message" in cached_warning:
+            cached_warning = Diagnostic.from_dict(cached_warning)
         shared.setdefault("__warnings__", {})[node_id] = cached_warning
     shared[node_id] = restored
     completed_nodes.append(node_id)
@@ -503,7 +506,9 @@ def write_memo_cache(
         output_dict = dict(node_output) if isinstance(node_output, dict) else {"value": node_output}
         node_warning = shared.get("__warnings__", {}).get(node_id)
         if node_warning is not None:
-            output_dict["__pflow_warnings__"] = node_warning
+            output_dict["__pflow_warnings__"] = (
+                node_warning.to_dict() if isinstance(node_warning, Diagnostic) else node_warning
+            )
         if duration_ms is not None:
             output_dict["__pflow_stats__"] = {"duration_ms": float(duration_ms)}
         memo_cache.put(cache_key, node_id, workflow_path, action or "default", output_dict)

--- a/src/pflow/runtime/node_state.py
+++ b/src/pflow/runtime/node_state.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
+from pflow.core.diagnostic import Diagnostic
+
 
 class NodeStatus(Enum):
     """Three execution states a node can be in."""
@@ -92,8 +94,10 @@ def get_node_failure(shared: dict[str, Any], node_id: str) -> dict[str, Any] | N
             "data": {...},        # what was at shared[node_id] before the move
             "category": "...",    # one of the FAILURE_CATEGORY_* constants
             "error": "...",       # human-readable error message (optional)
-            "warning": "...",     # set for api_warning and on-error recovery (optional)
         }
+
+    Warning text is NOT mirrored here — structured warnings live only in
+    ``shared["__warnings__"][node_id]`` (their sole consumer boundary).
 
     Trusts the single-writer invariant — see ``get_node_output``.
     """
@@ -107,7 +111,7 @@ def mark_node_failed(
     *,
     category: str,
     error: str | None = None,
-    warning: str | None = None,
+    warning: Diagnostic | str | None = None,
 ) -> None:
     """Archive a failed node's output and update execution state.
 
@@ -164,8 +168,6 @@ def mark_node_failed(
     }
     if error is not None:
         record["error"] = str(error)
-    if warning is not None:
-        record["warning"] = str(warning)
 
     shared.setdefault("__failures__", {})[node_id] = record
     shared["__execution__"]["failed_node"] = node_id

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from pflow.core.diagnostic import Diagnostic
+from pflow.core.diagnostic import Diagnostic, warning_degrades_status
 from pflow.core.exceptions import OnlySnapshotMissingError
 from pflow.core.node_type_display import is_llm_node_type
 from pflow.core.trace_io import intern_blobs, load_trace_file
@@ -127,8 +127,7 @@ def _trace_warnings_provably_benign(data: dict[str, Any]) -> bool:
 
     Returns True only when there IS a readable ``warnings`` array AND every entry
     is provably non-degrading — INFO severity, or a parser/validator source
-    (input-quality, not runtime data loss; mirrors the trace-level status
-    blacklist and the result-level ``_is_degrading_warning`` severity rule). An
+    (input-quality, not runtime data loss; mirrors ``warning_degrades_status``). An
     INFO-only advisory (empty-input batch, loop-cap) is benign → no snapshot
     advisory; a WARNING/ERROR runtime warning (e.g. a batch host with
     ``error_handling: continue`` that dropped failed items) is NOT benign → the
@@ -143,11 +142,20 @@ def _trace_warnings_provably_benign(data: dict[str, Any]) -> bool:
     warnings = data.get("warnings")
     if not isinstance(warnings, list) or not warnings:
         return False
-    return all(
-        isinstance(warning, dict)
-        and (str(warning.get("severity", "")).lower() == "info" or warning.get("source") in ("parser", "validator"))
-        for warning in warnings
-    )
+    return all(not warning_degrades_status(warning) for warning in warnings)
+
+
+def _unrecovered_failed_node_ids(
+    final_events: dict[str, dict[str, Any]],
+    execution_warnings: list[dict[str, Any]] | None,
+) -> set[str]:
+    failed_node_ids = {node_id for node_id, event in final_events.items() if not event.get("success", True)}
+    recovered_node_ids: set[str] = set()
+    for warning in execution_warnings or []:
+        node_id = warning.get("node_id") if isinstance(warning, dict) else None
+        if isinstance(node_id, str) and warning.get("type") == "on_error_recovery":
+            recovered_node_ids.add(node_id)
+    return failed_node_ids - recovered_node_ids
 
 
 def _strip_redundant_llm_trace_fields(event: dict[str, Any]) -> None:
@@ -824,24 +832,13 @@ class WorkflowTraceCollector:
         """
         if final_events is None:
             final_events = final_events_by_node(self.events)
-        if any(not e.get("success", True) for e in final_events.values()):
+        execution_warnings = self.execution_warnings or []
+        unrecovered_failures = _unrecovered_failed_node_ids(final_events, execution_warnings)
+        if unrecovered_failures:
             return "failed"
-        if self.execution_warnings and any(
-            self._warning_changes_status(warning) for warning in self.execution_warnings
-        ):
+        if execution_warnings and any(warning_degrades_status(warning) for warning in execution_warnings):
             return "degraded"
         return "success"
-
-    @staticmethod
-    def _warning_changes_status(warning: dict[str, Any]) -> bool:
-        """Return whether a warning should mark the trace as degraded.
-
-        Blacklist (not whitelist) is intentional: unknown sources default to
-        degrading, so new source types are fail-closed rather than silently
-        ignored.  Only parser and validator warnings are excluded — they
-        indicate input quality issues, not runtime degradation.
-        """
-        return warning.get("source") not in {"parser", "validator"}
 
     def _collect_llm_summary(self, events: list[dict[str, Any]]) -> dict[str, Any]:
         """Recursively collect LLM call data from tree-structured events.
@@ -899,7 +896,7 @@ class WorkflowTraceCollector:
         # list is walked once per save. See GH #240.
         final_events = final_events_by_node(self.events)
         final_status = self._determine_trace_status(final_events)
-        failed_node_ids = sorted(nid for nid, e in final_events.items() if not e.get("success", True))
+        failed_node_ids = sorted(_unrecovered_failed_node_ids(final_events, self.execution_warnings))
 
         # Prepare trace data with format version
         trace_data: dict[str, Any] = {

--- a/tests/test_cli/test_direct_execution_helpers.py
+++ b/tests/test_cli/test_direct_execution_helpers.py
@@ -1,9 +1,12 @@
 """Tests for direct execution helper functions in CLI."""
 
+from types import SimpleNamespace
+
 import click
 import click.testing
 
 from pflow.cli.param_parsing import infer_type, parse_workflow_params
+from pflow.cli.workflow_errors import _display_text_error_details
 from pflow.cli.workflow_output import _display_execution_summary, _format_cost_summary_lines
 from pflow.cli.workflow_resolution import is_likely_workflow_name
 from pflow.core.diagnostic import Diagnostic, Severity
@@ -381,3 +384,29 @@ class TestDisplayExecutionSummaryAdvisories:
         cli_result = click.testing.CliRunner().invoke(cmd)
         assert "✓ Workflow completed" in cli_result.output
         assert "with 1 warnings" not in cli_result.output
+
+
+class TestDisplayFailureDetailsAdvisories:
+    def test_info_advisory_renders_under_advisories_not_warnings(self) -> None:
+        error = Diagnostic(
+            severity=Severity.ERROR,
+            message="workflow failed",
+            source="runtime",
+        )
+        advisory = Diagnostic(
+            severity=Severity.INFO,
+            message="Line 3: '## Input' looks like a typo for '## Inputs'.",
+            source="parser",
+        )
+
+        @click.command()
+        def cmd() -> None:
+            _display_text_error_details(SimpleNamespace(errors=[error], diagnostics=[error, advisory]))
+
+        cli_result = click.testing.CliRunner(mix_stderr=False).invoke(cmd)
+
+        assert cli_result.exit_code == 0, cli_result.output
+        assert "Advisories:" in cli_result.stderr
+        assert "⚠️ Warnings:" not in cli_result.stderr
+        assert "1 warning" not in cli_result.stderr
+        assert "## Input" in cli_result.stderr

--- a/tests/test_cli/test_validate_only.py
+++ b/tests/test_cli/test_validate_only.py
@@ -624,6 +624,7 @@ class TestValidationErrorDiagnosticShape:
             f"Parser warning not in validate-only JSON diagnostics.\nFull output: {json.dumps(data, indent=2)}"
         )
         assert any("Input" in w["message"] for w in parser_warnings)
+        assert all(w["severity"] == "info" for w in parser_warnings)
 
     def test_parser_typo_warning_appears_in_execution_output(self, tmp_path: Path) -> None:
         """A parser warning must survive through execution (not just validate-only)."""
@@ -706,8 +707,10 @@ class TestFailurePathShowsWarnings:
         assert "failed" in result.stderr.lower() or "error" in result.stderr.lower(), (
             f"Expected error in output.\nstderr: {result.stderr}"
         )
-        # Parser warning must ALSO be present — this is the regression guard
-        assert "Warning" in result.stderr, f"Expected warnings section in failure output.\nstderr: {result.stderr}"
+        # Parser advisory must ALSO be present — this is the regression guard
+        assert "Input" in result.stderr and "Inputs" in result.stderr, (
+            f"Expected parser advisory in failure output.\nstderr: {result.stderr}"
+        )
 
 
 class TestValidateOnlyWithComplexWorkflows:

--- a/tests/test_cli/test_validate_only.py
+++ b/tests/test_cli/test_validate_only.py
@@ -761,3 +761,32 @@ class TestValidateOnlyWithComplexWorkflows:
         assert result.exit_code != 0, "Should have caught forward reference"
         combined = (result.output + result.stderr).lower()
         assert "node1" in combined or "execution order" in combined or "reference" in combined
+
+    def test_retry_on_workflow_node_surfaces_inert_advisory(self, tmp_path: Path) -> None:
+        """`retry:` on a `workflow` node validates OK but emits an INFO advisory.
+
+        Anti-silent-footgun (#471 review): a `workflow` (sub-workflow) node
+        returns child failures as an action rather than raising, so node-level
+        retry never fires there. The validator surfaces an advisory instead of
+        silently accepting the inert config. The run still validates (exit 0) —
+        the advisory is INFO severity, which is non-degrading.
+        """
+        child = tmp_path / "child.pflow.md"
+        child.write_text(
+            "# Child\n\n## Steps\n\n### do-it\n\nDoes a thing.\n\n- type: shell\n- cache: false\n- command: echo hi\n",
+            encoding="utf-8",
+        )
+        parent = tmp_path / "parent.pflow.md"
+        parent.write_text(
+            "# Parent\n\n## Steps\n\n### call-child\n\nCalls the child with a (no-op) retry block.\n\n"
+            f"- type: workflow\n- workflow: {child}\n- retry:\n    max: 3\n    backoff: exponential\n",
+            encoding="utf-8",
+        )
+
+        result = invoke_cli(["--validate-only", str(parent)])
+
+        assert result.exit_code == 0, f"Workflow should validate.\nstderr: {result.stderr}"
+        stderr_lower = result.stderr.lower()
+        assert "retry" in stderr_lower and "no effect" in stderr_lower, (
+            f"Expected the inert-retry advisory on the workflow node.\nstderr: {result.stderr}"
+        )

--- a/tests/test_core/test_diagnostic.py
+++ b/tests/test_core/test_diagnostic.py
@@ -10,6 +10,7 @@ from pflow.core.diagnostic import (
     deduplicate_diagnostics,
     exception_to_diagnostics,
     normalize_runtime_warning,
+    warning_degrades_status,
 )
 from pflow.core.diagnostic_render import format_diagnostic
 from pflow.core.exceptions import (
@@ -529,3 +530,31 @@ def test_all_see_also_literals_resolve_to_real_guide_topics() -> None:
         "No see_also=[...] literals found in src/pflow — regex drift or feature regressed. "
         "Expected at least the 8 annotated sites from Issue #311."
     )
+
+
+def test_warning_degrades_status_honors_source_dimension() -> None:
+    """A WARNING-severity parser/validator diagnostic must NOT degrade run status.
+
+    Regression guard for the dual-dimension predicate (Issue #471): status
+    degradation is ``severity is not INFO AND source not in {parser, validator}``.
+    If the predicate ever regresses to severity-only, the parser/validator
+    WARNING cases below flip to True and this test fails loudly. The
+    runtime-WARNING controls prove the predicate is not simply "always False",
+    and both the live ``Diagnostic`` and the ``to_display_dict()`` dict shapes
+    are pinned because the runner and the trace layer feed it different shapes.
+    """
+    # Definition-quality WARNINGs (parser/validator) are non-degrading.
+    for source in ("parser", "validator"):
+        assert warning_degrades_status(Diagnostic(severity=Severity.WARNING, message="x", source=source)) is False
+        assert warning_degrades_status({"severity": "warning", "source": source}) is False
+
+    # Runtime WARNINGs DO degrade (control — guards against an always-False regression).
+    assert warning_degrades_status(Diagnostic(severity=Severity.WARNING, message="x", source="runtime")) is True
+    assert warning_degrades_status({"severity": "warning", "source": "runtime"}) is True
+
+    # INFO never degrades, regardless of source (severity dimension).
+    assert warning_degrades_status(Diagnostic(severity=Severity.INFO, message="x", source="runtime")) is False
+    assert warning_degrades_status({"severity": "info", "source": "runtime"}) is False
+
+    # Legacy/untyped shapes (no severity) fail closed — degrade.
+    assert warning_degrades_status("plain string warning") is True

--- a/tests/test_core/test_ir_schema_retry.py
+++ b/tests/test_core/test_ir_schema_retry.py
@@ -1,0 +1,48 @@
+"""Tests for top-level per-node retry IR schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from pflow.core import validate_ir
+from pflow.core.exceptions import SchemaValidationError
+
+
+def _workflow_with_retry(retry: dict[str, object]) -> dict[str, object]:
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "step",
+                "type": "shell",
+                "params": {"command": "echo hi"},
+                "retry": retry,
+            }
+        ],
+    }
+
+
+def test_retry_config_accepts_max_wait_and_backoff() -> None:
+    validate_ir(_workflow_with_retry({"max": 3, "wait": 0.25, "backoff": "exponential"}))
+
+
+@pytest.mark.parametrize("wait", [float("inf"), float("nan")])
+def test_retry_wait_must_be_finite(wait: float) -> None:
+    with pytest.raises(SchemaValidationError, match="finite"):
+        validate_ir(_workflow_with_retry({"wait": wait}))
+
+
+@pytest.mark.parametrize("max_attempts", [0, 11])
+def test_retry_max_range_rejected(max_attempts: int) -> None:
+    with pytest.raises(SchemaValidationError):
+        validate_ir(_workflow_with_retry({"max": max_attempts}))
+
+
+def test_retry_backoff_enum_rejected() -> None:
+    with pytest.raises(SchemaValidationError):
+        validate_ir(_workflow_with_retry({"backoff": "linear"}))
+
+
+def test_retry_unknown_key_rejected() -> None:
+    with pytest.raises(SchemaValidationError):
+        validate_ir(_workflow_with_retry({"max": 2, "jitter": True}))

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -22,6 +22,9 @@ import textwrap
 
 import pytest
 
+from pflow.core.diagnostic import Severity
+from pflow.core.exceptions import SchemaValidationError
+from pflow.core.ir_schema import validate_ir
 from pflow.core.markdown_parser import (
     MarkdownParseError,
     _coerce_yaml_scalar,
@@ -291,7 +294,10 @@ class TestSectionHandling:
         """)
         result = parse_markdown(content)
         warnings = result.warnings
-        assert any("Input" in w.message and "Inputs" in w.message for w in warnings)
+        near_miss = [w for w in warnings if "Input" in w.message and "Inputs" in w.message]
+        assert near_miss
+        assert near_miss[0].severity is Severity.INFO
+        assert near_miss[0].source == "parser"
 
     def test_missing_steps_section_error(self) -> None:
         content = _md("""\
@@ -309,6 +315,63 @@ class TestSectionHandling:
         """)
         with pytest.raises(MarkdownParseError, match="Missing '## Steps' section"):
             parse_markdown(content)
+
+    def test_retry_field_is_hoisted_to_node_top_level(self) -> None:
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### fetch
+
+            Fetches a transient source with an explicit retry policy.
+
+            - type: shell
+            - retry:
+                max: 3
+                wait: 0.25
+                backoff: exponential
+
+            ```shell command
+            echo ok
+            ```
+        """)
+
+        result = parse_markdown(content)
+        node = result.ir["nodes"][0]
+
+        assert node["retry"] == {"max": 3, "wait": 0.25, "backoff": "exponential"}
+        assert "retry" not in node["params"]
+
+    @pytest.mark.parametrize("wait_literal", [".inf", ".nan"])
+    def test_non_finite_retry_wait_from_markdown_is_rejected(self, wait_literal: str) -> None:
+        content = _md(f"""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### fetch
+
+            Fetches a transient source with an invalid retry wait.
+
+            - type: shell
+            - retry:
+                wait: {wait_literal}
+
+            ```shell command
+            echo ok
+            ```
+        """)
+
+        result = parse_markdown(content)
+        result.ir["ir_version"] = "0.1.0"
+
+        with pytest.raises(SchemaValidationError, match="finite"):
+            validate_ir(result.ir)
 
 
 # ===========================================================================
@@ -2476,7 +2539,10 @@ echo step {i}
             ```
         """)
         result = parse_markdown(content)
-        assert any("Unparsed content" in w.message and "Inputs" in w.message for w in result.warnings)
+        orphan_warnings = [w for w in result.warnings if "Unparsed content" in w.message and "Inputs" in w.message]
+        assert orphan_warnings
+        assert orphan_warnings[0].severity is Severity.INFO
+        assert orphan_warnings[0].source == "parser"
         # Workflow still parses correctly
         assert "message" in result.ir["inputs"]
 
@@ -2513,7 +2579,10 @@ echo step {i}
             ```
         """)
         result = parse_markdown(content)
-        assert any("Unparsed content" in w.message and "Inputs" in w.message for w in result.warnings)
+        orphan_warnings = [w for w in result.warnings if "Unparsed content" in w.message and "Inputs" in w.message]
+        assert orphan_warnings
+        assert orphan_warnings[0].severity is Severity.INFO
+        assert orphan_warnings[0].source == "parser"
 
     def test_no_orphan_detection_for_unknown_sections(self) -> None:
         """Content under unknown ## sections does not trigger orphan warnings."""

--- a/tests/test_core/test_node_retry.py
+++ b/tests/test_core/test_node_retry.py
@@ -1,0 +1,102 @@
+"""Tests for core node retry semantics."""
+
+from unittest.mock import patch
+
+from pflow.core.exceptions import LLMTransientError
+from pflow.core.node import Node
+
+
+class _AlwaysFailNode(Node):
+    def __init__(self, exc: Exception, *, max_retries: int = 3, wait: float = 0.0, backoff: str = "fixed") -> None:
+        super().__init__(max_retries=max_retries, wait=wait, backoff=backoff)
+        self.exc = exc
+        self.attempts = 0
+        self.fallback_exc: Exception | None = None
+
+    def exec(self, prep_res: object) -> object:
+        self.attempts += 1
+        raise self.exc
+
+    def exec_fallback(self, prep_res: object, exc: Exception) -> str:
+        self.fallback_exc = exc
+        return "fallback"
+
+
+class _DeterministicError(Exception):
+    retriable = False
+
+
+def test_plain_exception_retries_to_max_retries() -> None:
+    exc = Exception("temporary")
+    node = _AlwaysFailNode(exc, max_retries=3, wait=0)
+
+    assert node._exec(None) == "fallback"
+
+    assert node.attempts == 3
+    assert node.fallback_exc is exc
+
+
+def test_llm_transient_error_retries_to_max_retries() -> None:
+    exc = LLMTransientError("rate limit", model="openai/gpt-4o-mini", kind="rate_limit")
+    node = _AlwaysFailNode(exc, max_retries=3, wait=0)
+
+    assert node._exec(None) == "fallback"
+
+    assert node.attempts == 3
+    assert node.fallback_exc is exc
+
+
+def test_retriable_false_short_circuits_without_sleeping() -> None:
+    exc = _DeterministicError("bad config")
+    node = _AlwaysFailNode(exc, max_retries=3, wait=10)
+
+    with patch("pflow.core.node.time.sleep") as sleep:
+        assert node._exec(None) == "fallback"
+
+    assert node.attempts == 1
+    assert node.fallback_exc is exc
+    sleep.assert_not_called()
+
+
+def test_retry_delay_fixed_backoff_returns_wait() -> None:
+    node = _AlwaysFailNode(Exception("temporary"), wait=2.5, backoff="fixed")
+    node.cur_retry = 3
+
+    assert node._retry_delay() == 2.5
+
+
+def test_retry_delay_exponential_backoff_uses_current_retry() -> None:
+    node = _AlwaysFailNode(Exception("temporary"), wait=0.5, backoff="exponential")
+    node.cur_retry = 3
+
+    assert node._retry_delay() == 4.0
+
+
+def test_retry_delay_exponential_backoff_clamps_at_sixty_seconds() -> None:
+    node = _AlwaysFailNode(Exception("temporary"), wait=10.0, backoff="exponential")
+    node.cur_retry = 10
+
+    assert node._retry_delay() == 60.0
+
+
+def test_exponential_backoff_sleeps_between_attempts_only() -> None:
+    exc = Exception("temporary")
+    node = _AlwaysFailNode(exc, max_retries=3, wait=0.5, backoff="exponential")
+
+    with patch("pflow.core.node.time.sleep") as sleep:
+        assert node._exec(None) == "fallback"
+
+    assert node.attempts == 3
+    assert node.fallback_exc is exc
+    assert [call.args[0] for call in sleep.call_args_list] == [0.5, 1.0]
+
+
+def test_final_attempt_does_not_sleep() -> None:
+    exc = Exception("temporary")
+    node = _AlwaysFailNode(exc, max_retries=1, wait=10)
+
+    with patch("pflow.core.node.time.sleep") as sleep:
+        assert node._exec(None) == "fallback"
+
+    assert node.attempts == 1
+    sleep.assert_not_called()

--- a/tests/test_execution/test_on_error_recovery.py
+++ b/tests/test_execution/test_on_error_recovery.py
@@ -7,7 +7,7 @@ exercise the full pipeline: engine step 17.5 → mark_node_failed →
 __warnings__ → _determine_status → _extract_runtime_warnings.
 """
 
-from pflow.core.diagnostic import Severity
+from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.core.workflow.status import WorkflowStatus
 from pflow.execution.result import RunnerConfig
 from pflow.execution.runner import WorkflowRunner
@@ -192,18 +192,26 @@ def test_api_warning_not_classified_as_recovery():
 
 def test_sub_workflow_recovery_classified_correctly_without_failures():
     """When a child sub-workflow recovers via on-error, __warnings__ propagates
-    to the parent but __failures__ stays in child scope. The cross-reference
-    fails — fall back to message pattern detection."""
+    to the parent as a producer-built Diagnostic while __failures__ stays in
+    child scope."""
     runner = WorkflowRunner()
+    recovery_warning = Diagnostic(
+        severity=Severity.WARNING,
+        message="Node 'child-node' failed \u2014 on-error \u2192 'handler'",
+        node_id="child-node",
+        source="runtime",
+        context={"type": "on_error_recovery", "category": "node_action_error"},
+    )
     shared = {
         "__warnings__": {
-            "child-node": "Node 'child-node' failed \u2014 on-error \u2192 'handler'",
+            "child-node": recovery_warning,
         },
         # No __failures__ entry — child's __failures__ didn't propagate
     }
     diagnostics = runner._extract_runtime_warnings(shared)
 
     recovery_diags = [d for d in diagnostics if d.context and d.context.get("type") == "on_error_recovery"]
-    assert len(recovery_diags) == 1, f"Sub-workflow recovery should be detected via message pattern, got: {diagnostics}"
+    assert len(recovery_diags) == 1, f"Sub-workflow recovery should preserve propagated Diagnostic, got: {diagnostics}"
     assert recovery_diags[0].node_id == "child-node"
+    assert recovery_diags[0].context.get("category") == "node_action_error"
     assert not recovery_diags[0].suggestions, "Recovery diagnostic should have no suggestions"

--- a/tests/test_execution/test_runner.py
+++ b/tests/test_execution/test_runner.py
@@ -76,6 +76,39 @@ def test_successful_workflow_runs_through_full_pipeline():
     assert result.metrics is not None
 
 
+def test_parser_section_typo_is_info_and_non_degrading_end_to_end(tmp_path: Path):
+    workflow_path = tmp_path / "typo.pflow.md"
+    workflow_path.write_text(
+        "# Typo\n\n"
+        "## Input\n\n"
+        "### api-key\n\n"
+        "Unused input typo.\n\n"
+        "- type: string\n\n"
+        "## Steps\n\n"
+        "### echo\n\n"
+        "Echo hello.\n\n"
+        "- type: shell\n"
+        "- cache: false\n"
+        "- command: echo hello\n",
+        encoding="utf-8",
+    )
+
+    result = WorkflowRunner().run(str(workflow_path), {}, RunnerConfig())
+
+    assert result.success is True
+    assert result.status == WorkflowStatus.SUCCESS
+    parser_advisories = [
+        diagnostic
+        for diagnostic in result.diagnostics
+        if diagnostic.source == "parser" and "## Input" in diagnostic.message
+    ]
+    assert len(parser_advisories) == 1
+    assert parser_advisories[0].severity is Severity.INFO
+
+    assert result.trace is not None
+    assert result.trace.execution_warnings[0]["severity"] == "info"
+
+
 def test_llm_structured_warning_survives_runner_pipeline(mock_llm_client):
     """E2E: structured LLM warnings render as text and preserve context.
 
@@ -800,7 +833,7 @@ def test_child_parser_warning_survives_prep_failure(tmp_path: Path):
     parser_warnings = [
         diagnostic
         for diagnostic in result.diagnostics
-        if diagnostic.severity == Severity.WARNING and diagnostic.source == "parser"
+        if diagnostic.severity == Severity.INFO and diagnostic.source == "parser"
     ]
     assert len(parser_warnings) == 1
     assert "## Input" in parser_warnings[0].message
@@ -839,7 +872,7 @@ def test_sibling_child_parser_warnings_not_collapsed_by_dedup(tmp_path: Path):
 
     result = WorkflowRunner().run(str(parent), {}, RunnerConfig())
 
-    parser_warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING and d.source == "parser"]
+    parser_warnings = [d for d in result.diagnostics if d.severity == Severity.INFO and d.source == "parser"]
     # Both children's parser warnings must survive — not collapsed by dedup
     assert len(parser_warnings) == 2, (
         f"Expected 2 parser warnings (one per child), got {len(parser_warnings)}: "
@@ -1205,6 +1238,34 @@ class TestDetermineStatusSeverity:
         success, status = self._run_status(warnings_dict={"n": self._warning()})
         assert success is True
         assert status == WorkflowStatus.DEGRADED
+
+    def test_parser_warning_diagnostic_is_success(self):
+        success, status = self._run_status(
+            warnings_dict={
+                "n": Diagnostic(
+                    severity=Severity.WARNING,
+                    source="parser",
+                    message="definition advisory",
+                    node_id="n",
+                )
+            }
+        )
+        assert success is True
+        assert status == WorkflowStatus.SUCCESS
+
+    def test_validator_warning_diagnostic_is_success(self):
+        success, status = self._run_status(
+            warnings_dict={
+                "n": Diagnostic(
+                    severity=Severity.WARNING,
+                    source="validator",
+                    message="definition advisory",
+                    node_id="n",
+                )
+            }
+        )
+        assert success is True
+        assert status == WorkflowStatus.SUCCESS
 
     def test_error_severity_diagnostic_is_degraded(self):
         """ERROR severity in __warnings__ also flips DEGRADED — only INFO is

--- a/tests/test_mcp_server/test_execution_workflow.py
+++ b/tests/test_mcp_server/test_execution_workflow.py
@@ -84,6 +84,30 @@ class TestExecuteWorkflowSuccess:
         assert "Workflow output:" in result, "Success output should include the workflow output header"
         assert "hello" in result, "Success output should include the workflow output value"
 
+    def test_file_workflow_surfaces_parser_info_advisory(self, tmp_path):
+        workflow_path = tmp_path / "typo.pflow.md"
+        workflow_path.write_text(
+            "# Typo\n\n"
+            "## Input\n\n"
+            "### api-key\n\n"
+            "Unused typo.\n\n"
+            "- type: string\n\n"
+            "## Steps\n\n"
+            "### echo\n\n"
+            "Echo hello.\n\n"
+            "- type: shell\n"
+            "- cache: false\n"
+            "- command: echo hello\n",
+            encoding="utf-8",
+        )
+
+        result = ExecutionService.execute_workflow(str(workflow_path))
+
+        assert "Workflow completed" in result
+        assert "Advisories:" in result
+        assert "## Input" in result
+        assert "## Inputs" in result
+
     def test_library_workflow_returns_success_string(self, isolate_pflow_config):
         """When given a saved workflow name, execute_workflow resolves it
         from the library and returns a success string."""
@@ -137,6 +161,31 @@ class TestExecuteWorkflowErrors:
 
         with pytest.raises(RuntimeError):
             ExecutionService.execute_workflow(str(workflow_path))
+
+    def test_failure_surfaces_parser_info_advisory(self, tmp_path):
+        workflow_path = tmp_path / "fail-with-typo.pflow.md"
+        workflow_path.write_text(
+            "# Typo Failure\n\n"
+            "## Input\n\n"
+            "### api-key\n\n"
+            "Unused typo.\n\n"
+            "- type: string\n\n"
+            "## Steps\n\n"
+            "### fail\n\n"
+            "Fail intentionally.\n\n"
+            "- type: shell\n"
+            "- cache: false\n"
+            "- command: exit 1\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            ExecutionService.execute_workflow(str(workflow_path))
+
+        text = str(exc_info.value)
+        assert "Advisories:" in text
+        assert "## Input" in text
+        assert "## Inputs" in text
 
     def test_large_batch_failure_text_uses_compact_item_summary(self, tmp_path):
         workflow_path = tmp_path / "large-batch-fail.pflow.md"

--- a/tests/test_mcp_server/test_validation_service.py
+++ b/tests/test_mcp_server/test_validation_service.py
@@ -192,6 +192,36 @@ class TestValidationCorrectBehavior:
         assert "## Input" in result
         assert "## Inputs" in result
 
+    def test_invalid_markdown_surfaces_parser_info_advisory(self, tmp_path):
+        """A FAILED validation still separates parser INFO advisories under 'Advisories:'.
+
+        The validate failure branch must mirror the success branch (and the CLI):
+        parser/validator advisories go under a dedicated 'Advisories:' section, not
+        bundled with warnings. Regression guard for the across-error-surfaces
+        consistency fix (#471 review).
+        """
+        workflow_path = tmp_path / "typo-and-error.pflow.md"
+        workflow_path.write_text(
+            "# Typo And Error\n\n"
+            "## Input\n\n"  # parser typo -> INFO advisory
+            "### api-key\n\n"
+            "Unused typo.\n\n"
+            "- type: string\n\n"
+            "## Steps\n\n"
+            "### echo\n\n"
+            "Echo something.\n\n"
+            "- type: shell\n"
+            "- cache: false\n"
+            "- command: echo ${nonexistent.stdout}\n",  # undefined ref -> validation ERROR
+            encoding="utf-8",
+        )
+
+        result = ExecutionService.validate_workflow(str(workflow_path))
+
+        assert not result.startswith("✓ Workflow is valid")
+        assert "Advisories:" in result
+        assert "## Input" in result and "## Inputs" in result
+
     def test_accepts_workflow_with_valid_templates(self):
         """Valid template variables should pass."""
         workflow = {

--- a/tests/test_mcp_server/test_validation_service.py
+++ b/tests/test_mcp_server/test_validation_service.py
@@ -167,6 +167,31 @@ class TestValidationCorrectBehavior:
         # Minimal success message (token-efficient), may include cache lint warnings
         assert result.startswith("✓ Workflow is valid")
 
+    def test_valid_markdown_surfaces_parser_info_advisory(self, tmp_path):
+        """MCP validation should mirror CLI validate-only for parser INFO advisories."""
+        workflow_path = tmp_path / "typo.pflow.md"
+        workflow_path.write_text(
+            "# Typo\n\n"
+            "## Input\n\n"
+            "### api-key\n\n"
+            "Unused typo.\n\n"
+            "- type: string\n\n"
+            "## Steps\n\n"
+            "### echo\n\n"
+            "Echo hello.\n\n"
+            "- type: shell\n"
+            "- cache: false\n"
+            "- command: echo hello\n",
+            encoding="utf-8",
+        )
+
+        result = ExecutionService.validate_workflow(str(workflow_path))
+
+        assert result.startswith("✓ Workflow is valid")
+        assert "Advisories:" in result
+        assert "## Input" in result
+        assert "## Inputs" in result
+
     def test_accepts_workflow_with_valid_templates(self):
         """Valid template variables should pass."""
         workflow = {

--- a/tests/test_nodes/test_file/test_file_retry.py
+++ b/tests/test_nodes/test_file/test_file_retry.py
@@ -304,19 +304,7 @@ class TestFileNodeRetryBehavior:
             pass
 
     def test_configuration_errors_vs_transient_errors_behave_differently(self):
-        """Test that retry mechanism is properly activated for different error types.
-
-        BEHAVIOR: Verifies that retry mechanism triggers for both config and system errors.
-
-        FIX HISTORY:
-        - Replaced flaky timing comparison with behavior-based assertions
-        - Discovered that NonRetriableError still triggers retries (implementation issue)
-        - Simplified to focus on retry behavior verification without timing comparisons
-        - Uses attempt counting to confirm retry mechanism activation
-
-        LESSON LEARNED: Current implementation retries NonRetriableError despite intention.
-        This test verifies retry behavior works as currently implemented.
-        """
+        """Configuration errors fail fast while transient system errors retry."""
         # Test 1: Configuration error (directory instead of file)
         node1 = CopyFileNode()
         node1.wait = 0  # Speed up tests by removing retry delays
@@ -329,10 +317,13 @@ class TestFileNodeRetryBehavior:
 
             node1.set_params({"source_path": source_path, "dest_path": dest_path})
             shared = {}
-            action = node1.run(shared)
+            with patch.object(node1, "exec", wraps=node1.exec) as exec_spy:
+                action = node1.run(shared)
 
             # BEHAVIOR: Configuration errors should fail with descriptive message
             assert action == "error"
+            assert exec_spy.call_count == 1
+            assert shared["error"].startswith("Error: ")
             assert "file" in shared["error"].lower()  # Mentions file requirement
             assert (
                 "not a file" in shared["error"]

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -14,6 +14,7 @@ The core behavior under test:
 
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -579,6 +580,71 @@ class TestErrorHandling:
         assert error["item"] == large_item
         assert error["item_summary"]["label"] == "oversized-item"
         assert "PAYLOAD-START" not in error["item_summary"]["summary"]
+
+    def test_non_retriable_exception_is_fatal_without_batch_retries(self):
+        """retriable=False exceptions propagate instead of becoming per-item errors."""
+
+        class DeterministicBatchError(Exception):
+            retriable = False
+
+        attempts = 0
+
+        def execute_single_fn(node, config, item_shared):
+            nonlocal attempts
+            attempts += 1
+            raise DeterministicBatchError("invalid item config")
+
+        shared: dict = {"data": ["bad"]}
+
+        with (
+            patch("pflow.runtime.engine.batch_executor.time.sleep") as sleep,
+            pytest.raises(DeterministicBatchError, match="invalid item config"),
+        ):
+            _run_batch(
+                MockInnerNode("test_node"),
+                shared,
+                error_handling="continue",
+                max_retries=3,
+                retry_wait=10,
+                execute_single_fn=execute_single_fn,
+            )
+
+        assert attempts == 1
+        assert "test_node" not in shared
+        sleep.assert_not_called()
+
+    def test_parallel_non_retriable_exception_is_fatal_without_batch_retries(self):
+        """Parallel futures must not convert retriable=False exceptions into item errors."""
+
+        class DeterministicBatchError(Exception):
+            retriable = False
+
+        attempts = 0
+
+        def execute_single_fn(node, config, item_shared):
+            nonlocal attempts
+            attempts += 1
+            raise DeterministicBatchError("invalid item config")
+
+        shared: dict = {"data": ["bad"]}
+
+        with (
+            patch("pflow.runtime.engine.batch_executor.time.sleep") as sleep,
+            pytest.raises(DeterministicBatchError, match="invalid item config"),
+        ):
+            _run_batch(
+                MockInnerNode("test_node"),
+                shared,
+                error_handling="continue",
+                parallel=True,
+                max_retries=3,
+                retry_wait=10,
+                execute_single_fn=execute_single_fn,
+            )
+
+        assert attempts == 1
+        assert "test_node" not in shared
+        sleep.assert_not_called()
 
     def test_parallel_executor_error_records_item_summary_and_full_item(self):
         """Parallel future-level exceptions use the same batch error shape."""

--- a/tests/test_runtime/test_memoization_integration.py
+++ b/tests/test_runtime/test_memoization_integration.py
@@ -11,6 +11,9 @@ after the shim was deprecated (Task 135/138).
 
 from typing import Any
 
+import pytest
+
+from pflow.core.diagnostic import Diagnostic, Severity, warning_degrades_status
 from pflow.runtime.cache import MemoizationCache
 
 # ---------------------------------------------------------------------------
@@ -268,6 +271,69 @@ def test_memo_cache_rehydrates_node_warning(tmp_path: Any) -> None:
 
     assert replay_shared["review"] == {"result": "raw text", "_schema_error": warning["text"]}
     assert replay_shared["__warnings__"]["review"] == warning
+
+
+@pytest.mark.parametrize(
+    ("severity", "degrades"),
+    [(Severity.WARNING, True), (Severity.INFO, False)],
+)
+def test_memo_cache_round_trips_diagnostic_warning(
+    tmp_path: Any,
+    severity: Severity,
+    degrades: bool,
+) -> None:
+    """Diagnostic warnings keep severity/message/source through SQLite memo cache."""
+    from pflow.runtime.engine.instrumentation import apply_memo_hit, write_memo_cache
+
+    cache = MemoizationCache(db_path=tmp_path / f"{severity.value}.db")
+    warning = Diagnostic(
+        severity=severity,
+        message=f"{severity.value} diagnostic",
+        title="Cached Diagnostic",
+        suggestions=["Inspect the cached warning."],
+        node_id="review",
+        source="runtime",
+        context={"type": "on_error_recovery", "category": "shell_failure"},
+        id=f"test.{severity.value}",
+    )
+    shared = {
+        "__memoization_cache__": cache,
+        "__warnings__": {"review": warning},
+        "_pflow_workflow_file": "workflow.pflow.md",
+        "review": {"result": "raw text"},
+    }
+
+    write_memo_cache(
+        "review",
+        shared,
+        "cache-key",
+        node_type_name="ShellNode",
+    )
+    cached = cache.get("cache-key")
+    assert cached is not None
+    cached_action, cached_output = cached
+    assert isinstance(cached_output["__pflow_warnings__"], dict)
+    assert cached_output["__pflow_warnings__"]["severity"] == severity.value
+    assert cached_output["__pflow_warnings__"]["message"] == warning.message
+
+    replay_shared: dict[str, Any] = {}
+    apply_memo_hit(
+        "review",
+        replay_shared,
+        cached_action,
+        cached_output,
+        "config-hash",
+        node_type_name="ShellNode",
+    )
+
+    replay_warning = replay_shared["__warnings__"]["review"]
+    assert isinstance(replay_warning, Diagnostic)
+    assert replay_warning.severity is severity
+    assert replay_warning.message == warning.message
+    assert replay_warning.source == "runtime"
+    assert replay_warning.id == warning.id
+    assert warning_degrades_status(replay_warning) is degrades
+    assert replay_shared["review"] == {"result": "raw text"}
 
 
 def test_memo_cache_no_write_on_error(tmp_path: Any) -> None:

--- a/tests/test_runtime/test_node_state.py
+++ b/tests/test_runtime/test_node_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.runtime.node_state import (
     FAILURE_CATEGORY_API_WARNING,
     FAILURE_CATEGORY_EXCEPTION,
@@ -201,3 +202,25 @@ class TestClearNodeFailure:
 
         assert "flaky" not in shared["__failures__"]
         assert "flaky" not in shared["__warnings__"]
+
+    def test_preserves_diagnostic_warning_only_in_warnings_channel(self):
+        """Structured warnings stay structured in __warnings__ for runner consumers."""
+        warning = Diagnostic(
+            severity=Severity.WARNING,
+            message="Node 'flaky' failed \u2014 on-error \u2192 'handler'",
+            node_id="flaky",
+            source="runtime",
+            context={"type": "on_error_recovery", "category": FAILURE_CATEGORY_SHELL},
+        )
+        shared: dict = {"__execution__": {}, "flaky": {"error": "boom"}}
+
+        mark_node_failed(
+            shared,
+            "flaky",
+            category=FAILURE_CATEGORY_SHELL,
+            error="boom",
+            warning=warning,
+        )
+
+        assert shared["__warnings__"]["flaky"] is warning
+        assert "warning" not in shared["__failures__"]["flaky"]

--- a/tests/test_runtime/test_only_snapshot.py
+++ b/tests/test_runtime/test_only_snapshot.py
@@ -384,6 +384,23 @@ def test_degraded_trace_with_info_only_reports_success(tmp_path: Path) -> None:
     assert status == "success"
 
 
+@pytest.mark.parametrize("source", ["parser", "validator"])
+def test_degraded_trace_with_definition_warning_reports_success(tmp_path: Path, source: str) -> None:
+    """Parser/validator WARNING dicts are definition advisories, not degraded runtime data."""
+    wf = f"ir-hash:degraded-{source}"
+    _write_trace(
+        tmp_path,
+        wf,
+        timestamp="20260101-000000",
+        final_status="degraded",
+        warnings=[{"severity": "warning", "source": source, "message": f"{source} advisory"}],
+    )
+    loaded = load_full_run_events(wf, debug_dir=tmp_path)
+    assert loaded is not None
+    _nodes, status = loaded
+    assert status == "success"
+
+
 def test_degraded_trace_without_warnings_stays_degraded(tmp_path: Path) -> None:
     """Fail-safe: a degraded trace with NO usable warning detail must NOT downgrade to
     success. We can't prove it lost no data, so the advisory still fires (PR #459 CODEX-3)."""

--- a/tests/test_runtime/test_retry_config.py
+++ b/tests/test_runtime/test_retry_config.py
@@ -1,0 +1,296 @@
+"""Compiler and runtime coverage for top-level node ``retry:`` config."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pflow.core.exceptions import CompilationError
+from pflow.core.node import BaseNode, Node
+from pflow.registry import Registry
+from pflow.runtime.cache import MemoizationCache
+from pflow.runtime.compilation.compiler import compile_workflow
+from pflow.runtime.engine import WorkflowEngine
+
+
+class RetryProbeNode(Node):
+    def __init__(self) -> None:
+        super().__init__(max_retries=4, wait=1.25)
+
+    def prep(self, shared: dict[str, Any]) -> Any:
+        return self.params.get("value")
+
+    def exec(self, prep_res: Any) -> Any:
+        return prep_res
+
+    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+        shared["result"] = exec_res
+        return "default"
+
+
+class RetryOnceNode(Node):
+    def __init__(self) -> None:
+        super().__init__(max_retries=1, wait=0)
+        self.attempts = 0
+
+    def prep(self, shared: dict[str, Any]) -> Any:
+        return self.params.get("value")
+
+    def exec(self, prep_res: Any) -> Any:
+        self.attempts += 1
+        if self.attempts == 1:
+            raise RuntimeError("transient")
+        return prep_res
+
+    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+        shared["result"] = exec_res
+        shared["attempts"] = self.attempts
+        return "default"
+
+
+class ValueNode(Node):
+    def prep(self, shared: dict[str, Any]) -> Any:
+        return self.params.get("value")
+
+    def exec(self, prep_res: Any) -> Any:
+        return prep_res
+
+    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+        shared["result"] = exec_res
+        return "default"
+
+
+class BaseOnlyNode(BaseNode):
+    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+        shared["result"] = exec_res
+        return "default"
+
+
+@pytest.fixture
+def retry_registry() -> Registry:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        registry = Registry(Path(tmpdir) / "registry.json")
+        module = "tests.test_runtime.test_retry_config"
+        registry.save({
+            "retry-probe": {
+                "module": module,
+                "class_name": "RetryProbeNode",
+                "type": "core",
+                "interface": {
+                    "params": [{"name": "value", "type": "any"}],
+                    "outputs": [{"name": "result", "type": "any"}],
+                },
+            },
+            "retry-once": {
+                "module": module,
+                "class_name": "RetryOnceNode",
+                "type": "core",
+                "interface": {
+                    "params": [{"name": "value", "type": "any"}],
+                    "outputs": [{"name": "result", "type": "any"}, {"name": "attempts", "type": "integer"}],
+                },
+            },
+            "value-node": {
+                "module": module,
+                "class_name": "ValueNode",
+                "type": "core",
+                "interface": {
+                    "params": [{"name": "value", "type": "any"}],
+                    "outputs": [{"name": "result", "type": "any"}],
+                },
+            },
+            "base-only": {
+                "module": module,
+                "class_name": "BaseOnlyNode",
+                "type": "core",
+                "interface": {
+                    "params": [{"name": "value", "type": "any"}],
+                    "outputs": [{"name": "result", "type": "any"}],
+                },
+            },
+        })
+        yield registry
+
+
+def _single_node_ir(*, retry: Any | None = None) -> dict[str, Any]:
+    node: dict[str, Any] = {"id": "step", "type": "retry-probe", "params": {"value": "ok"}}
+    if retry is not None:
+        node["retry"] = retry
+    return {"ir_version": "0.1.0", "nodes": [node], "edges": []}
+
+
+def test_retry_overrides_node_type_default(retry_registry: Registry) -> None:
+    compiled = compile_workflow(
+        _single_node_ir(retry={"max": 2, "wait": 0.5, "backoff": "exponential"}), retry_registry
+    )
+    node = compiled.start_node
+
+    assert node.__class__.__name__ == "RetryProbeNode"
+    assert node.max_retries == 2
+    assert node.wait == 0.5
+    assert node.backoff == "exponential"
+
+
+def test_omitted_retry_preserves_node_type_default(retry_registry: Registry) -> None:
+    compiled = compile_workflow(_single_node_ir(), retry_registry)
+    node = compiled.start_node
+
+    assert node.__class__.__name__ == "RetryProbeNode"
+    assert node.max_retries == 4
+    assert node.wait == 1.25
+    assert node.backoff == "fixed"
+
+
+def test_retry_backoff_only_preserves_default_budget(retry_registry: Registry) -> None:
+    compiled = compile_workflow(_single_node_ir(retry={"backoff": "exponential"}), retry_registry)
+    node = compiled.start_node
+
+    assert node.__class__.__name__ == "RetryProbeNode"
+    assert node.max_retries == 4
+    assert node.wait == 1.25
+    assert node.backoff == "exponential"
+
+
+def test_retry_on_non_node_instance_compiles_without_mutating(retry_registry: Registry) -> None:
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [{"id": "step", "type": "base-only", "params": {"value": "ok"}, "retry": {"max": 3}}],
+        "edges": [],
+    }
+
+    compiled = compile_workflow(ir, retry_registry)
+
+    assert compiled.start_node.__class__.__name__ == "BaseOnlyNode"
+    assert not hasattr(compiled.start_node, "max_retries")
+
+
+@pytest.mark.parametrize(
+    "retry",
+    [
+        [],
+        {"max": 0},
+        {"max": 11},
+        {"max": 1.9},
+        {"max": "2"},
+        {"max": True},
+        {"wait": -0.1},
+        {"wait": True},
+        {"wait": float("inf")},
+        {"wait": float("nan")},
+        {"backoff": "linear"},
+        {"max": 2, "jitter": True},
+    ],
+)
+def test_invalid_retry_config_rejected_on_direct_compile(retry_registry: Registry, retry: Any) -> None:
+    with pytest.raises(CompilationError, match="retry"):
+        compile_workflow(_single_node_ir(retry=retry), retry_registry)
+
+
+def test_invalid_retry_config_rejected_on_non_node_instance(retry_registry: Registry) -> None:
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "step",
+                "type": "base-only",
+                "params": {"value": "ok"},
+                "retry": {"max": 0, "backoff": "linear", "jitter": True},
+            }
+        ],
+        "edges": [],
+    }
+
+    with pytest.raises(CompilationError, match="retry"):
+        compile_workflow(ir, retry_registry)
+
+
+def test_retry_on_workflow_node_compiles_without_mutating(retry_registry: Registry) -> None:
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "child", "type": "workflow", "params": {"workflow": "child-flow"}, "retry": {"max": 3}},
+        ],
+        "edges": [],
+    }
+
+    compiled = compile_workflow(ir, retry_registry)
+
+    assert compiled.start_node.__class__.__name__ == "WorkflowExecutor"
+    assert not hasattr(compiled.start_node, "max_retries")
+
+
+def test_invalid_retry_config_rejected_on_workflow_node(retry_registry: Registry) -> None:
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "child", "type": "workflow", "params": {"workflow": "child-flow"}, "retry": {"backoff": "linear"}},
+        ],
+        "edges": [],
+    }
+
+    with pytest.raises(CompilationError, match="retry"):
+        compile_workflow(ir, retry_registry)
+
+
+def test_retry_config_does_not_change_memo_cache_key(tmp_path: Path) -> None:
+    cache = MemoizationCache(db_path=tmp_path / "cache.db")
+    tracking_file = tmp_path / "attempts.txt"
+
+    def ir_with_retry(retry: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "tracked",
+                    "type": "shell",
+                    "cache": True,
+                    "params": {"command": f"echo executed >> {tracking_file}"},
+                    "retry": retry,
+                },
+            ],
+            "edges": [],
+        }
+
+    registry = Registry()
+    first = compile_workflow(ir_with_retry({"max": 1}), registry)
+    first_shared: dict[str, Any] = {"__memoization_cache__": cache}
+    first_shared.update(first.resolved_defaults)
+    WorkflowEngine().run(first, first_shared)
+
+    assert tracking_file.read_text().count("executed") == 1
+
+    second = compile_workflow(ir_with_retry({"max": 3, "wait": 0.25, "backoff": "exponential"}), registry)
+    second_shared: dict[str, Any] = {"__memoization_cache__": cache}
+    second_shared.update(second.resolved_defaults)
+    WorkflowEngine().run(second, second_shared)
+
+    assert tracking_file.read_text().count("executed") == 1
+    assert second_shared["tracked"] == first_shared["tracked"]
+
+
+def test_parallel_batch_workers_inherit_retry_budget(retry_registry: Registry) -> None:
+    ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "source", "type": "value-node", "params": {"value": [1, 2, 3]}},
+            {
+                "id": "batch",
+                "type": "retry-once",
+                "params": {"value": "${item}"},
+                "retry": {"max": 2},
+                "batch": {"items": "${source.result}", "parallel": True, "max_concurrent": 3},
+            },
+        ],
+        "edges": [{"from": "source", "to": "batch"}],
+    }
+    compiled = compile_workflow(ir, retry_registry)
+    shared: dict[str, Any] = dict(compiled.resolved_defaults)
+
+    WorkflowEngine().run(compiled, shared)
+
+    assert shared["batch"]["success_count"] == 3
+    assert [result["attempts"] for result in shared["batch"]["results"]] == [2, 2, 2]
+    assert [result["result"] for result in shared["batch"]["results"]] == [1, 2, 3]

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor.py
@@ -213,7 +213,7 @@ class TestWorkflowExecutor:
         assert isinstance(parser_diagnostics, list)
         assert len(parser_diagnostics) == 1
         diagnostic = parser_diagnostics[0]
-        assert diagnostic.severity == Severity.WARNING
+        assert diagnostic.severity == Severity.INFO
         assert diagnostic.source == "parser"
         assert "## Input" in diagnostic.message
 

--- a/tests/test_runtime/test_workflow_trace.py
+++ b/tests/test_runtime/test_workflow_trace.py
@@ -541,7 +541,7 @@ class TestWorkflowTraceCollector:
             )
             collector.set_warnings([
                 Diagnostic(
-                    severity=Severity.WARNING,
+                    severity=Severity.INFO,
                     message="Line 3: '## Input' looks like a typo for '## Inputs'.",
                     source="parser",
                     suggestions=["Rename to '## Inputs'."],
@@ -555,6 +555,32 @@ class TestWorkflowTraceCollector:
 
             assert trace_data["final_status"] == "success"
             assert trace_data["warnings"][0]["source"] == "parser"
+
+    @pytest.mark.parametrize("source", ["parser", "validator"])
+    def test_final_status_success_with_definition_warning_dict(self, collector, temp_home, source):
+        """Dict-shaped parser/validator WARNINGs are definition advisories, not runtime degradation."""
+        with patch("pathlib.Path.home", return_value=temp_home):
+            collector.record_node_execution(
+                node_id="node-1",
+                node_type="TestNode",
+                duration_ms=10.0,
+                success=True,
+            )
+            collector.set_warnings([
+                {
+                    "severity": "warning",
+                    "source": source,
+                    "message": f"{source} advisory",
+                }
+            ])
+
+            filepath = collector.save_to_file()
+
+            with open(filepath) as f:
+                trace_data = json.load(f)
+
+            assert trace_data["final_status"] == "success"
+            assert trace_data["warnings"][0]["source"] == source
 
     def test_final_status_degraded_with_runtime_warning(self, collector, temp_home):
         """Runtime warnings should still mark the trace as degraded."""
@@ -582,6 +608,41 @@ class TestWorkflowTraceCollector:
 
             assert trace_data["final_status"] == "degraded"
             assert trace_data["warnings"][0]["source"] == "runtime"
+
+    def test_final_status_degraded_with_on_error_recovery(self, collector, temp_home):
+        """Recovered error-route failures should be degraded, not failed."""
+        with patch("pathlib.Path.home", return_value=temp_home):
+            collector.record_node_execution(
+                node_id="fail",
+                node_type="ShellNode",
+                duration_ms=10.0,
+                success=False,
+                error="exit 1",
+            )
+            collector.record_node_execution(
+                node_id="recover",
+                node_type="ShellNode",
+                duration_ms=10.0,
+                success=True,
+            )
+            collector.set_warnings([
+                Diagnostic(
+                    severity=Severity.WARNING,
+                    message="Node 'fail' failed \u2014 on-error \u2192 'recover'",
+                    node_id="fail",
+                    source="runtime",
+                    context={"type": "on_error_recovery", "category": "shell_failure"},
+                )
+            ])
+
+            filepath = collector.save_to_file()
+
+            with open(filepath) as f:
+                trace_data = json.load(f)
+
+            assert trace_data["final_status"] == "degraded"
+            assert trace_data["nodes_failed"] == 0
+            assert trace_data["failed_node_ids"] == []
 
     def test_llm_summary_in_trace(self, collector, temp_home):
         """Test that LLM summary is included when LLM calls are present in events.


### PR DESCRIPTION
## Summary

Makes pflow's error/resilience model first-class and internally consistent. Three things, shipped as commits B → C → A:

- **Settable node-level `retry:` with exponential backoff** (was: retry hardcoded per node type, author-settable only via `batch:`).
- **A real `NonRetriableError` short-circuit** (was: a documented-but-no-op marker — deterministic validation failures were retried anyway).
- **A unified run-status model** so on-error recovery, parser/validator advisories, and cached warnings are classified the same way across the runner, trace, CLI, and MCP surfaces (was: two divergent status authorities).

Fixes #471

## Changes

**Settable retry + backoff**
- New top-level `retry:` node field — `max` (1–10, total attempts), `wait` (≥0 finite seconds), `backoff` (`fixed`|`exponential`, clamped at 60s). Applied to the node instance at compile time, so it stays out of the memo cache key and is inherited by parallel-batch deep-copies.
- Inert no-op on `workflow`/non-`Node` nodes (validated, not applied). Strict validation on both the schema and the direct `compile_workflow()` paths, including rejection of non-finite (`.inf`/`.nan`) waits.

**`NonRetriableError` short-circuit**
- Added `PflowError.retriable` (`False` on `CompilationError` and `NonRetriableError`), honored in `Node._exec` and the batch executor (sequential + parallel). Deterministic failures now fail on attempt 1 instead of burning the full retry budget — byte-identical user-facing error/action.

**Unified run-status model**
- One `warning_degrades_status()` predicate (severity **and** source) replaces the runner's severity rule and the trace layer's source-blacklist; both now agree. Fixes a bug where INFO advisories (empty-batch, loop-cap) degraded the trace.
- On-error recovery now emits a structured `Diagnostic` (removes the fragile `— on-error →` string-match), and the trace's `final_status`/`failed_node_ids` treat a recovered node as recovered — previously a recovered run reported trace `failed` while the runner said `degraded`.
- Parser advisories (section typo / unparsed content) reclassified to INFO so a clean run reads `✓ completed` + advisory instead of `⚠️ with warnings`; rendered consistently on CLI run, CLI `--validate-only`, and MCP surfaces.
- The memo cache now round-trips `Diagnostic` warnings (`to_dict`/`from_dict`), so a cached INFO advisory can't flip to degrading on a cache hit (also fixes a pre-existing live LLM-advisory cache bug).

## Explanation

pflow's bet is that the framework owns correctness-critical control flow so agents can't get it wrong. Retry/backoff and recovery-status were the one error-handling gap that was both naturally expected and not cleanly expressible. Rather than add a "recovered" status (the issue's first idea), the change leans on the primitive the codebase already has — `Diagnostic` + `Severity` — and consolidates everything onto one predicate, so "recovered-cleanly" is just SUCCESS-with-an-advisory and the two status authorities can no longer disagree. The on-error → DEGRADED default is deliberately preserved (GH #246); this PR makes the *mechanism* consistent, not the policy. 46 files, +1506/-168.

## Docs
- `docs/how-it-works/batch-processing.mdx`, `src/pflow/guide/core.md`, `src/pflow/guide/features/batch.md` — document `retry:`, the `batch.max_retries × node.max_retries` multiplication (only for re-raising nodes like http/claude), and that `retry:` does not re-run shell non-zero exits (those are `error` actions from `post()`, not raised exceptions).
- `examples/error-handling/retry-with-backoff.pflow.md`, `examples/error-handling/non-retriable-file-error.pflow.md` — runnable examples (auto-validated by `test_docs/test_example_validation.py`).
- `context/CONTEXT.md` — glossary additions: Retry, Backoff, Fallback, Degraded, Advisory.

## Testing
- `test_node_retry.py` — `_retry_delay` fixed vs exponential math + 60s clamp; no sleep after the final attempt; `retriable=False` short-circuits without sleeping; transient errors and `LLMTransientError` still retry.
- `test_retry_config.py` — strict direct-compile validation (rejects float/string/bool/non-finite/unknown-key/out-of-range); `retry:` overrides the per-type default; inert on `workflow`/non-`Node`; parallel-batch workers each inherit the retry budget; editing only `retry:` is a memo cache hit (proves retry is not in the cache key).
- `test_ir_schema_retry.py` + `test_markdown_parser.py::test_non_finite_retry_wait_from_markdown_is_rejected` — schema accept/reject incl. non-finite wait from authored markdown.
- `test_memoization_integration.py` — a `Diagnostic` warning round-trips through the SQLite memo cache (WARNING degrades, INFO does not; severity/message/source intact).
- `test_workflow_trace.py` — a recovered on-error run yields `final_status="degraded"` with `failed_node_ids=[]`; a dict-shaped parser/validator WARNING stays non-degrading.
- `test_on_error_recovery.py` — sub-workflow recovery classified via the propagated structured Diagnostic.
- `test_file_retry.py` — a `NonRetriableError` fails on attempt 1 (replaces the prior test that encoded the no-op bug as expected).
- Manual: `examples/error-handling/retry-with-backoff.pflow.md` (copy-file retried 2×, routed to on-error, completed degraded) and `non-retriable-file-error.pflow.md` (deterministic, no retry sleep); `pflow --validate-only` on a section-typo workflow renders the INFO advisory at exit 0.

## Reviews
Two multi-agent review passes (plan-stage, then staged-code). Notable defects caught and fixed: an undocumented `pool.shutdown(wait=True)` 60s abort-hang regression (reverted to `wait=False`), permissive direct-compile retry coercion + a non-finite `wait` crash hole (hardened on both schema and compile paths), and an on-error-recovery trace/runner status divergence (aligned via per-node recovery tracking).

> Note: the full `make test`/`make check` was not runnable in the dev sandbox (documented `uv`/make panic); verification used the project virtualenv. Recommend a clean `make test` + `make check` in CI before merge.