### PR TITLE
docs: fix changelog render crash + add MDX leak guard (#475)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Docs
+
+# Validate the Mintlify docs build whenever docs change. `mint validate` runs
+# the build in strict mode and exits non-zero on any warning or error, catching
+# broken config, bad OpenAPI, and MDX syntax errors before they ship.
+#
+# Note: `mint validate` does NOT catch ${...} templates that leak out of code
+# blocks (they compile to valid-but-undefined JS expressions and only crash at
+# render). That class is covered by the check-mdx-fences pre-commit hook, which
+# also runs in CI via the `quality` job in main.yml (make check).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Mintlify CLI
+        run: npm install -g mint
+
+      - name: Validate docs build
+        working-directory: docs
+        run: mint validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,14 @@ repos:
       - id: ruff
         args: [--exit-non-zero-on-fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      # Catches ${...} templates leaking out of code blocks in docs — these
+      # compile to live JS expressions and crash the page at render, a class
+      # `mint validate` does not catch. See scripts/check_mdx_fences.py.
+      - id: check-mdx-fences
+        name: check MDX for leaked templates and unclosed fences
+        entry: python3 scripts/check_mdx_fences.py
+        language: system
+        files: \.mdx$

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,7 +10,7 @@ rss: true
 
   We introduced provider-level prompt caching as a declarative workflow surface. By defining a top-level `## Cache` section and declaring chunks on your LLM nodes, prompt prefixes are cached directly at the provider level (such as Anthropic and Gemini), dramatically reducing costs and latency for repetitive system instructions and context.
 
-  ```markdown
+  ````markdown
   ## Cache
   - ttl: 5m
 
@@ -23,7 +23,7 @@ rss: true
   - type: llm
   - prompt_cache: [brief]
   - prompt: Extract features from ${input.text}
-  ```
+  ````
 
   To help discover caching opportunities, the new `pflow analyze-cache` command performs static and trace-driven analysis of your workflow. It estimates cacheable tokens, models per-call cost projections, and provides actionable, headline-led recommendations without executing live model calls.
 
@@ -50,7 +50,7 @@ rss: true
 
   We replaced Claude Code's prompt-injected and regex-extracted structured output system with native JSON Schema support using `claude_agent_sdk`'s native structured output capabilities. This ensures guaranteed schema compliance without competing system instructions or fragile string parsing.
 
-  ```markdown
+  ````markdown
   ### audit-code
   - type: claude-code
   - max_turns: 5
@@ -65,6 +65,7 @@ rss: true
         type: string
   required: [vulnerabilities]
   ```
+  ````
 
   <Note>
     Claude Code structured output failures are now treated as "soft failures." If the session fails to comply with the schema, the raw text is preserved, a `_schema_error` is set, and the run continues in a `DEGRADED` status rather than raising a hard error that aborts your workflow.

--- a/scripts/check_mdx_fences.py
+++ b/scripts/check_mdx_fences.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Catch MDX render-time bugs that `mint validate` misses.
+
+Mintlify compiles every `.mdx` page to JSX. A `${...}` template that leaks out
+of a code block becomes a *live JavaScript expression* — e.g. `${input.text}`
+compiles to the JS `input.text`, which throws `ReferenceError: input is not
+defined` when the page renders and takes the whole page down.
+
+The usual cause is a fenced example that uses the *same* backtick count as a
+code block nested inside it: the nested block's bare ``` closes the outer fence
+early, dumping the rest of the example into raw MDX prose. `mint validate` does
+not catch this — the compiled JS is syntactically valid, so the build passes;
+the error only fires at render, which `validate` never does.
+
+This script flags, per file:
+  1. `${` appearing in prose *outside* fenced and inline code — a leaked
+     template that will compile to an expression and crash the page.
+  2. A fenced code block left unclosed at end of file.
+
+Why only `${` and not every `{`: `${...}` is pflow's workflow-template syntax.
+Inside a code block it is harmless literal text; in rendered MDX prose it is
+always a leak. A bare `{...}` (e.g. `cols={2}`) is legitimate JSX in MDX, so
+flagging all braces would drown the signal in false positives.
+
+Usage:
+    python3 scripts/check_mdx_fences.py [FILE ...]
+
+With no arguments, scans every `docs/**/*.mdx`. Pre-commit passes the staged
+`.mdx` files as arguments. Exits non-zero (and prints `file:line:col` problems)
+when anything is found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A fence line: any leading whitespace, then >= 3 backticks, then an optional
+# info string. CommonMark caps fence indent at 3 spaces, but MDX indents fences
+# freely inside JSX components (<CodeGroup>, <Accordion>, <Update>) and Mintlify
+# renders them, so we allow any indent. A closing fence uses at least as many
+# backticks as its opener and never carries an info string.
+FENCE_RE = re.compile(r"^\s*(`{3,})(.*)$")
+# Inline code span: a run of backticks, content, then a matching run.
+INLINE_CODE_RE = re.compile(r"(`+)(.+?)\1")
+
+
+def _strip_inline_code(text: str) -> str:
+    """Drop inline `code` spans so ${...} inside them is not mistaken for a leak."""
+    return INLINE_CODE_RE.sub("", text)
+
+
+def check_text(text: str, path: str) -> list[str]:
+    """Return human-readable problem strings for one MDX document."""
+    problems: list[str] = []
+    lines = text.splitlines()
+
+    # Skip YAML frontmatter: a leading `---` block. Its contents are config,
+    # not rendered MDX, so ${...} there (rare) is not a render hazard.
+    start = 0
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                start = i + 1
+                break
+
+    fence_len: int | None = None  # backtick count of the open fence, else None
+    fence_open_line = 0
+    for offset, raw in enumerate(lines[start:]):
+        lineno = start + offset + 1
+        match = FENCE_RE.match(raw)
+        if fence_len is None:
+            # Outside any code block.
+            if match:
+                fence_len = len(match.group(1))
+                fence_open_line = lineno
+                continue
+            prose = _strip_inline_code(raw)
+            idx = prose.find("${")
+            if idx != -1:
+                col = raw.find("${") + 1
+                problems.append(
+                    f"{path}:{lineno}:{col}: leaked `${{...}}` template in prose — "
+                    "this compiles to a live JS expression and crashes the page at "
+                    "render (mint validate will NOT catch it). Wrap it in a code "
+                    "block; if it is already inside one, give the OUTER fence more "
+                    f"backticks than the nested block.\n    {raw.strip()}"
+                )
+        else:
+            # Inside a code block: only a bare fence at least as long as the
+            # opener closes it. A fence carrying an info string is content.
+            if match and len(match.group(1)) >= fence_len and match.group(2).strip() == "":
+                fence_len = None
+
+    if fence_len is not None:
+        problems.append(f"{path}:{fence_open_line}:1: code fence opened here is never closed.")
+
+    return problems
+
+
+def _iter_target_files(argv: list[str]) -> list[Path]:
+    if argv:
+        return [Path(a) for a in argv]
+    docs_dir = Path(__file__).resolve().parent.parent / "docs"
+    return sorted(docs_dir.rglob("*.mdx"))
+
+
+def main(argv: list[str]) -> int:
+    problems: list[str] = []
+    for path in _iter_target_files(argv):
+        if path.suffix != ".mdx" or not path.is_file():
+            continue
+        problems.extend(check_text(path.read_text(encoding="utf-8"), str(path)))
+
+    if problems:
+        print("MDX fence/leak check failed:\n", file=sys.stderr)
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        print(
+            f"\n{len(problems)} problem(s) found. See scripts/check_mdx_fences.py for why this matters.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_mdx_fences.py
+++ b/scripts/check_mdx_fences.py
@@ -46,9 +46,14 @@ FENCE_RE = re.compile(r"^\s*(`{3,})(.*)$")
 INLINE_CODE_RE = re.compile(r"(`+)(.+?)\1")
 
 
-def _strip_inline_code(text: str) -> str:
-    """Drop inline `code` spans so ${...} inside them is not mistaken for a leak."""
-    return INLINE_CODE_RE.sub("", text)
+def _blank_inline_code(text: str) -> str:
+    """Replace inline `code` spans with equal-length runs of spaces.
+
+    Blanking (rather than deleting) hides any ${...} inside inline code from
+    the leak check while keeping the string the same length as the original,
+    so a column index found here maps straight back to the source line.
+    """
+    return INLINE_CODE_RE.sub(lambda m: " " * len(m.group(0)), text)
 
 
 def check_text(text: str, path: str) -> list[str]:
@@ -76,10 +81,13 @@ def check_text(text: str, path: str) -> list[str]:
                 fence_len = len(match.group(1))
                 fence_open_line = lineno
                 continue
-            prose = _strip_inline_code(raw)
+            prose = _blank_inline_code(raw)
             idx = prose.find("${")
             if idx != -1:
-                col = raw.find("${") + 1
+                # `prose` is the same length as `raw` (inline code blanked to
+                # spaces), so this index is the true column even when an earlier
+                # ${...} sits inside inline code on the same line.
+                col = idx + 1
                 problems.append(
                     f"{path}:{lineno}:{col}: leaked `${{...}}` template in prose — "
                     "this compiles to a live JS expression and crashes the page at "

--- a/tests/test_docs/test_mdx_fences.py
+++ b/tests/test_docs/test_mdx_fences.py
@@ -1,0 +1,99 @@
+"""Tests for the MDX fence/leak linter (scripts/check_mdx_fences.py).
+
+The linter guards against `${...}` workflow templates leaking out of code
+blocks in docs. When that happens Mintlify compiles them to live JS expressions
+that throw `ReferenceError` at render and crash the page — a failure `mint
+validate` does not catch because the compiled JS is syntactically valid.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_mdx_fences.py"
+
+
+def _load_linter():
+    spec = importlib.util.spec_from_file_location("check_mdx_fences", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_linter = _load_linter()
+
+
+# The exact shape of the bug that broke the changelog: a 3-backtick outer fence
+# wrapping a nested 3-backtick block, so the nested block's bare ``` closes the
+# outer fence early and the `${input.text}` line lands in raw prose.
+BROKEN = """\
+---
+title: "T"
+---
+
+<Update label="x">
+  ```markdown
+  ## Cache
+
+  ```cache [brief]
+  ${brief}
+  ```
+
+  ### extract-features
+  - prompt: Extract features from ${input.text}
+  ```
+</Update>
+"""
+
+# Same example, fixed by giving the outer fence one extra backtick.
+FIXED = """\
+---
+title: "T"
+---
+
+<Update label="x">
+  ````markdown
+  ## Cache
+
+  ```cache [brief]
+  ${brief}
+  ```
+
+  ### extract-features
+  - prompt: Extract features from ${input.text}
+  ````
+</Update>
+
+Inline `${item}` in prose is fine, and so is JSX like `cols={2}`.
+"""
+
+
+def test_flags_leaked_template_in_prose():
+    problems = _linter.check_text(BROKEN, "broken.mdx")
+    assert problems, "linter should flag the leaked ${input.text}"
+    assert any("input.text" in p and "leaked" in p for p in problems), problems
+
+
+def test_fixed_example_is_clean():
+    assert _linter.check_text(FIXED, "fixed.mdx") == []
+
+
+def test_inline_and_jsx_braces_are_not_flagged():
+    # `${item}` inside inline code and bare JSX `{2}` must not trip the check.
+    text = "A line with `${item}` inline code and a <Columns cols={2}> tag.\n"
+    assert _linter.check_text(text, "prose.mdx") == []
+
+
+def test_unclosed_fence_is_flagged():
+    text = "intro\n\n```python\nx = 1\n"
+    problems = _linter.check_text(text, "unclosed.mdx")
+    assert any("never closed" in p for p in problems), problems
+
+
+def test_real_docs_have_no_leaks():
+    docs_dir = _REPO_ROOT / "docs"
+    problems: list[str] = []
+    for mdx in sorted(docs_dir.rglob("*.mdx")):
+        problems.extend(_linter.check_text(mdx.read_text(encoding="utf-8"), str(mdx)))
+    assert not problems, "Leaked templates / unclosed fences in docs:\n" + "\n".join(problems)

--- a/tests/test_docs/test_mdx_fences.py
+++ b/tests/test_docs/test_mdx_fences.py
@@ -91,6 +91,15 @@ def test_unclosed_fence_is_flagged():
     assert any("never closed" in p for p in problems), problems
 
 
+def test_column_points_past_inline_code_on_same_line():
+    # A line with a harmless ${...} inside inline code AND a real leak in prose.
+    # The reported column must point at the leak (col 34), not the inline one.
+    text = "Some `${inline}` and then leaked ${leak}\n"
+    problems = _linter.check_text(text, "test.mdx")
+    assert len(problems) == 1, problems
+    assert problems[0].startswith("test.mdx:1:34:"), problems[0]
+
+
 def test_real_docs_have_no_leaks():
     docs_dir = _REPO_ROOT / "docs"
     problems: list[str] = []


### PR DESCRIPTION
## Summary
The Changelog page failed to render. The May 2026 / v0.13.0 entry used 3-backtick outer fences around examples containing nested 3-backtick blocks, so the nested block's bare closing fence ended the outer fence early and leaked `${input.text}` into raw MDX — where `{input.text}` is a JSX expression that throws `ReferenceError` at render and crashes the page. This fixes the render bug and adds a guard so the class can't ship silently again.

Fixes #475

## Changes
- **Fix render crash** (`docs/changelog.mdx`): bump the two affected May 2026 examples from 3- to 4-backtick outer fences so nested ` ``` ` blocks stay as content.
- **New linter** (`scripts/check_mdx_fences.py`, stdlib-only): flags `${...}` templates leaking out of code blocks (tracking fenced + inline code spans) and unclosed fences. Reports `file:line:col` with a fix hint.
- **Pre-commit hook** (`.pre-commit-config.yaml`): `check-mdx-fences` runs on every `.mdx`; also runs in CI via the `quality` job (`make check` → `pre-commit run -a`).
- **CI** (`.github/workflows/docs.yml`): runs `mint validate` (strict build) on `docs/**` changes.
- **Tests** (`tests/test_docs/test_mdx_fences.py`): regression coverage.

## Explanation
`mint validate` does **not** catch this bug: the leaked `input.text` compiles to *syntactically valid* JS, so the strict build passes; the `ReferenceError` only fires at render, which `validate` never performs (verified empirically — reintroducing the bug still passed `mint validate` with exit 0, while `mint dev` compiled `{input.text}` into a live JS expression). So two complementary layers are needed: `mint validate` for build/config/OpenAPI/MDX-syntax errors, and `check-mdx-fences` for the leaked-expression render-crash class.

The linter allows arbitrarily-indented fences because MDX indents fences inside JSX components (`<CodeGroup>`, `<Accordion>`, `<Update>`) and Mintlify renders them — a strict 3-space CommonMark cap produced false positives on existing `<CodeGroup>` examples.

Diff: 5 files changed, 284 insertions(+), 3 deletions(-).

## Testing
- `test_flags_leaked_template_in_prose` — the exact changelog bug shape is flagged.
- `test_fixed_example_is_clean` — the 4-backtick fix passes.
- `test_inline_and_jsx_braces_are_not_flagged` — `` `${item}` `` inline code and `cols={2}` JSX don't false-positive.
- `test_unclosed_fence_is_flagged` — unterminated fences are reported.
- `test_real_docs_have_no_leaks` — guards the whole `docs/` tree going forward.
- Manual: `mint dev` renders `/changelog` cleanly (no compile errors); `mint validate` passes on current docs; pre-commit hook Passes on the tree and Fails (exit 1) on a reintroduced bug.