### PR TITLE
fix(validator): offer remove-or-add for assigned orphan code annotations (#477)

### DIFF
--- a/src/pflow/guide/nodes/code.md
+++ b/src/pflow/guide/nodes/code.md
@@ -60,6 +60,7 @@ result: dict = {
 **Code node rules:**
 - Templates go in `- inputs:` param, NEVER in the `python code` block (code is literal Python, not a template)
 - All inputs and `result` MUST have type annotations: `data: list`, `result: dict = ...`
+- The reverse also holds: a top-level `name: type` IS read as an input declaration, so do NOT annotate locals — write `total = ...`, not `total: int = ...`. Only declared inputs plus `result`/`next` take annotations.
 - Upstream JSON is auto-parsed before your code runs — if source is JSON, declare `dict`/`list` not `str`
 - Use `Any` as the type when you don't want type validation (see syntax table below — auto-injected, no import needed)
 - Single output via `result` variable — use dict for structured output
@@ -73,11 +74,18 @@ Three code-node input errors are now caught at validate time (`pflow
 1. **Input bound, annotation missing** — `inputs: {x: ${ref}}` with no `x:
    <type>` in code. The suggestion uses the upstream's declared type when
    known (`Add an annotation (in params.code): x: str  (inferred from ...)`).
-2. **Annotation declared, no input bound** — opinionated one-fix-per-case:
-   `Remove the annotation 'y: list' — it is never read in the code` for dead
-   annotations, `Add 'y' to the inputs dict` when the name is read in the
-   body, `Rename the annotation to 'items'` when a fuzzy-matched input key
-   exists (typo case).
+2. **Annotation declared, no input bound** — the fix depends on whether the
+   name is assigned in the body:
+   - **assigned** (`all_items: list = ...`) → it's a local, so removing the
+     annotation is safe. Offers both, local first: `Remove the annotation
+     'all_items: list' — '...' is assigned in the code, so it's a local
+     variable` *or* `add 'all_items' to the inputs dict` (if it was meant as
+     an input).
+   - **read but not assigned** (`y: list` + `len(y)`) → removing would leave
+     `y` unbound, so the only fix is `Add 'y' to the inputs dict` (or `Rename
+     the annotation to 'items'` for a fuzzy-matched typo).
+   - **neither read nor assigned** → dead annotation: `Remove the annotation
+     'y: list' — it is never read in the code`.
 3. **Type mismatch** — `x: dict` bound to `${upstream.result}` that declares
    `list`:
 

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -260,6 +260,47 @@ def extract_code_load_references(code: str) -> set[str]:
     return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)}
 
 
+def extract_code_assigned_names(code: str) -> set[str]:
+    """Return module-level names the author *binds to a value* in ``code``.
+
+    A declared code-node input is a **bare** annotation (``x: T``) whose value is
+    injected from ``inputs:``. A **local** carries a value — ``x: T = expr`` or a
+    plain ``x = expr``. This returns the latter set.
+
+    It distinguishes the two orphan-annotation fixes that ``extract_code_load_references``
+    alone cannot: removing an orphan annotation is only safe when the name is
+    assigned (it stays a working local); for a read-but-unassigned orphan,
+    removing would leave the name unbound at runtime, so ``inputs`` is the only fix.
+
+    Scoped to module level (skips ``def``/``class``/``lambda`` bodies) so a
+    same-named function local can't flip the decision. Bare annotations
+    (``AnnAssign`` with no value) are NOT assignments. Returns an empty set on
+    SyntaxError so callers fail-open at validate time.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return set()
+    assigned: set[str] = set()
+    boundaries = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+    stack: list[ast.AST] = list(tree.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, boundaries):
+            continue  # Don't descend into new scopes.
+        if isinstance(node, ast.AnnAssign) and node.value is not None and isinstance(node.target, ast.Name):
+            assigned.add(node.target.id)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                for sub in ast.walk(target):
+                    if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
+                        assigned.add(sub.id)
+        elif isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Name):
+            assigned.add(node.target.id)
+        stack.extend(ast.iter_child_nodes(node))
+    return assigned
+
+
 # Reverse of _PYTHON_TO_S1_CANONICAL for display in code-node diagnostics.
 # Code-block annotations speak Python, so diagnostic messages and suggestions
 # must too — otherwise a user copy-pasting "x: array" gets a NameError.

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -260,44 +260,76 @@ def extract_code_load_references(code: str) -> set[str]:
     return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)}
 
 
+def _loaded_names(node: ast.AST) -> set[str]:
+    """Names read (``ast.Load``) anywhere within ``node`` (an expression subtree)."""
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+
+
+def _stored_names(node: ast.AST) -> set[str]:
+    """Names written (``ast.Store``) anywhere within ``node`` (handles tuple/list unpack)."""
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)}
+
+
+def _top_level_bound_names(node: ast.stmt) -> set[str]:
+    """Names a single module-top-level statement *unconditionally* binds.
+
+    Returns the empty set for statements that don't establish a definite binding
+    before use — ``AugAssign``, control flow, and ``for``/``with``/comprehension
+    targets simply don't match here. See ``extract_code_assigned_names`` for the
+    full rationale.
+    """
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return {node.name}
+    if isinstance(node, ast.Assign):
+        stores: set[str] = set()
+        for target in node.targets:
+            stores |= _stored_names(target)
+        return stores - _loaded_names(node.value)  # drop read-before-write (x = x[...])
+    if isinstance(node, ast.AnnAssign) and node.value is not None and isinstance(node.target, ast.Name):
+        return {node.target.id} - _loaded_names(node.value)
+    return set()
+
+
 def extract_code_assigned_names(code: str) -> set[str]:
-    """Return module-level names the author *binds to a value* in ``code``.
+    """Return names *unconditionally bound* at module top level in ``code``.
 
     A declared code-node input is a **bare** annotation (``x: T``) whose value is
-    injected from ``inputs:``. A **local** carries a value — ``x: T = expr`` or a
-    plain ``x = expr``. This returns the latter set.
+    injected from ``inputs:``. A safely-removable **local** is one the code itself
+    binds before use. This returns the names for which removing an orphan
+    annotation is safe — i.e. the name stays bound at runtime.
 
-    It distinguishes the two orphan-annotation fixes that ``extract_code_load_references``
-    alone cannot: removing an orphan annotation is only safe when the name is
-    assigned (it stays a working local); for a read-but-unassigned orphan,
-    removing would leave the name unbound at runtime, so ``inputs`` is the only fix.
+    "Safe" means *definitely bound before use*, approximated soundly as an
+    **unconditional, top-level** binding that does not read the name in its own
+    right-hand side:
 
-    Scoped to module level (skips ``def``/``class``/``lambda`` bodies) so a
-    same-named function local can't flip the decision. Bare annotations
-    (``AnnAssign`` with no value) are NOT assignments. Returns an empty set on
-    SyntaxError so callers fail-open at validate time.
+    - ``x = expr`` / ``x: T = expr`` as a direct module statement (tuple/list
+      unpack targets included), excluding any target that is read in ``expr``
+      (``x = x[...]`` is a read-before-write, not a safe local).
+    - ``def x`` / ``async def x`` / ``class x`` — the definition binds ``x`` at
+      module scope; the name is recorded without descending into the body.
+
+    Deliberately NOT counted, because removing the annotation would (or could)
+    leave the name unbound at runtime — for these the only safe fix is to bind
+    the input:
+
+    - ``x += 1`` (``AugAssign`` reads the prior value before storing; a plain
+      ``x = ...`` earlier still counts via the rule above).
+    - bindings nested in ``if``/``for``/``while``/``with``/``try`` (conditional —
+      may not run).
+    - ``for`` targets (empty iterable → unbound), ``with ... as`` targets, and
+      comprehension/walrus targets (loop-scoped or conditional).
+
+    Erring toward "not safe" is intentional: a missed local just gets the
+    always-valid "add to inputs" suggestion instead of "remove". Returns an
+    empty set on SyntaxError so callers fail-open at validate time.
     """
     try:
         tree = ast.parse(code)
     except SyntaxError:
         return set()
     assigned: set[str] = set()
-    boundaries = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
-    stack: list[ast.AST] = list(tree.body)
-    while stack:
-        node = stack.pop()
-        if isinstance(node, boundaries):
-            continue  # Don't descend into new scopes.
-        if isinstance(node, ast.AnnAssign) and node.value is not None and isinstance(node.target, ast.Name):
-            assigned.add(node.target.id)
-        elif isinstance(node, ast.Assign):
-            for target in node.targets:
-                for sub in ast.walk(target):
-                    if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
-                        assigned.add(sub.id)
-        elif isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Name):
-            assigned.add(node.target.id)
-        stack.extend(ast.iter_child_nodes(node))
+    for node in tree.body:  # module top level only — nested bindings are conditional
+        assigned |= _top_level_bound_names(node)
     return assigned
 
 

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -257,7 +257,7 @@ def extract_code_load_references(code: str) -> set[str]:
         tree = ast.parse(code)
     except SyntaxError:
         return set()
-    return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)}
+    return _loaded_names(tree)
 
 
 def _loaded_names(node: ast.AST) -> set[str]:
@@ -284,7 +284,11 @@ def _top_level_bound_names(node: ast.stmt) -> set[str]:
         stores: set[str] = set()
         for target in node.targets:
             stores |= _stored_names(target)
-        return stores - _loaded_names(node.value)  # drop read-before-write (x = x[...])
+        # Drop read-before-write (`x = x[...]`, swaps). This also excludes a name
+        # reused as a comprehension target in its own RHS (`x = [x for x in ...]`),
+        # where the outer `x` IS bound — a false negative in the SAFE direction
+        # (yields "add to inputs" rather than an unsafe "remove").
+        return stores - _loaded_names(node.value)
     if isinstance(node, ast.AnnAssign) and node.value is not None and isinstance(node.target, ast.Name):
         return {node.target.id} - _loaded_names(node.value)
     return set()

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -462,17 +462,23 @@ def _build_orphan_code_annotation_diagnostics(
     annotation_keys: set[str],
     annotations: dict[str, str],
     load_refs: set[str],
+    assigned_names: set[str],
     batch_alias: Optional[str],
 ) -> list[Diagnostic]:
     """Build diagnostics for annotations with no matching input binding.
 
-    Chooses a canonical single-fix suggestion per orphan (Task 154 pattern):
+    The fix depends on whether the orphan name is *assigned* a value in the body,
+    because that decides which fixes are even safe:
 
-    - Orphan key appears as ``ast.Name(ctx=Load())`` in the code body → the
-      author expected the variable to be bound at runtime. Canonical fix is
-      "Add to the inputs dict". Typo-level fuzzy matches against existing
-      input keys are surfaced via ``similar_names``.
-    - Orphan key has no Load reference → dead annotation. Canonical fix is
+    - Orphan key is assigned (``x: T = ...`` / ``x = ...``) → it's a local. BOTH
+      fixes are valid: drop the annotation (it stays a working local) or, if it
+      was meant as an input, bind it. We list both, leading with the more-likely
+      local reading.
+    - Orphan key is read but never assigned (``ast.Name(ctx=Load())`` only) → the
+      author expected it bound at runtime. Removing the annotation would leave the
+      name unbound, so the only valid fix is "Add to the inputs dict" (or "Rename"
+      for a typo-level fuzzy match against an existing input key).
+    - Orphan key is neither read nor assigned → dead annotation; the fix is
       "Remove the annotation".
 
     ``batch_alias`` (when present) narrows the "add to inputs" suggestion to
@@ -485,6 +491,7 @@ def _build_orphan_code_annotation_diagnostics(
     for key in sorted(annotation_keys - input_keys):
         annotation_str = annotations[key]
         is_used = key in load_refs
+        is_assigned = key in assigned_names
         context: dict[str, Any] = {
             "category": "validation",
             "path": f"nodes[id={node_id}].params.code",
@@ -492,7 +499,21 @@ def _build_orphan_code_annotation_diagnostics(
             "annotation_key": key,
         }
 
-        if is_used:
+        if is_assigned:
+            # The author binds this name to a value, so it's a local, not an
+            # injected input. Removing the annotation is safe (it stays a working
+            # local); binding it is also valid if it was meant as an input. Offer
+            # both, local first.
+            fixes = [
+                f"Remove the annotation '{key}: {annotation_str}' — '{key}' is assigned in the code, "
+                f"so it's a local variable (only declared inputs and result/next take annotations).",
+                f"Or add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}} "
+                f"— if it's a workflow input.",
+            ]
+        elif is_used:
+            # Read but never assigned: removing the annotation would leave '{key}'
+            # unbound at runtime, so only add/rename is a valid fix.
+            #
             # Batch alias is deterministic metadata and must win over fuzzy
             # matching. Otherwise a near-miss between `item` (the alias) and
             # a user input like `items` produces "Rename to 'items'", which
@@ -501,19 +522,19 @@ def _build_orphan_code_annotation_diagnostics(
                 # The engine injects the batch alias into template resolution
                 # only — code-exec requires an explicit binding. The canonical
                 # fix is to route the alias through `inputs:` verbatim.
-                fix = (
+                fixes = [
                     f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{{key}}} "
                     f"(binds the batch alias into the code block)"
-                )
+                ]
             else:
                 similar = find_similar_items(key, sorted(input_keys), method="fuzzy", cutoff=0.6, max_results=3)
                 if similar:
-                    fix = f"Rename the annotation to '{similar[0]}' to match the existing input binding."
+                    fixes = [f"Rename the annotation to '{similar[0]}' to match the existing input binding."]
                     context["similar_names"] = similar
                 else:
-                    fix = f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}}"
+                    fixes = [f"Add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}}"]
         else:
-            fix = f"Remove the annotation '{key}: {annotation_str}' — it is never read in the code."
+            fixes = [f"Remove the annotation '{key}: {annotation_str}' — it is never read in the code."]
 
         diagnostics.append(
             Diagnostic(
@@ -522,7 +543,7 @@ def _build_orphan_code_annotation_diagnostics(
                 title="Validation Error",
                 node_id=node_id,
                 message=f"Annotation '{key}: {annotation_str}' has no corresponding entry in 'inputs'.",
-                suggestions=[fix],
+                suggestions=fixes,
                 context=context,
             )
         )
@@ -745,6 +766,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
     from pflow.nodes.python.python_code import (
         _extract_annotations,
         _get_outer_type,
+        extract_code_assigned_names,
         extract_code_load_references,
         extract_top_level_annotations,
     )
@@ -857,6 +879,9 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         # Load references disambiguate orphan annotations: a name read in the
         # body signals "add to inputs"; an unused annotation is dead code.
         load_refs = extract_code_load_references(code)
+        # Assigned names mark locals (`x: T = ...` / `x = ...`): removing their
+        # annotation is safe, so the orphan builder offers remove-or-add there.
+        assigned_names = extract_code_assigned_names(code)
         # Batch alias is used to produce a specific `${alias}` suggestion when
         # the orphan is the batch iteration variable.
         batch_cfg = node.get("batch")
@@ -869,7 +894,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         )
         diagnostics.extend(
             _build_orphan_code_annotation_diagnostics(
-                node_id, input_keys, annotation_keys, annotations, load_refs, batch_alias
+                node_id, input_keys, annotation_keys, annotations, load_refs, assigned_names, batch_alias
             )
         )
         diagnostics.extend(

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -499,11 +499,17 @@ def _build_orphan_code_annotation_diagnostics(
             "annotation_key": key,
         }
 
-        if is_assigned:
+        if is_assigned and not (batch_alias and key == batch_alias):
             # The author binds this name to a value, so it's a local, not an
             # injected input. Removing the annotation is safe (it stays a working
             # local); binding it is also valid if it was meant as an input. Offer
             # both, local first.
+            #
+            # The batch alias is excluded: it is NOT injected into code exec
+            # (only into template resolution), so removing its annotation would
+            # leave it unbound regardless of any in-code assignment. It falls
+            # through to the batch-alias branch below, which gives the exact
+            # `alias: ${alias}` binding.
             fixes = [
                 f"Remove the annotation '{key}: {annotation_str}' — '{key}' is assigned in the code, "
                 f"so it's a local variable (only declared inputs and result/next take annotations).",

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -467,12 +467,40 @@ class TestAnnotationExtractionHelper:
         assert "total" in assigned
         assert "x" not in assigned  # bare annotation, not assigned
 
-    def test_assigned_names_excludes_function_locals(self):
-        code = "def helper():\n    y: int = 1\n    z = 2\n    return y + z\nresult: int = helper()"
+    def test_assigned_names_records_def_and_class_names(self):
+        # The def statement binds the name at module scope (C2): removing an
+        # orphan annotation on it is the right fix. Function-internal locals
+        # (different scope) stay excluded.
+        code = "helper: Any\ndef helper():\n    y: int = 1\n    z = 2\n    return y + z\nresult: int = helper()"
         assigned = extract_code_assigned_names(code)
+        assert "helper" in assigned  # def name = module-level binding
         assert "result" in assigned
         assert "y" not in assigned  # function-local, different scope
         assert "z" not in assigned
+
+    def test_assigned_names_records_class_name(self):
+        code = "Config: Any\nclass Config:\n    pass\nresult: Any = Config"
+        assert "Config" in extract_code_assigned_names(code)
+
+    def test_assigned_names_excludes_conditional_assignment(self):
+        # Assignment nested in `if` may not run -> not a safe local (C1).
+        code = "items: list\nif True:\n    items = []\nresult: int = len(items)"
+        assert "items" not in extract_code_assigned_names(code)
+
+    def test_assigned_names_excludes_augmented_assignment(self):
+        # `count += 1` reads before storing -> needs a prior binding (C4).
+        code = "count: int\ncount += 1\nresult: int = count"
+        assert "count" not in extract_code_assigned_names(code)
+
+    def test_assigned_names_excludes_read_before_write(self):
+        # `x = x[...]` reads x before binding -> removing the annotation unbinds it.
+        code = "data: dict\ndata = data['x']\nresult: dict = data"
+        assert "data" not in extract_code_assigned_names(code)
+
+    def test_assigned_names_excludes_for_target(self):
+        # `for x in ...` leaves x unbound when the iterable is empty.
+        code = "x: int\nfor x in [1, 2, 3]:\n    pass\nresult: int = x"
+        assert "x" not in extract_code_assigned_names(code)
 
     def test_assigned_names_malformed_code_returns_empty(self):
         assert extract_code_assigned_names("x: dict =") == set()

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -502,6 +502,14 @@ class TestAnnotationExtractionHelper:
         code = "x: int\nfor x in [1, 2, 3]:\n    pass\nresult: int = x"
         assert "x" not in extract_code_assigned_names(code)
 
+    def test_assigned_names_comprehension_reuse_is_safe_false_negative(self):
+        # `x = [x for x in range(3)]` DOES bind the outer x, but the comprehension's
+        # `x` (Load) lands in the RHS read set, so the read-before-write guard
+        # excludes it. Documented false negative in the SAFE direction: the user
+        # gets "add to inputs", never an unsafe "remove".
+        code = "x = [x for x in range(3)]\nresult: int = len(x)"
+        assert "x" not in extract_code_assigned_names(code)
+
     def test_assigned_names_malformed_code_returns_empty(self):
         assert extract_code_assigned_names("x: dict =") == set()
 

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -15,6 +15,7 @@ from pflow.nodes.python.python_code import (
     _get_outer_type_name,
     _is_optional_type,
     extract_code_annotation_type,
+    extract_code_assigned_names,
     extract_code_load_references,
     extract_optional_input_keys,
     extract_top_level_annotations,
@@ -453,6 +454,28 @@ class TestAnnotationExtractionHelper:
 
     def test_load_references_malformed_code_returns_empty(self):
         assert extract_code_load_references("x: dict =") == set()
+
+    def test_assigned_names_annotated_local_with_value(self):
+        # `data: list` is a bare annotation (an input) — NOT assigned.
+        # `all_items: list = [...]` and `result: int = ...` carry values — assigned.
+        code = "data: list\nall_items: list = [data]\nresult: int = len(all_items)"
+        assert extract_code_assigned_names(code) == {"all_items", "result"}
+
+    def test_assigned_names_plain_assignment(self):
+        code = "x: int\ntotal = x + 1\nresult: int = total"
+        assigned = extract_code_assigned_names(code)
+        assert "total" in assigned
+        assert "x" not in assigned  # bare annotation, not assigned
+
+    def test_assigned_names_excludes_function_locals(self):
+        code = "def helper():\n    y: int = 1\n    z = 2\n    return y + z\nresult: int = helper()"
+        assigned = extract_code_assigned_names(code)
+        assert "result" in assigned
+        assert "y" not in assigned  # function-local, different scope
+        assert "z" not in assigned
+
+    def test_assigned_names_malformed_code_returns_empty(self):
+        assert extract_code_assigned_names("x: dict =") == set()
 
     def test_get_outer_type_name_unwraps_forward_ref(self):
         """Forward-ref annotations (`x: "list"`) come through as `"'list'"` via ast.unparse.

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1480,6 +1480,40 @@ class TestCodeNodeInputAnnotationValidation:
         assert any("Add 'y' to the inputs dict" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
         assert not any("Remove" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
 
+    def test_orphan_annotation_assigned_suggests_remove_or_add(self, test_registry):
+        """Orphan annotation that is ALSO assigned is a local — offer remove (lead) or add.
+
+        Removing the annotation is safe because the name carries a value, so both
+        fixes are valid. Contrast with the read-but-unassigned case above, where
+        removing would leave the name unbound and only "add" is offered.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        # all_items is annotated AND assigned -> a local, not an input.
+                        "code": "x: dict\nall_items: list = [x]\nresult: int = len(all_items)",
+                        "inputs": {"x": "literal_value"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        annotation_errors = [
+            d for d in errors if "has no corresponding entry in 'inputs'" in d.message and "all_items" in d.message
+        ]
+        assert len(annotation_errors) == 1
+        suggestions = annotation_errors[0].suggestions or []
+        # Both fixes present...
+        assert any("Remove the annotation 'all_items" in s and "local variable" in s for s in suggestions), suggestions
+        assert any("add 'all_items' to the inputs dict" in s.lower() for s in suggestions), suggestions
+        # ...and the local reading leads.
+        assert "Remove" in suggestions[0], suggestions
+
     def test_orphan_annotation_typo_surfaces_fuzzy_match(self, test_registry):
         """Typo'd orphan (read in body) surfaces fuzzy-matched input key via similar_names."""
         workflow_ir = {

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1514,6 +1514,93 @@ class TestCodeNodeInputAnnotationValidation:
         # ...and the local reading leads.
         assert "Remove" in suggestions[0], suggestions
 
+    def test_orphan_annotation_conditional_assignment_is_not_safe_local(self, test_registry):
+        """Orphan assigned only inside `if` may be unbound at runtime — add, don't lead with remove (C1)."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "items: list\nif True:\n    items = []\nresult: int = len(items)",
+                        "inputs": {},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann = [d for d in errors if "Annotation 'items: list'" in d.message]
+        assert len(ann) == 1, [d.message for d in errors]
+        suggestions = ann[0].suggestions or []
+        assert any("Add 'items' to the inputs dict" in s for s in suggestions), suggestions
+        assert not any("local variable" in s for s in suggestions), suggestions
+
+    def test_orphan_annotation_augmented_assignment_is_not_safe_local(self, test_registry):
+        """`count += 1` reads before storing, so removing the annotation unbinds it — add, not remove (C4)."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "count: int\ncount += 1\nresult: int = count",
+                        "inputs": {},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann = [d for d in errors if "Annotation 'count: int'" in d.message]
+        assert len(ann) == 1, [d.message for d in errors]
+        suggestions = ann[0].suggestions or []
+        assert any("Add 'count' to the inputs dict" in s for s in suggestions), suggestions
+        assert not any("local variable" in s for s in suggestions), suggestions
+
+    def test_orphan_annotation_on_def_name_suggests_remove(self, test_registry):
+        """A def name is a module-level local binding — removing the orphan annotation is right (C2)."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "consumer",
+                    "type": "code",
+                    "params": {
+                        "code": "helper: Any\ndef helper():\n    return 1\nresult: int = helper()",
+                        "inputs": {},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann = [d for d in errors if "Annotation 'helper: Any'" in d.message]
+        assert len(ann) == 1, [d.message for d in errors]
+        suggestions = ann[0].suggestions or []
+        assert any("Remove the annotation 'helper" in s and "local variable" in s for s in suggestions), suggestions
+        assert "Remove" in suggestions[0], suggestions
+
+    def test_orphan_batch_alias_assigned_preserves_alias_suggestion(self, test_registry):
+        """An assigned batch alias still needs `item: ${item}` — the alias isn't injected into exec (C3)."""
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "batched",
+                    "type": "code",
+                    "params": {"code": "item: dict\nitem = {'k': 1}\nresult: dict = item"},
+                    "batch": {"items": [1, 2, 3]},  # default alias = "item"
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        ann = [d for d in errors if "Annotation 'item: dict'" in d.message]
+        assert len(ann) == 1, [d.message for d in errors]
+        suggestions = ann[0].suggestions or []
+        # Batch alias keeps its exact binding, not the remove-local lead.
+        assert any("item: ${item}" in s for s in suggestions), suggestions
+        assert not any("local variable" in s for s in suggestions), suggestions
+
     def test_orphan_annotation_typo_surfaces_fuzzy_match(self, test_registry):
         """Typo'd orphan (read in body) surfaces fuzzy-matched input key via similar_names."""
         workflow_ir = {


### PR DESCRIPTION
## Summary

In a `code` node a top-level annotation declares an input. An annotated **local** that carries a value (e.g. `all_items: list = [...]`) was flagged as an orphan whose only suggested fix was "Add to inputs" — the wrong fix for a local. The validator now uses whether the name is *assigned* to decide which fixes are safe to offer.

Fixes #477

## Changes

- **`extract_code_assigned_names()`** (`nodes/python/python_code.py`) — module-level names bound to a value (`x: T = …` / `x = …`), skipping `def`/`class`/`lambda` scopes. Bare annotations (`x: T`) are NOT assignments.
- **`_build_orphan_code_annotation_diagnostics`** (`runtime/template_validation/type_validation.py`) now branches on whether the orphan is assigned:
  - **assigned** → offer remove (local) **or** add (input), local-first
  - **read but unassigned** → add/rename only (removing would leave the name unbound)
  - **neither** → remove (dead annotation)
- **`guide/nodes/code.md`** — documents the three-way fix and the reverse rule: a top-level `name: type` *is* an input declaration, so don't annotate locals.

## Explanation

The prior heuristic chose the fix from a single signal — is the name read (`ast.Load`)? — so it couldn't distinguish an accidentally-annotated local from a forgotten input binding, and pointed the wrong way for the former. Assignment is the missing signal: removing an annotation is only safe when the name carries a value, which is exactly the case where *both* fixes are valid. (5 files, +151/−20.)

## Testing

- `test_assigned_names_annotated_local_with_value`, `_plain_assignment`, `_excludes_function_locals`, `_malformed_code_returns_empty` — the new helper
- `test_orphan_annotation_assigned_suggests_remove_or_add` — assigned orphan offers both fixes, remove leads
- Existing `test_orphan_annotation_used_suggests_adding_to_inputs` and `_unused_suggests_removal` unchanged and still pass (read-but-unassigned and dead cases preserved)
- Full suite: `make test` → 7653 passed, 1 skipped; `make check` → ruff, mypy (229 files), deptry all clean
- Manual: `--validate-only` on the repro now prints remove-or-add, local-first