### PR TITLE
feat: render `loop:` nodes in `pflow visualize` — ⟳ badge + self-edge (#452)

### DIFF
--- a/.taskmaster/tasks/task_155/starting-context/braindump-loop-rendering-and-155-implications.md
+++ b/.taskmaster/tasks/task_155/starting-context/braindump-loop-rendering-and-155-implications.md
@@ -1,0 +1,156 @@
+# Braindump: loop rendering in mermaid — done, and what it hands to Task 155
+
+**Date:** 2026-06-06. This replaces a formal plan doc (the user asked for a braindump instead — they
+don't want plan docs lingering once the work is done). The fix described is **implemented + verified +
+uncommitted**. This is the tacit layer; the durable payload is "What this hands to 155" below.
+
+## Where this came from (the journey — not in any file)
+
+This is a **leaf of a much bigger thread.** The master narrative is
+`scratchpads/handoff-see-control-storage/session-progress-log.md` — read it first. The user opened with
+*"Task 125 (HITL) vs Task 155 (graph model → visual UI), leading into a visual UI"* and the load-bearing
+quote that recurs everywhere: **"It's very hard for me as a human user to understand how this agentic
+workflow actually works and I NEED to have full control."** They're building Task 163 (a plan→code
+agentic harness — a *tree* of `.pflow.md` sub-workflows) and can't SEE or CONTROL it.
+
+The path to this loop fix:
+1. Dissolved "125 vs 155" → orthogonal substrates (155 = SEE/static; 125 = CONTROL/runtime), not competing.
+2. Rendered the harness as Mermaid → the intelligence lives in the **prompts** (truncated in mermaid); the
+   highest-value UI feature is **click-node → read-prompt**.
+3. User asked: can we visualize the six workflow patterns (`src/pflow/guide/features/patterns.md`:
+   classify, fan-out, adversarial-verify, generate-filter, tournament, loop-until-done) **without the
+   trace**? → Yes: *structure* is static; only the chosen-path highlight, dynamic fan width, and tournament
+   unrolling need the trace.
+4. **The user caught that `loop:` might not render** (*"im unsure if loops works in visualize right now
+   since we just implemented it"*). They were right. That triggered this fix.
+5. User's instinct: mermaid is a dead-end for loops; *"using react flow we can probably come up with
+   something great?"* → Yes — and that is exactly 155's thesis (one semantic model, many renderers).
+
+**This loop fix is the first actual code in the whole strategic thread.** It is deliberately a tiny,
+near-throwaway *honesty* fix; the real value is (a) informing 155 and (b) the react-flow direction.
+
+## The fix is DONE — don't re-explain it, read the code
+
+`make check` clean; full mermaid/visualize suite (92) green; **zero existing-golden regressions** (verified:
+no golden renders a loop workflow). Files (uncommitted — user commits, never the agent):
+`mermaid/_context.py` (`_loop_label` + `_strip_template`), `_render.py` (2 append sites + a `loop` param on
+`_render_subgraph`), `__init__.py` (re-export), `tests/test_core/test_mermaid.py` (13 tests), new golden
+`tests/test_core/golden_mermaid/stateful-loop-tournament.mmd` + its parametrize entry.
+
+Mechanic worth holding in your head: **a looped node has NO edge in the graph** (the engine self-re-enters
+in place), so the renderer *synthesizes* a label badge `⟳ while <cond> · ≤N · carry <keys>` from
+`node.get("loop")`. Single node → badge on the node; sub-workflow node → badge on the subgraph title.
+
+## The multinode finding (the user's specific question — the durable insight)
+
+They asked: *"let me know if you find any way to handle loops with multinode bodies for mermaid."* There are
+**three** structurally-different loop shapes, and the clean multinode path already exists:
+
+1. `loop:` on a **single node** → body = 1 node → badge on node. Trivial.
+2. **`loop:` on a sub-workflow node → body = the whole sub-workflow, which is ALREADY a subgraph box →
+   badge on the box. This is the legible multinode answer; nothing new structurally.** (The tournament's
+   `run-rounds`. Verified: `loop:` is legal on ALL node types — no allowlist.)
+3. **Hand-wired backward-edge cycle** across siblings (the harness group loop:
+   `group-tick → implement-chunk → check-groups`) → already renders as a visible back-edge; containerizing
+   needs SCC/cycle detection → NOT minimal → out of scope.
+
+**The convergence (tell the user — they like this framing):** declarative `loop:` (single OR sub-workflow)
+= renderable/containerizable; hand-wired cycle = back-edge-only → another reason to **prefer `loop:`**, and
+a reason the harness's group loop could be refactored into a `loop:`-on-a-sub-workflow (which would also
+make it containerizable in react-flow).
+
+## What this hands to Task 155 (the REAL payload — why we did it)
+
+When 155 extracts the GraphModel:
+- **The node record needs an optional first-class `loop` field** — `{polarity (while|until), condition ref,
+  cap (literal int | template), carry map}`. Keep it a **node property, NOT an edge** — mirror the engine
+  (it creates no edge; a loop is evaluated at the re-entry seam).
+- **The loop-on-subgraph case must be representable** so react-flow draws a collapsible **container**
+  ("repeats while X · ≤N" box) and mermaid draws the **badge** — from the *same* model. **The loop is the
+  single strongest demonstration of 155's "one semantic model, many renderers" thesis**: it's where
+  renderer quality diverges most (mermaid: ugly badge/back-edge; react-flow: great container). Get the loop
+  right in the model and both renderers win.
+- `_loop_label` is the throwaway *location* of a durable *decision* (what a loop carries + how it surfaces);
+  155 relocates it from the renderer into `build_graph` (model) + render split.
+- `carry:` as data-flow-style edges (`contenders ← survivors`) = deferred renderer concern; flag known-future.
+- Hand-wired cycle containerization (SCC detection) = out of scope for the minimal fix AND 155's first cut,
+  but the model should not *preclude* it.
+
+## The react-flow direction (a parallel fork — important context)
+
+A forked agent built a self-contained react-flow mockup proving the "great" version:
+`scratchpads/handoff-see-control-storage/loop-containers-mockup.html` + screenshot
+`loop-containers-final.png`. It renders **both** harness loops as collapsible first-class containers (the
+hand-wired group loop AND the declarative review loop get identical treatment — the point being mermaid can
+render *neither* well). That is the visual target 155 → the UI should hit. The user wants, verbatim: *"run
+in a react server locally on demand using something like react flow,"* *"clicking to read prompts."*
+(Side effect of that fork: it ran `pflow mcp sync chrome-devtools`, registering 29 chrome-devtools tools in
+the local registry.)
+
+## User's mental model & working style (as it showed up in THIS thread)
+
+- **Reasons from PROPERTIES not categories.** "Is this static or runtime? a node property or an edge?" wins.
+- **"why is X?" / "im unsure if X works" is a CATCH, not a question.** This thread they caught (a) that I'd
+  conflated hand-wired back-edge loops (which DO render) with declarative `loop:` (which did NOT) — I had
+  wrongly claimed "loops render statically"; (b) the loop-invisibility itself. **Verify, concede, don't
+  defend.** Right both times.
+- **They corrected a misread that matters:** when they said *"this will help the 155 task to understand this
+  needs to be handled,"* I wrote a plan doc. They meant **implement now** — *"I meant for us to implement
+  this right now, did you not agree with that or why put it in task 155?"* **When this user says a fix
+  "helps 155," they mean DO the fix — the doing is what helps — not write a plan for later.**
+- **Prioritizes simplicity of the FINAL code; elegance earned; prove the cheap path first; solve OBSERVED
+  (not theorized) problems.** The loop fix is exactly that: an observed gap, the cheap honest fix (label
+  badge, no new edges), beauty deferred to react-flow.
+- **NEVER commit/push without explicit instruction** (hard repo rule; an auto-stage hook stages writes).
+
+## Assumptions & uncertainties
+
+- **Open micro-decision (badge format).** I shipped `⟳ while result.continue · ≤ max_review_rounds` (strip
+  `${}`, strip the leading `<node_id>.` self-prefix). For `review-round` the condition is
+  `${review-round.result.continue}` → renders `result.continue` — slightly verbose (I'd shown plain
+  `continue` in an earlier mockup). **The user has NOT explicitly signed off on the final format.** They may
+  want `.result` also stripped, or the badge on its own `<br/>` line vs inline. All trivially tweakable in
+  `_loop_label`.
+- **NEEDS VERIFICATION:** I only string-grepped the badge lines — I did NOT render the full harness on
+  mermaid.live after the fix. The mermaid `CLAUDE.md` explicitly warns "string-level assertions can pass
+  while the rendered diagram is broken." The badge is a low-risk label append, but a visual check is the
+  documented standard for rendering changes.
+- **ASSUMPTION:** batch + loop are mutually exclusive (verified `data_flow.py:580-581`), so I did not handle
+  a `dynamic_batch_label` + loop-badge collision in `_render_node`. If that validation ever loosens, that
+  interaction is untested.
+
+## Verified facts worth keeping (hard-won — a ~100k-token searcher pass; don't re-derive)
+
+- `loop:` is a **top-level node field** `node["loop"]` (sibling to batch/retry/cache), raw dict keys
+  `while`/`until`/`carry`/`max_iterations`. Parser `markdown_parser.py:1187-1190`, `:1600`; schema
+  `ir_schema.py:147-196`, attached `:252`.
+- Compiled form: `LoopConfig` dataclass `runtime/engine/types.py:38-53` (attrs differ from IR keys:
+  `while_template`/`until_template`/`max_iterations`/`max_iterations_template`/`carry`), on
+  `NodeConfig.loop_config:71`; built `compilation/compiler.py:389-444`.
+- **Exactly one of while/until required** (polarity) — `core/workflow/loop_validation.py:6-18`.
+- **NO node-type allowlist** for `loop:` — valid on `workflow` nodes (the tournament). Only forbidden
+  *combos*: loop+batch, loop+`enable_namespacing:false`, loop+`storage_mode:shared` (`data_flow.py:546-589`).
+- **A looped node is a SINGLE self-re-entering node — NO graph edge** (`engine.py:573-617`,
+  `_loop_should_reenter:712-761`). This is *why* it was invisible and *why* a label (not an edge) is right.
+- `${__iteration__}` = reserved shared key, 1-based, template-accessible (`core/types.py:218-227`).
+- Task 166 (carry+until) merged to `main` via `b5dc37ff`; the loop skeleton (while/max_iterations) predates
+  it (Task 162 / #445). Branch `feat/declarative-stateful-loop` is **stale** (behind main) — target `main`.
+
+## For the next agent (likely picking up Task 155 itself)
+
+- **Start by** reading `session-progress-log.md` (master) → this → `task-155.md` +
+  `braindump-static-substrate-for-visual-ui.md`.
+- **The loop fix is DONE and is your concrete reference** for what the GraphModel must carry for loops. Read
+  `_loop_label` + the two append sites in `_render.py`; they ARE the "what a loop looks like" decision,
+  ready to relocate into `build_graph`.
+- **Use the react-flow mockup** (`scratchpads/handoff-see-control-storage/loop-containers-mockup.html`) as
+  the visual target AND the 155 acceptance check — the spec's "throwaway react-flow sketch" should render
+  the six workflow patterns (incl. both loop shapes) from the GraphModel.
+- **The user's real priority** is SEEING + CONTROLLING the Task 163 harness. 155 is the SEE substrate; this
+  loop fix is a tiny down-payment that proves the renderer-divergence thesis.
+
+> **Note to next agent**: Read this document fully before taking any action. When ready, confirm you've read
+> and understood by summarizing the key points — especially (1) the three loop shapes and the
+> loop-on-subgraph = clean-multinode finding, (2) what 155 must carry (a first-class loop **node property**,
+> loop-on-subgraph representable, the loop as the strongest multi-renderer demonstration), (3) the loop fix
+> is done/verified/uncommitted, (4) the react-flow mockup is the visual target — then state you're ready.

--- a/src/pflow/core/workflow/mermaid/CLAUDE.md
+++ b/src/pflow/core/workflow/mermaid/CLAUDE.md
@@ -25,7 +25,7 @@ Consumers: `cli/commands/visualize.py`, `tests/test_core/test_mermaid.py`, `test
 
 ```
 mermaid/
-├── __init__.py    # Re-exports generate_mermaid + 5 test-visible helpers
+├── __init__.py    # Re-exports generate_mermaid + 6 test-visible helpers
 ├── _context.py    # MermaidConfig (frozen), MermaidContext (mutable), constants, pure utilities
 ├── _scope.py      # Scope — single primitive for template-ref → mermaid-ID resolution
 ├── _edges.py      # Edge dedup/detection, routing resolution, data-flow edge generation
@@ -69,7 +69,7 @@ mermaid/
 | `_connect_sources_to_output` | `_io.py` | Parse source expression → connect producing nodes to output |
 | `MermaidConfig` | `_context.py` | Frozen config dataclass (resolve_child, max_depth, etc.) |
 | `MermaidContext` | `_context.py` | Mutable per-level state (routing maps, indent, prefix) |
-| Pure utilities (11) | `_context.py` | `_to_mermaid_id`, `_escape_label`, `_get_node_shape`, `_format_label`, `_first_sentence`, `_classdef_to_style`, `_subgraph_style`, `_get_item_label`, `_dynamic_batch_label`, `_format_node_type`, `_render_classdefs` |
+| Pure utilities (13) | `_context.py` | `_to_mermaid_id`, `_escape_label`, `_get_node_shape`, `_format_label`, `_first_sentence`, `_classdef_to_style`, `_subgraph_style`, `_get_item_label`, `_dynamic_batch_label`, `_format_node_type`, `_render_classdefs`, `_strip_template`, `_loop_label` |
 
 ## Two Kinds of Edges
 

--- a/src/pflow/core/workflow/mermaid/__init__.py
+++ b/src/pflow/core/workflow/mermaid/__init__.py
@@ -3,6 +3,7 @@
 from pflow.core.workflow.mermaid._context import (
     _first_sentence,
     _get_item_label,
+    _loop_label,
 )
 from pflow.core.workflow.mermaid._edges import (
     _deduplicate_edges,
@@ -17,5 +18,6 @@ __all__ = [
     "_find_terminal_nodes",
     "_first_sentence",
     "_get_item_label",
+    "_loop_label",
     "generate_mermaid",
 ]

--- a/src/pflow/core/workflow/mermaid/_context.py
+++ b/src/pflow/core/workflow/mermaid/_context.py
@@ -178,9 +178,11 @@ def _format_label(
 ) -> str:
     """Format the full display label for a node.
 
-    The loop badge is placed BEFORE the description: mermaid clips multi-line
-    subgraph titles after ~2 lines, so a loop pushed below a description would
-    be hidden. Loop is structural metadata (like the type), so it reads well
+    The loop badge is placed BEFORE the description for consistency with
+    subgraph titles, which mermaid clips after ~2 lines — a badge pushed below
+    a description there would be hidden (see ``_render_subgraph``). Node labels
+    don't clip, but keeping the order identical means both label builders share
+    one rule. Loop is structural metadata (like the type), so it reads well
     directly under the name/type anyway.
 
     The batch suffix (e.g., ``(parallel x|sources|)``) is appended AFTER

--- a/src/pflow/core/workflow/mermaid/_context.py
+++ b/src/pflow/core/workflow/mermaid/_context.py
@@ -174,18 +174,25 @@ def _format_label(
     descriptions: bool,
     purpose: str,
     batch_suffix: str = "",
+    loop: Optional[dict[str, Any]] = None,
 ) -> str:
     """Format the full display label for a node.
+
+    The loop badge is placed BEFORE the description: mermaid clips multi-line
+    subgraph titles after ~2 lines, so a loop pushed below a description would
+    be hidden. Loop is structural metadata (like the type), so it reads well
+    directly under the name/type anyway.
 
     The batch suffix (e.g., ``(parallel x|sources|)``) is appended AFTER
     escaping because it contains ``|`` delimiters that must be preserved
     in ``@{ shape: procs }`` labels.
     """
     display_type = _format_node_type(node_type)
-    label = f"{node_id} ({display_type})"
+    label = _escape_label(f"{node_id} ({display_type})")
+    if loop:
+        label += _loop_label(loop, node_id)
     if descriptions and purpose:
-        label += f"<br/>{_first_sentence(purpose)}"
-    label = _escape_label(label)
+        label += f"<br/>{_escape_label(_first_sentence(purpose))}"
     if batch_suffix:
         label += f"<br/>{batch_suffix}"
     return label
@@ -255,6 +262,63 @@ def _dynamic_batch_label(batch: Optional[dict[str, Any]]) -> str:
     source_name = refs[0][0] if refs else "N"
     parallel_prefix = "parallel " if batch.get("parallel", False) else ""
     return f" ({parallel_prefix}x|{source_name}|)"
+
+
+def _strip_template(ref: Any) -> str:
+    """Strip a single ``${...}`` wrapper to its inner expression for display.
+
+    Leaves non-template strings untouched. Does not parse the inner expression
+    (it may be any ``${.+}`` content — a path, a coalesce, an index).
+    """
+    if not isinstance(ref, str):
+        return ""
+    s = ref.strip()
+    if s.startswith("${") and s.endswith("}"):
+        return s[2:-1].strip()
+    return s
+
+
+def _loop_label(loop: dict[str, Any], node_id: str) -> str:
+    """Return a loop suffix like ``<br/>⟳ while result.continue · ≤ 10`` for a ``loop:`` config.
+
+    A looped node re-enters itself in place — the engine creates NO graph edge for the
+    iteration (it is a node property, evaluated at the engine's re-entry seam) — so the loop
+    is invisible unless surfaced on the node/subgraph label. This renders the polarity
+    (``while``/``until``), the gating condition, the iteration cap, and a marker for carried
+    state. Returns ``""`` when there is no usable loop config.
+
+    The condition's leading ``<node_id>.`` is stripped for readability: a loop condition refers
+    to the node's own fresh output, so the self-prefix is noise (``${run-rounds.more}`` ->
+    ``more``). A non-self-referential condition is left intact (the prefix simply won't match).
+    """
+    if not isinstance(loop, dict):
+        return ""
+    # Exactly one of while/until is required by validation; be defensive if neither is present.
+    if "until" in loop:
+        polarity, raw_cond = "until", loop.get("until")
+    elif "while" in loop:
+        polarity, raw_cond = "while", loop.get("while")
+    else:
+        return ""
+
+    cond = _strip_template(raw_cond)
+    if cond.startswith(f"{node_id}."):
+        cond = cond[len(node_id) + 1 :]
+    badge = f"⟳ {polarity} {cond}".rstrip()
+
+    cap = loop.get("max_iterations")
+    if isinstance(cap, bool):
+        pass  # bool is an int subclass; a loop cap is never a bool — ignore.
+    elif isinstance(cap, int):
+        badge += f" · ≤ {cap}"
+    elif isinstance(cap, str) and cap.strip():
+        badge += f" · ≤ {_strip_template(cap)}"
+
+    carry = loop.get("carry")
+    if isinstance(carry, dict) and carry:
+        badge += f" · carry {', '.join(carry)}"
+
+    return f"<br/>{_escape_label(badge)}"
 
 
 def _render_classdefs(ctx: MermaidContext) -> None:

--- a/src/pflow/core/workflow/mermaid/_render.py
+++ b/src/pflow/core/workflow/mermaid/_render.py
@@ -16,6 +16,7 @@ from pflow.core.workflow.mermaid._context import (
     _format_node_type,
     _get_item_label,
     _get_node_shape,
+    _loop_label,
     _render_classdefs,
     _subgraph_style,
     _to_mermaid_id,
@@ -130,6 +131,16 @@ def _render_workflow(ir: dict[str, Any], ctx: MermaidContext) -> dict[str, dict[
     return ctx.outgoing_routes
 
 
+def _render_loop_self_edge(mermaid_id: str, ctx: MermaidContext) -> None:
+    """Emit a dotted self-loop arrow so a ``loop:`` node visually reads as a loop.
+
+    A looped node re-enters itself with no IR edge, so we synthesize one. Dotted
+    (``-.->``) to distinguish it from structural/data edges; marked ``⟳``. The full
+    condition / cap / carry detail lives in the node label badge (``_loop_label``).
+    """
+    ctx.lines.append(f'{ctx.indent}{mermaid_id} -.->|"⟳"| {mermaid_id}')
+
+
 def _render_node(node: dict[str, Any], ctx: MermaidContext) -> None:
     """Render a single node declaration (regular, batch, or sub-workflow)."""
     node_id = node.get("id", "unknown")
@@ -173,6 +184,7 @@ def _render_node(node: dict[str, Any], ctx: MermaidContext) -> None:
                 ctx,
                 purpose=purpose,
                 suppress_io=True,
+                loop=node.get("loop"),
             )
 
             # 3. External output wrapper (AFTER subgraph, replaces _populate_outgoing_map)
@@ -190,9 +202,13 @@ def _render_node(node: dict[str, Any], ctx: MermaidContext) -> None:
                 }
             return
 
-    # Regular node declaration
+    # Regular node declaration. A looped node re-enters itself in place (no IR edge), so surface
+    # it two ways: the loop condition as a label badge (placed BEFORE the description so it survives
+    # mermaid's subgraph-title clip), and a self-loop arrow so it visually reads as a loop.
+    # (batch + loop are mutually exclusive, so this never collides with dynamic_batch_label.)
     is_decision = node_id in ctx.decision_nodes
-    label = _format_label(node_id, node_type, ctx.config.descriptions, purpose, dynamic_batch_label)
+    loop = node.get("loop")
+    label = _format_label(node_id, node_type, ctx.config.descriptions, purpose, dynamic_batch_label, loop=loop)
 
     if dynamic_batch_label:
         # Dynamic batch: use procs (stacked rectangles) shape via @{} syntax.
@@ -203,6 +219,8 @@ def _render_node(node: dict[str, Any], ctx: MermaidContext) -> None:
     else:
         shape_open, shape_close, css_class = _get_node_shape(node_type, is_decision)
         ctx.lines.append(f'{ctx.indent}{mermaid_id}{shape_open}"{label}"{shape_close}:::{css_class}')
+    if loop:
+        _render_loop_self_edge(mermaid_id, ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -359,11 +377,16 @@ def _render_subgraph(
     ctx: MermaidContext,
     purpose: str = "",
     suppress_io: bool = False,
+    loop: Optional[dict[str, Any]] = None,
 ) -> dict[str, dict[str, str]]:
     """Render a sub-workflow as a mermaid subgraph.
 
     Returns the child's ``outgoing_routes`` so the parent can route edges
     through nested sub-workflow outputs.
+
+    When the sub-workflow node carries a ``loop:`` (the body is the whole
+    sub-workflow), the loop badge is appended to the subgraph title — the
+    multinode-body loop renders as the existing box plus a ``⟳`` annotation.
     """
     path_key = str(child_result.path) if child_result.path else None
     if path_key:
@@ -375,6 +398,8 @@ def _render_subgraph(
         subgraph_label = _escape_label(f"{node_id} ({node_type})")
     if ctx.config.descriptions and purpose:
         subgraph_label += f"<br/>{_escape_label(_first_sentence(purpose))}"
+    if loop:
+        subgraph_label += _loop_label(loop, node_id)
 
     ctx.lines.append(f'{ctx.indent}subgraph {mermaid_id} ["{subgraph_label}"]')
 
@@ -384,6 +409,9 @@ def _render_subgraph(
 
     ctx.lines.append(f"{ctx.indent}end")
     ctx.lines.append(f"{ctx.indent}{_subgraph_style(mermaid_id, ctx.current_depth + 1)}")
+    # NB: no self-loop arrow on the subgraph box — mermaid renders a subgraph self-edge as an
+    # ugly dangling line. The loop is surfaced via the title badge (`_loop_label`) instead. A
+    # single-node loop DOES get a self-edge (it renders as a clean arc); see `_render_node`.
 
     if path_key:
         ctx.seen.discard(path_key)

--- a/src/pflow/core/workflow/mermaid/_render.py
+++ b/src/pflow/core/workflow/mermaid/_render.py
@@ -387,6 +387,10 @@ def _render_subgraph(
     When the sub-workflow node carries a ``loop:`` (the body is the whole
     sub-workflow), the loop badge is appended to the subgraph title — the
     multinode-body loop renders as the existing box plus a ``⟳`` annotation.
+    The badge goes BEFORE the description: mermaid clips multi-line subgraph
+    titles after ~2 lines, so a badge pushed below a description is hidden.
+    This is the path where that clip actually bites (node labels don't clip);
+    the order mirrors ``_format_label``.
     """
     path_key = str(child_result.path) if child_result.path else None
     if path_key:
@@ -396,10 +400,10 @@ def _render_subgraph(
         subgraph_label = _escape_label(node_id) + dynamic_batch_label
     else:
         subgraph_label = _escape_label(f"{node_id} ({node_type})")
-    if ctx.config.descriptions and purpose:
-        subgraph_label += f"<br/>{_escape_label(_first_sentence(purpose))}"
     if loop:
         subgraph_label += _loop_label(loop, node_id)
+    if ctx.config.descriptions and purpose:
+        subgraph_label += f"<br/>{_escape_label(_first_sentence(purpose))}"
 
     ctx.lines.append(f'{ctx.indent}subgraph {mermaid_id} ["{subgraph_label}"]')
 

--- a/tests/test_core/golden_mermaid/stateful-loop-tournament.mmd
+++ b/tests/test_core/golden_mermaid/stateful-loop-tournament.mmd
@@ -1,0 +1,29 @@
+graph LR
+    classDef code fill:#D5E8D4,stroke:#82B366,color:#000
+    classDef llm fill:#E8D5F5,stroke:#7B2D8E,color:#000
+    classDef shell fill:#DAE8FC,stroke:#6C8EBF,color:#000
+    classDef mcp fill:#FFE6CC,stroke:#D79B00,color:#000
+    classDef writefile fill:#F8CECC,stroke:#B85450,color:#000
+    classDef workflow fill:#FFF2CC,stroke:#D6B656,color:#000
+    classDef decision fill:#F5F5F5,stroke:#666666,color:#000
+    classDef input fill:#F5F5F5,stroke:#666666,stroke-dasharray:5 5,color:#000
+    classDef output fill:#E8E8E8,stroke:#666666,color:#000
+    subgraph run-rounds-in ["run-rounds inputs"]
+        run-rounds__in_contenders[/"contenders (array)"/]:::input
+    end
+    style run-rounds-in fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
+    run-rounds__in_contenders --> run-rounds__judge
+    subgraph run-rounds ["run-rounds (workflow)<br/>⟳ while more · ≤ 10 · carry contenders"]
+        run-rounds__judge["judge (code)"]:::code
+    end
+    style run-rounds fill:#808080,fill-opacity:0.14,stroke:#999
+    subgraph run-rounds-out ["run-rounds outputs"]
+        run-rounds__out_survivors(["survivors"]):::output
+        run-rounds__out_more(["more"]):::output
+    end
+    style run-rounds-out fill:#808080,fill-opacity:0.04,stroke:#999,stroke-dasharray:4 4
+    run-rounds__judge --> run-rounds__out_survivors
+    run-rounds__judge --> run-rounds__out_more
+    announce[["announce (shell)"]]:::shell
+    run-rounds__out_survivors --> announce
+    run-rounds__out_more --> announce

--- a/tests/test_core/test_mermaid.py
+++ b/tests/test_core/test_mermaid.py
@@ -1671,3 +1671,28 @@ def test_loop_badge_precedes_description_to_survive_subgraph_clip() -> None:
     out = generate_mermaid(ir, descriptions=True)
     label_line = next(ln for ln in out.splitlines() if ln.strip().startswith("hunt["))
     assert label_line.index("⟳") < label_line.index("Keep searching")
+
+
+def test_subworkflow_loop_badge_precedes_description_in_subgraph_title() -> None:
+    # The clip that hides a single-node badge also hides a sub-workflow badge pushed below its
+    # description. The subgraph title must order the loop badge BEFORE the description, like
+    # _format_label — this is the path where mermaid's subgraph-title clip actually bites.
+    child_ir = _ir(nodes=[{"id": "judge", "type": "code", "params": {}}])
+
+    def resolver(params: dict[str, Any], base_path: Optional[Path]) -> Optional[SubWorkflowResult]:
+        return SubWorkflowResult(ir=child_ir, path=Path("/x/round.pflow.md"), warnings=())
+
+    parent_ir = _ir(
+        nodes=[
+            {
+                "id": "run-rounds",
+                "type": "workflow",
+                "params": {"workflow": "round"},
+                "purpose": "Run elimination rounds until a single winner remains.",
+                "loop": {"while": "${run-rounds.more}", "max_iterations": 10},
+            },
+        ],
+    )
+    out = generate_mermaid(parent_ir, resolve_child=resolver, descriptions=True)
+    title_line = next(ln for ln in out.splitlines() if ln.strip().startswith("subgraph run-rounds"))
+    assert title_line.index("⟳") < title_line.index("Run elimination")

--- a/tests/test_core/test_mermaid.py
+++ b/tests/test_core/test_mermaid.py
@@ -9,6 +9,7 @@ from pflow.core.workflow.mermaid import (
     _find_terminal_nodes,
     _first_sentence,
     _get_item_label,
+    _loop_label,
     generate_mermaid,
 )
 from pflow.core.workflow.sub_workflow_resolver import SubWorkflowResult
@@ -1530,3 +1531,143 @@ def test_output_source_from_input_in_subworkflow() -> None:
     # Within the sub-workflow scope, the input-root ref resolves to the
     # sub-workflow's input wrapper, not a top-level ``input_*`` node.
     assert "sub__in_data --> sub__out_echo" in out
+
+
+# ---------------------------------------------------------------------------
+# Loop rendering (`loop:` is a node property, not a graph edge — it must be
+# synthesized onto the label, else a looped node renders as a one-shot node)
+# ---------------------------------------------------------------------------
+
+
+def test_loop_label_while_strips_self_prefix_and_shows_literal_cap() -> None:
+    # The condition refers to the node's own fresh output, so the `<node_id>.`
+    # prefix is noise and is stripped; a literal cap renders as `≤ N`.
+    label = _loop_label({"while": "${run-rounds.more}", "max_iterations": 10}, "run-rounds")
+    assert label == "<br/>⟳ while more · ≤ 10"
+
+
+def test_loop_label_until_polarity() -> None:
+    label = _loop_label({"until": "${check.done}"}, "check")
+    assert label == "<br/>⟳ until done"
+
+
+def test_loop_label_template_cap_is_stripped() -> None:
+    # A `${...}` cap (resolved at runtime) renders by name, not as a raw template.
+    label = _loop_label(
+        {"while": "${review-round.result.continue}", "max_iterations": "${max_review_rounds}"},
+        "review-round",
+    )
+    assert label == "<br/>⟳ while result.continue · ≤ max_review_rounds"
+
+
+def test_loop_label_shows_carried_state_keys() -> None:
+    label = _loop_label(
+        {"while": "${r.more}", "max_iterations": 10, "carry": {"contenders": "${r.survivors}"}},
+        "r",
+    )
+    assert label == "<br/>⟳ while more · ≤ 10 · carry contenders"
+
+
+def test_loop_label_no_cap_omits_bound() -> None:
+    # max_iterations is optional; when absent the cap defaults to MAX_NODE_VISITS
+    # at runtime — not meaningful to display, so no `≤` is shown.
+    assert _loop_label({"while": "${r.go}"}, "r") == "<br/>⟳ while go"
+
+
+def test_loop_label_non_self_condition_left_intact() -> None:
+    # The prefix strip only fires for a self-referential condition; a condition on
+    # another node's output is shown whole.
+    assert _loop_label({"while": "${other.flag}"}, "r") == "<br/>⟳ while other.flag"
+
+
+def test_loop_label_bool_cap_ignored() -> None:
+    # bool is an int subclass; a loop cap is never a bool. Guard against rendering `≤ True`.
+    assert _loop_label({"while": "${r.go}", "max_iterations": True}, "r") == "<br/>⟳ while go"
+
+
+def test_loop_label_defensive_on_empty_and_malformed() -> None:
+    assert _loop_label({}, "r") == ""  # neither while nor until
+    assert _loop_label({"max_iterations": 5}, "r") == ""  # no polarity
+    assert _loop_label("not-a-dict", "r") == ""  # type: ignore[arg-type]
+
+
+def test_loop_label_escapes_special_chars() -> None:
+    # Pipes/quotes in a (pathological) carried key must not break mermaid label syntax.
+    label = _loop_label({"while": "${r.go}", "carry": {"a|b": "${r.x}"}}, "r")
+    assert "|" not in label.split("<br/>")[1]  # raw pipe escaped to &#124;
+    assert "&#124;" in label
+
+
+def test_loop_renders_on_single_node_label() -> None:
+    # End-to-end: a node carrying `loop:` surfaces the badge in the rendered graph.
+    ir = _ir(
+        nodes=[
+            {
+                "id": "hunt",
+                "type": "llm",
+                "params": {"prompt": "find a flaky failure"},
+                "loop": {"until": "${hunt.found}", "max_iterations": 20},
+            },
+        ],
+    )
+    out = generate_mermaid(ir)
+    assert "hunt (llm)<br/>⟳ until found · ≤ 20" in out
+
+
+def test_loop_renders_on_subworkflow_subgraph_title() -> None:
+    # `loop:` on a sub-workflow node (multinode body) badges the subgraph title.
+    child_ir = _ir(nodes=[{"id": "judge", "type": "code", "params": {}}])
+
+    def resolver(params: dict[str, Any], base_path: Optional[Path]) -> Optional[SubWorkflowResult]:
+        return SubWorkflowResult(ir=child_ir, path=Path("/x/round.pflow.md"), warnings=())
+
+    parent_ir = _ir(
+        nodes=[
+            {
+                "id": "run-rounds",
+                "type": "workflow",
+                "params": {"workflow": "round"},
+                "loop": {"while": "${run-rounds.more}", "max_iterations": 10},
+            },
+        ],
+    )
+    out = generate_mermaid(parent_ir, resolve_child=resolver)
+    assert 'subgraph run-rounds ["run-rounds (workflow)<br/>⟳ while more · ≤ 10"]' in out
+    # A subgraph self-edge renders as an ugly dangling line in mermaid — the box badge carries
+    # the loop instead, so NO self-edge is emitted for a sub-workflow loop.
+    assert "run-rounds -.->" not in out
+
+
+def test_single_node_loop_emits_self_edge() -> None:
+    # A single-node loop gets a dotted self-edge (a clean self-loop arc in mermaid) so it
+    # visually reads as a loop, in addition to the label badge.
+    ir = _ir(
+        nodes=[{"id": "hunt", "type": "code", "params": {}, "loop": {"until": "${hunt.result}"}}],
+    )
+    out = generate_mermaid(ir)
+    assert 'hunt -.->|"⟳"| hunt' in out
+
+
+def test_no_loop_means_no_self_edge() -> None:
+    ir = _ir(nodes=[{"id": "plain", "type": "code", "params": {}}])
+    out = generate_mermaid(ir)
+    assert "-.->" not in out
+
+
+def test_loop_badge_precedes_description_to_survive_subgraph_clip() -> None:
+    # mermaid clips multi-line subgraph titles after ~2 lines; the loop badge must come BEFORE
+    # the description, or it gets pushed into the clip zone and disappears (the bug the user hit).
+    ir = _ir(
+        nodes=[
+            {
+                "id": "hunt",
+                "type": "code",
+                "params": {},
+                "purpose": "Keep searching until nothing new turns up at all.",
+                "loop": {"until": "${hunt.result}", "max_iterations": 20},
+            },
+        ],
+    )
+    out = generate_mermaid(ir, descriptions=True)
+    label_line = next(ln for ln in out.splitlines() if ln.strip().startswith("hunt["))
+    assert label_line.index("⟳") < label_line.index("Keep searching")

--- a/tests/test_core/test_mermaid_golden.py
+++ b/tests/test_core/test_mermaid_golden.py
@@ -51,6 +51,9 @@ def _generate_from_file(
         ("real-workflows/generate-changelog/workflow.pflow.md", "generate-changelog.mmd", "LR"),
         ("nested/deep-research/deep-research.pflow.md", "deep-research-TD.mmd", "TD"),
         ("nested/deep-research/deep-research.pflow.md", "deep-research-LR.mmd", "LR"),
+        # Loop rendering: `loop:` on a sub-workflow node (multinode body) renders the
+        # loop badge on the subgraph title — the only golden exercising loop visibility.
+        ("core/stateful-loop-tournament.pflow.md", "stateful-loop-tournament.mmd", "LR"),
     ],
 )
 def test_golden_example_workflow(workflow_rel: str, golden_name: str, direction: str) -> None:


### PR DESCRIPTION
## Summary

`pflow visualize` rendered a node carrying a declarative `loop:` modifier as a plain one-shot node — the iteration, condition, and cap were invisible (the renderer had zero loop-awareness). This makes a `loop:` node read as a loop.

Addresses the `loop:`-node portion of #452. (The other half of #452 — distinct styling for **hand-wired backward (loop) edges** like the worker/checker triangle — is **not** in this PR and remains open.)

## Changes

- **`_loop_label(loop, node_id)`** (`mermaid/_context.py`) — synthesizes a `⟳ while|until <cond> · ≤N · carry <keys>` badge from the raw `node["loop"]` dict (a looped node has **no graph edge** — it self-re-enters in place — so the loop must be synthesized from the node property, not picked up from `edges`).
- **Badge placement before the description** (`_format_label`) — mermaid clips multi-line subgraph titles after ~2 lines; placing the badge after a description pushed it into the clip zone and hid it. It now renders directly under the name/type.
- **Single-node self-edge** (`_render_node` → `_render_loop_self_edge`) — a dotted `-.->|"⟳"|` arc back to the node, so single-node loops visually read as a loop.
- **No self-edge on sub-workflow boxes** (`_render_subgraph`) — a subgraph self-edge renders as an ugly dangling line in mermaid; the box-title badge carries the loop there instead.

## Explanation

This emerged from rendering a real agentic harness (a tree of `.pflow.md` sub-workflows) and discovering its loops were invisible: the `review-round` node (a `loop:` modifier) looked identical to a node that runs once. Verified the structural reason — `loop:` is a top-level node property (`node["loop"]`, keys `while`/`until`/`carry`/`max_iterations`), and the engine re-enters the same node in place with **no** synthetic graph edge — so the renderer must detect `node.get("loop")` and synthesize the visual itself.

The single-node-vs-subgraph asymmetry is deliberate and evidence-based (rendered both via mermaid.js): a self-edge on a single node draws a clean self-loop arc, but on a subgraph box it draws a dangling line into empty space — so subgraph loops use the title badge only.

This also lands the substrate the planned web-graph-model work (Task 155) needs: a loop is a first-class **node property** (not an edge), and `loop:`-on-a-sub-workflow is the clean multinode-body case (the body is already a subgraph; the loop annotates the box).

`6 files changed, 272 insertions(+), 5 deletions(-)`. No existing golden changed (no goldened workflow contains a loop); a new tournament golden was added.

## Testing

- `test_loop_label_*` (8) — badge synthesis: while/until polarity, literal vs `${template}` cap, carried-state keys, self-prefix stripping, escaping, defensive/malformed input.
- `test_single_node_loop_emits_self_edge` — single-node loop emits `hunt -.->|"⟳"| hunt`.
- `test_loop_renders_on_subworkflow_subgraph_title` + `assert "run-rounds -.->" not in out` — sub-workflow loop badges the box title and emits **no** self-edge.
- `test_loop_badge_precedes_description_to_survive_subgraph_clip` — badge ordering (the clipping fix).
- `test_no_loop_means_no_self_edge` — non-loop nodes unaffected.
- New golden `stateful-loop-tournament.mmd` pins end-to-end output.
- Full suite: **7679 passed, 1 skipped**; `make check` clean; existing mermaid goldens unchanged.