### PR TITLE
fix: batch `errors` output is always a list, never `None` when empty (#484)

### DIFF
--- a/src/pflow/core/trace_report.py
+++ b/src/pflow/core/trace_report.py
@@ -1144,7 +1144,7 @@ def _format_remaining_node_output(output: dict[str, Any], lines: list[str]) -> N
 
 def _has_batch_error_output(output: dict[str, Any]) -> bool:
     errors = output.get("errors")
-    if output.get("batch_metadata") and isinstance(errors, list):
+    if output.get("batch_metadata") and isinstance(errors, list) and errors:
         return True
     return _looks_like_batch_error_list(errors)
 

--- a/src/pflow/execution/formatters/batch_errors.py
+++ b/src/pflow/execution/formatters/batch_errors.py
@@ -81,7 +81,7 @@ def compact_batch_output_value(value: Any) -> Any:
     if not isinstance(value, Mapping):
         return value
     errors = value.get("errors")
-    if not isinstance(errors, list):
+    if not isinstance(errors, list) or not errors:
         return value
     if not value.get("batch_metadata") and not all(
         isinstance(error, Mapping) and "index" in error and "error" in error for error in errors

--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -1924,7 +1924,7 @@ def _build_batch_output_shape(
         "count": len(items),
         "success_count": len(item_outputs),
         "error_count": 0,
-        "errors": None,
+        "errors": [],
         "batch_metadata": {
             "parallel": batch_config.parallel,
             "max_concurrent": batch_config.max_concurrent if batch_config.parallel else None,

--- a/src/pflow/guide/features/batch.md
+++ b/src/pflow/guide/features/batch.md
@@ -63,7 +63,7 @@ your-command | jq -R -s 'split("\n") | map(select(. != ""))'
 ```
 
 **All outputs**: `${node.results}`, `.count`, `.success_count`, `.error_count`, `.errors`
-Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`.
+Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`. `.errors` is always an array — `[]` when there are no failures, never `null` — so a downstream node can safely annotate it as a `list`/`array`.
 
 **Batching over results nests one layer per stage.** When a later node batches over `${first.results}`, each `${item}` IS one of those entries — so `${item.response}` is the first node's output for that row and `${item.item}` is its original input. A third stage batched over the second's results adds another layer: `${item.item.response}` reaches two stages back. To avoid deep `item.item.item` chains, correlate earlier stages directly — see **Correlating parallel arrays** below.
 

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -259,7 +259,7 @@ Peak memory is `O(events_per_item x max_concurrent)`. No hard cap today.
 
 ### Output shape
 
-`{results, count, success_count, error_count, errors, batch_metadata}`. `results` contains only successful items (failed items filtered out via `error_indices`). `errors` is the authoritative failure record with index, item, and error message per failure. `count` = total items attempted. `success_count` = `len(results)`. `error_count` = `len(errors)`. Verified by `BATCH_OUTPUTS` contract in `template_validation/validator.py`.
+`{results, count, success_count, error_count, errors, batch_metadata}`. `results` contains only successful items (failed items filtered out via `error_indices`). `errors` is the authoritative failure record with index, item, and error message per failure — **always a list (`[]` when there are no failures, never `None`)**, matching its declared `type: array`. `count` = total items attempted. `success_count` = `len(results)`. `error_count` = `len(errors)`. Verified by `BATCH_OUTPUTS` contract in `template_validation/validator.py`.
 
 ### Synthetic Cache Warmup Item (`is_warmup` flag)
 

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -1001,7 +1001,7 @@ def _aggregate_batch_results(
         "count": len(exec_res),
         "success_count": success_count,
         "error_count": len(errors),
-        "errors": errors if errors else None,
+        "errors": errors,
         "batch_metadata": {
             "parallel": batch_config.parallel,
             "max_concurrent": batch_config.max_concurrent if batch_config.parallel else None,

--- a/src/pflow/runtime/template_validation/validator.py
+++ b/src/pflow/runtime/template_validation/validator.py
@@ -55,7 +55,7 @@ BATCH_OUTPUTS: list[dict[str, str]] = [
     {"key": "count", "type": "number", "description": "Total items processed"},
     {"key": "success_count", "type": "number", "description": "Items that succeeded"},
     {"key": "error_count", "type": "number", "description": "Items that failed"},
-    {"key": "errors", "type": "array", "description": "Error details (null if none)"},
+    {"key": "errors", "type": "array", "description": "Error details (empty array when no failures)"},
     {"key": "batch_metadata", "type": "dict", "description": "Execution statistics"},
 ]
 

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -51,7 +51,7 @@ def make_batch_shape(
         "count": count,
         "success_count": success_count,
         "error_count": error_count,
-        "errors": error_list if error_list else None,
+        "errors": error_list,
         "batch_metadata": {
             "parallel": parallel,
             "max_concurrent": 10 if parallel else None,
@@ -1520,19 +1520,32 @@ class TestOutputKeyDottedPath:
         assert captured.out.strip() == "alpha"
 
     def test_output_key_dotted_path_returns_null_for_none_value(self, capsys):
-        """``-o node.errors`` on a successful batch emits JSON ``null``, NOT a warning.
+        """``-o node.field`` on a present-but-``None`` value emits JSON ``null``, NOT a warning.
 
         Pins the ``variable_exists`` + ``resolve_value`` design — a future
         refactor that uses just ``resolve_value`` and checks for None would fail
-        this test.
+        this test. (Batch ``errors`` is no longer ``None`` — it is ``[]`` — so
+        this uses an explicit ``None``-valued output key to keep exercising the
+        present-but-``None`` distinction.)
         """
         from pflow.cli.workflow_output import _handle_text_output
 
-        shared = {"batch-llm": make_batch_shape(results=[{"result": "ok"}])}
-        assert shared["batch-llm"]["errors"] is None
-        _handle_text_output(shared, output_key="batch-llm.errors", workflow_ir=None, verbose=False)
+        shared = {"node": {"value": None}}
+        _handle_text_output(shared, output_key="node.value", workflow_ir=None, verbose=False)
         captured = capsys.readouterr()
         assert captured.out.strip() == "null"
+        assert "Warning" not in captured.err
+        assert "not found" not in captured.err
+
+    def test_output_key_dotted_path_returns_empty_list_for_batch_errors(self, capsys):
+        """``-o batch.errors`` on a successful batch emits ``[]`` (issue #484), NOT a warning."""
+        from pflow.cli.workflow_output import _handle_text_output
+
+        shared = {"batch-llm": make_batch_shape(results=[{"result": "ok"}])}
+        assert shared["batch-llm"]["errors"] == []
+        _handle_text_output(shared, output_key="batch-llm.errors", workflow_ir=None, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "[]"
         assert "Warning" not in captured.err
         assert "not found" not in captured.err
 
@@ -1626,15 +1639,19 @@ class TestOutputKeyMissHints:
         assert "'node.text' is a string (value: 'hello world'), cannot descend." in captured.err
 
     def test_output_key_miss_describes_null_dead_end(self, capsys):
-        """None mid-path uses 'null value' type label (likely real-world hit:
-        ``node.errors.field`` where ``errors`` is None on a successful batch).
+        """None mid-path uses the 'null value' type label.
+
+        (Batch ``errors`` is no longer ``None`` — it is ``[]`` (issue #484), and
+        descending into it is covered by ``test_output_key_miss_describes_empty_list``.
+        This uses an explicit ``None``-valued mid-path key to keep pinning the
+        null-value label.)
         """
         from pflow.cli.workflow_output import _handle_text_output
 
-        shared = {"batch-llm": make_batch_shape(results=[{"r": 1}])}
-        _handle_text_output(shared, output_key="batch-llm.errors.first", workflow_ir=None, verbose=False)
+        shared = {"node": {"value": None}}
+        _handle_text_output(shared, output_key="node.value.first", workflow_ir=None, verbose=False)
         captured = capsys.readouterr()
-        assert "'batch-llm.errors' is a null value (value: None), cannot descend." in captured.err
+        assert "'node.value' is a null value (value: None), cannot descend." in captured.err
 
     def test_output_key_miss_describes_boolean_dead_end(self, capsys):
         """Boolean uses its own label, not 'number' (bool subclasses int)."""

--- a/tests/test_core/test_trace_report.py
+++ b/tests/test_core/test_trace_report.py
@@ -193,6 +193,46 @@ class TestGenerateReport:
         assert "```json" not in markdown
         assert "## Output" not in markdown
 
+    def test_successful_batch_aggregate_report_surfaces_metadata_no_error_section(self, tmp_path: Path) -> None:
+        """A zero-failure batch report must NOT render a "## Batch Errors" section and
+        MUST keep its aggregate metadata (count/success_count/error_count/batch_metadata)
+        visible in "## Output" (issue #484 companion fix).
+
+        This is the success-case mirror of
+        ``test_failed_batch_aggregate_report_compacts_error_items`` and the ONLY guard
+        on the ``_has_batch_error_output`` ``and errors`` companion fix. With ``errors``
+        now ``[]`` (not ``None``), removing ``and errors`` makes ``_has_batch_error_output``
+        return ``True`` for a successful batch, which suppresses these keys from
+        ``_format_remaining_node_output``'s "## Output" dump while "## Batch Errors" stays
+        empty — so the batch metadata would vanish from the report entirely. The
+        ``"success_count" in markdown`` assertion below fails loudly under that regression.
+        """
+        batch_event = _make_event(
+            node_id="ok-batch",
+            node_type="ShellNode",
+            success=True,
+            node_output={
+                "count": 2,
+                "success_count": 2,
+                "error_count": 0,
+                "errors": [],
+                "batch_metadata": {"execution_mode": "sequential"},
+                "results": [{"stdout": "ok-a"}, {"stdout": "ok-b"}],
+            },
+        )
+        trace = _make_trace(nodes=[batch_event])
+        trace_file = tmp_path / "trace.json"
+        trace_file.write_text(json.dumps(trace))
+
+        report_dir = generate_report(trace_file, str(tmp_path / "report"))
+
+        assert report_dir is not None
+        markdown = (report_dir / "01-ok-batch.md").read_text()
+        assert "## Batch Errors" not in markdown
+        assert "## Output" in markdown
+        # The regression catcher: this key is suppressed if `and errors` is removed.
+        assert "success_count" in markdown
+
     def test_batch_node_creates_directory(self, tmp_path: Path) -> None:
         batch_event = _make_event(
             node_id="process",

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -1134,7 +1134,7 @@ class TestAppendOutputsCliMcpParity:
                 "count": 1,
                 "success_count": 1,
                 "error_count": 0,
-                "errors": None,
+                "errors": [],
                 "batch_metadata": {"timing": {"total_items_ms": 1400.0}},
             }
         }
@@ -1163,18 +1163,28 @@ class TestCollectOutputsDottedPath:
     def test_resolves_dotted_output_key(self):
         from pflow.execution.formatters.success_formatter import _collect_outputs
 
-        shared = {"batch-llm": {"success_count": 2, "count": 2, "errors": None}}
+        shared = {"batch-llm": {"success_count": 2, "count": 2, "errors": []}}
         result = _collect_outputs(shared, workflow_ir={}, output_key="batch-llm.success_count")
         assert result == {"batch-llm.success_count": 2}
 
     def test_resolved_none_emits_null(self):
-        """``-o batch.errors`` on a successful batch preserves the ``None`` value
-        in the JSON outputs dict — distinct from "key missing"."""
+        """A present-but-``None`` value is preserved in the JSON outputs dict —
+        distinct from "key missing". (Batch ``errors`` is now ``[]``, never
+        ``None`` — issue #484 — so this uses an explicit ``None``-valued key to
+        keep exercising the present-but-``None`` distinction.)"""
         from pflow.execution.formatters.success_formatter import _collect_outputs
 
-        shared = {"batch-llm": {"errors": None, "success_count": 1, "count": 1}}
+        shared = {"node": {"value": None, "success_count": 1, "count": 1}}
+        result = _collect_outputs(shared, workflow_ir={}, output_key="node.value")
+        assert result == {"node.value": None}
+
+    def test_resolved_batch_errors_emits_empty_list(self):
+        """``-o batch.errors`` on a successful batch resolves to ``[]`` (issue #484)."""
+        from pflow.execution.formatters.success_formatter import _collect_outputs
+
+        shared = {"batch-llm": {"errors": [], "success_count": 1, "count": 1}}
         result = _collect_outputs(shared, workflow_ir={}, output_key="batch-llm.errors")
-        assert result == {"batch-llm.errors": None}
+        assert result == {"batch-llm.errors": []}
 
     def test_missing_key_returns_empty(self):
         """JSON-mode silently omits a missed key — no human-prose hint."""

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -267,7 +267,7 @@ class TestBatchExecutionBasic:
         assert shared["test_node"]["count"] == 0
         assert shared["test_node"]["success_count"] == 0
         assert shared["test_node"]["error_count"] == 0
-        assert shared["test_node"]["errors"] is None
+        assert shared["test_node"]["errors"] == []
 
     def test_batch_single_item(self):
         """Single item processed correctly."""
@@ -713,14 +713,14 @@ class TestResultStructure:
         assert "error_count" in result
         assert "errors" in result
 
-    def test_errors_none_when_no_errors(self):
-        """errors field is None when all items succeed."""
+    def test_errors_empty_list_when_no_errors(self):
+        """errors field is an empty list (not None) when all items succeed (issue #484)."""
         inner = MockInnerNode("test_node")
         shared: dict = {"data": ["a", "b"]}
 
         _run_batch(inner, shared)
 
-        assert shared["test_node"]["errors"] is None
+        assert shared["test_node"]["errors"] == []
 
     def test_none_is_valid_success(self):
         """None result from node is treated as success, not error."""
@@ -2477,7 +2477,7 @@ class TestBatchActionFallbackErrorDetection:
 
         assert shared["test_node"]["error_count"] == 0
         assert shared["test_node"]["success_count"] == 2
-        assert shared["test_node"]["errors"] is None
+        assert shared["test_node"]["errors"] == []
 
     def test_exec_single_no_error_when_none_action(self):
         """When _run() returns None, item succeeds (no false positive)."""
@@ -2497,7 +2497,7 @@ class TestBatchActionFallbackErrorDetection:
 
         assert shared["test_node"]["error_count"] == 0
         assert shared["test_node"]["success_count"] == 1
-        assert shared["test_node"]["errors"] is None
+        assert shared["test_node"]["errors"] == []
 
     def test_exec_single_with_node_detects_error_via_action(self):
         """Parallel path: all error-action items → all-fail abort."""
@@ -2682,6 +2682,90 @@ class TestBatchSubWorkflowErrorPropagationIntegration:
 
         assert results[1]["item"] == "good-c"
         assert results[1].get("error") is None
+
+    def test_batch_continue_all_success_errors_is_empty_list(self):
+        """continue-mode batch with zero failures → ``errors == []`` (issue #484).
+
+        Pins the contract that ``errors`` is always a list. It used to collapse
+        to ``None`` when empty, breaking its declared ``type: array`` and any
+        downstream consumer that annotates it as a list. ``None == []`` is False,
+        so this assertion fails loudly if the producer ever regresses to ``None``.
+        """
+        from pflow.registry.registry import Registry
+        from pflow.runtime import compile_workflow
+        from pflow.runtime.engine import WorkflowEngine
+
+        registry = Registry()
+        parent_ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "fetch",
+                    "type": "shell",
+                    "params": {"command": "echo ok-${item}"},
+                    "batch": {
+                        "items": ["a", "b", "c"],
+                        "error_handling": "continue",
+                    },
+                    "purpose": "Batch shell node where every item succeeds",
+                }
+            ],
+            "edges": [],
+        }
+
+        workflow = compile_workflow(parent_ir, registry=registry)
+        shared: dict = dict(workflow.resolved_defaults)
+        engine = WorkflowEngine()
+        engine.run(workflow, shared)
+
+        batch_output = shared["fetch"]
+        assert batch_output["success_count"] == 3
+        assert batch_output["error_count"] == 0
+        assert batch_output["errors"] == []
+
+    def test_batch_errors_consumed_by_downstream_code_node_as_list(self):
+        """End-to-end (issue #484): a downstream ``code`` node consuming
+        ``${batch.errors}`` annotated ``errors: list`` validates and runs when
+        the batch had zero failures.
+
+        Before the fix this failed at runtime with
+        ``Input 'errors' expects list but received NoneType``. Routed through
+        ``WorkflowRunner`` so the full producer → template-resolution →
+        code-node input-validation path is exercised (tests/CLAUDE.md gotcha #20).
+        """
+        from pflow.execution import RunnerConfig, WorkflowRunner
+
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "fetch",
+                    "type": "shell",
+                    "params": {"command": "echo ok-${item}"},
+                    "batch": {
+                        "items": ["a", "b", "c"],
+                        "error_handling": "continue",
+                    },
+                    "purpose": "Batch shell node where every item succeeds",
+                },
+                {
+                    "id": "parse",
+                    "type": "code",
+                    "params": {
+                        "inputs": {"errors": "${fetch.errors}"},
+                        "code": 'errors: list\nresult: str = f"got {len(errors)} errors"\n',
+                    },
+                    "purpose": "Code node consuming the batch errors output as a list",
+                },
+            ],
+            "edges": [{"from": "fetch", "to": "parse", "action": "default"}],
+            "start_node": "fetch",
+        }
+
+        result = WorkflowRunner().run(ir, {}, config=RunnerConfig())
+
+        assert result.success, [d.message for d in result.diagnostics]
+        assert result.shared_after["parse"]["result"] == "got 0 errors"
 
     def test_batch_workflow_partial_failure_parallel(self, tmp_path):
         """Parallel variant of partial-fail: exercises the parallel code path."""


### PR DESCRIPTION
## Summary
A batch node's `errors` output collapsed to `None` when there were zero failures, instead of an empty list `[]`. It was the only batch output field that did this — its siblings (`results`, `error_count`) use their natural empty values (`[]`, `0`). This broke the field's own declared `type: "array"` contract and rejected downstream consumers that annotate it as a list:

```
Input 'errors' expects list but received NoneType
```

This makes the runtime match the already-declared contract: batch `errors` is now always a list (`[]` when empty), never `None`.

Fixes #484

## Changes
**Producers (both, to keep `test_plan_drift` parity):**
- `runtime/engine/batch_executor.py` — `_aggregate_batch_results`: `"errors": errors if errors else None` → `"errors": errors`
- `execution/plan.py` — `_build_batch_output_shape`: `"errors": None` → `"errors": []`

**Consumer companion fixes (behavior-preserving — keep report/formatter output byte-identical):**
- `core/trace_report.py` — `_has_batch_error_output` now requires a non-empty list (`and errors`), so a successful batch's report output is unchanged (and "has batch **error** output" is correctly `False` when there are zero errors)
- `execution/formatters/batch_errors.py` — `compact_batch_output_value` early-returns on empty, preserving "pass through unchanged when no errors"

**Contract + docs:**
- `template_validation/validator.py` — `BATCH_OUTPUTS` description `"Error details (null if none)"` → `"Error details (empty array when no failures)"` (the old description self-contradicted `type: "array"`)
- `guide/features/batch.md` + `runtime/engine/CLAUDE.md` — note that `.errors` is always a list (`[]` when none)

## Explanation
`type: "array"` … `null if none` was validation-vs-runtime drift baked into one line: validation said `array` (so a downstream `errors: list` annotation passed validation), runtime delivered `None` (so it failed at execution). `[]` strictly dominates `None` here — both are falsy (display gains nothing), but `[]` gives type stability to programmatic/agent consumers and is the canonical Python practice for an empty sequence. The runtime already builds `errors: list = []` and did *extra* work to throw it away.

Net production change: 2 producer lines + 2 small consumer guards + 1 contract description (+10 lines incl. docs/tests).

## Testing
- `test_batch_continue_all_success_errors_is_empty_list` — engine-level: `continue`-mode batch with zero failures → `errors == []` (regression pin; `None == []` is False so it fails loudly on regression)
- `test_batch_errors_consumed_by_downstream_code_node_as_list` — end-to-end through `WorkflowRunner`: a `code` node consuming `${batch.errors}` annotated `errors: list` validates and runs (the exact failing path from the issue)
- `test_output_key_dotted_path_returns_empty_list_for_batch_errors` / `test_resolved_batch_errors_emits_empty_list` — CLI text + JSON `-o batch.errors` now emit `[]`
- Migrated all batch-`errors` `is None` / `": None"` assertions to `== []` across `test_batch_node.py`, `test_workflow_output_handling.py`, `test_success_formatter.py`
- Preserved three present-but-`None` design pins (output miss-hint null label, dotted-path null rendering, JSON null preservation) with explicit `None`-valued keys rather than eroding them — these used batch `errors` only because it was a convenient real-`None` example
- Manual: reproduced the original `expects list but received NoneType` failure, confirmed the fix runs clean
- `make check` (ruff + mypy + deptry) green; `make test` green (7684 passed, 1 skipped)