### PR TITLE
[codex] Fix MCP result warning detection

### DIFF
--- a/.agents/skills/pflow-sandbox-testing/SKILL.md
+++ b/.agents/skills/pflow-sandbox-testing/SKILL.md
@@ -65,6 +65,17 @@ Sandbox limits to keep in mind:
 - Filesystem writes are limited to the workspace and writable temp roots; workflows writing elsewhere may hit permission errors.
 - Read-only inspection of accessible local folders can work, but do not assume arbitrary user-home writes are allowed.
 
+## Sandbox Permissions
+
+If an important command fails because of sandbox permissions, shared metadata outside the workspace, restricted network access, blocked credentials, GUI access, or non-interactive approval limits, stop and ask the user to run `/permissions` and choose **"approve for me"**. Do this before trying connector workarounds, hand-assembling commits through APIs, or building brittle alternatives around the sandbox.
+
+Common symptoms:
+
+- `git add` or `git commit` cannot create `.git/.../index.lock`
+- `git push` cannot reach the remote because network is restricted
+- `gh pr create`, `gh auth status`, or other `gh` commands fail because the CLI cannot access credentials or network
+- dependency managers, package downloads, external CLIs, browser/GUI tools, or subprocesses fail only because they need access outside the sandbox
+
 ## Known Failures
 
 Do not trust `make test` or `uv run ...` inside this sandbox. `uv` may fail with:

--- a/docs/reference/nodes/mcp.mdx
+++ b/docs/reference/nodes/mcp.mdx
@@ -55,21 +55,20 @@ All MCP nodes write to:
 | Key | Type | Description |
 |-----|------|-------------|
 | `result` | any | Tool execution result |
-| `{server}_{tool}_result` | any | Same result with unique key |
 | `error` | str | Error message (only on failure) |
 
-For dict results, top-level fields are also extracted directly:
+For dict results, read nested fields through `result`:
 
-If a tool returns `{"issue_url": "...", "issue_number": 123}`, the shared store contains:
+If a tool returns `{"issue_url": "...", "issue_number": 123}`, use:
 
-```json
-{
-  "result": {"issue_url": "...", "issue_number": 123},
-  "github_create_issue_result": {"issue_url": "...", "issue_number": 123},
-  "issue_url": "...",
-  "issue_number": 123
-}
+```markdown
+${github-issue.result.issue_url}
+${github-issue.result.issue_number}
 ```
+
+MCP nodes do not extract top-level result fields into `${node.field}` and do not
+write a `{server}_{tool}_result` alias. Each workflow node already has its own
+namespace, so `${node.result}` is the canonical success output.
 
 ## Example workflow
 

--- a/src/pflow/execution/formatters/CLAUDE.md
+++ b/src/pflow/execution/formatters/CLAUDE.md
@@ -37,7 +37,7 @@ Single-source-of-truth formatters ensuring CLI and MCP return identical output. 
 - `output_mode` (structure format only): `smart` (values + LLM filtering via `smart_filter_fields_cached`), `structure` (paths only), `full` (all values, no truncation)
 - MCPNode error detection: checks BOTH `action == "error"` AND `"error"` key in outputs/shared_store — because `MCPNode.post()` returns "default" action even on errors (workaround for missing error edges in workflows)
 - JSON string auto-parsing: `flatten_runtime_value()` tries to parse strings as JSON via `core.json_utils.try_parse_json`. If a string looks like JSON, it's recursively flattened as structure. This is critical for MCP nodes that return JSON strings as output values.
-- Deduplication: `get_value_hash()` detects when MCP nodes return identical data under different keys (e.g., both `result` and `server_TOOL_result`). Shows a warning and skips duplicates.
+- Deduplication: `get_value_hash()` detects identical data under different keys in legacy traces or custom node output. Shows a warning and skips duplicates.
 
 **error_formatter** uses lazy import of `mcp_server.utils.errors.sanitize_parameters` to avoid circular deps. Sanitizes `raw_response` and `response_headers` fields.
 

--- a/src/pflow/execution/formatters/node_output_formatter.py
+++ b/src/pflow/execution/formatters/node_output_formatter.py
@@ -420,8 +420,8 @@ def extract_runtime_paths(outputs: dict[str, Any]) -> tuple[list[tuple[str, str]
     for key, value in outputs.items():
         if isinstance(key, str) and key.startswith("_"):
             continue  # Skip reserved keys (engine-injected metadata, private markers).
-        # Check if this value is identical to one we've already processed
-        # (MCP nodes often return both 'result' and 'server_TOOL_result' with same data)
+        # Check if this value is identical to one we've already processed.
+        # This keeps legacy or custom duplicate structures from exploding paths.
         value_hash = get_value_hash(value)
 
         if value_hash in seen_structures:

--- a/src/pflow/guide/nodes/mcp.md
+++ b/src/pflow/guide/nodes/mcp.md
@@ -17,6 +17,13 @@ See `pflow mcp describe <tool> --help` for how to interpret tool details.
 
 ## ⚠️ MCP Output Has NO Standard Structure
 
+MCP nodes expose one canonical output namespace: `result`.
+
+Use `${node.result}` for the full tool payload and `${node.result.field}` for
+nested fields. Do not use `${node.field}` for MCP tool fields; validation only
+knows the declared `result` output because MCP servers do not publish stable
+output schemas.
+
 **Every MCP server is completely different. Even the SAME operation:**
 
 ```python
@@ -33,6 +40,33 @@ Server C:  result.Items[]                   # DynamoDB style
 
 **There are NO patterns. Test every MCP tool:**
 `pflow probe mcp-service-TOOL param=value`
+
+### MCP Tools Can Report Failure Inside `result`
+
+Some MCP tools return a successful MCP response while the service payload says
+the operation failed. Example: a tool can return:
+
+```json
+{
+  "status": "error",
+  "reason": "expired",
+  "error": "Cannot create audio: NotebookLM auth is not valid",
+  "hint": "nlm login"
+}
+```
+
+That payload is available as `${create-audio.result.status}`,
+`${create-audio.result.error}`, and so on. Guard workflows that poll, download,
+or mutate follow-up state by checking the tool's own success field before
+continuing.
+
+MCP failure paths:
+
+| Outcome | What it is | pflow behavior |
+|---|---|---|
+| Protocol/transport failure | MCP client/server call failed before a tool result | Writes `${node.error}` and `${node.error_details}` |
+| `isError: true` | Tool set the MCP tool-error flag | Returns `error`, so `on-error` can route it |
+| `result.status: "error"`, `result.ok: false`, etc. | Service failure inside a successful MCP payload | Stored under `${node.result}`; pflow surfaces explicit failure flags as API warnings |
 
 ### Node Creation Pattern
 

--- a/src/pflow/nodes/mcp/node.py
+++ b/src/pflow/nodes/mcp/node.py
@@ -420,30 +420,9 @@ class MCPNode(Node):
             # resource failures into user-facing warnings before execution stops.
             return "error"
 
-        # Store successful result
+        # Store successful result. MCP tools expose one canonical output shape:
+        # downstream workflows read fields through ${node.result.field}.
         shared["result"] = result
-
-        # For structured data from outputSchema, extract top-level fields
-        # This makes individual fields directly accessible in the shared store
-        if isinstance(result, dict) and not result.get("error"):
-            # Extract non-private fields to shared store for easier access
-            extracted_fields = []
-            for key, value in result.items():
-                if not key.startswith("_") and not key.startswith("is_"):
-                    # Skip private fields and internal flags
-                    shared[key] = value
-                    extracted_fields.append(key)
-
-            if extracted_fields:
-                logger.debug(
-                    "Extracted structured fields to shared store",
-                    extra={"fields": extracted_fields, "server": prep_res["server"], "tool": prep_res["tool"]},
-                )
-
-        # Store result with server-specific key
-        # This allows multiple MCP tools in same workflow
-        result_key = f"{prep_res['server']}_{prep_res['tool']}_result"
-        shared[result_key] = result
 
         logger.info(
             "MCP tool completed successfully",
@@ -452,7 +431,7 @@ class MCPNode(Node):
                 "tool": prep_res["tool"],
                 "result_type": type(result).__name__,
                 "is_structured": isinstance(result, dict),
-                "result_keys": ["result", result_key],
+                "result_keys": ["result"],
             },
         )
 

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -253,6 +253,9 @@ shared["_pflow_child_only_node"] = str   # Transient: remaining dotted --only pa
 - `resource_error` — not found, forbidden
 - API warnings: Slack `"ok": false`, Discord errors, GraphQL `"errors": []`
 - HTTP status codes: 401, 403, 404, 429
+- MCP canonical payloads: explicit failure flags under `${node.result}` (`status: "error"`, `ok: false`,
+  `success: false`, etc.) are trusted even when the message text does not match known resource phrases.
+  Bare `error` keys without a failure flag still use the conservative phrase checks.
 
 **Ambiguity rule**: When an error matches BOTH validation and resource patterns, it's treated as **validation** (validation wins).
 

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -313,9 +313,9 @@ All emitters wrap the callback in `contextlib.suppress(Exception)` so rendering 
 
 ## Utility Files
 
-### `api_warning_detector.py` (449 lines)
+### `api_warning_detector.py`
 
-Classifies node output as API warning based on 93+ patterns. See `runtime/CLAUDE.md` "Error Categorization" for the pattern categories and ambiguity rule. Key function: `detect_api_warning(node_id, shared) → Optional[str]`.
+Classifies node output as API warning based on explicit failure flags, error codes, and resource/validation message patterns. See `runtime/CLAUDE.md` "Error Categorization" for the pattern categories and ambiguity rule. Key function: `detect_api_warning(node_id, shared, *, node_type_name=None) → Optional[str]`. Pass `node_type_name` from the compiled node config so canonical `result` wrapper inspection is limited to MCP nodes.
 
 ### `template_errors.py`
 

--- a/src/pflow/runtime/engine/api_warning_detector.py
+++ b/src/pflow/runtime/engine/api_warning_detector.py
@@ -247,9 +247,7 @@ def _check_boolean_error_flags(output: dict) -> Optional[str]:
 
     if output.get("isError") is True:
         error_info = output.get("error", {})
-        if isinstance(error_info, dict):
-            return _first_error_message(error_info.get("message"), default="API request failed")
-        return _first_error_message(error_info, default="API request failed")
+        return _first_error_message(error_info, output.get("message"), default="API request failed")
 
     return None
 
@@ -361,12 +359,18 @@ def _coerce_error_message(value: Any) -> Optional[str]:
         return None
     if isinstance(value, str):
         return value
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            message = _coerce_error_message(item)
+            if message:
+                return message
+        return None
     if isinstance(value, dict):
         for key in ("message", "error", "reason"):
             message = _coerce_error_message(value.get(key))
             if message:
                 return message
-        return str(value)
+        return None
     return str(value)
 
 

--- a/src/pflow/runtime/engine/api_warning_detector.py
+++ b/src/pflow/runtime/engine/api_warning_detector.py
@@ -1,35 +1,48 @@
 """API warning detection for node execution results.
 
 Detects API errors in node output that should surface as warnings rather than
-failures. Uses a 3-tier priority system:
-1. Error codes (most reliable signal)
-2. Validation patterns (defer to normal error handling)
-3. Resource patterns (surface as API warning)
+clean successes. Uses a provenance-aware priority system:
+1. Explicit failure flags (status:error, ok:false, success:false, etc.)
+2. Error codes
+3. Validation patterns (defer to normal error handling)
+4. Resource patterns (surface as API warning)
 
 When an error matches both validation and resource patterns, validation wins.
 """
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 
-def detect_api_warning(node_id: str, shared: dict[str, Any]) -> Optional[str]:
+@dataclass(frozen=True)
+class _ErrorSignal:
+    message: str
+    from_explicit_failure_flag: bool
+
+
+def detect_api_warning(node_id: str, shared: dict[str, Any], *, node_type_name: Optional[str] = None) -> Optional[str]:
     """Detect API errors that should surface as warnings.
 
-    Returns None for validation-style errors so normal error handling can proceed.
+    Explicit failure flags are trusted as self-reported API failures. For
+    message-only signals, returns None for validation-style errors so normal
+    error handling can proceed.
 
     Strategy:
-    1. Check error codes first (most reliable)
-    2. Check for validation patterns (defer to normal execution errors)
-    3. Check for resource patterns (surface warning)
-    4. Default to no API warning
+    1. Check explicit failure flags first
+    2. Check error codes
+    3. Check for validation patterns (defer to normal execution errors)
+    4. Check for resource patterns (surface warning)
+    5. Default to no API warning
 
     Args:
         node_id: The node identifier to check in shared store
         shared: The shared store containing node outputs
+        node_type_name: Optional runtime node type. When provided, canonical
+            result-wrapper unwrapping is limited to MCP nodes.
 
     Returns:
         Warning message string if API warning detected, None otherwise
@@ -45,7 +58,7 @@ def detect_api_warning(node_id: str, shared: dict[str, Any]) -> Optional[str]:
     )
 
     # Handle MCP nested responses
-    output = unwrap_mcp_response(output)
+    output = unwrap_mcp_response(output, inspect_result=node_type_name in (None, "MCPNode"))
     if not output:
         return None
 
@@ -57,27 +70,54 @@ def detect_api_warning(node_id: str, shared: dict[str, Any]) -> Optional[str]:
 
     # Extract error information
     error_code = extract_error_code(output)
-    error_msg = extract_error_message(output)
+    error_signal = _extract_error_signal(output)
 
-    if not error_msg:
+    if not error_signal:
         return None  # No error detected
 
+    error_msg = error_signal.message
+
+    # Explicit top-level failure flags are a self-report from the tool/API. Do
+    # not discard them just because the free-text message is novel.
+    if error_signal.from_explicit_failure_flag:
+        return _format_explicit_failure_warning(error_msg, error_code)
+
     # PRIORITY 1: Check error codes (most reliable signal)
+    code_handled, code_warning = _warning_from_error_code(error_code, error_msg)
+    if code_handled:
+        return code_warning
+
+    return _warning_from_message(error_msg)
+
+
+def _format_explicit_failure_warning(error_msg: str, error_code: Optional[str]) -> str:
     if error_code:
-        error_category = _categorize_by_error_code(error_code)
+        logger.info(f"Explicit API failure detected: {error_code} - {error_msg}")
+        return f"API error ({error_code}): {error_msg}"
+    logger.info(f"Explicit API failure detected: {error_msg}")
+    return f"API error: {error_msg}"
 
-        if error_category == "validation":
-            # Validation error - leave it to normal execution handling
-            logger.debug(f"Validation error detected: {error_code} - {error_msg}")
-            return None
 
-        elif error_category == "resource":
-            # Resource error - surface as API warning
-            logger.info(f"Resource error detected: {error_code} - {error_msg}")
-            return f"API error ({error_code}): {error_msg}"
+def _warning_from_error_code(error_code: Optional[str], error_msg: str) -> tuple[bool, Optional[str]]:
+    if not error_code:
+        return False, None
 
-        # Unknown error code - continue to message analysis
+    error_category = _categorize_by_error_code(error_code)
+    if error_category == "validation":
+        # Validation error - leave it to normal execution handling
+        logger.debug(f"Validation error detected: {error_code} - {error_msg}")
+        return True, None
 
+    if error_category == "resource":
+        # Resource error - surface as API warning
+        logger.info(f"Resource error detected: {error_code} - {error_msg}")
+        return True, f"API error ({error_code}): {error_msg}"
+
+    # Unknown error code - continue to message analysis.
+    return False, None
+
+
+def _warning_from_message(error_msg: str) -> Optional[str]:
     # PRIORITY 2: Check if it's a validation error
     if _is_validation_error(error_msg):
         logger.debug(f"Validation error detected: {error_msg}")
@@ -93,7 +133,7 @@ def detect_api_warning(node_id: str, shared: dict[str, Any]) -> Optional[str]:
     return None
 
 
-def unwrap_mcp_response(output: Any) -> Optional[dict]:
+def unwrap_mcp_response(output: Any, *, inspect_result: bool = True) -> Optional[dict]:
     """Unwrap MCP nested responses to get actual API response."""
     if not isinstance(output, dict):
         return None
@@ -103,13 +143,15 @@ def unwrap_mcp_response(output: Any) -> Optional[dict]:
     if parsed is not None:
         return parsed
 
+    # Handle canonical MCP node output: {"result": {...}}.
+    if inspect_result and isinstance(output.get("result"), dict):
+        result = output["result"]
+        return _unwrap_successful_data(result) or result
+
     # Handle MCP dict with nested data
-    if output.get("successful") is True and "data" in output:
-        data = output["data"]
-        # Ensure data is a dict before returning
-        if isinstance(data, dict):
-            return data
-        return None
+    data = _unwrap_successful_data(output)
+    if data is not None:
+        return data
 
     # Handle HTTP node with response field
     if "response" in output and "status_code" in output:
@@ -142,6 +184,16 @@ def _parse_mcp_json_result(output: dict) -> Optional[dict]:
     except (json.JSONDecodeError, TypeError):
         pass
 
+    return None
+
+
+def _unwrap_successful_data(output: dict) -> Optional[dict]:
+    """Return nested MCP data from successful wrapper payloads."""
+    if output.get("successful") is True and "data" in output:
+        data = output["data"]
+        if isinstance(data, dict):
+            return data
+        return None
     return None
 
 
@@ -182,22 +234,22 @@ def _check_boolean_error_flags(output: dict) -> Optional[str]:
 
     # Check various boolean error indicators
     if output.get("ok") is False:
-        return output.get("error") or "API request failed"
+        return _first_error_message(output.get("error"), default="API request failed")
 
     if output.get("success") is False:
-        return output.get("error") or output.get("message") or "API request failed"
+        return _first_error_message(output.get("error"), output.get("message"), default="API request failed")
 
     if output.get("successful") is False or output.get("successfull") is False:  # MCP typo
-        return output.get("error") or output.get("message") or "API request failed"
+        return _first_error_message(output.get("error"), output.get("message"), default="API request failed")
 
     if output.get("succeeded") is False:
-        return output.get("error") or output.get("message") or "API request failed"
+        return _first_error_message(output.get("error"), output.get("message"), default="API request failed")
 
     if output.get("isError") is True:
         error_info = output.get("error", {})
         if isinstance(error_info, dict):
-            return error_info.get("message") or "API request failed"
-        return str(error_info) if error_info else "API request failed"
+            return _first_error_message(error_info.get("message"), default="API request failed")
+        return _first_error_message(error_info, default="API request failed")
 
     return None
 
@@ -217,7 +269,7 @@ def _check_status_field(output: dict) -> Optional[str]:
 
     status = str(output.get("status", "")).lower()
     if status in ["error", "failed", "failure"]:
-        return output.get("message") or output.get("error") or "API request failed"
+        return _first_error_message(output.get("message"), output.get("error"), default="API request failed")
     return None
 
 
@@ -260,26 +312,62 @@ def extract_error_message(output: dict) -> Optional[str]:
     if not isinstance(output, dict):
         return None
 
+    signal = _extract_error_signal(output)
+    if signal is None:
+        return None
+    return signal.message
+
+
+def _extract_error_signal(output: dict) -> Optional[_ErrorSignal]:
+    """Extract error text and whether it came from an explicit failure flag."""
+    # Defensive type check
+    if not isinstance(output, dict):
+        return None
+
     # Check boolean error flags
     error_msg = _check_boolean_error_flags(output)
     if error_msg:
-        return error_msg
+        return _ErrorSignal(error_msg, from_explicit_failure_flag=True)
 
     # Check status field
     error_msg = _check_status_field(output)
     if error_msg:
-        return error_msg
+        return _ErrorSignal(error_msg, from_explicit_failure_flag=True)
 
     # Check for GraphQL errors
     error_msg = _check_graphql_errors(output)
     if error_msg:
-        return error_msg
+        return _ErrorSignal(error_msg, from_explicit_failure_flag=False)
 
     # Check if there's an error field with content
     if output.get("error"):
-        return output.get("error")
+        error_text = _coerce_error_message(output.get("error"))
+        if error_text:
+            return _ErrorSignal(error_text, from_explicit_failure_flag=False)
 
     return None
+
+
+def _first_error_message(*values: Any, default: str) -> str:
+    for value in values:
+        message = _coerce_error_message(value)
+        if message:
+            return message
+    return default
+
+
+def _coerce_error_message(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("message", "error", "reason"):
+            message = _coerce_error_message(value.get(key))
+            if message:
+                return message
+        return str(value)
+    return str(value)
 
 
 def _categorize_by_error_code(code: str) -> str:

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -1018,7 +1018,7 @@ class WorkflowEngine:
                     child_trace_events = getattr(node, "_child_trace_events", None)
 
             # 10. API warning detection
-            warning = detect_api_warning(config.node_id, shared)
+            warning = detect_api_warning(config.node_id, shared, node_type_name=config.node_type_name)
             if warning:
                 # Drain the per-item buffer even though ``handle_api_warning``
                 # discards batch items today (pre-existing, see W2 in PR #405
@@ -1036,6 +1036,7 @@ class WorkflowEngine:
                     shared_keys_before,
                     config.node_type_name,
                     node.params,
+                    recovered=node.successors.get("error") is not None,
                 )
 
             # 11. Cache result (in-process only — not gated by cache_enabled)

--- a/src/pflow/runtime/engine/instrumentation.py
+++ b/src/pflow/runtime/engine/instrumentation.py
@@ -13,7 +13,7 @@ import os
 import time
 from typing import Any, Optional
 
-from pflow.core.diagnostic import Diagnostic
+from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.core.exceptions import MaxNodeVisitsError
 from pflow.core.node_type_display import is_llm_node_type
 
@@ -754,6 +754,7 @@ def handle_api_warning(
     shared_keys_before: set,
     node_type_name: str,
     node_params: dict,
+    recovered: bool = False,
 ) -> str:
     """Handle API warning: record trace/metrics, archive via ``mark_node_failed``.
 
@@ -809,12 +810,24 @@ def handle_api_warning(
     # of category — ``_extract_error_info`` in the runner just reads it.
     from pflow.runtime.node_state import FAILURE_CATEGORY_API_WARNING, mark_node_failed
 
+    warning_diagnostic = Diagnostic(
+        severity=Severity.WARNING,
+        message=warning,
+        suggestions=[
+            f"Inspect '{node_id}' upstream inputs and output to verify the warning is expected.",
+            "If unintended, fix the upstream data or add error handling to this node.",
+        ],
+        node_id=node_id,
+        source="runtime",
+        context={"type": "api_warning", "recovered": recovered},
+    )
+
     mark_node_failed(
         shared,
         node_id,
         category=FAILURE_CATEGORY_API_WARNING,
         error=warning,
-        warning=warning,
+        warning=warning_diagnostic,
     )
 
     return "error"

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -153,7 +153,11 @@ def _unrecovered_failed_node_ids(
     recovered_node_ids: set[str] = set()
     for warning in execution_warnings or []:
         node_id = warning.get("node_id") if isinstance(warning, dict) else None
-        if isinstance(node_id, str) and warning.get("type") == "on_error_recovery":
+        if not isinstance(node_id, str):
+            continue
+        if warning.get("type") == "on_error_recovery":
+            recovered_node_ids.add(node_id)
+        if warning.get("type") == "api_warning" and warning.get("recovered") is True:
             recovered_node_ids.add(node_id)
     return failed_node_ids - recovered_node_ids
 

--- a/tests/test_execution/formatters/test_node_output_formatter.py
+++ b/tests/test_execution/formatters/test_node_output_formatter.py
@@ -272,13 +272,13 @@ class TestDeduplicationGuards:
     def test_duplicate_structure_detection(self):
         """DEDUPLICATION: Same structure in multiple keys must be detected.
 
-        Real bug this catches: MCP nodes return both "result" and
-        "mcp_server_TOOL_result" with identical data. Without deduplication,
-        agents see 500 duplicate template paths making output unusable.
+        Real bug this catches: duplicate runtime values, whether from legacy
+        traces or custom nodes, can produce hundreds of duplicate template paths
+        and make output unusable.
 
         AI refactoring might break the hash comparison logic.
         """
-        # MCP pattern: duplicate data in different keys
+        # Legacy/custom duplicate data in different keys.
         duplicate_data = {"status": "ok", "count": 42}
         outputs = {
             "result": duplicate_data,

--- a/tests/test_execution/test_api_warning_system.py
+++ b/tests/test_execution/test_api_warning_system.py
@@ -3,7 +3,7 @@
 import json
 import time
 
-from pflow.core.diagnostic import Diagnostic, Severity
+from pflow.core.diagnostic import Diagnostic, Severity, normalize_runtime_warning
 from pflow.execution.executor_service import build_error_list
 from pflow.runtime.engine.api_warning_detector import detect_api_warning
 from pflow.runtime.engine.instrumentation import handle_api_warning
@@ -47,7 +47,10 @@ class TestCriticalAPIWarningScenarios:
 
         # Verify it stops workflow execution and records a warning
         assert result == "error", "Should stop workflow"
-        assert shared["__warnings__"]["send_response"] == "API error: channel_not_found"
+        message, context = normalize_runtime_warning(shared["__warnings__"]["send_response"])
+        assert message == "API error: channel_not_found"
+        assert context["type"] == "api_warning"
+        assert context["recovered"] is False
 
     def test_graphql_http_200_with_errors(self):
         """Test GraphQL returning HTTP 200 with errors (common GitHub API case)."""
@@ -108,9 +111,9 @@ class TestCriticalAPIWarningScenarios:
             ({"success": False, "error_code": "UNAUTHORIZED", "error": "Invalid token"}, True),
             # Not found errors
             ({"ok": False, "error": "user_not_found"}, True),
-            # Validation errors - these are now allowed for repair
-            ({"ok": False, "error": "invalid_parameter"}, False),
-            ({"status": "error", "message": "Invalid input format"}, False),
+            # Explicit failure flags are trusted even when wording looks like validation
+            ({"ok": False, "error": "invalid_parameter"}, True),
+            ({"status": "error", "message": "Invalid input format"}, True),
             # Success cases that should NOT trigger
             ({"ok": True, "data": {"messages": []}}, False),
             ({"status": "success", "result": {"id": 123}}, False),
@@ -125,6 +128,48 @@ class TestCriticalAPIWarningScenarios:
                 assert "API error" in warning
             else:
                 assert warning is None, f"Should NOT detect error in: {data}"
+
+    def test_mcp_result_status_error_with_unfamiliar_message_warns(self):
+        """Canonical MCP ``result`` payloads keep explicit failure provenance.
+
+        Regression for GH #486/#488: once MCP nodes stop splaying result keys,
+        ``status`` and ``error`` live under ``result``. The detector must still
+        trust the explicit status failure instead of requiring a known phrase.
+        """
+        payload = {
+            "status": "error",
+            "reason": "expired",
+            "error": (
+                "Cannot create audio: NotebookLM auth is not valid (reason: expired). Run nlm login in a terminal."
+            ),
+            "hint": "nlm login",
+        }
+
+        warning = detect_api_warning("create-audio", {"create-audio": {"result": payload}})
+
+        assert warning is not None
+        assert "Cannot create audio" in warning
+
+    def test_mcp_result_boolean_failure_with_unfamiliar_message_warns(self):
+        shared = {"api": {"result": {"success": False, "message": "Upstream rejected the request oddly"}}}
+
+        warning = detect_api_warning("api", shared)
+
+        assert warning == "API error: Upstream rejected the request oddly"
+
+    def test_bare_error_key_inside_result_stays_conservative(self):
+        shared = {"api": {"result": {"error": "Something unfamiliar happened"}}}
+
+        warning = detect_api_warning("api", shared)
+
+        assert warning is None
+
+    def test_nested_status_error_data_does_not_warn(self):
+        shared = {"api": {"result": {"rows": [{"status": "error", "error": "archived row"}]}}}
+
+        warning = detect_api_warning("api", shared)
+
+        assert warning is None
 
 
 class TestIntegrationWithExistingSystems:

--- a/tests/test_execution/test_api_warning_system.py
+++ b/tests/test_execution/test_api_warning_system.py
@@ -145,10 +145,24 @@ class TestCriticalAPIWarningScenarios:
             "hint": "nlm login",
         }
 
-        warning = detect_api_warning("create-audio", {"create-audio": {"result": payload}})
+        warning = detect_api_warning("create-audio", {"create-audio": {"result": payload}}, node_type_name="MCPNode")
 
         assert warning is not None
         assert "Cannot create audio" in warning
+
+    def test_result_wrapper_not_unwrapped_for_non_mcp_nodes(self):
+        shared = {"calc": {"result": {"status": "error", "error": "boom"}}}
+
+        warning = detect_api_warning("calc", shared, node_type_name="PythonCodeNode")
+
+        assert warning is None
+
+    def test_top_level_explicit_failure_flags_remain_type_agnostic(self):
+        shared = {"calc": {"status": "error", "message": "Invalid input format"}}
+
+        warning = detect_api_warning("calc", shared, node_type_name="PythonCodeNode")
+
+        assert warning == "API error: Invalid input format"
 
     def test_mcp_result_boolean_failure_with_unfamiliar_message_warns(self):
         shared = {"api": {"result": {"success": False, "message": "Upstream rejected the request oddly"}}}
@@ -163,6 +177,23 @@ class TestCriticalAPIWarningScenarios:
         warning = detect_api_warning("api", shared)
 
         assert warning is None
+
+    def test_unknown_error_dict_uses_default_instead_of_repr(self):
+        shared = {"api": {"ok": False, "error": {"code": 500}}}
+
+        warning = detect_api_warning("api", shared)
+
+        assert warning == "API error (500): API request failed"
+
+    def test_is_error_flag_uses_nested_error_and_reason_fields(self):
+        assert (
+            detect_api_warning("api", {"api": {"isError": True, "error": {"error": "nested boom"}}})
+            == "API error: nested boom"
+        )
+        assert (
+            detect_api_warning("api", {"api": {"isError": True, "error": {"reason": "expired auth"}}})
+            == "API error: expired auth"
+        )
 
     def test_nested_status_error_data_does_not_warn(self):
         shared = {"api": {"result": {"rows": [{"status": "error", "error": "archived row"}]}}}

--- a/tests/test_mcp/test_mcp_node_critical.py
+++ b/tests/test_mcp/test_mcp_node_critical.py
@@ -54,14 +54,13 @@ class TestMCPNodeCriticalBehaviors:
                 # Should have tried exactly once
                 assert exec_count == 1
 
-    def test_structured_data_extraction_to_shared_store(self):
-        """Test that structured data fields are extracted to shared store.
+    def test_structured_data_stays_under_result(self):
+        """Structured MCP output uses result as its only success namespace.
 
-        CRITICAL: When MCP returns structured data (e.g., from GitHub),
-        individual fields must be accessible in shared store for downstream nodes.
-
-        Example: GitHub's create-issue returns {"issue_url": "...", "issue_number": 123}
-        Both fields should be directly accessible as shared["issue_url"] and shared["issue_number"]
+        The validator only declares ``result`` for MCP nodes because MCP servers
+        do not publish stable output schemas. Keeping fields under result makes
+        runtime, validation, and probe teach the same downstream path:
+        ``${node.result.field}``.
         """
         node = MCPNode()
         node.set_params({"__mcp_server__": "github", "__mcp_tool__": "create-issue"})
@@ -82,20 +81,15 @@ class TestMCPNodeCriticalBehaviors:
 
         action = node.post(shared, prep_res, exec_res)
 
-        # Verify structured fields were extracted
-        assert shared["issue_url"] == "https://github.com/test/repo/issues/123"
-        assert shared["issue_number"] == 123
-        assert shared["issue_id"] == "I_kwDOBkpqZc5_y5mq"
-
-        # Private fields should NOT be extracted
-        assert "_internal_field" not in shared
-        assert "is_closed" not in shared  # Fields starting with "is_" are internal
-
-        # Full result still available
+        # Full result is available through the canonical result key.
         assert shared["result"] == exec_res["result"]
 
-        # Server-specific result key also available
-        assert shared["github_create-issue_result"] == exec_res["result"]
+        # Structured fields are not splayed into a second namespace.
+        assert "issue_url" not in shared
+        assert "issue_number" not in shared
+        assert "issue_id" not in shared
+        assert "_internal_field" not in shared
+        assert "is_closed" not in shared
 
         # Should return "default" action
         assert action == "default"
@@ -134,32 +128,19 @@ class TestMCPNodeCriticalBehaviors:
         assert "error" in shared
         assert shared["error"] == "Repository not found"
 
-    def test_multiple_server_results_dont_collide(self):
-        """Test that multiple MCP tools in same workflow don't overwrite results.
+    def test_mcp_node_does_not_write_server_specific_result_alias(self):
+        """MCP nodes do not expose duplicate server/tool result aliases.
 
-        CRITICAL: Without proper namespacing, second MCP tool would overwrite
-        first tool's results in shared store.
+        In a real workflow each MCP node is already namespaced by node id. A
+        second ``<server>_<tool>_result`` key inside that namespace is not
+        validator-addressable and creates duplicate probe paths.
         """
-        # First tool execution
-        node1 = MCPNode()
-        node1.set_params({"__mcp_server__": "github", "__mcp_tool__": "list-issues"})
+        node = MCPNode()
+        node.set_params({"__mcp_server__": "github", "__mcp_tool__": "list-issues"})
 
         shared = {}
-        prep1 = {"server": "github", "tool": "list-issues", "arguments": {}}
-        exec1 = {"result": ["issue1", "issue2", "issue3"]}
-        node1.post(shared, prep1, exec1)
+        prep = {"server": "github", "tool": "list-issues", "arguments": {}}
+        exec_res = {"result": ["issue1", "issue2", "issue3"]}
+        node.post(shared, prep, exec_res)
 
-        # Second tool execution (same workflow, different tool)
-        node2 = MCPNode()
-        node2.set_params({"__mcp_server__": "filesystem", "__mcp_tool__": "read-file"})
-
-        prep2 = {"server": "filesystem", "tool": "read-file", "arguments": {}}
-        exec2 = {"result": "File contents here"}
-        node2.post(shared, prep2, exec2)
-
-        # Both results should be available
-        assert shared["github_list-issues_result"] == ["issue1", "issue2", "issue3"]
-        assert shared["filesystem_read-file_result"] == "File contents here"
-
-        # Generic "result" gets overwritten (last one wins)
-        assert shared["result"] == "File contents here"
+        assert shared == {"result": ["issue1", "issue2", "issue3"]}

--- a/tests/test_runtime/test_engine_behavior.py
+++ b/tests/test_runtime/test_engine_behavior.py
@@ -8,6 +8,7 @@ Covers: unmatched action warnings, --only + output resolution, custom error_acti
 batch template error propagation.
 """
 
+from pflow.core.diagnostic import normalize_runtime_warning
 from pflow.core.node import BaseNode
 from pflow.runtime.engine.engine import WorkflowEngine
 from pflow.runtime.engine.types import BatchConfig, CompiledWorkflow, NodeConfig, TemplateConfig
@@ -51,6 +52,14 @@ class _CaptureNode(BaseNode):
 
     def post(self, shared, prep_res, exec_res):
         shared["seen"] = prep_res
+        return "default"
+
+
+class _McpApiWarningNode(BaseNode):
+    """Writes a canonical MCP result payload that self-reports API failure."""
+
+    def post(self, shared, prep_res, exec_res):
+        shared["result"] = {"status": "error", "error": "expired auth"}
         return "default"
 
 
@@ -486,6 +495,49 @@ class TestLoopReentryFailureRecovery:
         assert shared["flaky"]["stdout"] == "recovered"
         assert shared["sink"]["seen"] == "recovered"
         assert "flaky" in shared["__execution__"]["completed_nodes"]
+
+
+class TestApiWarningRecovery:
+    """API warnings with on-error successors should be marked recovered."""
+
+    def test_mcp_result_api_warning_with_error_successor_marks_warning_recovered(self):
+        api = _McpApiWarningNode()
+        api.node_id = "api"
+        recover = _OutputNode()
+        recover.node_id = "recover"
+        recover.set_params({"output_value": "handled"})
+
+        api - "error" >> recover
+
+        configs = {
+            "api": NodeConfig(
+                node_id="api",
+                node_type_name="MCPNode",
+                template_config=None,
+                batch_config=None,
+                namespaced=True,
+                interface_metadata=None,
+            ),
+            "recover": NodeConfig(
+                node_id="recover",
+                node_type_name="OutputNode",
+                template_config=None,
+                batch_config=None,
+                namespaced=True,
+                interface_metadata=None,
+            ),
+        }
+
+        workflow = CompiledWorkflow(start_node=api, node_configs=configs)
+        shared: dict = {}
+        result = WorkflowEngine().run(workflow, shared)
+
+        assert result == "default"
+        assert shared["recover"]["result"] == "handled"
+        message, context = normalize_runtime_warning(shared["__warnings__"]["api"])
+        assert message == "API error: expired auth"
+        assert context["type"] == "api_warning"
+        assert context["recovered"] is True
 
 
 class TestBatchTemplateErrorPropagation:

--- a/tests/test_runtime/test_workflow_trace.py
+++ b/tests/test_runtime/test_workflow_trace.py
@@ -644,6 +644,41 @@ class TestWorkflowTraceCollector:
             assert trace_data["nodes_failed"] == 0
             assert trace_data["failed_node_ids"] == []
 
+    def test_final_status_degraded_with_recovered_api_warning(self, collector, temp_home):
+        """API warnings routed through on-error should be degraded, not failed."""
+        with patch("pathlib.Path.home", return_value=temp_home):
+            collector.record_node_execution(
+                node_id="api",
+                node_type="MCPNode",
+                duration_ms=10.0,
+                success=False,
+                error="API error: expired auth",
+            )
+            collector.record_node_execution(
+                node_id="recover",
+                node_type="PythonCodeNode",
+                duration_ms=10.0,
+                success=True,
+            )
+            collector.set_warnings([
+                Diagnostic(
+                    severity=Severity.WARNING,
+                    message="API error: expired auth",
+                    node_id="api",
+                    source="runtime",
+                    context={"type": "api_warning", "recovered": True},
+                )
+            ])
+
+            filepath = collector.save_to_file()
+
+            with open(filepath) as f:
+                trace_data = json.load(f)
+
+            assert trace_data["final_status"] == "degraded"
+            assert trace_data["nodes_failed"] == 0
+            assert trace_data["failed_node_ids"] == []
+
     def test_llm_summary_in_trace(self, collector, temp_home):
         """Test that LLM summary is included when LLM calls are present in events.
 


### PR DESCRIPTION
## Summary

By making MCP node outputs canonical under `result`, and updating API warning detection to inspect canonical MCP payloads without relying on result-key splaying.

Fixes #486
Fixes #488 

## Changes

- Store MCP tool output only under `node.result`
- Detect explicit MCP failure flags inside MCP `result` payloads
- Avoid accidental result-wrapper unwrapping for non-MCP nodes
- Preserve recovered API warnings in diagnostics/traces
- Update MCP guide/runtime docs
- Adjust and expand regression tests

## Validation

- `make check`
- `make test`
- Manual pflow CLI workflows covering canonical MCP output, explicit MCP failures, recovered warnings, bare error payloads, nested status payloads, and non-MCP result wrappers