### PR TITLE
fix: unify input_tokens semantics across LLM-producing nodes (#492)

### DIFF
--- a/docs/how-it-works/template-variables.mdx
+++ b/docs/how-it-works/template-variables.mdx
@@ -258,7 +258,7 @@ Available fields on `${node_id.llm_usage}`:
 | `total_tokens` | int | Input + output |
 | `cache_creation_input_tokens` | int | Tokens used for cache creation |
 | `cache_read_input_tokens` | int | Tokens read from cache |
-| `input_token_accounting` | str | How LiteLLM prompt tokens were normalized (`total_includes_cache` or `split_cache_fields`) |
+| `input_token_accounting` | str | How `input_tokens` was derived. The `llm` node reports `total_includes_cache` or `split_cache_fields` depending on what the provider returned; `claude-code` always reports `split_cache_fields` (the Claude SDK splits cached tokens into separate fields). |
 
 ### Claude Code metadata
 

--- a/docs/reference/nodes/claude-code.mdx
+++ b/docs/reference/nodes/claude-code.mdx
@@ -106,7 +106,7 @@ The node always returns `default` from `post()` — schema soft-failures and SDK
 
 `cost_usd` is the SDK-reported API-equivalent estimated cost. Actual billing depends on auth method; Claude Pro/Max subscription runs may report an API-equivalent cost without a direct per-call charge.
 
-The `retries` field (optional) contains an array of usage records for schema retry attempts. Token/cost values shown at the top level aggregate the main call and all retries — when reading `llm_usage` for cost tracking, use the top-level fields (they already include retry costs).
+The `retries` field (optional) contains an array of usage records for superseded schema retry attempts. The top-level `llm_usage` fields reflect the **final (successful) attempt only** — the superseded attempts live in `retries[]`. The run's reported cost and token totals (the cost summary and the execution trace) aggregate the main call and all retries; the per-node `llm_usage` you read via `${node.llm_usage}` does not.
 
 ## Authentication
 

--- a/docs/reference/nodes/claude-code.mdx
+++ b/docs/reference/nodes/claude-code.mdx
@@ -73,11 +73,13 @@ The node always returns `default` from `post()` — schema soft-failures and SDK
 ```json
 {
   "model": "claude-sonnet-4-5",
-  "input_tokens": 1500,
+  "input_tokens": 21500,
+  "uncached_input_tokens": 1500,
   "output_tokens": 450,
-  "total_tokens": 1950,
+  "total_tokens": 21950,
   "cache_creation_input_tokens": 0,
-  "cache_read_input_tokens": 0,
+  "cache_read_input_tokens": 20000,
+  "input_token_accounting": "split_cache_fields",
   "cost_usd": 0.0234,
   "duration_ms": 3450,
   "num_turns": 2,
@@ -85,9 +87,11 @@ The node always returns `default` from `post()` — schema soft-failures and SDK
   "retries": [
     {
       "input_tokens": 500,
+      "uncached_input_tokens": 400,
       "output_tokens": 150,
       "cache_creation_input_tokens": 0,
       "cache_read_input_tokens": 100,
+      "input_token_accounting": "split_cache_fields",
       "cost_usd": 0.0078,
       "duration_ms": 1200,
       "num_turns": 1,
@@ -97,6 +101,8 @@ The node always returns `default` from `post()` — schema soft-failures and SDK
   ]
 }
 ```
+
+`input_tokens` is the cache-inclusive total — it includes `cache_creation_input_tokens` and `cache_read_input_tokens`. `uncached_input_tokens` is the slice that wasn't served from cache. In the example above, 20,000 of the 21,500 input tokens were read from cache, leaving 1,500 uncached.
 
 `cost_usd` is the SDK-reported API-equivalent estimated cost. Actual billing depends on auth method; Claude Pro/Max subscription runs may report an API-equivalent cost without a direct per-call charge.
 

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -673,15 +673,16 @@ def _format_cost_summary_lines(total_cost: float | None, formatted_result: dict[
     if total_cost is None or total_cost <= 0:
         return []
 
-    # Get token count for context
+    # Get token count for context. The key is ``tokens_total`` (set by
+    # MetricsCollector._build_execution_metrics) — cache-inclusive input + output.
     workflow_metrics = metrics.get("workflow", {})
-    total_tokens = workflow_metrics.get("total_tokens", 0)
+    tokens_total = workflow_metrics.get("tokens_total", 0)
 
     detail_parts: list[str] = []
     if total_llm_calls > 0:
         detail_parts.append(f"{total_llm_calls} call{'s' if total_llm_calls != 1 else ''}")
-    if total_tokens > 0:
-        detail_parts.append(f"{total_tokens:,} tokens")
+    if tokens_total > 0:
+        detail_parts.append(f"{tokens_total:,} tokens")
 
     if detail_parts:
         return [f"💰 Cost: ${total_cost:.4f} ({', '.join(detail_parts)})"]

--- a/src/pflow/core/trace_report.py
+++ b/src/pflow/core/trace_report.py
@@ -348,20 +348,16 @@ def _format_cost(cost: float | None) -> str:
 
 
 def _input_token_total(llm_call: dict[str, Any]) -> tuple[int, int]:
-    """Return ``(total_input_tokens, cache_read_tokens)`` for one LLM call.
+    """Return ``(input_tokens, cache_read_tokens)`` for one LLM call.
 
-    LLM input is billed in three tiers that SUM to the true input the model
-    processed: uncached (``input_tokens``) + cache-write
-    (``cache_creation_input_tokens``) + cache-read (``cache_read_input_tokens``).
-    The report headlines that total and surfaces the cache-read share as a
-    cache-hit %, rather than showing the uncached slice alone \u2014 which made
-    cache-heavy agent runs look like ``in`` << ``out`` and divorced the cache
-    numbers from the token line.
+    ``input_tokens`` is pflow's cache-INCLUSIVE input total (see
+    ``core/llm_usage.py``) \u2014 every producer (LLMNode and ClaudeCodeNode) emits it
+    that way, so the report headlines it directly with no render-time cache
+    arithmetic. ``cache_read`` is returned only for the cache-hit % display.
     """
-    uncached = llm_call.get("input_tokens", llm_call.get("prompt_tokens", 0)) or 0
-    cache_write = llm_call.get("cache_creation_input_tokens", 0) or 0
+    total_in = llm_call.get("input_tokens", llm_call.get("prompt_tokens", 0)) or 0
     cache_read = llm_call.get("cache_read_input_tokens", 0) or 0
-    return uncached + cache_write + cache_read, cache_read
+    return total_in, cache_read
 
 
 def _format_tokens(total_in: int, tokens_out: int, cache_read: int, *, with_cache_pct: bool) -> str:
@@ -798,10 +794,11 @@ def _build_summary(
                 llm.get("total_num_turns", 0),
             )
         )
-        # `in` is the TRUE total: uncached + cache-write + cache-read (the three
-        # billing tiers). total_input_tokens alone is just the uncached slice.
+        # total_input_tokens is the cache-INCLUSIVE input total (every producer
+        # emits inclusive input_tokens; see core/llm_usage.py). cache_read is read
+        # only for the cache-% suffix, NOT added back into the input total.
         cache_read = llm.get("total_cache_read_tokens", 0)
-        total_in = llm.get("total_input_tokens", 0) + llm.get("total_cache_creation_tokens", 0) + cache_read
+        total_in = llm.get("total_input_tokens", 0)
         tokens_out = llm.get("total_output_tokens", 0)
         if total_in or tokens_out:
             lines.append(f"- Tokens: {_format_tokens(total_in, tokens_out, cache_read, with_cache_pct=True)}")

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -356,14 +356,16 @@ def format_success_as_text(  # noqa: C901
         if total_llm_calls > 0:
             lines.append(f"   Total LLM calls: {total_llm_calls}")
     elif total_cost and total_cost > 0:
+        # The key is ``tokens_total`` (set by MetricsCollector._build_execution_metrics)
+        # — cache-inclusive input + output. Mirrors the CLI cost line.
         workflow_metrics = metrics.get("workflow", {})
-        total_tokens = workflow_metrics.get("total_tokens", 0)
+        tokens_total = workflow_metrics.get("tokens_total", 0)
 
         detail_parts: list[str] = []
         if total_llm_calls > 0:
             detail_parts.append(f"{total_llm_calls} call{'s' if total_llm_calls != 1 else ''}")
-        if total_tokens > 0:
-            detail_parts.append(f"{total_tokens:,} tokens")
+        if tokens_total > 0:
+            detail_parts.append(f"{tokens_total:,} tokens")
 
         if detail_parts:
             lines.append(f"💰 Cost: ${total_cost:.4f} ({', '.join(detail_parts)})")

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -11,11 +11,13 @@ Interface:
 - Writes: shared["_schema_error"]: str  # Soft-failure message for structured-output mode: set when structured output was unavailable, the SDK reported an error alongside the output, or the schema reference resolved to None (optional)
 - Writes: shared["llm_usage"]: dict  # Token usage and execution metadata (empty dict {} if unavailable)
     - model: str  # Model identifier used
-    - input_tokens: int  # Non-cached input tokens
+    - input_tokens: int  # Total input tokens, including cached prefix
+    - uncached_input_tokens: int  # Input tokens not served from cache
     - output_tokens: int  # Output tokens generated
-    - total_tokens: int  # Total tokens (input + output)
+    - total_tokens: int  # Total tokens (input + output); input includes cache
     - cache_creation_input_tokens: int  # Tokens used for cache creation
     - cache_read_input_tokens: int  # Tokens read from cache
+    - input_token_accounting: str  # How input_tokens was derived (always "split_cache_fields" for claude-code)
     - cost_usd: float  # Cost in USD from Claude Code SDK
     - duration_ms: int  # Execution time in milliseconds
     - num_turns: int  # Number of conversation turns
@@ -50,6 +52,7 @@ import asyncio
 import json
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any, Optional
 
 from pflow.core.node import Node
@@ -135,6 +138,27 @@ _AUTH_ERROR_MARKERS = (
 )
 
 
+def _claude_token_fields(usage: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize Claude SDK usage to pflow's inclusive token contract.
+
+    The Claude SDK reports Anthropic's disjoint model — ``input_tokens`` is the
+    UNCACHED count, with ``cache_creation_input_tokens`` / ``cache_read_input_tokens``
+    as separate addends. pflow's contract (see ``core/llm_usage.py``) treats
+    ``input_tokens`` as the cache-INCLUSIVE total, matching LLMNode. Claude's split is
+    always known, so the total is a deterministic sum (no value-based heuristic).
+    """
+    base_input = usage.get("input_tokens", 0) or 0
+    cache_creation = usage.get("cache_creation_input_tokens", 0) or 0
+    cache_read = usage.get("cache_read_input_tokens", 0) or 0
+    return {
+        "input_tokens": base_input + cache_creation + cache_read,
+        "uncached_input_tokens": base_input,
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+        "input_token_accounting": "split_cache_fields",
+    }
+
+
 class ClaudeCodeNode(Node):
     """Claude Code agentic super node for AI-assisted development tasks.
 
@@ -156,11 +180,13 @@ class ClaudeCodeNode(Node):
     - Writes: shared["_schema_error"]: str  # Soft-failure message for structured-output mode: set when structured output was unavailable, the SDK reported an error alongside the output, or the schema reference resolved to None (optional)
     - Writes: shared["llm_usage"]: dict  # Token usage and execution metadata (empty dict {} if unavailable)
         - model: str  # Model identifier used
-        - input_tokens: int  # Non-cached input tokens
+        - input_tokens: int  # Total input tokens, including cached prefix
+        - uncached_input_tokens: int  # Input tokens not served from cache
         - output_tokens: int  # Output tokens generated
-        - total_tokens: int  # Total tokens (input + output)
+        - total_tokens: int  # Total tokens (input + output); input includes cache
         - cache_creation_input_tokens: int  # Tokens used for cache creation
         - cache_read_input_tokens: int  # Tokens read from cache
+        - input_token_accounting: str  # How input_tokens was derived (always "split_cache_fields" for claude-code)
         - cost_usd: float  # Cost in USD from Claude Code SDK
         - duration_ms: int  # Execution time in milliseconds
         - num_turns: int  # Number of conversation turns
@@ -784,11 +810,14 @@ class ClaudeCodeNode(Node):
         usage = metadata.get("usage") or {}
         if not usage:
             return None
+        # Inclusive input_tokens per pflow's contract — REQUIRED here, not just in
+        # post(): the retry aggregator (workflow_trace.aggregate_llm_usage_with_retries)
+        # sums per-attempt input_tokens, so a uncached-only record here would silently
+        # mix inclusive + uncached. total_tokens is intentionally omitted (the
+        # aggregator recomputes it from the summed inputs/outputs).
         return {
-            "input_tokens": usage.get("input_tokens", 0),
+            **_claude_token_fields(usage),
             "output_tokens": usage.get("output_tokens", 0),
-            "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0),
-            "cache_read_input_tokens": usage.get("cache_read_input_tokens", 0),
             "cost_usd": metadata.get("total_cost_usd"),
             "duration_ms": metadata.get("duration_ms"),
             "num_turns": metadata.get("num_turns"),
@@ -1432,19 +1461,17 @@ class ClaudeCodeNode(Node):
         if metadata:
             usage = metadata.get("usage") or {}
 
-            # Store token counts separately - do NOT aggregate cache tokens into input_tokens
-            base_input = usage.get("input_tokens", 0)
-            cache_creation = usage.get("cache_creation_input_tokens", 0)
-            cache_read = usage.get("cache_read_input_tokens", 0)
+            # Normalize the SDK's disjoint token split into pflow's inclusive
+            # contract (input_tokens = total including cached prefix). See
+            # _claude_token_fields / core/llm_usage.py.
+            token_fields = _claude_token_fields(usage)
             total_output = usage.get("output_tokens", 0)
 
             shared["llm_usage"] = {
                 "model": self.params.get("model", "claude-sonnet-4-5"),
-                "input_tokens": base_input,  # Only non-cached input tokens
+                **token_fields,
                 "output_tokens": total_output,
-                "total_tokens": base_input + total_output,
-                "cache_creation_input_tokens": cache_creation,
-                "cache_read_input_tokens": cache_read,
+                "total_tokens": token_fields["input_tokens"] + total_output,
                 # ClaudeCodeNode mirrors total_cost_usd (Claude SDK convention)
                 # into cost_usd at its producer boundary so the rest of the
                 # pipeline reads a single key (matching LLMNode/LiteLLM output).

--- a/src/pflow/nodes/claude/claude_code.py
+++ b/src/pflow/nodes/claude/claude_code.py
@@ -817,7 +817,7 @@ class ClaudeCodeNode(Node):
         # aggregator recomputes it from the summed inputs/outputs).
         return {
             **_claude_token_fields(usage),
-            "output_tokens": usage.get("output_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0) or 0,  # None-safe, matching the helper's guards
             "cost_usd": metadata.get("total_cost_usd"),
             "duration_ms": metadata.get("duration_ms"),
             "num_turns": metadata.get("num_turns"),
@@ -1465,7 +1465,10 @@ class ClaudeCodeNode(Node):
             # contract (input_tokens = total including cached prefix). See
             # _claude_token_fields / core/llm_usage.py.
             token_fields = _claude_token_fields(usage)
-            total_output = usage.get("output_tokens", 0)
+            # ``or 0``: an explicit ``output_tokens: None`` from the SDK would slip past
+            # the ``, 0`` default (only absent keys default), then crash the total_tokens
+            # sum below. Coerce to match _claude_token_fields' None-guards.
+            total_output = usage.get("output_tokens", 0) or 0
 
             shared["llm_usage"] = {
                 "model": self.params.get("model", "claude-sonnet-4-5"),

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -315,7 +315,8 @@ class _LLMSummaryAccumulator:
         }
         # Additive within trace 2.x — omitted when zero so older readers and
         # non-caching/non-agent runs stay unchanged. ``total_input_tokens`` is
-        # the UNCACHED slice; renderers add the two cache tiers for the true total.
+        # the cache-inclusive total (every producer emits inclusive input_tokens;
+        # see core/llm_usage.py); the cache tiers are emitted as a subset breakdown.
         if self.total_cache_creation_tokens:
             result["total_cache_creation_tokens"] = self.total_cache_creation_tokens
         if self.total_cache_read_tokens:
@@ -596,6 +597,11 @@ class WorkflowTraceCollector:
         # Sum input/output tokens (None-safe: use `or 0` to coerce explicit None to 0)
         aggregated["input_tokens"] = llm_usage.get("input_tokens") or 0
         aggregated["output_tokens"] = llm_usage.get("output_tokens") or 0
+        # uncached_input_tokens is summed alongside input_tokens so the aggregated dict
+        # keeps the invariant input_tokens == uncached + cache_creation + cache_read for
+        # retried claude-code calls (#492). Producers that omit it (and never retry)
+        # default to 0.
+        aggregated["uncached_input_tokens"] = llm_usage.get("uncached_input_tokens") or 0
 
         # Sum cache tokens (None-safe)
         for cache_key in ["cache_creation_input_tokens", "cache_read_input_tokens"]:
@@ -619,6 +625,7 @@ class WorkflowTraceCollector:
         # Aggregate retry contributions to tokens (None-safe)
         for retry in retries:
             aggregated["input_tokens"] += retry.get("input_tokens") or 0
+            aggregated["uncached_input_tokens"] += retry.get("uncached_input_tokens") or 0
             aggregated["output_tokens"] += retry.get("output_tokens") or 0
             for cache_key in ["cache_creation_input_tokens", "cache_read_input_tokens"]:
                 aggregated[cache_key] += retry.get(cache_key) or 0

--- a/tests/shared/trace_fixture_builder.py
+++ b/tests/shared/trace_fixture_builder.py
@@ -21,6 +21,11 @@ class TraceFixtureBuilder:
         success: bool = True,
         system: str | list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
+        """Live (non-cached) LLM event matching production shape.
+
+        ``input_tokens`` is the cache-INCLUSIVE total (it includes any cache tiers),
+        matching pflow's contract for every producer — see ``core/llm_usage.py``.
+        """
         event: dict[str, Any] = {
             "node_id": node_id,
             "node_type": "LLMNode",
@@ -86,6 +91,11 @@ class TraceFixtureBuilder:
         cache record retains the original spend), plus ``cache_source``,
         ``cache_key``, ``cache_age_sec`` augmented at restore.
         ``node_output.llm_usage`` mirrors ``llm_call``.
+
+        ``input_tokens`` is the cache-INCLUSIVE total (it includes
+        ``cache_read_input_tokens`` / ``cache_creation_input_tokens``), matching
+        pflow's contract for every producer — see ``core/llm_usage.py``. The
+        default 1000/950 means "1000 total of which 950 was a cache read".
         """
         llm_call = {
             "model": model,

--- a/tests/test_cli/test_direct_execution_helpers.py
+++ b/tests/test_cli/test_direct_execution_helpers.py
@@ -188,17 +188,22 @@ class TestDisplayCostSummary:
         partial_cost_usd: float | None = None,
         unavailable_models_unnamed_count: int = 0,
         total_calls: int = 0,
+        tokens_total: int = 15,
     ) -> dict:
         """Build a synthetic formatted result for cost-display tests.
 
         ``unavailable_models`` uses the F#17-deferred shape
         ``list[{name, calls}]`` consumed by the helper-normalizer in
         ``cli/workflow_output.py::_format_cost_summary_lines``.
+
+        The cost line reads ``metrics.workflow.tokens_total`` (production keeps
+        it equal to ``metrics.total.tokens_total`` — both summed from the same
+        llm_calls). ``tokens_input``/``tokens_output`` are unread display filler.
         """
         total: dict = {
             "tokens_input": 10,
             "tokens_output": 5,
-            "tokens_total": 15,
+            "tokens_total": tokens_total,
             "total_calls": total_calls,
             "cost_usd": None,
         }
@@ -208,7 +213,7 @@ class TestDisplayCostSummary:
             total["unavailable_models_unnamed_count"] = unavailable_models_unnamed_count
             if partial_cost_usd is not None:
                 total["partial_cost_usd"] = partial_cost_usd
-        return {"metrics": {"total": total, "workflow": {"total_tokens": 15}}}
+        return {"metrics": {"total": total, "workflow": {"tokens_total": tokens_total}}}
 
     def test_unknown_model_shows_warning(self) -> None:
         """When LiteLLM has no pricing for the model, show warning with model name."""
@@ -245,6 +250,24 @@ class TestDisplayCostSummary:
         assert "unavailable" not in out.lower()
         # F#17 deferred: priced multi-call line carries the call count
         assert "3 calls" in out
+
+    def test_priced_cost_line_shows_token_count(self) -> None:
+        """The priced cost line surfaces the cache-inclusive total-token count.
+
+        Regression guard: the code read the wrong key (``total_tokens``) while
+        MetricsCollector emits ``tokens_total``, so this detail silently rendered
+        as 0 (never shown) for every run. The fixture now uses the production key.
+        """
+        result = self._make_formatted_result(total_calls=2, tokens_total=28000)
+        out = "\n".join(_format_cost_summary_lines(0.05, result))
+        assert "28,000 tokens" in out
+
+    def test_priced_cost_line_token_count_over_one_million_uses_separators(self) -> None:
+        """Token counts ≥ 1M render with thousands separators, no overflow or
+        abbreviation — matching the trace-report summary convention."""
+        result = self._make_formatted_result(total_calls=9, tokens_total=2137122)
+        out = "\n".join(_format_cost_summary_lines(0.05, result))
+        assert "2,137,122 tokens" in out
 
     def test_known_model_singular_call_uses_singular_noun(self) -> None:
         """F#17 wording lock: single LLM call renders as ``1 call``."""

--- a/tests/test_core/test_trace_report.py
+++ b/tests/test_core/test_trace_report.py
@@ -28,6 +28,7 @@ from pflow.core.trace_report import (
     _extract_item_label,
     _find_notable_items,
     _format_cost,
+    _input_token_total,
     _item_filename,
     _replace_report_dir,
     _slugify_label,
@@ -614,13 +615,16 @@ class TestBuildSummary:
 
     def test_agent_calls_label_with_turns_and_cache(self) -> None:
         """claude-code runs render 'Agent calls: N (T turns)', and `in` is the
-        true total (uncached + cache-write + cache-read) with a cache-% suffix."""
+        cache-inclusive input total read directly from ``total_input_tokens`` — the
+        renderer no longer re-adds the cache tiers (#492), with a cache-% suffix."""
         trace = _make_trace(
             llm_summary={
                 "total_calls": 9,
                 "agent_calls": 9,
                 "total_num_turns": 104,
-                "total_input_tokens": 1743,
+                # Inclusive total (uncached 1,743 + cache tiers). Every producer emits
+                # inclusive input_tokens, so the summary stores the inclusive sum here.
+                "total_input_tokens": 2137122,
                 "total_cache_creation_tokens": 153248,
                 "total_cache_read_tokens": 1982131,
                 "total_output_tokens": 41733,
@@ -629,7 +633,7 @@ class TestBuildSummary:
         )
         md = _build_summary(trace, source_path="test")
         assert "- Agent calls: 9 (104 turns)" in md
-        # 1,743 + 153,248 + 1,982,131 = 2,137,122 in; 1,982,131 / 2,137,122 ≈ 93%
+        # `in` is total_input_tokens verbatim; 1,982,131 / 2,137,122 ≈ 93% cached.
         assert "- Tokens: 2,137,122 in / 41,733 out  ·  93% of input cached" in md
         assert "LLM calls" not in md
 
@@ -769,13 +773,14 @@ class TestBuildNodeFile:
 
     def test_cached_llm_metadata_splits_paid_and_historical_cost(self) -> None:
         builder = TraceFixtureBuilder()
-        event = builder.cached_llm_event_with_call("draft", cost_usd=0.07)
+        # input_tokens is the cache-INCLUSIVE total (950 of the 1,950 was a cache read).
+        event = builder.cached_llm_event_with_call("draft", cost_usd=0.07, input_tokens=1950)
 
         md = _build_node_file(event)
 
         assert "- Status: success [cached]" in md
         assert "- Source model: anthropic/claude-sonnet-4-5" in md
-        # `in` is the true total: 1,000 uncached + 950 cache-read = 1,950 (49% cached).
+        # `in` is the inclusive total read verbatim: 950 / 1,950 ≈ 49% cached.
         assert "- Source tokens: 1,950 in / 100 out  ·  49% of input cached" in md
         assert "- Paid this run: $0.0000" in md
         assert "- Historical source cost: $0.0700" in md
@@ -1046,15 +1051,146 @@ class TestBuildNodeFile:
         assert md.count('"cache_control"') == 3
 
 
+class TestInclusiveInputTokenContract:
+    """``input_tokens`` is the cache-inclusive total at every consumer (#492).
+
+    The bug: ``trace_report`` used to add the cache tiers on top of ``input_tokens``
+    (correct only for ClaudeCodeNode's old disjoint shape), double-counting every
+    inclusive LLMNode call. After the fix the renderer reads ``input_tokens`` verbatim,
+    so it agrees with ``metrics.py`` for both node types.
+    """
+
+    def test_input_token_total_returns_inclusive_input_no_cache_addition(self) -> None:
+        """_input_token_total returns ``input_tokens`` verbatim and does NOT re-add the
+        cache tiers; cache_read is returned only for the cache-% display."""
+        total_in, cache_read = _input_token_total({
+            "input_tokens": 26000,
+            "cache_creation_input_tokens": 5000,
+            "cache_read_input_tokens": 20000,
+        })
+        assert (total_in, cache_read) == (26000, 20000)
+
+    def test_per_node_render_does_not_double_count_inclusive_call(self) -> None:
+        """A per-node Tokens line shows the inclusive input total and a sane cache-%
+        (20,000 / 26,000 ≈ 77%) — not the pre-fix 51,000 from re-summing cache."""
+        event = _make_event(
+            node_type="ClaudeCodeNode",
+            llm_call={
+                "model": "claude-sonnet-4-5",
+                "input_tokens": 26000,
+                "uncached_input_tokens": 1000,
+                "output_tokens": 2000,
+                "total_tokens": 28000,
+                "cache_creation_input_tokens": 5000,
+                "cache_read_input_tokens": 20000,
+                "input_token_accounting": "split_cache_fields",
+            },
+        )
+        md = _build_node_file(event)
+        assert "- Tokens: 26,000 in / 2,000 out  ·  77% of input cached" in md
+
+    def test_summary_render_does_not_double_count_inclusive_total(self) -> None:
+        """The summary Tokens line reads ``total_input_tokens`` verbatim (no cache
+        addition) — same 26,000 in / 77% as the per-node path."""
+        trace = _make_trace(
+            llm_summary={
+                "total_calls": 1,
+                "agent_calls": 1,
+                "total_num_turns": 4,
+                "total_input_tokens": 26000,
+                "total_cache_creation_tokens": 5000,
+                "total_cache_read_tokens": 20000,
+                "total_output_tokens": 2000,
+                "models_used": ["claude-sonnet-4-5"],
+            }
+        )
+        md = _build_summary(trace, source_path="test")
+        assert "- Tokens: 26,000 in / 2,000 out  ·  77% of input cached" in md
+
+    def test_metrics_and_report_agree_on_inclusive_input_total(self) -> None:
+        """#492's real surface: ``metrics.py`` and ``trace_report.py`` must report the
+        SAME input total for a trace mixing a claude-code (inclusive-with-cache) call and
+        an LLMNode call. Pre-fix, trace_report added cache on top of ``input_tokens`` and
+        diverged from metrics. Runs the real consumers, not mocks (tests/CLAUDE.md #20):
+        the trace's ``llm_summary`` is produced by the real ``WorkflowTraceCollector``
+        aggregation and the metrics by the real ``MetricsCollector``.
+        """
+        from pflow.core.metrics import MetricsCollector
+        from pflow.runtime.workflow_trace import WorkflowTraceCollector
+
+        claude_event = {
+            "node_id": "agent",
+            "node_type": "ClaudeCodeNode",
+            "duration_ms": 10.0,
+            "success": True,
+            "timestamp": "2026-03-23T10:00:01",
+            "llm_call": {
+                "model": "claude-sonnet-4-5",
+                "input_tokens": 26000,  # inclusive: 1000 uncached + 5000 + 20000
+                "uncached_input_tokens": 1000,
+                "output_tokens": 2000,
+                "total_tokens": 28000,
+                "cache_creation_input_tokens": 5000,
+                "cache_read_input_tokens": 20000,
+                "input_token_accounting": "split_cache_fields",
+                "cost_usd": 0.05,
+                "num_turns": 3,
+            },
+        }
+        llm_event = TraceFixtureBuilder().llm_event("draft", input_tokens=1000, output_tokens=500, cost_usd=0.01)
+        events = [claude_event, llm_event]
+
+        collector = WorkflowTraceCollector(workflow_name="x")
+        collector.events = events
+        metrics = MetricsCollector().get_summary(collector.collect_llm_calls())
+        tokens_input = metrics["metrics"]["total"]["tokens_input"]
+
+        llm_summary = collector._collect_llm_summary(events)
+        trace = _make_trace(llm_summary=llm_summary, nodes=events)
+        md = _build_summary(trace, source_path="test")
+
+        # Both consumers report 27,000 in (26,000 + 1,000) — no render-time cache addition.
+        assert tokens_input == 27000
+        assert f"- Tokens: {tokens_input:,} in" in md
+        # Second independent inclusive total: llm_summary.total_tokens is summed from each
+        # call's inclusive total_tokens (28,000 + 1,500). Pinned so it can't silently drift.
+        assert llm_summary["total_tokens"] == 29500
+
+    def test_cached_claude_event_source_tokens_render_sane_cache_pct(self) -> None:
+        """A cached claude-code event where cache_read (20,000) exceeds the old uncached
+        slice (1,000): the now-inclusive denominator keeps the 'Source tokens' cache-%
+        under 100% (77%). Pre-fix this latent case could render a nonsensical >100%."""
+        event = _make_event(
+            node_type="ClaudeCodeNode",
+            cached=True,
+            llm_call={
+                "model": "claude-sonnet-4-5",
+                "input_tokens": 26000,
+                "uncached_input_tokens": 1000,
+                "output_tokens": 2000,
+                "total_tokens": 28000,
+                "cache_creation_input_tokens": 5000,
+                "cache_read_input_tokens": 20000,
+                "input_token_accounting": "split_cache_fields",
+                "cost_usd": 0.05,
+            },
+        )
+        md = _build_node_file(event)
+        assert "- Source tokens: 26,000 in / 2,000 out  ·  77% of input cached" in md
+
+
 class TestCacheTelemetrySection:
     """Trace report per-call cache telemetry rendering."""
 
-    def test_live_cache_write_folds_into_tokens_line_no_section(self) -> None:
-        """A live (non-replay, non-declared) cache no longer emits a divorced
-        ``## Cache telemetry`` section — the tiers are part of the input total
-        on the Tokens line. cache-write only (0 read) ⇒ no cache-% suffix."""
+    def test_cache_write_only_renders_inclusive_input_no_section(self) -> None:
+        """The renderer displays the already-inclusive ``input_tokens`` directly — it
+        does NOT re-add the cache tiers (#492). cache-write only (0 read) ⇒ no cache-%
+        suffix and no divorced ``## Cache telemetry`` section. Keeping
+        ``cache_creation_input_tokens == input_tokens`` is the mutation guard: if the
+        renderer ever re-summed cache, ``in`` would render 3,000 instead of 1,500."""
         event = _make_event(
             llm_call={
+                "input_tokens": 1500,  # inclusive total (all of it was cache-creation)
                 "cache_creation_input_tokens": 1500,
                 "cache_read_input_tokens": 0,
             },
@@ -1064,11 +1200,14 @@ class TestCacheTelemetrySection:
         assert "## Cache telemetry" not in md
         assert "- Tokens: 1,500 in / 0 out" in md
 
-    def test_live_cache_read_folds_into_tokens_line_with_pct(self) -> None:
-        """A live cache-read fold: ``in`` is the total and the cache-read share
-        shows as ``% of input cached`` — no separate section."""
+    def test_cache_read_renders_inclusive_input_with_pct(self) -> None:
+        """The renderer displays the already-inclusive ``input_tokens`` and surfaces the
+        cache-read share as ``% of input cached`` — no render-time folding (#492). Here
+        the full input was a cache hit, so it reads 100% and ``in`` stays 8,062 (not
+        16,124, which is what re-summing the read tier would produce)."""
         event = _make_event(
             llm_call={
+                "input_tokens": 8062,  # inclusive total (all of it was a cache read)
                 "cache_creation_input_tokens": 0,
                 "cache_read_input_tokens": 8062,
             },
@@ -1193,11 +1332,11 @@ class TestCacheTelemetrySection:
         assert "Cache write: 0 tokens" in md
         assert "Cache read: 0 tokens" in md
 
-    def test_cache_tiers_fold_into_tokens_line_in_batch_item_file(self) -> None:
-        """Batch per-item files reuse the shared metadata helper, so a live
-        cache's tiers land on the item's Tokens line (input total), not in a
-        separate section. Pins the contract against future refactors that move
-        batch-item rendering off the shared helper."""
+    def test_batch_item_renders_inclusive_input_no_section(self) -> None:
+        """Batch per-item files reuse the shared metadata helper, so the item's Tokens
+        line shows the already-inclusive ``input_tokens`` — no render-time cache folding
+        (#492). Pins the contract against refactors that move batch-item rendering off
+        the shared helper."""
         from pflow.core.trace_report import _build_batch_item_file
 
         parent_event = _make_event(node_id="batch-parent", node_type="LLMNode")
@@ -1206,6 +1345,7 @@ class TestCacheTelemetrySection:
             "duration_ms": 50,
             "success": True,
             "llm_call": {
+                "input_tokens": 1500,  # inclusive total (all of it was cache-creation)
                 "cache_creation_input_tokens": 1500,
                 "cache_read_input_tokens": 0,
             },

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -577,19 +577,24 @@ class TestPricingUnavailableWarning:
         total_cost_usd: float | None = None,
         unavailable_models_unnamed_count: int = 0,
         total_calls: int = 0,
+        tokens_total: int = 10,
     ) -> dict:
         """Build a synthetic result dict for cost-display tests.
 
         ``unavailable_models`` uses the F#17-deferred shape ``list[{name, calls}]``.
         Tests that need to exercise the legacy ``list[str]`` shape pass that
         directly; the renderer's normalizer accepts both for forward-compat.
+
+        The cost line reads ``metrics.workflow.tokens_total`` (production keeps it
+        equal to ``metrics.total.tokens_total`` — both summed from the same
+        llm_calls). ``tokens_input``/``tokens_output`` are unread display filler.
         """
         metrics: dict = {
-            "workflow": {"duration_ms": 100, "nodes_executed": 1, "total_tokens": 10},
+            "workflow": {"duration_ms": 100, "nodes_executed": 1, "tokens_total": tokens_total},
             "total": {
                 "tokens_input": 5,
                 "tokens_output": 5,
-                "tokens_total": 10,
+                "tokens_total": tokens_total,
                 "total_calls": total_calls,
                 "cost_usd": total_cost_usd,
             },
@@ -657,6 +662,21 @@ class TestPricingUnavailableWarning:
         assert "$0.0500" in text
         assert "1 call" in text
         assert "1 calls" not in text
+
+    def test_priced_cost_line_shows_token_count(self):
+        """Parity with the CLI cost line: the priced MCP cost line surfaces the
+        cache-inclusive total-token count. Regression guard for the wrong-key
+        bug (``total_tokens`` vs the emitted ``tokens_total``)."""
+        result_dict = self._make_result_dict(total_cost_usd=0.05, total_calls=2, tokens_total=28000)
+        text = format_success_as_text(result_dict)
+        assert "28,000 tokens" in text
+
+    def test_priced_cost_line_token_count_over_one_million_uses_separators(self):
+        """Token counts ≥ 1M render with thousands separators, no overflow or
+        abbreviation — matching the CLI and trace-report token conventions."""
+        result_dict = self._make_result_dict(total_cost_usd=0.05, total_calls=9, tokens_total=2137122)
+        text = format_success_as_text(result_dict)
+        assert "2,137,122 tokens" in text
 
     def test_unnamed_only_renders_count_phrase(self):
         """When all unpriced calls are genuinely-unrecorded, the rendered

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -38,7 +38,7 @@ import pytest
 
 from pflow.core.diagnostic import Severity
 from pflow.core.workflow.validator import WorkflowValidator
-from pflow.nodes.claude.claude_code import ClaudeCodeNode
+from pflow.nodes.claude.claude_code import ClaudeCodeNode, _claude_token_fields
 from pflow.registry.metadata_extractor import PflowMetadataExtractor
 
 # The mock ``claude_agent_sdk`` is installed by this directory's conftest.py (via
@@ -1809,6 +1809,185 @@ def test_schema_retry_records_superseded_attempt_for_cost(claude_node):
     assert agg["output_tokens"] == 30
     assert agg["num_turns"] == 5
     assert agg["cost_usd"] == pytest.approx(0.03)
+
+
+def test_claude_token_fields_sums_cache_into_inclusive_total():
+    """_claude_token_fields folds the SDK's disjoint split into pflow's inclusive total.
+
+    The Claude SDK reports input_tokens as the UNCACHED count; pflow's contract treats
+    it as the cache-inclusive total = uncached + cache_creation + cache_read (#492).
+    """
+    fields = _claude_token_fields({
+        "input_tokens": 1000,
+        "cache_creation_input_tokens": 5000,
+        "cache_read_input_tokens": 20000,
+    })
+    assert fields == {
+        "input_tokens": 26000,  # 1000 + 5000 + 20000
+        "uncached_input_tokens": 1000,
+        "cache_creation_input_tokens": 5000,
+        "cache_read_input_tokens": 20000,
+        "input_token_accounting": "split_cache_fields",
+    }
+
+
+def test_claude_token_fields_defaults_missing_and_none_to_zero():
+    """Empty usage and None-valued fields default to 0; accounting is always split."""
+    assert _claude_token_fields({}) == {
+        "input_tokens": 0,
+        "uncached_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "input_token_accounting": "split_cache_fields",
+    }
+    # Missing cache keys but present input → input is the inclusive total (no cache).
+    assert _claude_token_fields({"input_tokens": 1500}) == {
+        "input_tokens": 1500,
+        "uncached_input_tokens": 1500,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "input_token_accounting": "split_cache_fields",
+    }
+    # Explicit None coerces to 0 (the `or 0` guard), so the sum never raises.
+    assert _claude_token_fields({"input_tokens": None, "cache_read_input_tokens": None})["input_tokens"] == 0
+
+
+def test_post_emits_inclusive_input_tokens_with_cache(claude_node):
+    """post() emits pflow's inclusive token contract for a cache-heavy run (#492).
+
+    The SDK reports input_tokens=1000 (uncached only) alongside 5000 cache-creation and
+    20000 cache-read tokens. pflow's llm_usage must headline the inclusive total (26000),
+    keep the uncached slice and cache tiers as a subset breakdown, and tag the accounting.
+    """
+    claude_node.params = {"prompt": "do work"}
+    claude_node.node_id = "agent"
+    shared = {"__warnings__": {}}
+    claude_node.shared = shared
+
+    async def mock_response(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text="done")])
+        yield ResultMessage(
+            result="done",
+            usage={
+                "input_tokens": 1000,
+                "output_tokens": 2000,
+                "cache_creation_input_tokens": 5000,
+                "cache_read_input_tokens": 20000,
+            },
+            total_cost_usd=0.05,
+            num_turns=4,
+            session_id="s1",
+        )
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
+
+    lu = shared["llm_usage"]
+    assert lu["input_tokens"] == 26000  # inclusive: 1000 + 5000 + 20000
+    assert lu["uncached_input_tokens"] == 1000
+    assert lu["cache_creation_input_tokens"] == 5000
+    assert lu["cache_read_input_tokens"] == 20000
+    assert lu["output_tokens"] == 2000
+    assert lu["total_tokens"] == 28000  # inclusive input + output
+    assert lu["input_token_accounting"] == "split_cache_fields"  # noqa: S105 (not a secret — accounting tag)
+    # Shape guard: claude's llm_usage emits exactly the inclusive token contract plus its
+    # execution metadata — no LLMNode-only fields (has_cache_telemetry, thinking_*, etc.).
+    # No existing test pins claude's producer-shape, so this is the guard (see plan §5).
+    assert set(lu) == {
+        "model",
+        "input_tokens",
+        "uncached_input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "input_token_accounting",
+        "cost_usd",
+        "duration_ms",
+        "num_turns",
+        "session_id",
+    }
+
+
+def test_schema_retry_aggregates_inclusive_input_tokens_with_cache(claude_node):
+    """Retry aggregation sums the INCLUSIVE per-attempt input_tokens (#492).
+
+    The existing cache-zero retry test can't catch a half-fix: with zero cache the SDK's
+    uncached count already equals the inclusive total, so a non-inclusive
+    ``_usage_record_from`` is invisible. Here the main attempt AND the superseded attempt
+    both carry non-zero cache, so the aggregated input_tokens only matches if BOTH producer
+    sites (``post`` and ``_usage_record_from``) emit inclusive values. This is the test the
+    "revert _usage_record_from only" mutation check fails against (plan §5).
+    """
+    from pflow.runtime.workflow_trace import WorkflowTraceCollector
+
+    schema = {"type": "object", "properties": {"continue": {"type": "boolean"}}, "required": ["continue"]}
+    claude_node.params = {"prompt": "decide", "output_schema": schema, "schema_retries": 1}
+    claude_node.node_id = "review"
+    shared = {"__warnings__": {}}
+    claude_node.shared = shared
+
+    async def attempt1(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text="maybe?")])
+        yield ResultMessage(
+            structured_output={"continue": "maybe"},  # not coercible to bool → retry
+            usage={
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "cache_creation_input_tokens": 200,
+                "cache_read_input_tokens": 300,
+            },
+            total_cost_usd=0.01,
+            num_turns=3,
+            session_id="s1",
+        )
+
+    async def attempt2(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text='{"continue": "true"}')])
+        yield ResultMessage(
+            structured_output={"continue": "true"},  # coerces to True → conforming
+            usage={
+                "input_tokens": 200,
+                "output_tokens": 20,
+                "cache_creation_input_tokens": 400,
+                "cache_read_input_tokens": 600,
+            },
+            total_cost_usd=0.02,
+            num_turns=2,
+            session_id="s1",
+        )
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.side_effect = [attempt1(), attempt2()]
+
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)
+
+    lu = shared["llm_usage"]
+    # Main = final attempt, INCLUSIVE: 200 + 400 + 600 = 1200 (not the SDK's bare 200).
+    assert lu["input_tokens"] == 1200
+    assert lu["uncached_input_tokens"] == 200
+    # Superseded attempt recorded INCLUSIVE: 100 + 200 + 300 = 600 (not the SDK's bare 100).
+    assert [r["input_tokens"] for r in lu["retries"]] == [600]
+    assert [r["uncached_input_tokens"] for r in lu["retries"]] == [100]
+
+    agg = WorkflowTraceCollector.aggregate_llm_usage_with_retries(lu)
+    assert agg["input_tokens"] == 1800  # 1200 + 600 (inclusive per-attempt)
+    assert agg["uncached_input_tokens"] == 300  # 200 + 100 (summed across attempts)
+    assert agg["output_tokens"] == 30  # 20 + 10
+    assert agg["cache_creation_input_tokens"] == 600  # 400 + 200
+    assert agg["cache_read_input_tokens"] == 900  # 600 + 300
+    assert agg["total_tokens"] == 1830  # sum(inclusive input) + sum(output)
+    # The aggregator must keep input_tokens == uncached + creation + read on the
+    # aggregated dict (#492): uncached is summed, not carried main-only.
+    assert agg["input_tokens"] == (
+        agg["uncached_input_tokens"] + agg["cache_creation_input_tokens"] + agg["cache_read_input_tokens"]
+    )
 
 
 def test_schema_retries_no_op_without_output_schema(claude_node):

--- a/tests/test_nodes/test_claude/test_claude_code.py
+++ b/tests/test_nodes/test_claude/test_claude_code.py
@@ -1913,6 +1913,41 @@ def test_post_emits_inclusive_input_tokens_with_cache(claude_node):
     }
 
 
+def test_post_coerces_none_output_tokens_to_zero(claude_node):
+    """An explicit ``output_tokens: None`` from the SDK must not crash post().
+
+    ``usage.get("output_tokens", 0)`` returns ``None`` (not 0) when the key is present
+    with a None value, which would TypeError on the ``input_tokens + total_output`` sum.
+    The ``or 0`` guard coerces it, matching _claude_token_fields' None-handling.
+    """
+    claude_node.params = {"prompt": "do work"}
+    claude_node.node_id = "agent"
+    shared = {"__warnings__": {}}
+    claude_node.shared = shared
+
+    async def mock_response(*args, **kwargs):
+        yield AssistantMessage(content=[TextBlock(text="done")])
+        yield ResultMessage(
+            result="done",
+            usage={"input_tokens": 1000, "output_tokens": None},
+            total_cost_usd=0.01,
+            num_turns=1,
+            session_id="s1",
+        )
+
+    with patch("pflow.nodes.claude.claude_code.query") as mock_query:
+        mock_query.return_value = mock_response()
+
+        prep_res = claude_node.prep(shared)
+        result = claude_node.exec(prep_res)
+        claude_node.post(shared, prep_res, result)  # must not raise
+
+    lu = shared["llm_usage"]
+    assert lu["output_tokens"] == 0
+    assert lu["input_tokens"] == 1000
+    assert lu["total_tokens"] == 1000  # 1000 + 0, no TypeError
+
+
 def test_schema_retry_aggregates_inclusive_input_tokens_with_cache(claude_node):
     """Retry aggregation sums the INCLUSIVE per-attempt input_tokens (#492).
 


### PR DESCRIPTION
## Summary
pflow's two LLM-producing nodes recorded `input_tokens` with opposite meanings, so displayed token totals were wrong whenever cache tokens were non-zero or a run mixed `llm` and `claude-code` nodes. This unifies the contract — `input_tokens` is the cache-**inclusive** total at every producer — by fixing the single violating producer (ClaudeCodeNode) and deleting the compensating cache-adding arithmetic in `trace_report.py`.

Fixes #492

## Changes
- **ClaudeCodeNode** emits the inclusive total via a deterministic `_claude_token_fields` helper (used by both `post()` and the schema-retry record), plus `uncached_input_tokens` + `input_token_accounting` for parity with LLMNode's documented `llm_usage` shape.
- **trace_report.py** `_input_token_total` and the summary read `input_tokens` verbatim — no render-time cache re-adding (pure deletion). `workflow_trace.py`'s `total_input_tokens` contract comment flipped to "inclusive".
- **`aggregate_llm_usage_with_retries`** now also sums `uncached_input_tokens`, preserving the `input == uncached + creation + read` invariant on retried claude-code calls.
- **Docs** — `claude-code.mdx` llm_usage example made cache-inclusive and gains `uncached_input_tokens`/`input_token_accounting`; `template-variables.mdx` wording broadened (claude-code is always `split_cache_fields`).
- **Bundled pre-existing fix** (surfaced during review): the CLI/MCP cost line read a non-existent `total_tokens` metrics key (the metrics dict emits `tokens_total`), so the token count silently rendered as 0 — corrected on both surfaces.

## Explanation
Root cause is a provider model mismatch: Anthropic (Claude SDK) reports tokens disjoint-additively (`input_tokens` = uncached only; cache tiers are separate addends), while OpenAI/LiteLLM and pflow's documented contract are inclusive-subset (`input_tokens` = total incl. cache; cache tiers are a subset). LLMNode converts via the LiteLLM adapter; ClaudeCodeNode leaked the disjoint shape. `trace_report` then re-added the cache tiers — correct only for the disjoint shape, double-counting every inclusive LLMNode call. The fix converts at the one producer that knows its provider's semantics (Claude's split is always known, so the inclusive total is a deterministic sum — no value-based heuristic), which leaves all consumers branch-free. `metrics.py` needed no change (it already treats `input_tokens` as the total).

12 files, +476/-64.

## Testing
- `test_claude_token_fields_sums_cache_into_inclusive_total` / `..._defaults_missing_and_none_to_zero` — the helper folds the SDK split into the inclusive total and is None/missing-safe.
- `test_post_emits_inclusive_input_tokens_with_cache` — full prep/exec/post: input 1000 + 25000 cache → `input_tokens=26000`, `total_tokens=28000`, `input_token_accounting=split_cache_fields`; includes an exact key-set shape guard for claude's `llm_usage`.
- `test_schema_retry_aggregates_inclusive_input_tokens_with_cache` — non-zero-cache retry requiring both producer sites inclusive; pins aggregated `input_tokens=1800`, `uncached_input_tokens=300`, and the `uncached + creation + read == input_tokens` invariant (the pre-existing cache-zero retry test could not catch a half-fix).
- `test_metrics_and_report_agree_on_inclusive_input_total` — the bug's real surface: a mixed claude+llm trace run through the real `MetricsCollector` and `WorkflowTraceCollector` asserts metrics `tokens_input` == trace_report rendered "in" (27,000), plus pins `llm_summary.total_tokens`.
- Three trace_report "fold" tests rewritten as inclusive-render tests that double as mutation guards (`cache_creation == input_tokens`, so re-summing would render `3,000` not `1,500`).
- `test_priced_cost_line_shows_token_count` (CLI + MCP, incl. a >1M separator case) — the bundled cost-line fix.
- Mutation-checked: reverting `post()` fails the producer test; reverting only `_usage_record_from` fails the retry test (isolation proven). `make test` 7757 passed; ruff/mypy green in CI.

## Follow-ups
- GH #494 — abbreviate human-facing token counts (`2.1M`/`153K`) via a shared helper (excludes JSON + cache thresholds).
- The claude-code docstring change to `Writes:` subfields only becomes agent-visible after a registry rebuild (`pflow registry scan`); no "unknown parameter" errors (these are outputs, not params).