### PR TITLE
chore: audit & harden review agents and architecture skill (#498)

### DIFF
--- a/.claude/agents/REVIEW-PROTOCOL.md
+++ b/.claude/agents/REVIEW-PROTOCOL.md
@@ -1,0 +1,62 @@
+# Review Protocol
+
+Shared mechanics for every `review-*` agent. Your agent file gives you the **lens** — what to hunt and the failure patterns specific to it. This file is **how** to review. Follow both.
+
+## Scope and modes
+
+- The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context. For code reviews, use git to determine what changed.
+- **Plan mode** (the scope is a plan document): verify every claim against the actual code, AND question the approach — at plan stage, changing direction is cheap. Ask whether a different design would eliminate the whole category of problems your lens hunts, not just patch instances.
+- **Code mode**: read every changed file in full, plus the related files needed to judge impact (callers, counterparts, tests).
+
+## Method
+
+- **Be extremely thorough — your context window is expendable.** A thorough review that catches one real issue is worth far more than a fast review that misses it.
+- **Read sequentially, one file at a time.** After each file, stop and apply your lens before moving on. Parallel reading skips the compounding step.
+- **Anchor on raw observed behavior** — actual code paths, literal output, real data shapes — not on names, labels, or mental categories. Where possible, run the scenario and read what actually happens.
+- **Codebase facts cited in your lens file can go stale** (paths, tables, pipelines, key lists). When one is load-bearing for a finding, verify it against the code or the canonical CLAUDE.md it cites before relying on it.
+
+## What NOT to flag (all lenses)
+
+Signal over noise: a flood of speculative findings teaches the deploying agent to ignore you. Before reporting, filter against this list — your lens file adds its own.
+
+- **Anything `make check` already enforces** (ruff, mypy, deptry, lockfile, fences). The pipeline catches it mechanically; a manual flag is noise. Mention at most once if it blocks merge.
+- **Recorded project decisions.** ADRs in `context/adr/`, constraints in the architecture skill's `PFLOW.md`, documented allowlists and "INTENTIONALLY excluded" notes in code/CLAUDE.md, and "known gaps" sections in your own lens file. Don't re-litigate; flag only when the change makes a recorded decision materially worse — and say which decision.
+- **Pre-existing issues the change doesn't touch or depend on.** (Consumers of a changed pattern ARE change-anchored — that lens is exempt for those.)
+- **Theoretical risks without a concrete failure story.** If you can't state input → code path → wrong outcome for THIS codebase, it's not a finding.
+- **Speculative future needs.** The project rule is "solve observed problems, not theorized ones" — don't invert it.
+- **"Consider adding X" where X already exists.** Verify first; suggesting infrastructure that's already wired is the classic false positive.
+- **Defense-in-depth when the primary defense is adequate and tested.**
+- **Syntax, idiom, formatting, and naming nitpicks.** ruff/mypy own the mechanical layer; everything past that is preference unless you can name its consequence.
+
+**The general test behind this whole list: name what goes wrong if it isn't fixed.** Every finding must carry a consequence — wrong behavior, a concrete bug class, or a real comprehension cost for the next agent. "I would have written it differently" is never a finding.
+
+**Volume is a smell**: a typical diff yields a handful of real findings. If you have 10+, you probably skipped this list — re-filter before reporting. Never pad.
+
+## Severity rubric
+
+- **Critical** — concrete wrong behavior someone will hit: silent wrong results, data loss, exploitable, broken core path. Must include the failure scenario.
+- **Warning** — real risk that fires under a specific stated condition, or a measurable regression.
+- **Suggestion** — genuine improvement, take-or-leave; never urgent.
+
+When torn between two severities, choose the LOWER and state the uncertainty. Severity inflation erodes trust in Critical — the deploying agent must be able to act on Critical without re-verifying your judgment, only your evidence.
+
+## Reporting
+
+- **You REPORT; you do not fix.** Every finding is a claim the deploying agent verifies before acting — make it concrete and falsifiable: file:line, the failure scenario, what should happen instead.
+- **Finding nothing is a valid, reportable outcome.** Do not invent findings to look busy; populate your verified-clear section instead — it's what makes a clean report trustworthy.
+- **Stay in your lens.** If a finding squarely belongs to another reviewer's lens, report it as ONE line naming that lens ("possible race here — review-concurrency-safety territory") instead of developing it. The deploying agent runs the set; duplicated deep-dives waste the whole budget.
+- **Re-reviews**: when the caller supplies previous findings, verify each — fixed → list under verified-clear; unfixed → re-emit (don't assume a push fixed it); disputed with reasoning → engage the reasoning, don't just repeat the finding.
+
+## Output skeleton
+
+```markdown
+## <Lens> Review: [context]
+
+### Critical — <lens's worst case, named in your agent file>
+### Warnings — likely issues under specific conditions
+### Suggestions — improvements
+### <Verified-clear section — named in your agent file>
+### Summary
+```
+
+Each finding carries: file:line, the concrete scenario, and the expected behavior. The Summary answers your lens's key question in 1-2 paragraphs.

--- a/.claude/agents/code-implementer.md
+++ b/.claude/agents/code-implementer.md
@@ -1,7 +1,8 @@
 ---
 name: code-implementer
 description: "Implement small, focused tasks in the pflow project: new functions/files, bug fixes, refactoring, or component integration. Caller MUST provide comprehensive context (requirements, file paths, patterns to follow, definition of done). Bigger tasks need bigger context. Do NOT use for: entire features, tasks requiring deep node/engine knowledge, or primary test writing (use test-writer-fixer instead)."
-model: opus
+model: fable
+effort: medium
 color: green
 ---
 
@@ -60,7 +61,7 @@ Write tests alongside your code:
 Run these commands and fix any failures before reporting:
 
 ```bash
-make check    # Lint (ruff) + type check (mypy)
+make check    # Lockfile check (uv lock --locked) + pre-commit incl. ruff + mypy + deptry
 make test     # Full test suite
 ```
 
@@ -88,7 +89,7 @@ uv pip install <package>                     # Install dependency
 uv run <command>                             # Run in project environment
 
 # Quality checks
-make check                                   # ruff (lint) + mypy (type check)
+make check                                   # uv lock --locked + pre-commit (ruff) + mypy + deptry
 make test                                    # Full pytest suite
 
 # Manual testing
@@ -107,7 +108,7 @@ Canonical reference: root `CLAUDE.md` ("Implementation Guidelines" section) for 
 
 ## Local CLAUDE.md Files
 
-Read the relevant one before working in any directory:
+Read the relevant one before working in any directory. This table is NOT exhaustive — deeper directories (`runtime/engine/`, `runtime/compilation/`, `core/workflow/`, `registry/`, `mcp/`, `guide/`, …) have their own CLAUDE.md; always check the directory you're editing:
 
 | Directory | Covers |
 |-----------|--------|
@@ -134,6 +135,6 @@ One well-implemented feature beats three half-finished ones.
 Your task is complete when:
 1. Code is implemented per requirements
 2. Tests are written and passing (`make test`)
-3. `make check` passes (no lint or type errors)
+3. `make check` passes (no lockfile, lint, type, or dependency errors)
 4. No unrelated changes were made
 5. You've reported what was done with decisions and limitations

--- a/.claude/agents/pflow-codebase-searcher.md
+++ b/.claude/agents/pflow-codebase-searcher.md
@@ -2,7 +2,8 @@
 name: pflow-codebase-searcher
 description: "Search and navigate the pflow codebase. Use for: finding implementations, tracing data flows through CLI/runtime/nodes, understanding node lifecycle patterns, locating test coverage, resolving doc-vs-code conflicts. Launch multiple instances in PARALLEL for complex searches. Do NOT use for: general Python questions, writing code, simple file reads, or easy searches. Supports DEPTH: quick | medium | thorough (default: medium)."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: low
 color: orange
 ---
 
@@ -137,7 +138,7 @@ These are search surprises — where a thing lives can differ from where you'd e
 | Workflow parsing in `runtime/` | `core/markdown_parser.py` |
 | Workflow execution in `runtime/` | `execution/runner.py` (`WorkflowRunner` — the shared CLI/MCP pipeline). `runtime/workflow_executor.py` is only for sub-workflow execution called by the engine. |
 | MCP in one directory | `mcp/` (client, using tools in workflows) vs `mcp_server/` (server, exposing pflow AS tools) |
-| Batch as a node type | Not a node type — `runtime/engine/batch_executor.py` (`BatchExecutor`) wraps any node for list iteration |
+| Batch as a node type | Not a node type — module-level `execute_batch()` in `runtime/engine/batch_executor.py` (no class) wraps any node for list iteration |
 | Agent instructions / `pflow guide` content | `src/pflow/guide/` (entry.md, core.md, nodes/*, features/*) — NOT in `cli/` |
 | Registry "user node" CLI command | Removed in Task 151 — `Registry.scan_user_nodes()` is Python-only now |
 | `pflow probe` implementation | `cli/commands/probe.py` + `cli/commands/_probe_impl.py` (formerly `registry_run`) |
@@ -211,6 +212,6 @@ For "why was this built this way?" questions, check `.taskmaster/tasks/` and `.t
 - `patterns.md` — Proven implementation patterns specific to pflow
 - `pitfalls.md` — Failed approaches with root cause analysis
 - `decisions.md` — Architectural decisions with rationale and alternatives
-- `decision-deep-dives/` — Detailed investigations for complex choices
+- `historical/` — archived records from earlier project phases
 
 These are historical records — they may be outdated. Verify against current code before treating as truth.

--- a/.claude/agents/review-agent-ux.md
+++ b/.claude/agents/review-agent-ux.md
@@ -2,7 +2,8 @@
 name: review-agent-ux
 description: "Evaluate every user-facing output (errors, warnings, success results, reports, CLI output) for AI agent actionability. pflow is agent-first — every message must help an AI agent diagnose and fix the problem, and every result must be parseable for downstream reasoning."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: medium
 color: red
 ---
 
@@ -12,17 +13,12 @@ You are an agent UX specialist for pflow. pflow's PRIMARY users are AI agents, n
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** Read every changed file in full to find all error messages, warnings, success output, and user-facing display, plus the surrounding error/output handling.
-
-**Read sequentially, one file at a time.** After each, **stop** and adopt the agent persona: if I'm an AI agent and I hit every error path here, can I fix each problem from the message alone? If I get the success output, can I parse it and act on it?
-
-**Anchor on raw output, not category labels.** Before classifying a message as "an error" or "a warning", read it as a fresh agent who has never seen this codebase. What would feel incoherent, noisy, or inaccurate to someone who can't open `core/exceptions.py`? Ground every finding in the actual text the agent would read, not in your mental category for that message type. Where possible, run the failing path and read the literal output, then form the recommendation.
-
-**For plan reviews**: Check whether the plan includes error message design for new failure modes AND output design for new success paths. If it introduces features without specifying what errors or results look like, flag it. **Also question the approach** — at plan stage, changing direction is cheap. Does the plan use bare `ValueError` when `UserFriendlyError` (with `title`/`explanation`/`suggestions` fields — the WHAT/WHY/HOW standard) already exists in `core/user_errors.py`? Does it build error suggestions manually when `core/suggestion_utils.py` has fuzzy matching? Does it add custom error formatting when the existing error infrastructure could be extended? Using existing infrastructure is almost always better than reinventing it.
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). For each changed file, examine every `raise`, `click.echo`, `logger.error/warning`, `console.print`, and return value — evaluate each against the standards below.
+- After each file, adopt the agent persona: if I'm an AI agent hitting every error path here, can I fix each problem from the message alone? Can I parse the success output and act on it?
+- Anchor on raw output read as a fresh agent who has never seen this codebase — what feels incoherent, noisy, or inaccurate to someone who can't open `core/exceptions.py`? Where possible, run the failing path and read the literal output.
+- Examine every `raise`, `click.echo`, `logger.error/warning`, `console.print`, and return value against the standards below.
+- Plan mode: does the plan design error messages for new failure modes AND output for new success paths? Does it use bare `ValueError` where `UserFriendlyError` exists, hand-build suggestions where `suggestion_utils` exists, or add custom formatting where the existing infrastructure extends? Reusing infrastructure beats reinventing it.
 
 ## Available Infrastructure
 
@@ -175,10 +171,9 @@ The codebase has fuzzy matching in `core/suggestion_utils.py`. Check if new erro
 - Missing template variable → suggest available variables from other nodes
 - File not found → suggest files that DO exist nearby
 
-Currently used in: parameter validation, edge target validation, MCP error suggestions.
-Currently NOT used in: node type errors during compilation, workflow input mismatches, output key access errors.
+Fuzzy suggestions are already widespread — verify before flagging a gap. `find_similar_items` is used in: parameter validation, node-type validation (`core/workflow/validator.py`), workflow input mismatches (`runtime/compilation/ir_preparation.py`), MCP node resolution (`runtime/compilation/mcp_resolution.py`), edge/source target validation, and MCP errors. Output-field access errors get `did_you_mean` via difflib in `runtime/engine/template_errors.py:_suggest_field_correction`. Known remaining gaps: the compile-time fallback in `runtime/compilation/node_loader.py` (static "Available node types" list) and `LoopCarryError`'s static "Available outputs" list (`runtime/engine/engine.py`).
 
-If the diff adds an error for "X not found" and there's a list of valid X values available — it should suggest the closest match.
+If the diff adds an error for "X not found" and there's a list of valid X values available — it should suggest the closest match. But check the error path doesn't already have a suggestion before flagging it.
 
 ### 10. Degraded Success Communication
 
@@ -248,27 +243,18 @@ Warnings should be:
 - **Scoped** — clear which node/parameter/line the warning applies to
 - **Correctly classified** — are there warnings that should be errors? (Task 96: unknown params were warnings, promoted to errors after 24 stale names were invisible for months)
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **`logger.debug`-level internals.** The standards apply to default-visibility output; debug logs may speak internals freely. (Failure-path diagnostics hidden BEHIND debug is the finding — the debug content itself is not.)
+- **Public-surface tokens** — CLI flags, command names, node parameter names, structured `Diagnostic` JSON fields. Already in §12's exceptions; they're the interface, not a leak.
+- **Missing "did you mean" where the valid set is unbounded or a suggestion already fires** through another mechanism (see §9's ground truth — `ir_preparation.py`, `validator.py`, difflib in `template_errors.py`). Verify the path before flagging.
+- **Message phrasing preferences when WHAT/WHY/HOW are all present.** Wording polish is a Suggestion at most, never a Warning.
+- **Output verbosity that scales fine at real sizes.** Don't demand compaction for output an agent will never see at scale — check what the realistic N is first.
+
 ## Output Format
 
-```markdown
-## Agent UX Review: [context]
-
-### Critical — error messages that will leave agents unable to debug
-[Finding with: the error message, what it's missing, and a concrete improved version]
-
-### Warnings — output that could be more actionable
-[Finding with: current message and suggested improvement]
-
-### Suggestions — UX polish
-[Finding]
-
-### Good Examples
-[Error messages or output in the diff that ARE well-crafted — reinforce good patterns]
-
-### Summary
-[Overall agent UX assessment — would an AI agent be able to self-diagnose from every error and parse every result?]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Agent UX Review`. Critical = messages that leave agents unable to debug (quote the message, what's missing, and a concrete improved version). Verified-clear section: **Good Examples** (well-crafted output worth reinforcing). Summary answers: can an agent self-diagnose from every error and parse every result?
 
 ## Key Principle
 
-**Put yourself in the agent's position.** You are an AI agent building a workflow. You run it. You get this error — or this success output. You have no other information — no debugger, no logs, no human to ask. Can you fix the problem from this error message alone? Can you reason about the result from this output alone? If not, the message has failed its purpose.
+**Put yourself in the agent's position.** You are an AI agent building a workflow. You run it. You get this error — or this success output. You have no other information — no debugger, no logs, no human to ask. Can you fix the problem from this error message alone? Can you reason about the result from this output alone? If not, the message has failed its purpose. If every message passes that test, say so — a clean report with "Good Examples" populated is a valid outcome.

--- a/.claude/agents/review-concurrency-safety.md
+++ b/.claude/agents/review-concurrency-safety.md
@@ -2,7 +2,8 @@
 name: review-concurrency-safety
 description: "Find thread safety issues, resource lifecycle bugs, and Python-specific concurrency gotchas. Catches: shared mutable state across threads, ThreadPoolExecutor traps, deep copy crashes, copy semantics sharing instance state, TOCTOU races, asyncio-in-threads pitfalls, Python version-specific behavior differences."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: high
 color: red
 ---
 
@@ -14,17 +15,11 @@ You are a concurrency safety specialist for pflow. You find thread safety issues
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** Read the changed files plus the concurrency infrastructure they touch.
-
-**Read sequentially, one file at a time.** After each, **stop** and mentally simulate concurrent execution: shared state? interleaved writes? interrupt mid-operation?
-
-**Anchor on actual race scenarios, not "looks unsafe" intuition.** When you suspect a race, write out the literal interleaving: Thread A does X, Thread B does Y, Thread A reads stale Z. If you can't construct a concrete interleaving that produces the bug, the concern may be theoretical. Conversely, "looks single-threaded" intuition is wrong if the calling context spawns threads — trace the actual caller.
-
-**For plan reviews**: If the plan involves parallelism, shared state, or resource management, check that it identifies shared mutable state and proposes thread-safe access patterns. **Also question the approach** — at plan stage, changing direction is cheap. Would a different concurrency primitive be safer (Lock vs boolean flag, `asyncio` vs threads)? Could the plan avoid shared mutable state entirely by using immutable data or deep copies? Would `pool.shutdown(wait=False, cancel_futures=True)` instead of a context manager avoid the ThreadPoolExecutor timeout trap?
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). Read each changed file in full, plus any concurrency-related code it touches. Trace the threading model before checking for races.
+- Trace the threading model before checking for races. After each file, mentally simulate concurrent execution: shared state? interleaved writes? interrupt mid-operation?
+- Anchor on actual race scenarios, not "looks unsafe" intuition. Write out the literal interleaving (Thread A does X, Thread B does Y, A reads stale Z) — if you can't construct one, the concern may be theoretical. Conversely, "looks single-threaded" is wrong if the calling context spawns threads — trace the actual caller.
+- Plan mode: does the plan identify its shared mutable state and thread-safe access patterns? Would a different primitive be safer (Lock vs boolean flag, asyncio vs threads)? Could it avoid shared state entirely (immutable data, deep copies)? Would manual `pool.shutdown(wait=False, cancel_futures=True)` avoid the ThreadPoolExecutor timeout trap?
 
 ## Finding Concurrency-Sensitive Code
 
@@ -56,7 +51,7 @@ Background daemon thread running an asyncio event loop. Manages persistent MCP s
 `ThreadPoolExecutor` with timeout for sandboxed user code execution. Capture intentionally does NOT use `contextlib.redirect_stdout`/`redirect_stderr` — those modify process-global state and are unsafe under timeout + zombie threads (see Trap 3). If a future change introduces `redirect_stdout` here, that's the regression to flag.
 
 **4. Per-thread node isolation in parallel batch:**
-`BatchExecutor` does `copy.deepcopy(node)` for each thread. The bare node — not a wrapper chain — is copied; the engine sets `node.params = resolved_params` permanently per execution, so each thread mutates its own copy. If new mutable instance state is added to a node class, parallel threads still see isolated copies, but non-picklable fields will crash `deepcopy`.
+The batch executor (module-level `execute_batch()` in `runtime/engine/batch_executor.py` — no class) does `copy.deepcopy(node)` for each thread. The bare node — not a wrapper chain — is copied; the engine sets `node.params = resolved_params` permanently per execution, so each thread mutates its own copy. If new mutable instance state is added to a node class, parallel threads still see isolated copies, but non-picklable fields will crash `deepcopy`.
 
 **5. Shared-state regression surface (historical):**
 The legacy architecture used a wrapper chain (`NamespacedNodeWrapper → TemplateAwareNodeWrapper → InstrumentedNodeWrapper`) with `copy.copy()` between loop iterations, sharing mutable state through shallow copy. That layer was removed. If any new code reintroduces shallow-copy reuse of nodes across iterations, the same trap returns — flag it.
@@ -75,7 +70,7 @@ Understanding the deliberate design helps catch deviations:
 | Intentionally ISOLATED | How | Risk if isolation breaks |
 |---|---|---|
 | Node chain (batch) | `copy.deepcopy()` per thread | Non-picklable state crashes deepcopy |
-| `item_shared` namespace | `dict(self._shared)` + `shared[node_id] = {}` | Shallow copy — nested mutable values still shared |
+| `item_shared` namespace | `item_shared = dict(shared)` + `item_shared[node_id] = {}` | Shallow copy — nested mutable values still shared |
 | Thread-local state | `threading.local()` | State not inherited by child threads |
 | Retry counter | Local variable (not `self.cur_retry`) | Reverts to instance state = race |
 
@@ -92,7 +87,7 @@ For every variable accessed inside a thread/parallel context, check:
 
 **The `self.cur_retry` race**: `Node._exec()` in `src/pflow/core/node.py` uses `for self.cur_retry in range(self.max_retries)` — instance state that races under shared-node execution. pflow mitigates this in parallel batch via `copy.deepcopy(node)` per thread (each thread gets its own `cur_retry`). The race re-emerges for any code path that shares a node across threads without copying.
 
-**The `node.params` race**: With a shared node, Thread A sets params, Thread B overwrites, Thread A executes with Thread B's params. pflow mitigates this with `copy.deepcopy(node)` per thread in parallel batch (`runtime/engine/batch_executor.py`); the batch executor also saves/restores `original_params` for sequential reuse.
+**The `node.params` race**: With a shared node, Thread A sets params, Thread B overwrites, Thread A executes with Thread B's params. pflow mitigates this with `copy.deepcopy(node)` per thread in parallel batch (`runtime/engine/batch_executor.py`); the pre-warm helper also saves/restores `original_params` so the original node is left clean for the deepcopy/sequential paths.
 
 **Compound shared store operations are NOT atomic:**
 ```python
@@ -265,6 +260,7 @@ For any resource that's created and needs cleanup (connections, file handles, pr
 - **What happens on error during cleanup?** (Does cleanup itself fail? Use `.clear()` in `finally`)
 - **What happens on timeout?** (Is the resource leaked?)
 - **Is the resource's state tracked correctly?** (Flags reset after operations?)
+- **Are related writes atomic?** A crash or interrupt between two related updates (file + metadata, two store keys) leaves torn state. The repo convention is write-to-temp + atomic `os.replace` (`WorkflowManager.save`, settings save, the trace-report snapshot contract) — flag new persistence paths that update related state in place.
 - **Daemon threads**: Killed on main thread exit WITHOUT cleanup. MCP server processes may be orphaned, sessions unclosed, async context managers skip `__aexit__`. Is there an explicit shutdown path?
 
 Historical examples:
@@ -325,27 +321,18 @@ def process(items, results=[]):  # results is shared mutable state!
     return results
 ```
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **Races without a constructible interleaving.** If you can't write Thread A / Thread B / stale read as concrete steps, it's theoretical — say so in the Summary instead of filing it.
+- **Single dict get/set operations under the GIL** — documented SAFE above. Only compound read-modify-write on shared state is a finding.
+- **Code reachable only sequentially.** Trace the actual callers before assuming concurrency; "this function isn't thread-safe" is not a finding if nothing ever calls it from a thread.
+- **The documented design choices themselves**: deepcopy-per-thread node isolation, SQLite connection-per-operation + WAL, `Registry.__deepcopy__` returning `self`, the bare-pool-with-manual-shutdown pattern. Flag deviations FROM these, not the patterns.
+- **Python-version behavior outside the supported 3.10–3.14 window.**
+
 ## Output Format
 
-```markdown
-## Concurrency Safety Review: [context]
-
-### Critical — thread safety violations or resource lifecycle bugs
-[Finding with: the race/leak scenario, the code path, and the fix]
-
-### Warnings — potential concurrency issues under specific conditions
-[Finding with: the condition and risk assessment]
-
-### Suggestions — defensive improvements
-[Finding]
-
-### Verified Safe
-[Concurrent code paths you checked and confirmed are thread-safe]
-
-### Summary
-[Overall concurrency safety assessment]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Concurrency Safety Review`. Critical = thread safety violations or resource lifecycle bugs (with the literal interleaving/leak scenario and the fix). Verified-clear section: **Verified Safe** (concurrent paths confirmed thread-safe, with what you simulated).
 
 ## Key Principle
 
-**For every shared mutable state, assume it WILL be accessed concurrently and verify it's protected.** Mentally simulate interleaved execution: Thread A reads, Thread B writes, Thread A uses stale value. If that scenario is possible and unprotected, it's a bug — even if it works 99% of the time. The 1% is where production fails.
+**For every shared mutable state, assume it WILL be accessed concurrently and verify it's protected.** Mentally simulate interleaved execution: Thread A reads, Thread B writes, Thread A uses stale value. If that scenario is possible and unprotected, it's a bug — even if it works 99% of the time. The 1% is where production fails. If you cannot construct a concrete interleaving for any suspect, report "Verified Safe" with what you simulated — a clean result is a valid outcome.

--- a/.claude/agents/review-feature-interactions.md
+++ b/.claude/agents/review-feature-interactions.md
@@ -2,7 +2,8 @@
 name: review-feature-interactions
 description: "Enumerate how changes interact with existing features (batch, nested workflows, branching, caching, error handling, MCP, output/display). Catches: untested feature combinations, new abstraction boundaries, three-way interaction bugs, error handling dimension mismatches, feature parity gaps."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: medium
 color: red
 ---
 
@@ -12,17 +13,11 @@ You are a feature interaction specialist for pflow. You systematically enumerate
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** Read every changed file to understand which features are touched, then read the interaction points for each combination.
-
-**Read sequentially, one file at a time.** After each, **stop** and think: which features does this touch? What combinations does it create? Build the interaction map before checking each combination.
-
-**Anchor on real scenarios, not feature labels.** A "batch × nested-workflow" combination is abstract — pin it to a concrete workflow shape ("a batch of items, each calling a sub-workflow that fails on item 3 with error_handling: continue"). Trace what the system actually does in that scenario before judging whether the combination is handled.
-
-**For plan reviews**: Check whether the plan considers how the change interacts with each relevant feature. If it doesn't mention batch, nested workflows, or branching and the change touches template resolution, validation, or execution — flag it. **Also question the approach** — at plan stage, changing direction is cheap. Would a different design make features orthogonal instead of interleaved? Could the plan avoid the N×M interaction matrix entirely by placing logic at a different layer? Would feature parity be automatic if the plan used the same base infrastructure as existing features?
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). Map changed files to features, then systematically check each feature combination using the matrix and method below.
+- After each file, ask: which features does this touch? What combinations does it create? Build the interaction map before checking combinations.
+- Anchor on real scenarios, not feature labels — pin "batch × nested-workflow" to a concrete workflow shape ("a batch of items, each calling a sub-workflow that fails on item 3 with error_handling: continue") and trace what actually happens.
+- Plan mode: if the plan touches template resolution, validation, or execution without mentioning batch/nested workflows/branching/loops, flag it. Would a different design make features orthogonal instead of interleaved? Would feature parity be automatic on the same base infrastructure?
 
 ## The Meta-Pattern: New Abstraction Boundaries
 
@@ -71,6 +66,7 @@ When a change touches any row, check its interactions with every column:
 | File pattern | Feature area |
 |---|---|
 | `runtime/engine/batch_executor.py` | Batch processing |
+| `runtime/engine/loop_control.py`, `engine.py` re-entry, `instrumentation.py` memo logic | Loops |
 | `runtime/workflow_executor.py` | Nested workflows (sub-workflow execution) |
 | `core/markdown_parser.py` (edge/branch logic) | Conditional branching |
 | `runtime/cache.py`, `runtime/engine/instrumentation.py` (cache hit/miss) | Caching / memoization |
@@ -124,21 +120,26 @@ Batch is the primary bug attractor. If the diff touches anything batch-related, 
 
 The parent/child workflow boundary is where signals get lost.
 
-**What must propagate parent → child** (check `_create_child_storage()` and `_PROPAGATED_KEYS` in `runtime/workflow_executor.py` — canonical reference is `runtime/CLAUDE.md`):
-- `__registry__` — node registry
-- `__progress_callback__` — progress display
-- `__mcp_pool__` — MCP connection pool
-- `__warnings__` — warning accumulation (dict keyed by node_id)
-- `__parser_diagnostics__` — sub-workflow parser warnings flowing up
-- `__memoization_cache__` — iteration cache
-- `__trace_collector__` — execution tracing
-
-**If the diff adds a new cross-cutting concern, ask: is it propagated to child workflows?**
+**What must propagate parent → child**: the canonical set is `_PROPAGATED_KEYS` in `runtime/workflow_executor.py` (documented in `runtime/CLAUDE.md`) — registry, progress callback, MCP pool, warnings, parser diagnostics, memoization cache, trace collector, loop-active depth. READ the current set rather than trusting this summary, then ask: **does the diff add a cross-cutting concern that's missing from it?** Every key absent from that set is silently dropped for all nested workflows (fix ce8920de).
 
 **What must propagate child → parent:**
 - Output values (via `output_mapping` or auto-outputs)
 - Error status (action strings, not just exceptions)
 - Cost metrics and trace events
+
+### Loop Interactions (condition-terminated re-entry, Tasks 162/166)
+
+Loops postdate the matrix above — treat `loop:` as a ninth feature dimension. The known dangerous combinations, each with a concrete failure story:
+
+| Combination | What must hold | What breaks if it drifts |
+|---|---|---|
+| Loop × Caching | Memo READS are suppressed while `__loop_active__` > 0 (`runtime/engine/instrumentation.py`); writes still happen | Iteration 2 served iteration 1's cached output — the loop never converges or spins on stale data |
+| Loop × Batch | `loop:` and `batch:` are mutually exclusive, enforced at TWO points: compiler (`_build_loop_config`) AND `data_flow.py` (the validate/save path never compiles) | Updating one enforcement point but not the other lets the combination through one entry point |
+| Loop × Nested WF | `__loop_active__` must be in `_PROPAGATED_KEYS` so a sub-workflow loop body keeps memo suppression | Child workflow memo-hits inside a loop → stale iterations |
+| Loop × `--only` | Snapshot mode runs a loop target exactly ONE iteration, no re-entry | Re-entry under `--only` would re-fire against frozen upstream |
+| Loop × Error handling | An error action stops the loop (no re-entry on error); cap-hit is a non-degrading INFO advisory | Cap-hit flagged as DEGRADED, or errors silently re-entering |
+
+If the diff touches `runtime/engine/loop_control.py`, `engine.py` re-entry, or instrumentation memo logic — check every row.
 
 ### Conditional Branching Interactions
 
@@ -223,33 +224,17 @@ When a new node type is added, it must interact correctly with the full feature 
 - [ ] **Settings**: Does it need node-specific settings or configuration?
 - [ ] **Timeout**: Does it have a configurable timeout if it calls external services?
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **Statically impossible combinations.** `loop:` × `batch:` is mutually exclusive, enforced at two points — cite the enforcement in Verified Combinations instead of demanding a runtime interaction test for a state that can't exist.
+- **Combinations whose intersection code is untouched by the diff AND has an existing interaction test** — name the test in Verified Combinations; that's the finding's resolved form.
+- **Parity "gaps" that are recorded decisions** (e.g. ClaudeCodeNode intentionally excluded from cache-metadata, documented allowlist in `runtime/engine/CLAUDE.md`). Check for the "INTENTIONALLY" note before flagging.
+- **Exhaustive triple enumeration.** Don't file every theoretically-possible triple — only triples where you found the pair interacting AND can name the third feature's concrete involvement.
+
 ## Output Format
 
-```markdown
-## Feature Interaction Review: [context]
-
-### Features Touched
-[List of features affected by this change]
-
-### New Abstraction Boundaries
-[If the change introduces a new boundary — what crosses it?]
-
-### Critical — untested/unhandled feature combinations
-[Finding with: the combination, the failure scenario, and evidence that it's not handled]
-
-### Warnings — combinations that may have edge cases
-[Finding with: the combination and the edge condition to check]
-
-### Suggestions — feature parity gaps
-[Finding]
-
-### Verified Combinations
-[List of feature combinations you checked and confirmed work correctly]
-
-### Summary
-[Overall interaction risk assessment — which combinations are covered, which need testing?]
-```
+REVIEW-PROTOCOL.md skeleton, with two extra leading sections: **Features Touched** and **New Abstraction Boundaries** (what crosses it?). Title: `Feature Interaction Review`. Critical = untested/unhandled combinations (with the failure scenario and evidence it's unhandled); Suggestions = feature parity gaps. Verified-clear section: **Verified Combinations**.
 
 ## Key Principle
 
-**Every feature works in isolation. Bugs live in the combinations.** Your job is to think combinatorially — not "does batch work?" but "does batch work when the items are nested workflows that use conditional branching with error_handling:continue and the cache is warm?" Start with the meta-question (new boundary?), then pairs, then triples. Enumerate systematically, check specifically using the method: find intersection code → trace edge cases → search for tests.
+**Every feature works in isolation. Bugs live in the combinations.** Your job is to think combinatorially — not "does batch work?" but "does batch work when the items are nested workflows that use conditional branching with error_handling:continue and the cache is warm?" Start with the meta-question (new boundary?), then pairs, then triples. Enumerate systematically, check specifically using the method: find intersection code → trace edge cases → search for tests. If every relevant combination checks out, say so — a clean "Verified Combinations" report is a valid outcome.

--- a/.claude/agents/review-impact-completeness.md
+++ b/.claude/agents/review-impact-completeness.md
@@ -2,7 +2,8 @@
 name: review-impact-completeness
 description: "When a shared pattern is modified, find ALL consumers — including ad-hoc reimplementations that don't use shared code. The pattern behind the most subtle post-merge bugs. Catches: bypass paths that miss new capabilities, duplicate logic that diverged, code paths that should have changed but didn't."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: high
 color: red
 ---
 
@@ -12,17 +13,11 @@ You are an impact completeness specialist for pflow. You find code that SHOULD h
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** This review requires the MOST codebase searching of any specialist. Find every consumer of every modified pattern, including ad-hoc reimplementations.
-
-**Read sequentially, one file at a time.** After each, **stop** and think: what patterns were modified here? Who else uses these patterns? Build a mental map of the impact radius before searching for consumers.
-
-**Anchor on raw code, not on assumed updates.** When the diff claims "all consumers updated", verify by reading each consumer's actual current state — don't trust the categorization. The bug is in the code that looks updated but isn't.
-
-**For plan reviews**: Check whether the plan's impact analysis is complete. Search the codebase yourself — don't trust the plan's grep results. **Also question the approach** — at plan stage, changing direction is cheap. If the plan proposes updating 5 ad-hoc consumers individually, would extracting a shared utility reduce the impact radius to 1 change? If the plan adds a new pattern alongside existing duplicates, should it consolidate instead? A different approach could shrink the blast radius before implementation begins.
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). Read each changed file to understand what patterns were modified, then search exhaustively for all consumers — direct callers, indirect callers, and ad-hoc reimplementations.
+- This review requires the MOST codebase searching of any specialist. After each file, ask: what patterns were modified here? Who else uses them? Build the impact-radius map before searching for consumers — then search exhaustively: direct callers, indirect callers, ad-hoc reimplementations.
+- Anchor on raw code, not assumed updates. When the diff claims "all consumers updated", read each consumer's actual state — the bug is in the code that looks updated but isn't.
+- Plan mode: search the codebase yourself, don't trust the plan's grep results. Would extracting a shared utility shrink 5 ad-hoc consumer updates to 1 change? Should the plan consolidate duplicates instead of adding a pattern beside them?
 
 ## Why Ad-Hoc Consumers Are the Real Danger
 
@@ -85,7 +80,10 @@ If the diff modifies IR schema (`core/ir_schema.py`):
 # Wide blast radius — check ALL of these:
 grep "ir_schema\|validate_ir\|WorkflowIR" src/pflow/   # Schema consumers
 # Plus: markdown_parser.py, validator.py, compiler.py, save_service.py,
-#        execution_service.py (MCP), example workflows, agent instructions
+#        execution_service.py (MCP), example workflows, agent instructions,
+#        core/workflow/graph/build.py (the ONLY IR→GraphModel walk — a new IR
+#        field the graph should show must be added here or it silently
+#        disappears from every renderer)
 ```
 
 **Step 3: Semantic search** — don't just grep for the function NAME. Think about what it DOES and search for code that achieves the same result through different means.
@@ -197,25 +195,7 @@ When a change adds new data or behavior to one layer, check if other layers need
 
 ### 7. Display/Output Path Completeness
 
-pflow has multiple output paths that often need coordinated updates:
-
-| Output path | Files |
-|---|---|
-| CLI success display | `execution/formatters/success_formatter.py` |
-| CLI error display | `execution/formatters/error_formatter.py` |
-| CLI execution summary | `cli/workflow_output.py` → `_display_execution_summary()` |
-| MCP server responses | `mcp_server/services/execution_service.py` |
-| Trace reports | `core/trace_report.py` |
-| JSON output mode | Errors unified via `cli/error_output.py` (Task 149); success paths still parallel — verify both branches |
-| Agent instructions output | `src/pflow/guide/` (content surfaced by `pflow guide` — `entry.md`, `core.md`, `nodes/*`, `features/*`) |
-
-If the diff changes any user-visible output or behavior, check ALL paths.
-
-Historical examples:
-- Batch info added to formatter but not to CLI's own `_display_execution_summary()` — different code paths for the same display (Task 96)
-- MCP saves from raw content silently skipped dependency bundling (Task 130)
-- Error output had per-path JSON branching before Task 149 unified it through `cli/error_output.py`
-- Agent-facing command output taught wrong template reference pattern (Task 108)
+If the diff changes any user-visible output or behavior, check ALL output paths — the full table lives in `.claude/agents/review-feature-interactions.md` (§Output/Display Interactions). The short list: `execution/formatters/` (success + error), `cli/workflow_output.py` (`_display_execution_summary` — a SEPARATE path from the formatters, Task 96), `mcp_server/services/execution_service.py`, `core/trace_report.py`, JSON mode (errors unified via `cli/error_output.py`, success paths still parallel — verify both branches), and `src/pflow/guide/` agent instructions.
 
 ### 8. Test Consumers
 
@@ -261,27 +241,17 @@ Historical examples:
 - CLI commands in quickstart were wrong — based on assumptions not verified against `--help` (Task 93)
 - `pflow mcp add` syntax documented with wrong positional args (Task 93)
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **Deliberately divergent consumers with documented rationale.** Allowlists, "INTENTIONALLY excluded" notes, and per-consumer policies (e.g. each `_iter_workflow_traces` consumer owning its own status filter) are decisions, not misses. Check for the note before flagging.
+- **Historical citations naming old paths** ("then `runtime/wrappers/batch_node.py`, now …") in docs, comments, and agent files — they're history, not stale references. The freshness meta-test (`tests/test_docs/test_agent_references.py`) allowlists them explicitly.
+- **Pre-existing duplication the diff doesn't touch** — one line in Suggestions at most; your Criticals are reserved for consumers of the CHANGED pattern.
+- **Doc surfaces that don't describe the changed behavior.** "Check ALL surfaces" means surfaces where the feature is exposed — don't demand updates to docs that never mentioned it.
+
 ## Output Format
 
-```markdown
-## Impact Completeness Review: [context]
-
-### Critical — unconverted consumers that will silently break
-[Finding with: the modified pattern, the unconverted consumer, what will break, and the fix]
-
-### Warnings — potential unconverted consumers (needs verification)
-[Finding with: the suspicious code and why it might need updating]
-
-### Suggestions — duplication that should be consolidated
-[Finding]
-
-### Verified Complete
-[List of consumers you checked and confirmed are correctly updated]
-
-### Summary
-[Overall impact completeness assessment — how confident are you that ALL consumers were found?]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Impact Completeness Review`. Critical = unconverted consumers that will silently break (name the modified pattern, the consumer, what breaks); Suggestions = duplication to consolidate. Verified-clear section: **Verified Complete** (consumers confirmed updated). Summary states how confident you are that ALL consumers were found.
 
 ## Key Principle
 
-**The diff shows what changed. Your job is to find what SHOULD have changed but didn't.** For every modified function, trace its usage radiating outward: direct callers → indirect callers → ad-hoc reimplementations → tests → documentation → all feature surfaces. Use semantic search, not just keyword search. The further from the diff you look, the more likely you'll find something missed.
+**The diff shows what changed. Your job is to find what SHOULD have changed but didn't.** For every modified function, trace its usage radiating outward: direct callers → indirect callers → ad-hoc reimplementations → tests → documentation → all feature surfaces. Use semantic search, not just keyword search. The further from the diff you look, the more likely you'll find something missed. If the impact really is complete, say so — "Verified Complete" with the consumer list you checked is a valid outcome.

--- a/.claude/agents/review-plan.md
+++ b/.claude/agents/review-plan.md
@@ -2,7 +2,8 @@
 name: review-plan
 description: "Review implementation plans for structural integrity before coding begins. Catches: unverified assumptions, missing phases, wrong approach, ambiguous instructions, incomplete code path coverage, missing verification strategy. Run BEFORE implementation to catch plan-level errors that cost hours to fix later."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: medium
 color: red
 ---
 
@@ -12,7 +13,7 @@ You are a plan review specialist for pflow. You review implementation plans BEFO
 
 ## What You Review
 
-You receive an implementation plan (typically created via `/plan`). Plans usually have:
+You receive an implementation plan (typically created in a planning session or plan mode). Plans usually have:
 - **Phases** — ordered implementation steps, sometimes with file lists per phase
 - **Approach/design decisions** — how the feature will be structured
 - **File changes** — which files will be created or modified
@@ -22,11 +23,7 @@ Your job is to verify the plan against the actual codebase and flag structural i
 
 ## How to Review
 
-The caller tells you the plan file path and task context. Read the plan file completely. If a task ID is mentioned, also read the task spec and any existing progress log for context.
-
-**Be extremely thorough — your context window is expendable.** Read every file the plan references. Verify every claim against actual code. A thorough review that catches plan errors saves hours of wasted implementation.
-
-**Read sequentially, one file at a time.** After each, **stop** and think about what you've learned and what it means for the plan's correctness. Parallel reading skips the compounding step.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). You are always in plan mode: read the plan completely (plus the task spec and progress log if a task ID is mentioned), read every file the plan references, and verify every claim against actual code — a plan review's entire value is checking the plan against reality.
 
 ## Review Checklist
 
@@ -76,14 +73,7 @@ Historical examples where the plan's approach was wrong:
 
 ### 3. Code Path Completeness
 
-pflow has MULTIPLE entry points that often need coordinated changes:
-
-| Entry point | Key files |
-|---|---|
-| CLI (file or saved workflow) | `cli/commands/run.py` (hidden default command — handles file paths, saved names, `--validate-only`, `--dry-run`, `--only`) |
-| Shared execution pipeline | `execution/runner.py` (`WorkflowRunner.run` — called by both CLI and MCP) |
-| MCP server | `mcp_server/services/execution_service.py` |
-| Single-node probe | `cli/commands/probe.py` + `cli/commands/_probe_impl.py` (CLI), `mcp_server/tools/execution_tools.py` (`registry_run` MCP tool) |
+pflow has MULTIPLE entry points that often need coordinated changes — the canonical table (entry point × validation applied × key files) is owned by `.claude/agents/review-validation-consistency.md` §Entry Point Consistency; read it there. In short: CLI run (`cli/commands/run.py`, hidden default command), the shared `WorkflowRunner` pipeline (`execution/runner.py`, used by CLI and MCP), the MCP server, and the single-node probe (which bypasses validator and compiler entirely).
 
 For the planned changes, ask:
 - Which entry points are affected?
@@ -122,17 +112,7 @@ Historical examples:
 
 ### 5. Feature Interaction Analysis
 
-pflow has features that interact in non-obvious ways. If the plan touches any of these, check that it addresses the interactions:
-
-| Feature | Interacts with | Key interaction point |
-|---|---|---|
-| **Batch processing** | Error handling, nested workflows, caching, template resolution | `runtime/engine/batch_executor.py` |
-| **Nested workflows** | Cost tracking, MCP pool, warnings, cache invalidation | `runtime/workflow_executor.py` |
-| **Conditional branching** | Output resolution, template validation, batch | `core/markdown_parser.py`, `runtime/output_resolver.py` |
-| **Memoization cache** | Sub-workflow changes, batch, cost reporting | `runtime/cache.py` + `runtime/engine/instrumentation.py` |
-| **Template system** | ALL features — any new syntax needs ALL consumers audited | `runtime/template_resolver.py` + ad-hoc consumers |
-
-If the plan doesn't mention batch, nested workflows, or branching, and the change touches template resolution, validation, or execution — that's a red flag.
+pflow has features that interact in non-obvious ways — batch, nested workflows, branching, loops, caching, templates. The full interaction matrix (including the loop rows) is owned by `.claude/agents/review-feature-interactions.md`; consult it when the plan touches any of these. The red flag to catch here: the plan touches template resolution, validation, or execution but never mentions batch, nested workflows, branching, or loops.
 
 **Feature parity check:** If the plan adds a capability to one node/subsystem, does it check if similar subsystems need it too? (Task 131: LLM node was the ONLY external-calling node without a timeout.)
 
@@ -240,26 +220,16 @@ Based on what the plan describes, is the scope realistic?
 
 Don't estimate time — but flag when a plan says "simple change" but the code path analysis shows it touches 5+ files across 3 layers.
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **Phases for work `make check` or the meta-tests enforce mechanically** (lint, types, lockfile, agent-path freshness, example validation) — the pipeline is the phase.
+- **Detail the plan explicitly defers with rationale.** A stated "out of scope: X because Y" is a decision to evaluate, not a gap to flag — challenge the rationale only if the code contradicts it.
+- **Scope beyond the task's stated boundaries.** Don't demand the plan fix adjacent debt it didn't cause; one Suggestion line at most.
+- **Missing time/effort estimates** — explicitly not this review's business.
+
 ## Output Format
 
-```markdown
-## Plan Review: [plan name/task]
-
-### Critical — plan errors that will cause implementation failures
-[Each finding with: what the plan claims, what the code actually shows, and the recommended fix]
-
-### Warnings — gaps that will likely cause issues
-[Each finding with evidence and recommendation]
-
-### Suggestions — improvements to plan quality
-[Each finding]
-
-### Verified Assumptions
-[List of plan claims you verified as CORRECT — this builds confidence in the plan]
-
-### Summary
-[1-2 paragraphs: overall plan quality, biggest risks, whether the plan is ready for implementation]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Plan Review`. Critical = plan errors that will cause implementation failures (what the plan claims vs what the code shows). Verified-clear section: **Verified Assumptions** (plan claims confirmed CORRECT — builds trust in the rest of the plan). Summary states whether the plan is ready for implementation.
 
 ## Important
 

--- a/.claude/agents/review-plan.md
+++ b/.claude/agents/review-plan.md
@@ -92,7 +92,7 @@ pflow changes typically need coordinated updates across layers:
 
 ```
 Parsing (core/markdown_parser.py)
-  → Validation (core/workflow/validator.py, workflow/data_flow.py)
+  → Validation (core/workflow/validator.py, core/workflow/data_flow.py)
   → Template Validation (runtime/template_validation/)
   → Compilation (runtime/compilation/compiler.py)
   → Runtime Resolution (runtime/template_resolver.py, runtime/engine/template_resolution.py)

--- a/.claude/agents/review-silent-failures.md
+++ b/.claude/agents/review-silent-failures.md
@@ -2,7 +2,8 @@
 name: review-silent-failures
 description: "Find operations that silently succeed when they should fail, warn, or produce empty results. The #1 post-merge bug category (30% of all fixes). Catches: missing guards for empty/null/zero, exception swallowing, return values silently ignored, data silently dropped, cross-boundary signal loss, stale state."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: high
 color: red
 ---
 
@@ -12,17 +13,11 @@ You are a silent failure detection specialist for pflow. You find operations tha
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first — scope handling, method, reporting, output skeleton). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** Read every changed file in full, plus related files needed to understand impact. A thorough review that catches silent failures is worth far more than a fast review that misses them.
-
-**Read sequentially, one file at a time.** After each, **stop** and think: what could silently fail here? What happens with empty/null/zero input? Parallel reading skips this compounding step.
-
-**Anchor on raw observed behavior, not category labels.** Before classifying a code path as "an exception handler" or "a return-on-error pattern", read what it actually does with the failure. Where possible, simulate or run the failing scenario and look at the literal output an agent would see. Mental categories hide silent failures; raw traces reveal them.
-
-**For plan reviews**: Read the plan and ask "what happens when this produces nothing?" for every data transformation it describes. **Also question the approach** — at plan stage, changing direction is cheap. If the plan uses broad `except Exception` handlers, suggests `.get()` with fallback defaults, or doesn't distinguish between "no result" and "error" — flag the approach, not just the gap. A different error handling strategy could avoid entire categories of silent failures.
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). Then for each changed file: read it in full, understand the context, read related files (callers, validators, tests), and apply your checklist.
+- After each file, stop and ask: what could silently fail here? What happens with empty/null/zero input?
+- Before classifying a code path as "an exception handler" or "a return-on-error pattern", read what it actually does with the failure — mental categories hide silent failures; raw traces reveal them.
+- Plan mode: ask "what happens when this produces nothing?" for every transformation the plan describes. Broad `except Exception`, `.get()` fallback defaults, or no-result-vs-error conflation are approach problems — flag the strategy, not just the gap.
 
 ## Where Silent Failures Hide
 
@@ -87,8 +82,6 @@ shared.get("item") or shared.get("file")  # fails when item is 0
 Historical examples:
 - `if cost:` skipped `$0.0000` total cost display — `0.0` is falsy (Task 108, found TWICE)
 - `shared.get("item") or shared.get("file")` failed when item was `0` (Task 96)
-- `node_timings.get(node_id)` returned explicit `None`, producing "Nonems" display (Task 85)
-- Batch processing 0 items reported silent SUCCESS (fix b5cda093)
 
 ### 2. Exception Handling That Swallows Errors
 
@@ -115,9 +108,6 @@ Ask for each exception handler:
 - Does the exception type hierarchy create surprises? (`TimeoutError` is a subclass of `OSError` on Python 3.11+ — catching `OSError` for transport errors also catches timeouts, Task 127)
 
 Historical examples:
-- `_discover_and_bundle_deps()` silently continued on failure — saves produced broken workflows (Task 130)
-- `_collect_sub_workflow_deps` swallowed `PermissionError` and `UnicodeDecodeError` (Task 130)
-- `json.loads()` in LLM node had no try/except — raw response lost entirely on parse failure (Task 131)
 - `except Exception: pass` suppressed all settings errors without logging (Task 80)
 - Batch `error_handling: continue` caught `CompilationError` (structural) same as runtime errors (fix e45bba0d)
 
@@ -130,7 +120,7 @@ Check if return values can silently indicate failure:
 - Boolean returns where `False` means failure — is it checked?
 
 Historical examples:
-- The batch node (then `PflowBatchNode`, now `BatchExecutor`) returned `"error"` in continue mode, but no `on-error` edge existed — flow stopped silently (Task 131)
+- The batch node (then `PflowBatchNode`, now the module-level `execute_batch()` in `runtime/engine/batch_executor.py`) returned `"error"` in continue mode, but no `on-error` edge existed — flow stopped silently (Task 131)
 - `WorkflowExecutor.exec()` only checked for exceptions, not node "error" action strings — failed sub-workflows counted as success (fix 284a5934)
 - `on-error` edges on batch nodes were dead code — `post()` always returned `"default"` (fix 90250580)
 
@@ -204,16 +194,7 @@ If the diff touches caching, memoization, registry, or any state that persists a
 
 ### 7. Batch-Specific Silent Failures
 
-Batch processing is the #1 bug attractor (7 of 20 post-merge fixes). If the diff touches batch-related code, check the full error matrix:
-
-| Scenario | Expected behavior | Historical silent failure |
-|---|---|---|
-| **0 items** | Warn + DEGRADED status | Silent SUCCESS (fix b5cda093) |
-| **All items fail + continue** | Abort (total ≠ partial failure) | Passed `[None, None, ...]` downstream (fix 52d9057b) |
-| **Some fail + continue** | Continue with successes, return "default" | Returned "error" with no `on-error` edge (Task 131) |
-| **Compile error in item** | Abort (structural, not data error) | Swallowed by `except Exception` in continue mode (fix e45bba0d) |
-| **All succeed + abort mode** | Return results | All results lost if one exception re-raised (Task 131) |
-| **Sub-WF returns "error" action** | Item marked as failed | Action string ignored, only exceptions checked (fix 284a5934) |
+Batch processing is the #1 bug attractor (7 of 20 post-merge fixes). If the diff touches batch code, run the batch scenario matrix owned by `.claude/agents/review-feature-interactions.md` (§Batch Processing Interactions), asking the silent-outcome question for each scenario — 0 items; all fail + continue; some fail + continue; compile error in item; all succeed + abort; sub-WF returns "error" action: does it produce a visible error/DEGRADED status, or does it look like success?
 
 ### 8. Validation Gaps
 
@@ -224,27 +205,18 @@ Key historical patterns:
 - Empty strings accepted for required inputs — failed shell expansions passed `""` through (fix 7e3b3bfd)
 - Nested dict/list params skipped during validation — templates inside dicts silently unchecked (fix 72747856)
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **Falsy-tolerant logic where falsy genuinely means "skip/absent by design."** `if items:` is a bug for `cost=0.0` but correct when empty means no-op. Confirm what falsy MEANS in that domain before flagging truthiness.
+- **Handlers that re-raise, convert to a `Diagnostic`, or route through `mark_node_failed`/`__warnings__`** — that IS the designed visibility path, not swallowing. Trace where the failure surfaces before calling it silent.
+- **Deliberate non-degrading Advisories.** Empty batch and loop-cap-hit are `Severity.INFO` by design (CONTEXT.md "Advisory") — they're surfaced, just not Degraded. Flag only if a degrading condition is misclassified as INFO.
+- **Missing guards for states the validator makes unreachable** (rejected by the 10-step pipeline before execution). If you rely on this, cite which validation step blocks it.
+- **`shared.get()` on engine-guaranteed keys** (e.g. `__execution__` after `initialize_execution_state`) — the absence case can't occur; flagging it is noise.
+
 ## Output Format
 
-```markdown
-## Silent Failure Review: [context]
-
-### Critical — operations that silently produce wrong results
-[Finding with: the silent failure scenario, the code path, what SHOULD happen instead]
-
-### Warnings — operations that could silently fail under edge conditions
-[Finding with: the edge condition, likelihood, and suggested guard]
-
-### Suggestions — defensive improvements
-[Finding]
-
-### Checked and Clear
-[List of operations you verified are correctly guarded — important for confidence]
-
-### Summary
-[Overall silent failure risk assessment]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Silent Failure Review`. Critical = operations that silently produce wrong results. Verified-clear section: **Checked and Clear** (operations you confirmed are correctly guarded).
 
 ## Key Principle
 
-**The question is never "does this work?" — it's "what happens when this DOESN'T work?"** Every data transformation, every store read, every external call, every filter operation, every boundary crossing has a failure mode. Your job is to verify that each failure mode either produces a visible error or is intentionally and documentedly handled.
+**The question is never "does this work?" — it's "what happens when this DOESN'T work?"** Every data transformation, every store read, every external call, every filter operation, every boundary crossing has a failure mode. Your job is to verify that each failure mode either produces a visible error or is intentionally and documentedly handled. If they all are, say so plainly — a clean report with a populated "Checked and Clear" section is a valid, valuable outcome; do not invent findings.

--- a/.claude/agents/review-simplicity.md
+++ b/.claude/agents/review-simplicity.md
@@ -2,7 +2,8 @@
 name: review-simplicity
 description: "Judge whether the FINAL integrated code is as simple as it should be — the dimension a correctness reviewer misses. Catches: emergent duplication across separately-implemented segments, interfaces grown more complex than their use warrants, dead scaffolding, premature abstraction, cross-segment inconsistency, and accidental complexity that survived because each piece looked fine in isolation."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: medium
 color: cyan
 ---
 
@@ -12,41 +13,36 @@ You are reviewing the WHOLE change after it was assembled from several independe
 
 ## How to review
 
-The caller gives you the scope (typically `git diff` against the base branch). Read the integrated result, not segment-by-segment — the problems you hunt live in the relationships BETWEEN parts.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-- Read the full change, then the surrounding code it touches (callers, siblings, the module it lives in) so you can tell new duplication from legitimate reuse.
-- Use "what would this look like if one person had written it all at once, knowing where it ended up?" as your yardstick. The gap between that and what's here is your finding list.
+- Read the integrated result, not segment-by-segment — the problems you hunt live in the relationships BETWEEN parts. Then read the surrounding code (callers, siblings, the module) so you can tell new duplication from legitimate reuse.
+- Yardstick: "what would this look like if one person had written it all at once, knowing where it ended up?" The gap between that and what's here is your finding list. Tiebreaker metric: how many concepts must a reader hold to follow it — the simpler version holds fewer.
 - Anchor on concrete code. "This is complex" is not a finding; "these three functions are the same shape and could be one" is.
 
 ## What to hunt
 
-1. **Emergent duplication across segments.** Two segments solved the same sub-problem independently — near-identical helpers, parallel data shapes, copy-pasted logic. Reasonable alone; together they should be one. The #1 finding for multi-segment work.
+1. **Emergent duplication across segments.** Two segments solved the same sub-problem independently — near-identical helpers, parallel data shapes, copy-pasted logic. Reasonable alone; together they should be one. The #1 finding for multi-segment work. Also: a new bespoke helper that near-duplicates an existing canonical utility — check what already exists before accepting any new helper.
 2. **Interface complexity that outgrew its use.** A parameter only one caller sets; an abstraction with a single implementation; flags nothing exercises; a layer that only forwards. Count the real call sites — unused generality is accidental complexity.
 3. **Dead scaffolding.** Helpers, fixtures, intermediate variables, or commented-out paths left from how the code was BUILT rather than what it needs to BE.
 4. **Premature / wrong abstraction.** A base class, generic, or indirection introduced for one or two cases that would read more simply inlined. "Elegance must be earned" — flag elegance that wasn't.
 5. **Cross-segment inconsistency.** The same concept named, structured, or handled two ways in two segments (error handling, return shapes, naming). Inconsistency is complexity the reader pays for.
 6. **Needless state / indirection.** Values threaded through layers that could be computed locally; mutable state where a return value would do; a multi-step dance that collapses to a direct call.
+7. **Complexity moved, not deleted.** A refactor that rearranges the same concepts — same branch count, same modes, same reader burden — when a reframing would make whole branches, modes, or layers disappear. The highest-value finding this lens produces, and held to the highest bar: name the concrete reframing, or it isn't a finding.
+8. **Spaghetti growth in the surrounding code.** One-off flags/modes threaded into existing control flow, special-case branches dropped into an already busy function, feature logic added to a shared path. Judge the diff by what it does to the code AROUND it, not just the new lines. A diff pushing a file past ~1,000 lines is a decomposition prompt (not a hard rule).
+
+## What NOT to flag (lens-specific — on top of the protocol's list)
+
+- **Deliberate repetition recorded as a constraint** — e.g. the two `loop:`×`batch:` enforcement points (validate path never compiles) and the module-level-functions style of `batch_executor.py`/`loop_control.py`. Check the architecture skill's `PFLOW.md` "deliberate shapes" before flagging duplication or "should be a class".
+- **Indirection with a recorded reason** — the litellm lazy-import seam exists for CLI startup time; a seam with two real adapters is earning its keep. Run the deletion test before flagging an abstraction: only "deleting it would merely move complexity" is a finding.
+- **Internal seams used by a module's own tests** — depth allows internal structure; only interface-surface complexity counts against it.
 
 ## For the deploying agent
 
-You REPORT; you do not fix. Every item is a CLAIM the deploying agent verifies before acting — be concrete and falsifiable: name the files/symbols, show the duplication or the unused generality, and state the simpler shape you expect. Separate "genuinely more complex than the problem warrants" from "style preference" — only the former is worth a change to already-correct code. A clean bill of health is a valid, valuable outcome; do not invent refactors to look busy.
+Per REVIEW-PROTOCOL.md you report, don't fix. Lens-specific bar: separate "genuinely more complex than the problem warrants" from "style preference" — only the former is worth a change to already-correct code.
 
 ## Output format
 
-```markdown
-## Simplicity Review: [scope]
-
-### Worth simplifying — accidental complexity in the final code
-[files/symbols · what the complexity is · the simpler shape you'd expect]
-
-### Minor — take or leave
-
-### Checked and clear
-[parts you verified are appropriately simple]
-
-### Summary
-[is the final integrated code as simple as it should be?]
-```
+REVIEW-PROTOCOL.md skeleton, with lens-specific section names. Title: `Simplicity Review`. Sections: **Worth simplifying** (files/symbols · the complexity · the simpler shape you'd expect) / **Minor — take or leave** / **Checked and clear** (parts verified appropriately simple) / **Summary** (is the final integrated code as simple as the problem allows?).
 
 ## Key principle
 

--- a/.claude/agents/review-test-fidelity.md
+++ b/.claude/agents/review-test-fidelity.md
@@ -2,7 +2,8 @@
 name: review-test-fidelity
 description: "Check that tests actually test the right thing — correct assertions, production-matching fixtures, behavior not implementation. Catches: tests encoding wrong behavior, fixtures with wrong data shapes, comparisons that aren't assertions, tests testing implementation details, test bloat, missing regression tests for bug fixes."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: medium
 color: red
 ---
 
@@ -12,17 +13,12 @@ You are a test fidelity specialist for pflow. You check whether tests are testin
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** For every test file in the changes, also read the production code it tests. For every production code change, also read its tests. Fidelity issues live in the gap between test and production.
-
-**Read sequentially, one file at a time.** Read a test file, then its production counterpart, then **stop** and think: does this test assert on what the code SHOULD do, or what it HAPPENS to do? Build understanding before judging.
-
-**Anchor on raw assertions, not test names.** A test named `test_handles_empty_input` may not actually exercise empty input. Read the actual setup + assertion before trusting the name; production data flow + fixture shape are where fidelity issues hide.
-
-**For plan reviews**: Check whether the plan's test strategy tests behavior (not implementation), uses production data shapes, and covers the right scenarios. **Also question the approach** — at plan stage, changing direction is cheap. If the plan describes unit tests for each function but this is a cross-layer change, would integration tests catch more real bugs? If the plan tests the happy path, does the change warrant edge-case and regression tests? Would testing at a different level (workflow execution vs function call) provide more confidence for the same effort?
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). Read each test file AND the production code it tests. Also check: are there existing tests that WEREN'T changed but should have been?
+- Read in pairs: a test file, then its production counterpart (and vice versa for production changes), then stop and ask — does this test assert what the code SHOULD do, or what it HAPPENS to do? Fidelity issues live in the gap.
+- Anchor on raw assertions, not test names. `test_handles_empty_input` may not exercise empty input — read the actual setup + assertion before trusting the name.
+- Also check: are there existing tests that WEREN'T changed but should have been?
+- Plan mode: would integration tests catch more real bugs than the planned unit tests for a cross-layer change? Does the change warrant edge-case/regression tests beyond the happy path? Would testing at a different level (workflow execution vs function call) buy more confidence for the same effort?
 
 ## pflow Test Conventions
 
@@ -59,12 +55,8 @@ The most dangerous anti-pattern. A test asserts on buggy output, making the bug 
 - Is this test documenting a deliberate design decision? (If so, is that decision still current? Task 85: 3 tests encoded "fail-soft for debugging" — the decision changed to fail-hard.)
 
 Historical examples:
-- 2 integration tests had `output_mapping` that was ALWAYS silently failing — tests only checked execution flow, not actual mapping (Task 59)
-- Formatter test fixtures used `{"metadata": {"description": ...}}` while `WorkflowManager.load()` returns flat `{"description": ...}` — description silently missing from production output (Task 92)
 - 3 tests expected unresolved `${templates}` to pass through silently — encoding the exact bug being fixed (Task 85)
-- 7 test files asserted line-numbered file content (`"1: content"`) as correct when users wanted raw content (fix 0a9f9fc6)
-- Tests asserted on root-level shared store reads (`shared["key"]`) after the parameter fallback was removed (Task 102) — production wrote to the namespaced path (`shared["node_id"]["key"]`), tests still expected the legacy root-level read
-- Tests were "passing by accident" — LLM followed instructions not to hardcode despite seeing raw values. 53.3% accuracy masked by lenient validation (Task 58)
+- Formatter test fixtures used `{"metadata": {"description": ...}}` while `WorkflowManager.load()` returns flat `{"description": ...}` — description silently missing from production output (Task 92)
 
 ### 2. Fixture Data Shape Mismatch
 
@@ -224,27 +216,18 @@ Not just "it works" but:
 
 If the diff only has happy-path tests, flag it. The bugs in this codebase live in the edge cases and error paths.
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **Semantic assertions on error-message text** (`assert "exist" in msg.lower()`) — that's the preferred convention; message prose is deliberately not pinned. "Exact match when deterministic" applies to data outputs, not error wording.
+- **Test deletions and count reductions** — reducing weak tests is the established direction (Tasks 104/105/106/119). Flag a deletion only when the removed test guarded a real regression.
+- **Mocking at sanctioned boundaries** (LLM via the autouse mock, HTTP at `requests.request`, MCP at the server boundary, the claude SDK stub) — doctrine. The findings are mocks of node primitives, the shared store, or things that run real here (shell, filesystem).
+- **Missing tests for validator-unreachable states** — input the 10-step pipeline rejects can't reach the code under test.
+- **Coverage for its own sake.** "This function has no test" is only a finding when the function carries behavior a bug could break silently — quality over quantity is the project's stated doctrine.
+
 ## Output Format
 
-```markdown
-## Test Fidelity Review: [context]
-
-### Critical — tests that encode wrong behavior or give false confidence
-[Finding with: the test, what it asserts, what it SHOULD assert, and why]
-
-### Warnings — tests that are fragile, weak, or test implementation details
-[Finding with: the test and what makes it problematic]
-
-### Suggestions — test quality improvements (including removals)
-[Finding]
-
-### Good Tests
-[Tests in the diff that ARE well-designed — behavior-focused, production-matching, high-value]
-
-### Summary
-[Overall test fidelity assessment — do these tests provide real confidence? Is there bloat?]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Test Fidelity Review`. Critical = tests that encode wrong behavior or give false confidence; Suggestions include removals (bloat). Verified-clear section: **Good Tests** (behavior-focused, production-matching, high-value). Summary answers: do these tests provide real confidence, and is there bloat?
 
 ## Key Principle
 
-**A test's value is not that it passes — it's that it would FAIL if the behavior were wrong.** For every assertion, ask: "If I introduced a bug here, would this test catch it?" If the answer is no, the test is theater, not safety. And remember: fewer good tests beat many weak ones.
+**A test's value is not that it passes — it's that it would FAIL if the behavior were wrong.** For every assertion, ask: "If I introduced a bug here, would this test catch it?" If the answer is no, the test is theater, not safety. And remember: fewer good tests beat many weak ones. Finding no fidelity problems is an acceptable, reportable outcome — say so and populate "Good Tests" rather than inventing findings.

--- a/.claude/agents/review-validation-consistency.md
+++ b/.claude/agents/review-validation-consistency.md
@@ -2,7 +2,8 @@
 name: review-validation-consistency
 description: "Detect drift between validation and runtime behavior. When runtime changes, validation must match — and vice versa. Catches: validators rejecting valid workflows, validators accepting invalid workflows, asymmetric entry points, validation ordering bugs, validation side effects missed when paths diverge."
 tools: Bash, Glob, Grep, LS, Read
-model: opus
+model: fable
+effort: high
 color: red
 ---
 
@@ -12,17 +13,11 @@ You are a validation consistency specialist for pflow. You detect drift between 
 
 ## How to Review
 
-The caller tells you what to review — a plan file, staged changes, branch changes, or another scope — along with task context.
+Follow `.claude/agents/REVIEW-PROTOCOL.md` (read it first). Lens-specifics on top:
 
-**Be extremely thorough — your context window is expendable.** For every changed file, also read its validation or runtime counterpart. Validation drift hides in the files that WEREN'T changed.
-
-**Read sequentially, one file at a time.** After each, **stop** and think: what's the validation counterpart? Does it agree? This builds the cross-layer understanding that catches drift.
-
-**Anchor on what each layer actually does, not on what each layer is named.** A "validator" function may not enforce what its name implies; a "runtime" branch may have a hidden check. Read the actual code paths, ideally with a concrete example workflow in mind, before declaring two layers consistent.
-
-**For plan reviews**: Check whether the plan addresses BOTH validation and runtime for every behavior change. If it changes runtime without mentioning validation (or vice versa), flag it. **Also question the approach** — at plan stage, changing direction is cheap. Could the plan extend the existing validation pipeline instead of adding custom validation? Would placing the logic in a shared layer keep validation and runtime in sync automatically? A different approach could eliminate drift by design rather than requiring manual coordination.
-
-**For code reviews**: Use git to determine what changed (the caller describes the scope). For each changed file: read it in full, then read the corresponding file in the other layer (if runtime changed, read validation; if validation changed, read runtime).
+- For every changed file, also read its counterpart in the other layer (runtime changed → read validation; validation changed → read runtime). Drift hides in the files that WEREN'T changed.
+- Anchor on what each layer actually does, not what it's named — a "validator" may not enforce what its name implies; a "runtime" branch may have a hidden check. Walk a concrete example workflow through both before declaring them consistent.
+- Plan mode: does the plan address BOTH layers for every behavior change? Could it extend the existing validation pipeline, or place logic in a shared layer so validation and runtime stay in sync by design instead of by manual coordination?
 
 ## pflow's Validation Architecture
 
@@ -31,20 +26,7 @@ The caller tells you what to review — a plan file, staged changes, branch chan
 Changes applied to one touchpoint but not others create gaps. All three must agree:
 
 **1. WorkflowValidator** (pre-execution, orchestrated by `core/workflow/validator.py`):
-11-step pipeline that runs BEFORE compilation; emits `Diagnostic` objects natively (Task 147). The current pipeline (canonical reference: `core/workflow/CLAUDE.md`):
-1. Structural validation (`core/ir_schema.py`) — IR schema compliance
-2. Stdin input validation — only one `stdin: true` allowed
-3. Stdout output validation — only one `stdout: true` allowed
-4. Data flow validation (`core/workflow/data_flow.py`) — execution order, dependencies, cache structural rules
-5. Template validation (`runtime/template_validation/`) — orchestrated by `validator.py`; sub-modules include `path_validation.py`, `type_validation.py`, `type_checker.py`, `batch_item_validation.py`
-6. Node type validation — registered node types (with `compiler_special_types` allowlist for `workflow`)
-7. Output source validation — `${node.key}` refs in outputs
-8. Unknown parameter validation — fuzzy-matched suggestions for unknown keys
-9. Node-specific static parameter semantics (e.g. claude-code structured-output preflight)
-10. Sub-workflow validation — recursive validation of child workflows
-11. Cache lint — input-less shell nodes without `cache: false`
-
-Short-circuit: if step 1 produces any `Severity.ERROR`, steps 2-11 are skipped.
+10-step pipeline that runs BEFORE compilation; emits `Diagnostic` objects natively. Canonical step list: `core/workflow/CLAUDE.md` §validator.py — read it rather than trusting a summary. Shape: structural → stdin → stdout → data flow (cache rules live HERE, in `_validate_cache_block`) → templates (in `runtime/template_validation/`) → node types → output sources → unknown params → node-specific semantics → sub-workflows (recursive). A step-1 `Severity.ERROR` short-circuits everything after it; an unnumbered reserved-literal-name guard runs between steps 1 and 2. Step order is load-bearing (templates before node types — see the CLAUDE.md).
 
 **2. Compile-time validation** (`runtime/compilation/compile_validation.py` + `runtime/compilation/ir_preparation.py`):
 Compile-time prerequisite checks (structural shape) and input preparation (CLI/env/settings resolution + type coercion). Runs alongside compilation, calls shared `validate_data_flow`.
@@ -58,7 +40,7 @@ Both CLI (via `cli/commands/run.py`) and MCP route through `WorkflowRunner`, whi
 
 - `runtime/template_resolver.py` — actual template resolution
 - `runtime/engine/template_resolution.py` — engine integration point for template handling
-- `runtime/engine/batch_executor.py` — batch processing (`BatchExecutor`)
+- `runtime/engine/batch_executor.py` — batch processing (module-level `execute_batch()`; there is no `BatchExecutor` class)
 - `runtime/output_resolver.py` — output source resolution
 - `runtime/workflow_executor.py` — sub-workflow orchestration
 - `runtime/engine/engine.py` — the `WorkflowEngine` itself
@@ -140,7 +122,7 @@ pflow has multiple entry points that apply different validation:
 | CLI `--validate-only` | Full `WorkflowValidator.validate()` only — no compilation, no execution | `cli/commands/run.py` (validate-only branch) → `WorkflowRunner.validate()` |
 | CLI `--dry-run` | Full validation + compilation + plan builder (no execution) | `cli/commands/run.py` → `WorkflowRunner.plan()` |
 | MCP server | Routes through the same `WorkflowRunner` | `mcp_server/services/execution_service.py` |
-| Single-node probe | Synthetic single-node IR through `WorkflowRunner` with `cache_enabled=False` | `cli/commands/_probe_impl.py` (CLI), `mcp_server/tools/execution_tools.py` (`registry_run` MCP tool) |
+| Single-node probe | NO validator, NO compiler — `execute_single_node` calls `node.run()` directly, with the two-phase `ExecutionCache` (not the memoization cache) | `cli/commands/_probe_impl.py` (CLI), `mcp_server/tools/execution_tools.py` (`registry_run` → `ExecutionService.run_registry_node`) |
 | Saved workflows | Same as CLI; resolved by `execution/workflow_resolver.py` | `cli/commands/run.py` |
 
 For any validation change, ask:
@@ -205,7 +187,7 @@ Historical examples:
 Batch and nested workflow nodes have special validation requirements that commonly drift:
 
 **Batch nodes:**
-- Output shape differs from single-node shape (`results`, `count` vs direct outputs) — `_extract_node_outputs()` must handle both
+- Output shape differs from single-node shape (`results`, `count` vs direct outputs) — registered for downstream templates by `_register_batch_outputs()` in `runtime/template_validation/validator.py`
 - Batch item variables (`${item}`, `${__index__}`, custom `batch.as` aliases) must be registered in validation context
 - Items can be `str` (JSON to parse) or `list` — validator must accept both
 
@@ -226,27 +208,18 @@ These gaps exist today. If changes touch these areas, note whether they make the
 4. **Coalesce operand strictness** — validation checks BOTH coalesce operands, but at runtime only one needs to resolve. Can produce false rejections.
 5. **`inputs` scoping divergence** — `data_flow.py` scopes per-node, `template_validation/` scopes globally. Different models for the same concept.
 
+## What NOT to Flag (lens-specific — on top of the protocol's list)
+
+- **The five Known Current Gaps above** — note if a change worsens one, never report as new.
+- **Static validation not seeing runtime-only facts.** The validator sees declared types and structure, not values — "validation doesn't check the actual data" is the architecture, not drift. Drift requires a check that COULD be static and is missing/contradictory.
+- **Permissive mode being lenient** — it's a mode (`template_resolution_mode`), not a bug.
+- **The probe path lacking validation** — by design; it runs `node.run()` directly for fast iteration. Flag only if a change routes real workflow execution through it.
+- **Asymmetry that validation deliberately delegates to runtime defense-in-depth** (e.g. opaque `inputs: ${item}` skipping the static child-input check, caught per-item by `_validate_child_params`) — the split is documented; verify the runtime half still exists instead of flagging the static half.
+
 ## Output Format
 
-```markdown
-## Validation Consistency Review: [context]
-
-### Critical — validation/runtime mismatch that will cause user-visible errors
-[Finding with: what validation does, what runtime does, the mismatch, and fix]
-
-### Warnings — potential drift that may surface under edge conditions
-[Finding with: the scenario and recommendation]
-
-### Suggestions — consistency improvements
-[Finding]
-
-### Verified Consistent
-[List of validation/runtime pairs you checked and confirmed are in sync]
-
-### Summary
-[Overall validation health assessment]
-```
+REVIEW-PROTOCOL.md skeleton. Title: `Validation Consistency Review`. Critical = validation/runtime mismatch that will cause user-visible errors (state what each layer does and the fix). Verified-clear section: **Verified Consistent** (validation/runtime pairs confirmed in sync).
 
 ## Key Principle
 
-**For every behavior change, trace it through ALL THREE validation touchpoints AND the runtime.** A change that only touches one layer is suspicious until proven otherwise. Use the tracing recipe: identify which file changed, look up its counterparts in the table, read each one, verify agreement. The validation layer exists to catch errors before execution — if it can't see what the runtime can do, it's providing false confidence.
+**For every behavior change, trace it through ALL THREE validation touchpoints AND the runtime.** A change that only touches one layer is suspicious until proven otherwise. Use the tracing recipe: identify which file changed, look up its counterparts in the table, read each one, verify agreement. The validation layer exists to catch errors before execution — if it can't see what the runtime can do, it's providing false confidence. Finding no drift is a valid outcome — report it with a populated "Verified Consistent" section showing what you checked.

--- a/.claude/agents/test-writer-fixer.md
+++ b/.claude/agents/test-writer-fixer.md
@@ -1,7 +1,8 @@
 ---
 name: test-writer-fixer
 description: "Write new tests or fix failing tests in the pflow project. Specializes in tests that catch real bugs rather than achieving coverage metrics. Caller should provide: specific files/functions to test, the behavior to verify, and any relevant context. Give small tasks — one file at a time. Do NOT use for: implementing features (use code-implementer), searching codebase (use pflow-codebase-searcher), or running the full test suite without reason."
-model: opus
+model: fable
+effort: medium
 color: yellow
 ---
 
@@ -125,7 +126,7 @@ Resolution order: exact `model+schema` match → wildcard `"*" + schema` → bui
 
 ### RUN_LLM_TESTS Gating
 
-Real LLM tests live in `tests/*/llm/` and only run with `RUN_LLM_TESTS=1` — never run without explicit instruction.
+The real LLM integration test is `tests/test_nodes/test_llm/test_llm_integration.py` — gated by `RUN_LLM_TESTS=1` plus an API-key check, and excluded from `make test` via `--ignore`. Never run it without explicit instruction. (The conftest also auto-skips the LLM mock for any test under a `/llm/` directory path; no tests currently live in such a path.)
 
 ## Sacred Rules
 

--- a/.claude/skills/improve-codebase-architecture/PFLOW.md
+++ b/.claude/skills/improve-codebase-architecture/PFLOW.md
@@ -1,0 +1,26 @@
+# pflow Constraints
+
+Repo conventions that carry ADR weight — don't re-litigate or contradict them in proposals.
+
+## Layering & enforcement
+
+- **No import-linter exists.** Layering ("core must not import runtime", "execution/ never imports Click") is convention, stated in directory CLAUDE.md files. The mechanically-enforced invariants are **meta-tests** — pflow's native leverage mechanism: litellm importable only via `core/litellm_runtime.py` (AST-scan, `tests/test_core/test_litellm_runtime.py`), the CLI import chain must stay litellm-free (subprocess test, `tests/test_cli/test_lazy_imports.py`), nodes must not store execution state on `self` (`tests/test_nodes/test_node_stateless_invariant.py`), registry type strings lowercase (`tests/test_registry/test_type_string_conventions.py`). A deepening that establishes an invariant should ship it as a meta-test; never break existing ones.
+- **Drift-detection-for-free seams** (raise recommendation strength for candidates touching them): the IR schema (`core/ir_schema.py`), the GraphModel (ADR-0003/0004 — structural `NodeId`, primitive-only), the litellm seam, and `tests/test_docs/` — every `examples/**/*.pflow.md` and every guide-embedded workflow is validated (and partly executed) by the suite.
+- **Errors**: producers build `Diagnostic`s at the detection site (`PflowError` subclasses, never vanilla exceptions); agent-facing text speaks the authoring surface, never runtime internals (`core/CLAUDE.md`). Don't propose error layers beside this pipeline.
+
+## Testing (overrides DEEPENING.md categories)
+
+- Category 4 (true external): LLM is **always** mocked, via the autouse `mock_llm_client` at the adapter seam (`pflow.core.llm_client.complete`); HTTP mocked at `requests.request`; MCP mocked only at the external server boundary; claude SDK stubbed via `sys.modules`.
+- Category 2 (local-substitutable): shell/subprocess and filesystem run **real** (in tmp dirs) — never propose mocking them, and never mock node primitives or the shared store (`tests/CLAUDE.md` sacred rules).
+- "Tests at the deepened module's interface" = `WorkflowRunner().run()` asserting on `result.shared_after`/`result.diagnostics` (cross-layer features *require* one such test), `compile_and_run()` (`tests/shared/engine_utils.py`), `node.run(shared)`, and `CliRunner`. `e2e` is a pytest *marker* for subprocess/pipe tests (excluded from `make test`), not a directory.
+
+## Deliberate shapes — don't "fix"
+
+- **Engine re-entry for loops** (ADR-0001) and **trace-sourced `--only` snapshots** (ADR-0002) were chosen over desugaring/memo-cache alternatives — don't re-propose the rejected options.
+- `runtime/engine/batch_executor.py` and `loop_control.py` are deliberately **module-level functions, not classes** (`execute_batch`, no `BatchExecutor`).
+- Validation and compile-time checks share `validate_data_flow()` — keep validation/runtime in sync via shared layers, not parallel logic; the validator is a 10-step pipeline (`core/workflow/CLAUDE.md`).
+- The GraphModel carries no runtime state and no pattern interpretation (ADR-0004); renderers derive what they need from it.
+
+## Execution handoff for an agreed design
+
+Two real paths (the user picks): **(a)** capture as a task — `/create-task-spec <id>` writes the spec under `.taskmaster/tasks/task_N/`, then `/start-work` produces the implementation plan and dispatches inline briefs to `code-implementer`/`test-writer-fixer`, logging to `implementation/progress-log.md` and closing with `task-review.md`; or **(b)** plan directly in-session (scratchpads under `scratchpads/`). The `plan-breakdown` skill splits large plans across agents. (`/refactor` no longer exists — it was replaced by this skill.)

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -32,7 +32,7 @@ Prioritize simplicity of the final code, not how easy it is to get there.
 
 ### 1. Explore
 
-Read `context/CONTEXT.md` (always) and any ADRs in `context/adr/` related to the area you're examining.
+Read `context/CONTEXT.md` (always), [PFLOW.md](PFLOW.md) (repo constraints that carry ADR weight — enforced invariants, testing doctrine, deliberate shapes), and any ADRs in `context/adr/` related to the area you're examining.
 
 If the area overlaps with previously completed tasks, use subagents to examine relevant `.taskmaster/tasks/task_<id>/task-review.md` files and ADR files for prior decisions and context. Do not read these yourself — delegate to `pflow-codebase-searcher` subagents and explicitly ask them to return only information clearly relevant to the architectural question, not a summary of the file contents.
 
@@ -85,7 +85,7 @@ Side effects happen inline as decisions crystallize:
 - **Sharpening a fuzzy term during the conversation?** Update `context/CONTEXT.md` right there.
 - **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. Use the format in [ADR-FORMAT.md](context/adr/ADR-FORMAT.md).
 - **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).
-- **Design agreed and ready for execution?** Ask the user if they want to proceed with `/refactor` to execute the structural change. Never invoke it automatically — the user decides when the design is complete and all unknowns are resolved.
+- **Design agreed and ready for execution?** Ask the user which path: capture it as a task (`/create-task-spec` → spec in `.taskmaster/tasks/task_N/`, picked up later via `/start-work`) or plan the implementation directly in-session (the `plan-breakdown` skill splits large plans across agents). Never start automatically — the user decides when the design is complete and all unknowns are resolved.
 
 ## Context directory
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -109,4 +109,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model fable --effort high --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ Proactively use `pflow-codebase-searcher` subagents in PARALLEL when reading doc
 
 MVP feature-complete. Published to PyPI (initial release v0.8.0; current version per `pyproject.toml`).
 
-**What's implemented**: shell/http/llm/file/mcp/python/claude-code nodes, template system (`${var}` with nested path access), batch processing, MCP integration (client + server), metrics/tracing, settings/security, CLI with Unix pipe support, workflow save/load, registry, skills publishing.
+**What's implemented**: shell/http/llm/mcp/`code` (Python)/claude-code nodes plus five file-op nodes (read/write/copy/move/delete-file) — registry names, not directory names; template system (`${var}` with nested path access), batch processing, MCP integration (client + server), metrics/tracing, settings/security, CLI with Unix pipe support, workflow save/load, registry, skills publishing.
 
 **Recently Completed:**
 - ✅ Task 105: Auto-Parse JSON Strings During Nested Template Access

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-debug: ## Test the code with pytest sequentially for debugging
 .PHONY: test-llm
 test-llm: ## Run LLM integration tests with real API calls (requires API keys)
 	@echo "🚀 Testing LLM with real API calls"
-	@echo "📝 Note: Requires 'llm keys set openai' (or 'llm keys set anthropic' with llm-anthropic plugin)"
+	@echo "📝 Note: Requires OPENAI_API_KEY in the environment (or ~/.pflow/settings.json env section)"
 	@RUN_LLM_TESTS=1 uv run python -m pytest tests/test_nodes/test_llm/test_llm_integration.py -v
 
 .PHONY: test-all

--- a/context/CONTEXT.md
+++ b/context/CONTEXT.md
@@ -5,6 +5,11 @@ CLI-first system where AI agents author Markdown workflows (`.pflow.md`) chainin
 
 ## Language
 
+**Step** — one authored unit of work in a `.pflow.md` (a `### name` heading under `## Steps`);
+the authoring-surface noun. Each Step compiles to a *node* — a registered type instance the
+engine executes. Same concept, two surfaces: agent-facing text says step, code/IR/registry say
+node. _Avoid_: task, stage, action.
+
 **Batch** — a step run once per element of a *known* collection (fan-out). Count fixed
 before start; runs independent, may be parallel. _Avoid_: loop, map.
 
@@ -36,7 +41,7 @@ not retried. A retry that eventually succeeds leaves no trace — the run is a c
 _Avoid_: loop (advances across iterations), fallback, recursion.
 
 **Backoff** — the growing wait between Retry attempts, either *fixed* (constant) or
-*exponential* (doubling), clamped to a ceiling. _Avoid_: delay, sleep, cooldown.
+*exponential* (doubling, clamped to a ceiling). _Avoid_: delay, sleep, cooldown.
 
 **Fallback (on-error)** — routing to a *different* step when one fails, instead of re-running
 it. The original step genuinely failed, so the run is Degraded (data may be lost) — distinct
@@ -53,9 +58,13 @@ Degraded (an empty batch, a Loop hitting its cap, a section typo parsed around).
 with a degrading warning. _Avoid_: note, hint, info.
 
 **Snapshot** — the frozen prior-run state that `--only <step>` runs a single step against:
-every *other* step's output reused from the most recent full run, so only the target
+every *prior* step's output reused from the most recent full run, so only the target
 re-executes and upstream side effects never re-fire. Requires a prior full run.
 _Avoid_: replay, restore, checkpoint.
+
+**Prompt cache** — provider-side reuse of a static prompt *prefix* across LLM calls, declared
+in a workflow's `## Cache` block (or per-step `prompt_cache:`). Discounts input tokens; the
+step still executes and calls the provider every time. _Avoid_: cache (unqualified), KV cache.
 
 **Graph model** — the renderer-agnostic semantic structure of a workflow: its nodes, edges,
 and Containers as pure data, carrying no rendering syntax. Built once from the IR by a single
@@ -67,8 +76,8 @@ the Graph model is for showing. _Avoid_: AST, graph model.
 
 **Container** — a named grouping of nodes in the Graph model: a sub-workflow, a Batch fan-out,
 an input/output wrapper, or (future) a detected cycle. One record type for every grouping kind,
-carrying its members, nesting depth, parent, and optional Loop. _Avoid_: subgraph, cluster,
-box, group.
+carrying its members, nesting depth, and parent. A Loop is metadata on its node, not a
+Container. _Avoid_: subgraph, cluster, box, group.
 
 ## Ambiguity
 
@@ -82,6 +91,10 @@ each building on the last, until a condition goes falsy.
 **Retry vs Fallback** — both are failure responses. Retry re-runs the *same* step hoping it
 succeeds (→ Success). Fallback routes to a *different* step because the original failed
 (→ Degraded).
+
+**Cache vs Prompt cache** — both cut cost on repeat work. Discriminator: a (memoization) Cache
+hit skips executing the step entirely, reusing its prior output; a Prompt cache hit still runs
+the step and calls the provider — only the static prefix's input tokens are discounted.
 
 **Snapshot vs Cache** — both reuse prior output. Cache reuses a step's *own* output when
 its declared inputs are unchanged (correctness-gated, per-step, can still re-run the step).

--- a/context/adr/0002-443-only-snapshot-source.md
+++ b/context/adr/0002-443-only-snapshot-source.md
@@ -30,8 +30,10 @@ The snapshot needs the last full run's output for **every** upstream node, as a 
 3. **Debug trace** (chosen). Already records `node_output` for *every* executed node regardless
    of `cache_enabled`, as one coherent per-run record, with no TTL and at zero new write cost.
    Selection scaffolding (~80%) already exists in `prompt_cache_analysis/trace_loading.py`;
-   per-node extraction is `final_events_by_node(trace["nodes"])`. Nested `--only a.b.c` recurses
-   through the trace's `sub_workflow_events`, mirroring the workflow's own nesting.
+   per-node extraction is `final_events_by_node(trace["nodes"])`. Nested `--only a.b.c` is
+   designed to recurse through the trace's `sub_workflow_events`, mirroring the workflow's own
+   nesting — **deferred, not built**: v1 is flat-only (see Limitations) and dotted targets are
+   rejected at validation (`engine.py:_validate_only_target`); the dotted plumbing exists dormant.
 
 ## Consequences
 
@@ -42,7 +44,8 @@ The snapshot needs the last full run's output for **every** upstream node, as a 
   silent re-fire — which was the entire point of #443.
 - **`--only` runs must not poison the snapshot.** An `--only` run's trace contains only the
   target, so the trace records `only_node` and the snapshot loader selects only full runs
-  (`only_node is None`, `final_status == "success"`).
+  (`only_node is None`; status `success` or `degraded` — never `failed`; a degraded source
+  emits the loud advisory described in Limitations).
 - **Binary upstream outputs degrade.** Trace sanitization replaces `bytes` with a
   `"<binary data: N bytes>"` placeholder, so a target consuming binary upstream gets the
   placeholder. Rare; documented. The memo cache and a dedicated store would not have this loss —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ pythonpath = ["."]
 testpaths = ["tests"]
 markers = [
     "serial: marks tests that must run sequentially (deselect with '-m \"not serial\"')",
-    "integration: marks integration tests that spawn subprocesses",
+    "integration: marks cross-component integration tests (rarely used; subprocess/pipe tests use the e2e marker)",
     "e2e: marks real process, shell, pipe, or external-boundary tests",
     "trace_files: allows tests to write workflow trace JSON files",
     "no_fake_llm_keys: disable the autouse fake-LLM-key injection (for tests asserting the missing-key code path)",

--- a/scripts/tasks
+++ b/scripts/tasks
@@ -12,7 +12,6 @@
 set -e
 
 TASKS_DIR=".taskmaster/tasks"
-VERSIONS_FILE=".taskmaster/versions.md"
 
 # Colors (disabled if not terminal)
 if [ -t 1 ]; then
@@ -341,7 +340,6 @@ show_summary() {
     echo "  So prefer --since DATE over --all, read only what you need, and trust recent tasks over old ones."
     echo ""
     echo -e "📁 Raw task files ${YELLOW}(full text, heavier — only when a doc pointer says so)${NC}: .taskmaster/tasks/task_N/task-N.md"
-    echo -e "📁 Version history: .taskmaster/versions.md"
 }
 
 # Main

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -97,7 +97,7 @@ Pattern 3's cost is fixture drift: someone edits a fixture "to fix a typo" and s
 ## Autouse Fixtures (tests/conftest.py)
 
 These run automatically for every test — you do NOT need to set them up:
-- **`mock_llm_client`**: Patches `pflow.core.llm_client.complete` (and each consumer module's `complete` binding) with `MockLLMClient`. Returns `AdapterResponse` instances. **Skips** tests in `/llm/` directories (they use real APIs when `RUN_LLM_TESTS=1`).
+- **`mock_llm_client`**: Patches `pflow.core.llm_client.complete` (and each consumer module's `complete` binding) with `MockLLMClient`. Returns `AdapterResponse` instances. **Skips** tests whose path contains `/llm/` — a hook for real-API test dirs; no tests currently live in such a path. The actual real-API test is `tests/test_nodes/test_llm/test_llm_integration.py` (dir `test_llm`, NOT matched by the skip), gated by its own `RUN_LLM_TESTS=1` skipif plus `--ignore` in the Makefile targets.
 - **`isolate_pflow_config`**: Creates isolated `tmp_path/.pflow/` dir, redirects `Registry`, `SettingsManager`, `MCPServerManager`, and `WorkflowManager` to temp paths. Default `Registry()` loads precomputed core nodes from memory to avoid per-test registry JSON writes.
 - **`disable_trace_file_writes_by_default`**: Makes `WorkflowTraceCollector.save_to_file()` a no-op unless the test is marked `trace_files`. In-memory `ExecutionResult.trace` still exists; only disk writes to `.pflow/debug` are suppressed.
 

--- a/tests/test_docs/test_agent_references.py
+++ b/tests/test_docs/test_agent_references.py
@@ -1,36 +1,62 @@
-"""Agent instruction files must reference paths that exist.
+"""Agent instruction files must reference paths, files, and symbols that exist.
 
-Stale path references make a review agent confidently wrong (2026-06 audit:
-a dead `.taskmaster/knowledge/decision-deep-dives/` pointer and a renamed
-batch module survived in agent files long after the code moved). This test
-mechanically pins every backtick-quoted file reference in `.claude/agents/`
-to a real path. It cannot catch stale *structural claims* (step counts,
-mechanisms) — those need a periodic audit.
+Stale references make a review agent confidently wrong (2026-06 audit: a dead
+`.taskmaster/knowledge/decision-deep-dives/` pointer, a phantom `BatchExecutor`
+class, and a renamed batch module survived in agent files long after the code
+moved). Three mechanical checks pin every backtick-quoted reference in
+`.claude/agents/`:
+
+1. path-shaped tokens resolve to real files,
+2. bare filenames match some file in the repo (ambiguous hits pass — this is a
+   freshness guard, not a linker),
+3. symbol-shaped tokens (functions, _private names, CamelCase classes) appear
+   somewhere in `src/` or `tests/` source.
+
+The symbol check closes the phantom-symbol rot class; it CANNOT catch a
+misattributed symbol (a real function credited with the wrong behavior) or a
+stale structural claim (step counts, mechanisms) — those still need periodic
+audit.
 """
 
 import re
+from functools import lru_cache
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
 
-# Backtick-quoted tokens ending in a known file extension. Requires a "/" so
-# bare-filename shorthand (`engine.py`) and example names (`item-0.md`) are
-# skipped — only path-shaped references are unambiguous enough to pin.
+# Path-shaped: backtick token with a "/" and a known file extension.
 _PATH_RE = re.compile(r"`([A-Za-z_.][\w.-]*/[\w./-]*\.(?:py|md|toml|json|yaml|yml|cfg))`")
 
-# Tokens with template placeholders are examples, not references.
-_PLACEHOLDER_RE = re.compile(r"[{*<>]|task_N|test_X|test_Y|_N\b|\bX\b|\bY\b")
+# Bare filename: backtick token, no slash, .py/.md only.
+_BARE_FILE_RE = re.compile(r"`([A-Za-z_][\w.-]*\.(?:py|md))`")
 
-# Deliberate historical citations ("then X, now Y"). Each entry must still be
-# cited by some agent file — the companion test below fails when one goes
-# stale, so the allowlist can't accumulate dead weight.
-HISTORICAL_ALLOWLIST = {
+# Symbol-shaped: `name()` calls, `_private` names, CamelCase (two humps min).
+_SYMBOL_RE = re.compile(r"`([A-Za-z_][\w.]*\(\)|_[a-z]\w+|[A-Z][a-z]+(?:[A-Z][a-zA-Z]+)+)`")
+
+# Template placeholders and example names — not real references.
+_PLACEHOLDER_RE = re.compile(r"[{*<>]|task_N|test_X|test_Y|_N\b|\bX\b|\bY\b|item-\d+")
+
+# Deliberate historical citations ("then X, now Y") and other intentional
+# mentions of things that no longer (or never) exist in the codebase. Each
+# entry must still be cited by some agent file — the companion test fails when
+# one goes stale, so the allowlists can't accumulate dead weight.
+HISTORICAL_PATHS = {
     "runtime/wrappers/batch_node.py",  # pre-wrapper-removal architecture, cited as history
+    "batch_node.py",  # same module, cited by bare name in duplication tables
+}
+ALLOWED_MISSING_SYMBOLS = {
+    "BatchExecutor",  # deliberate NEGATIVE mention: "there is no BatchExecutor class"
+    "BaseExceptionGroup",  # Python 3.11+ stdlib name in the version-difference table
+    "_compute_batch_memo_key",  # historical duplication example (since consolidated)
+    "_current_node",  # historical instance-state race example (Task 108, removed)
 }
 
 
 def _resolves(token: str) -> bool:
+    # Prefix-guessing across the three common roots is intentionally loose for
+    # a freshness guard: a token meant for one root that happens to exist under
+    # another still passes. Acceptable — we pin existence, not addressing.
     candidates = [
         REPO_ROOT / token,
         REPO_ROOT / "src" / "pflow" / token,
@@ -42,31 +68,85 @@ def _resolves(token: str) -> bool:
     return any((REPO_ROOT / ".taskmaster" / "tasks").glob(f"*/{token}"))
 
 
-def _iter_agent_tokens():
+@lru_cache(maxsize=1)
+def _repo_filenames() -> frozenset[str]:
+    return frozenset(p.name for p in REPO_ROOT.rglob("*") if p.suffix in (".py", ".md") and ".git" not in p.parts)
+
+
+@lru_cache(maxsize=1)
+def _source_corpus() -> str:
+    """All Python source under src/ and tests/, concatenated for substring checks."""
+    parts = []
+    for root in (REPO_ROOT / "src", REPO_ROOT / "tests"):
+        parts.extend(p.read_text(errors="ignore") for p in root.rglob("*.py"))
+    return "\n".join(parts)
+
+
+def _iter_tokens(pattern: re.Pattern[str]):
     for agent_file in sorted(AGENTS_DIR.glob("*.md")):
-        for token in sorted(set(_PATH_RE.findall(agent_file.read_text()))):
+        for token in sorted(set(pattern.findall(agent_file.read_text()))):
             yield agent_file.name, token
 
 
-def test_agent_file_references_resolve():
+def test_agent_path_references_resolve():
     missing = [
         f"{name}: `{token}`"
-        for name, token in _iter_agent_tokens()
-        if not _PLACEHOLDER_RE.search(token) and token not in HISTORICAL_ALLOWLIST and not _resolves(token)
+        for name, token in _iter_tokens(_PATH_RE)
+        if not _PLACEHOLDER_RE.search(token) and token not in HISTORICAL_PATHS and not _resolves(token)
     ]
     assert not missing, (
         "Agent files reference paths that don't exist. Update the agent file, or add the "
-        "path to HISTORICAL_ALLOWLIST if it's a deliberate historical citation:\n" + "\n".join(missing)
+        "path to HISTORICAL_PATHS if it's a deliberate historical citation:\n" + "\n".join(missing)
+    )
+
+
+def test_agent_bare_filename_references_resolve():
+    names = _repo_filenames()
+    missing = [
+        f"{name}: `{token}`"
+        for name, token in _iter_tokens(_BARE_FILE_RE)
+        if "/" not in token
+        and not _PLACEHOLDER_RE.search(token)
+        and token not in HISTORICAL_PATHS
+        and token not in names
+    ]
+    assert not missing, (
+        "Agent files reference filenames that exist nowhere in the repo (renamed/deleted?). "
+        "Update the agent file, or add to HISTORICAL_PATHS:\n" + "\n".join(missing)
+    )
+
+
+def test_agent_symbol_references_exist():
+    corpus = _source_corpus()
+    missing = [
+        f"{name}: `{token}`"
+        for name, token in _iter_tokens(_SYMBOL_RE)
+        if not _PLACEHOLDER_RE.search(token)
+        and (base := token.rstrip("()").split(".")[-1]) not in ALLOWED_MISSING_SYMBOLS
+        and token.rstrip("()").split(".")[0] not in ALLOWED_MISSING_SYMBOLS
+        and base not in corpus
+    ]
+    assert not missing, (
+        "Agent files reference symbols that appear nowhere in src/ or tests/ "
+        "(renamed/deleted?). Update the agent file, or add to ALLOWED_MISSING_SYMBOLS "
+        "if the mention is deliberate (history, stdlib, negative mention):\n" + "\n".join(missing)
     )
 
 
 def test_agent_reference_scan_is_meaningful():
-    """Guard against the extractor silently matching nothing."""
-    tokens = list(_iter_agent_tokens())
-    assert len(tokens) >= 50, f"Expected 50+ path references across agent files, found {len(tokens)}"
+    """Guard against the extractors silently matching nothing."""
+    paths = list(_iter_tokens(_PATH_RE))
+    symbols = list(_iter_tokens(_SYMBOL_RE))
+    assert len(paths) >= 50, f"Expected 50+ path references across agent files, found {len(paths)}"
+    assert len(symbols) >= 50, f"Expected 50+ symbol references across agent files, found {len(symbols)}"
 
 
-def test_historical_allowlist_entries_still_cited():
-    cited = {token for _, token in _iter_agent_tokens()}
-    stale = HISTORICAL_ALLOWLIST - cited
+def test_allowlist_entries_still_cited():
+    cited_files = {t for _, t in _iter_tokens(_PATH_RE)} | {t for _, t in _iter_tokens(_BARE_FILE_RE)}
+    cited_symbol_bases = {
+        part
+        for _, t in _iter_tokens(_SYMBOL_RE)
+        for part in (t.rstrip("()").split(".")[-1], t.rstrip("()").split(".")[0])
+    }
+    stale = (HISTORICAL_PATHS - cited_files) | (ALLOWED_MISSING_SYMBOLS - cited_symbol_bases)
     assert not stale, f"Allowlist entries no longer cited by any agent file — remove them: {sorted(stale)}"

--- a/tests/test_docs/test_agent_references.py
+++ b/tests/test_docs/test_agent_references.py
@@ -1,0 +1,72 @@
+"""Agent instruction files must reference paths that exist.
+
+Stale path references make a review agent confidently wrong (2026-06 audit:
+a dead `.taskmaster/knowledge/decision-deep-dives/` pointer and a renamed
+batch module survived in agent files long after the code moved). This test
+mechanically pins every backtick-quoted file reference in `.claude/agents/`
+to a real path. It cannot catch stale *structural claims* (step counts,
+mechanisms) — those need a periodic audit.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
+
+# Backtick-quoted tokens ending in a known file extension. Requires a "/" so
+# bare-filename shorthand (`engine.py`) and example names (`item-0.md`) are
+# skipped — only path-shaped references are unambiguous enough to pin.
+_PATH_RE = re.compile(r"`([A-Za-z_.][\w.-]*/[\w./-]*\.(?:py|md|toml|json|yaml|yml|cfg))`")
+
+# Tokens with template placeholders are examples, not references.
+_PLACEHOLDER_RE = re.compile(r"[{*<>]|task_N|test_X|test_Y|_N\b|\bX\b|\bY\b")
+
+# Deliberate historical citations ("then X, now Y"). Each entry must still be
+# cited by some agent file — the companion test below fails when one goes
+# stale, so the allowlist can't accumulate dead weight.
+HISTORICAL_ALLOWLIST = {
+    "runtime/wrappers/batch_node.py",  # pre-wrapper-removal architecture, cited as history
+}
+
+
+def _resolves(token: str) -> bool:
+    candidates = [
+        REPO_ROOT / token,
+        REPO_ROOT / "src" / "pflow" / token,
+        REPO_ROOT / "tests" / token,
+    ]
+    if any(c.exists() for c in candidates):
+        return True
+    # Fragments relative to a per-task dir, e.g. `implementation/progress-log.md`.
+    return any((REPO_ROOT / ".taskmaster" / "tasks").glob(f"*/{token}"))
+
+
+def _iter_agent_tokens():
+    for agent_file in sorted(AGENTS_DIR.glob("*.md")):
+        for token in sorted(set(_PATH_RE.findall(agent_file.read_text()))):
+            yield agent_file.name, token
+
+
+def test_agent_file_references_resolve():
+    missing = [
+        f"{name}: `{token}`"
+        for name, token in _iter_agent_tokens()
+        if not _PLACEHOLDER_RE.search(token) and token not in HISTORICAL_ALLOWLIST and not _resolves(token)
+    ]
+    assert not missing, (
+        "Agent files reference paths that don't exist. Update the agent file, or add the "
+        "path to HISTORICAL_ALLOWLIST if it's a deliberate historical citation:\n" + "\n".join(missing)
+    )
+
+
+def test_agent_reference_scan_is_meaningful():
+    """Guard against the extractor silently matching nothing."""
+    tokens = list(_iter_agent_tokens())
+    assert len(tokens) >= 50, f"Expected 50+ path references across agent files, found {len(tokens)}"
+
+
+def test_historical_allowlist_entries_still_cited():
+    cited = {token for _, token in _iter_agent_tokens()}
+    stale = HISTORICAL_ALLOWLIST - cited
+    assert not stale, f"Allowlist entries no longer cited by any agent file — remove them: {sorted(stale)}"

--- a/tests/test_nodes/test_file/test_write_file.py
+++ b/tests/test_nodes/test_file/test_write_file.py
@@ -94,53 +94,43 @@ class TestWriteFileNode:
             with open(expected_path) as f:
                 assert f.read() == "Once upon a time, there was a clever cat..."
 
-    def test_append_mode(self):
+    def test_append_mode(self, tmp_path):
         """Test appending to existing file."""
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-            f.write("Initial content\n")
-            temp_path = f.name
+        target = tmp_path / "append.txt"
+        target.write_text("Initial content\n")
 
-        try:
-            node = WriteFileNode()
-            node.set_params({"append": True, "content": "Appended content", "file_path": temp_path})
-            shared = {}
+        node = WriteFileNode()
+        node.set_params({"append": True, "content": "Appended content", "file_path": str(target)})
+        shared = {}
 
-            prep_res = node.prep(shared)
-            exec_res = node.exec(prep_res)
-            action = node.post(shared, prep_res, exec_res)
+        prep_res = node.prep(shared)
+        exec_res = node.exec(prep_res)
+        action = node.post(shared, prep_res, exec_res)
 
-            assert action == "default"
-            # Check semantic meaning rather than exact string
-            success_msg = shared["written"]
-            assert "append" in success_msg.lower()
-            assert temp_path in success_msg  # Shows actual file path
+        assert action == "default"
+        # Check semantic meaning rather than exact string
+        success_msg = shared["written"]
+        assert "append" in success_msg.lower()
+        assert str(target) in success_msg  # Shows actual file path
 
-            with open(temp_path) as f:
-                assert f.read() == "Initial content\nAppended content"
-        finally:
-            os.unlink(temp_path)
+        assert target.read_text() == "Initial content\nAppended content"
 
-    def test_overwrite_existing(self):
+    def test_overwrite_existing(self, tmp_path):
         """Test overwriting existing file."""
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-            f.write("Old content")
-            temp_path = f.name
+        target = tmp_path / "overwrite.txt"
+        target.write_text("Old content")
 
-        try:
-            node = WriteFileNode()
-            node.set_params({"content": "New content", "file_path": temp_path})
-            shared = {}
+        node = WriteFileNode()
+        node.set_params({"content": "New content", "file_path": str(target)})
+        shared = {}
 
-            prep_res = node.prep(shared)
-            exec_res = node.exec(prep_res)
-            action = node.post(shared, prep_res, exec_res)
+        prep_res = node.prep(shared)
+        exec_res = node.exec(prep_res)
+        action = node.post(shared, prep_res, exec_res)
 
-            assert action == "default"
+        assert action == "default"
 
-            with open(temp_path) as f:
-                assert f.read() == "New content"
-        finally:
-            os.unlink(temp_path)
+        assert target.read_text() == "New content"
 
     def test_empty_content(self):
         """Test writing empty content."""


### PR DESCRIPTION
## Summary

Adversarial audit of the `.claude/agents/` review fleet and the `improve-codebase-architecture` skill against `src/` as the source of truth, followed by a locality-driven restructure: shared protocol, single-owner fact tables, project-grounded "What NOT to flag" lists, and a meta-test so the path-rot class can't silently return. Catch-power verified with seeded-bug fidelity probes before and after slimming.

Fixes #498

## Changes

- **`REVIEW-PROTOCOL.md` (new)** — shared mechanics for all 9 reviewers: scope/modes, method, severity rubric (Critical/Warning/Suggestion with definitions and an anti-inflation rule), a shared "What NOT to flag" list with the consequence test ("name what goes wrong if it isn't fixed"), volume-as-smell calibration, cross-lens dedup, and re-review rules.
- **All 12 agent files** — converted to lens-only (boilerplate extracted to the protocol); stale references fixed (the worst: `review-validation-consistency` taught an 11-step validator pipeline — it's 10 — plus a phantom "cache lint" step and a fabricated probe-runs-through-WorkflowRunner mechanism; cross-cutting: a `BatchExecutor` class that doesn't exist, it's module-level `execute_batch()`); duplicated fact tables given single owners with pointers (batch matrices + display paths → feature-interactions; entry points → validation-consistency; propagated keys + validator pipeline → canonical CLAUDE.md files); **Loop interaction coverage added** (loops postdated the matrix — loop × cache memo suppression, loop × batch dual enforcement, loop × `--only`, loop × nested WF, loop × errors); per-lens "What NOT to flag" sections grounded in recorded project decisions (ADRs, allowlists, doctrine); per-agent `model`/`effort` frontmatter tiers.
- **`PFLOW.md` (new)** — repo-constraints companion for the architecture skill: enforced-vs-convention layering (no import-linter exists; meta-tests are the leverage mechanism), testing doctrine overriding DEEPENING.md categories (LLM always mocked at the adapter seam, shell/filesystem real, `WorkflowRunner().run()` is the interface test surface), drift-detection-free seams, deliberate shapes, and the verified execution handoff. SKILL.md links it once and its handoff bullet now names the real chain (`/create-task-spec` → `/start-work`; `/refactor` was deleted in 8cf62656).
- **`context/CONTEXT.md`** — three verified corrections (Container claimed an "optional Loop" field — loop lives on `Node`, `graph/model.py:83`; Backoff clamp is exponential-only; Snapshot seeds *prior* steps, not "every other") plus `Step` and `Prompt cache` headwords and a `Cache vs Prompt cache` ambiguity entry (three mechanisms share the word).
- **`context/adr/0002`** — two amendments: nested `--only a.b.c` marked deferred-not-built (its own Limitations and `engine.py:_validate_only_target` say flat-only); loader policy stated as success-or-degraded.
- **`tests/test_docs/test_agent_references.py` (new)** — pins every path-shaped backtick reference in `.claude/agents/` to a real file: placeholder-aware, historical-citation allowlist with a staleness companion test, 50+-reference meaningfulness floor.
- **Doc/tooling contradiction fixes** — Makefile `test-llm` note (dead `llm keys set openai` → `OPENAI_API_KEY`, stale since Task 158), `integration` pytest marker description (subprocess tests use `e2e`), `tests/CLAUDE.md` `/llm/` skip wording (currently guards no files; the real gated test named), root CLAUDE.md node list (registry names: `code`, five file-op nodes), dead `versions.md` references removed from `scripts/tasks`, `test_write_file.py` converted to `tmp_path` per convention.

## Explanation

Every fact a review agent carries rots on a different clock than the agent file. The audit (14 parallel codebase-searcher verifications, every verdict with file:line evidence, disputed lines re-read directly) found that all five ADRs are ALIVE and CONTEXT.md is largely correct — but the agent files had drifted badly enough that one reviewer was confidently wrong about the very pipeline it reviews. The restructure addresses the root cause, not just the instances: volatile facts now live in exactly one place (preferably the CLAUDE.md maintained alongside the code), agents carry the durable lens, and the meta-test catches path rot mechanically.

The "What NOT to flag" layer (inspired by Cloudflare's review-orchestration writeup) is deliberately project-grounded rather than generic: each item is a recorded pflow decision — ADRs, documented allowlists, the Advisory-vs-Degraded distinction, "solve observed problems" — weaponized against re-litigation and noise.

Net: ~30 files, agent set shrinks while gaining loop coverage, protocol, severity semantics, and negative space.

## Testing

- **Fidelity probe 1 (precision)**: seeded a behavior-preserving change (removed `except CompilationError: raise` clauses made redundant by `retriable = False`) into a worktree; the slimmed `review-silent-failures` correctly issued a clean bill of health *with proof* (live simulation + the 166-test batch suite), filed the invariant-relocation as a Warning, and caught an unplanted dead-import issue. No false positive.
- **Fidelity probe 2 (recall)**: seeded the real `e45bba0d` regression (retriable guards also removed → structural errors swallowed by batch continue-mode); the agent flagged it Critical, reproduced it live, ran the regression test class (5/6 fail), cited the violated engine invariant, and used the batch scenario matrix through the new cross-file pointer — proving the de-dup chain works under fire.
- `test_agent_file_references_resolve` — every path-shaped reference in agent files resolves (its first run genuinely fired, on bare-filename shorthand, which drove the final design)
- `test_historical_allowlist_entries_still_cited` — the allowlist can't accumulate dead entries
- `test_agent_reference_scan_is_meaningful` — extractor regression guard (50+ references)
- `tests/test_nodes/test_file/test_write_file.py` — passes after tmp_path conversion
- `make check` green across the full change set (lockfile, ruff, mypy, deptry, fences, task-status hook); `scripts/tasks` verified to still run after the dead-reference removal