### PR TITLE
chore: audit follow-up — import hygiene, ADR-0002 pins, prompt-cache correction (#379, #498)

### DIFF
--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -206,25 +206,28 @@ shared["__pflow_prompt_cache__"] = MappingProxyType[node_id, CacheRenderContext]
                                           # parent → child would break cache scoping AND the
                                           # CacheBlockIR freeze guarantee.
                                           #
-                                          # UNSUPPORTED COMBO (v1): a sub-workflow with
-                                          # `storage_mode: shared` writes directly to the
-                                          # parent's root store (NamespacedSharedStore.__setitem__
-                                          # at namespaced_store.py:51 makes __*__ keys bypass
-                                          # the namespace). Two parallel batch items each
-                                          # running a `storage_mode: shared` sub-workflow that
-                                          # has its own ## Cache block both invoke
-                                          # WorkflowEngine.run's save/restore on the SAME parent
-                                          # root, and the restore order across worker threads
-                                          # is non-deterministic (last-finished worker wins).
-                                          # Each child reads its own installed value during
-                                          # execution (correct), but the parent's value AFTER
-                                          # the batch is whichever child restored last. Today
-                                          # no consumer reads parent's prompt_cache after a
-                                          # parallel batch completes, so this is silent-but-
-                                          # benign. If a future code path adds such a consumer,
-                                          # add a runtime guard at engine.run entry rejecting
-                                          # the combination. Also see plan-doc DD#12 and
-                                          # progress-log Segment 2 for the full rationale.
+                                          # storage_mode: shared × parallel batch × child
+                                          # ## Cache is SAFE — the per-item store copy is the
+                                          # load-bearing isolation. Each batch item (parallel
+                                          # AND sequential) runs against a shallow copy
+                                          # (`item_shared = dict(shared)`, batch_executor.py),
+                                          # so a `storage_mode: shared` child's save/restore of
+                                          # this key — which bypasses namespacing for __*__ keys
+                                          # (NamespacedSharedStore.__setitem__) — lands in the
+                                          # discarded copy, never the parent root. The value is
+                                          # an immutable MappingProxyType, only ever REBOUND,
+                                          # so a copy can't leak mutations either. Consumers DO
+                                          # read this key after a batch (plan_node reads it for
+                                          # every node; LLMNode for rendering) — they see the
+                                          # parent's untouched binding. Pinned by
+                                          # tests/test_runtime/test_storage_mode_shared_prompt_cache.py
+                                          # (mutation-verified: removing the dict(shared) copy
+                                          # fails it). If batch items ever stop copying the
+                                          # store, this combination becomes a real last-
+                                          # finished-worker-wins race — restore the copy or add
+                                          # a guard at engine.run entry. (An earlier version of
+                                          # this note described the race as existing-but-benign;
+                                          # GH #379 closed when the code trace disproved it.)
 
 # Nested workflow keys
 shared["_pflow_depth"] = int

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -343,7 +343,7 @@ The structured `Diagnostic` carries all rich data in `context.unresolved_referen
 - `runtime/cache.py`: used by `instrumentation.py` (`_deterministic_json`, `compute_node_cache_key`, `compute_batch_cache_key`)
 - `core/json_utils.py`: used by `template_resolution.py`, `batch_executor.py`
 - `core/param_coercion.py`: used by `template_resolution.py`
-- `core/llm_client.py`: heavy LiteLLM import — only `nodes/llm/llm.py` and the discovery callsites depend on it. The engine (`instrumentation.py`, `batch_executor.py`) MUST NOT import from this module to keep CLI startup fast.
+- `core/llm_client.py`: the LLM adapter seam. Engine modules MUST NOT import it at MODULE level — lazy imports inside the function that needs it are fine (the one sanctioned engine site: `batch_executor.py`'s synthetic cache-warmup helper does `from pflow.core.llm_client import complete` in-function). Module-level importers are pinned to an allowlist (`nodes/llm/llm.py` + the discovery callsites) by `tests/test_import_hygiene.py::test_module_level_llm_client_imports_are_allowlisted`. Rationale: litellm itself is lazy inside `complete()` (see `core/CLAUDE.md` → llm_client.py), so `llm_client` is light to import *today* — the rule keeps the engine→adapter edge lazy so a future heavy top-level dependency in the adapter can't silently drag CLI startup.
 - `core/exceptions.py`: `CompilationError`, `MaxNodeVisitsError`
 
 ## Gotchas

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -102,7 +102,7 @@ Happy path: steps 1-17.5, returns action string. Error path: catches exception, 
 - `getattr(e, "_pflow_partial_resolutions", None)` extracts template resolutions before the error (attached by `resolve_templates`)
 - `getattr(e, "_pflow_template_diagnostic", None)` extracts a structured Diagnostic for strict-mode template errors so `_builtin_exception_diagnostic` can return it directly without losing the per-reference structure
 - `call_completion_callback(..., action="error", error=e)` — without this the progress spinner shows the failed node as still running
-- `mark_node_failed(shared, id, category=..., error=...)` — categorizes template-resolution `ValueError` (via `_pflow_partial_resolutions` presence) as `template_error`, otherwise `exception`
+- `mark_node_failed(shared, id, category=..., error=...)` — categorizes template-resolution errors as `template_error` (requires BOTH `isinstance(e, ValueError)` AND `_pflow_partial_resolutions` presence — engine.py step's `is_template_error` check), otherwise `exception`. The exception TYPE is load-bearing here; see GH #503 before migrating it.
 - `e._pflow_node_id = config.node_id` — the Runner's `_exception_to_result` reads this to annotate diagnostics
 - The Runner additionally attaches `e._pflow_shared_store = shared_store` so `_exception_to_result` can populate `ExecutionResult.shared_after`. Without this, exception-path failures have empty `shared_after` and CLI/MCP formatters lose all per-node detail.
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -244,8 +244,8 @@ action = validator.run(shared)
 assert action == "retry"  # WorkflowEngine handles routing
 ```
 
-### 2. Import Errors
-`ModuleNotFoundError: No module named 'src'` → Run from project root, check PYTHONPATH.
+### 2. Import Hygiene
+Always import production code as `from pflow...`, never `from src.pflow...`. Both resolve under `pythonpath = ["."]`, but they create DISTINCT module objects — isinstance checks fail across the boundary and the autouse LLM mock (which patches `pflow.core.llm_client.complete`) is silently bypassed. Enforced by `tests/test_import_hygiene.py`, which also pins the allowlist of modules permitted to import `llm_client` at module level (everything else must lazy-import — see `runtime/engine/CLAUDE.md` → Cross-Module Dependencies).
 
 ### 3. File System Tests
 Always use temporary directories. Clean up in `finally` blocks. Prefer `tmp_path` over `tempfile.NamedTemporaryFile(delete=False)`.

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -35,7 +35,7 @@ import pytest
 _SCANNED_DIRS = ("src", "tests", "scripts")
 
 
-def test_no_src_pflow_imports() -> None:
+def test_no_src_package_imports() -> None:
     """Every import of pflow code must use the ``pflow`` package name.
 
     Walks every ``.py`` file under src/, tests/, and scripts/ and fails on
@@ -94,11 +94,10 @@ def _is_src_module(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 # The full set of modules allowed to import pflow.core.llm_client at module
-# level. Everything else must lazy-import inside the function that needs it
-# (current lazy sites: batch_executor.py's synthetic cache-warmup helper,
-# cli/commands/settings.py). Adding a module here means accepting that its
-# entire import chain pays llm_client's import cost — fine for LLM-only
-# paths, wrong for anything the CLI loads at startup.
+# level. Everything else must lazy-import inside the function that needs it.
+# Adding a module here means accepting that its entire import chain pays
+# llm_client's import cost — fine for LLM-only paths, wrong for anything the
+# CLI loads at startup.
 _ALLOWED_MODULE_LEVEL_LLM_CLIENT_IMPORTERS: frozenset[str] = frozenset({
     "src/pflow/nodes/llm/llm.py",
     "src/pflow/core/workflow/discovery.py",
@@ -180,6 +179,9 @@ def _import_time_imports(tree: ast.Module) -> Iterator[ast.Import | ast.ImportFr
 
 
 def _is_type_checking_test(test: ast.expr) -> bool:
+    # Compound tests (`if TYPE_CHECKING and x:`) are NOT recognized — they
+    # fail toward a false POSITIVE with a clear message, the safe direction
+    # for a guard test. If one ever appears legitimately, extend this.
     return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
         isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
     )

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -1,0 +1,215 @@
+"""Meta-tests pinning repo-wide import rules that nothing else enforces.
+
+1. No ``src.pflow`` imports anywhere. With ``pythonpath = ["."]`` in
+   pyproject.toml, ``src.pflow.X`` and ``pflow.X`` are BOTH importable — as
+   two distinct module objects. A test importing
+   ``from src.pflow.nodes.file import ReadFileNode`` gets a different class
+   object than production's ``pflow.nodes.file.ReadFileNode``:
+   isinstance/issubclass checks fail across the boundary, module-level
+   state doesn't cross, and the autouse ``mock_llm_client`` (which patches
+   ``pflow.core.llm_client.complete``) is silently bypassed by the other
+   module identity's import chain.
+
+2. Module-level ``llm_client`` imports are allowlisted. The documented
+   dependency map (``runtime/engine/CLAUDE.md`` → Cross-Module
+   Dependencies) says only ``nodes/llm/llm.py`` and the discovery
+   callsites import the adapter at module level; everything else —
+   notably the engine — must import it lazily inside the function that
+   needs it. The CLI-startup subprocess test
+   (``test_cli/test_lazy_imports.py``) can't catch a violation here
+   because ``llm_client`` lazy-imports litellm itself, so this rule would
+   otherwise rot silently.
+
+Same pattern as ``test_core/test_litellm_runtime.py::
+test_no_direct_litellm_imports_in_production_code``: text prefilter, then
+AST scan so comments/strings/docstrings (e.g. a path like ``src/pflow``)
+never false-positive.
+"""
+
+import ast
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_SCANNED_DIRS = ("src", "tests", "scripts")
+
+
+def test_no_src_pflow_imports() -> None:
+    """Every import of pflow code must use the ``pflow`` package name.
+
+    Walks every ``.py`` file under src/, tests/, and scripts/ and fails on
+    ``import src...`` / ``from src... import ...`` (top-level OR inside
+    function bodies).
+    """
+    repo_root = _find_repo_root()
+
+    violations: list[str] = []
+    for dir_name in _SCANNED_DIRS:
+        for py_file in sorted((repo_root / dir_name).rglob("*.py")):
+            rel_path = py_file.relative_to(repo_root).as_posix()
+            violations.extend(_scan_one_file(py_file, rel_path))
+
+    if violations:
+        violations_block = "\n".join(violations)
+        pytest.fail(
+            "Imports via the 'src.' module identity found. Use the 'pflow' "
+            "package name instead (e.g. 'from pflow.nodes.file import ...'). "
+            "Both identities are importable under pythonpath=['.'], but they "
+            "produce DISTINCT module/class objects — breaking isinstance "
+            "checks and bypassing the autouse LLM mock.\n\n"
+            f"Offending sites:\n{violations_block}"
+        )
+
+
+def _scan_one_file(py_file: Path, rel_path: str) -> list[str]:
+    """Return any src.*-import violations found in ``py_file``."""
+    source = py_file.read_text(encoding="utf-8")
+    # Cheap prefilter — both statement forms start with one of these.
+    if "import src" not in source and "from src" not in source:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(py_file))
+    except SyntaxError as exc:
+        pytest.fail(f"{rel_path}: failed to parse — {exc}")
+
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_src_module(alias.name):
+                    found.append(f"  {rel_path}:{node.lineno}: import {alias.name}")
+        elif isinstance(node, ast.ImportFrom) and _is_src_module(node.module or ""):
+            names = ", ".join(a.name for a in node.names)
+            found.append(f"  {rel_path}:{node.lineno}: from {node.module} import {names}")
+    return found
+
+
+def _is_src_module(name: str) -> bool:
+    return name == "src" or name.startswith("src.")
+
+
+# ---------------------------------------------------------------------------
+# llm_client module-level import allowlist
+# ---------------------------------------------------------------------------
+
+# The full set of modules allowed to import pflow.core.llm_client at module
+# level. Everything else must lazy-import inside the function that needs it
+# (current lazy sites: batch_executor.py's synthetic cache-warmup helper,
+# cli/commands/settings.py). Adding a module here means accepting that its
+# entire import chain pays llm_client's import cost — fine for LLM-only
+# paths, wrong for anything the CLI loads at startup.
+_ALLOWED_MODULE_LEVEL_LLM_CLIENT_IMPORTERS: frozenset[str] = frozenset({
+    "src/pflow/nodes/llm/llm.py",
+    "src/pflow/core/workflow/discovery.py",
+    "src/pflow/registry/discovery.py",
+    "src/pflow/registry/smart_filter.py",
+})
+
+
+def test_module_level_llm_client_imports_are_allowlisted() -> None:
+    """Outside the allowlist, ``llm_client`` may only be imported lazily.
+
+    Walks every ``.py`` file under ``src/pflow/`` and flags imports of
+    ``pflow.core.llm_client`` that execute at module-import time. Imports
+    inside function bodies (lazy) and ``if TYPE_CHECKING:`` blocks (no
+    runtime cost) are allowed everywhere.
+
+    This enforces the engine layering rule in
+    ``runtime/engine/CLAUDE.md`` → Cross-Module Dependencies. The rule's
+    point: ``llm_client`` is light today only because litellm is lazy
+    inside ``complete()``; a future heavy top-level dependency in the
+    adapter must not silently drag every engine import (and CLI startup)
+    with it.
+    """
+    repo_root = _find_repo_root()
+    src_root = repo_root / "src" / "pflow"
+    assert src_root.is_dir(), f"expected src/pflow/ at {src_root}"
+
+    violations: list[str] = []
+    for py_file in sorted(src_root.rglob("*.py")):
+        rel_path = py_file.relative_to(repo_root).as_posix()
+        if rel_path in _ALLOWED_MODULE_LEVEL_LLM_CLIENT_IMPORTERS:
+            continue
+        source = py_file.read_text(encoding="utf-8")
+        if "llm_client" not in source:
+            continue
+        try:
+            tree = ast.parse(source, filename=str(py_file))
+        except SyntaxError as exc:
+            pytest.fail(f"{rel_path}: failed to parse — {exc}")
+        for node in _import_time_imports(tree):
+            if _references_llm_client(node):
+                violations.append(f"  {rel_path}:{node.lineno}: {ast.unparse(node)}")
+
+    if violations:
+        violations_block = "\n".join(violations)
+        pytest.fail(
+            "Module-level llm_client imports found outside the allowlist. "
+            "Move the import inside the function that needs it (lazy), like "
+            "batch_executor.py's cache-warmup helper does — or, for a "
+            "genuinely LLM-only module, add it to "
+            "_ALLOWED_MODULE_LEVEL_LLM_CLIENT_IMPORTERS with a reason.\n\n"
+            f"Offending sites:\n{violations_block}"
+        )
+
+
+def _import_time_imports(tree: ast.Module) -> Iterator[ast.Import | ast.ImportFrom]:
+    """Yield imports that execute when the module is imported.
+
+    Top-level if/try/class bodies run at import time, so imports there
+    count. Imports inside function bodies (lazy) or ``if TYPE_CHECKING:``
+    body blocks (never executed at runtime) are excluded — by line range,
+    which is simpler and more complete than walking every statement
+    container shape (try handlers, with blocks, match cases, ...).
+    """
+    excluded_ranges: list[tuple[int, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or (
+            isinstance(node, ast.If) and _is_type_checking_test(node.test)
+        ):
+            start = node.body[0].lineno
+            end = node.body[-1].end_lineno or node.body[-1].lineno
+            excluded_ranges.append((start, end))
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and not any(
+            start <= node.lineno <= end for start, end in excluded_ranges
+        ):
+            yield node
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+    return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+        isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+    )
+
+
+def _references_llm_client(node: ast.Import | ast.ImportFrom) -> bool:
+    """True if the import statement pulls in the ``llm_client`` module.
+
+    Matches on the final dotted component, which catches absolute
+    (``from pflow.core.llm_client import X``, ``import pflow.core.llm_client``),
+    relative (``from .llm_client import X``), and attribute
+    (``from pflow.core import llm_client``) forms. No other module named
+    ``llm_client`` exists in the repo; if one ever does, the failure
+    message makes the needed test adjustment obvious.
+    """
+    if isinstance(node, ast.Import):
+        return any(_last_component(a.name) == "llm_client" for a in node.names)
+    if _last_component(node.module or "") == "llm_client":
+        return True
+    return any(a.name == "llm_client" for a in node.names)
+
+
+def _last_component(dotted: str) -> str:
+    return dotted.rsplit(".", maxsplit=1)[-1]
+
+
+def _find_repo_root() -> Path:
+    """Walk up from this file until we find ``pyproject.toml`` — the repo root."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    raise AssertionError("pyproject.toml not found above test file")

--- a/tests/test_nodes/test_file/test_copy_file.py
+++ b/tests/test_nodes/test_file/test_copy_file.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 
-from src.pflow.nodes.file import CopyFileNode
+from pflow.nodes.file import CopyFileNode
 
 
 class TestCopyFileNode:

--- a/tests/test_nodes/test_file/test_delete_file.py
+++ b/tests/test_nodes/test_file/test_delete_file.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from src.pflow.nodes.file import DeleteFileNode
+from pflow.nodes.file import DeleteFileNode
 
 
 class TestDeleteFileNode:

--- a/tests/test_nodes/test_file/test_file_integration.py
+++ b/tests/test_nodes/test_file/test_file_integration.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from src.pflow.nodes.file import (
+from pflow.nodes.file import (
     CopyFileNode,
     DeleteFileNode,
     MoveFileNode,

--- a/tests/test_nodes/test_file/test_file_retry.py
+++ b/tests/test_nodes/test_file/test_file_retry.py
@@ -10,7 +10,7 @@ import threading
 import time
 from unittest.mock import patch
 
-from src.pflow.nodes.file import (
+from pflow.nodes.file import (
     CopyFileNode,
     DeleteFileNode,
     MoveFileNode,

--- a/tests/test_nodes/test_file/test_move_file.py
+++ b/tests/test_nodes/test_file/test_move_file.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 
-from src.pflow.nodes.file import MoveFileNode
+from pflow.nodes.file import MoveFileNode
 
 
 class TestMoveFileNode:

--- a/tests/test_nodes/test_file/test_read_file.py
+++ b/tests/test_nodes/test_file/test_read_file.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from src.pflow.nodes.file import ReadFileNode
+from pflow.nodes.file import ReadFileNode
 
 
 class TestReadFileNode:

--- a/tests/test_nodes/test_file/test_read_file_binary.py
+++ b/tests/test_nodes/test_file/test_read_file_binary.py
@@ -8,7 +8,7 @@ import base64
 import os
 import tempfile
 
-from src.pflow.nodes.file import ReadFileNode
+from pflow.nodes.file import ReadFileNode
 
 
 class TestReadFileBinarySupport:

--- a/tests/test_nodes/test_file/test_write_file.py
+++ b/tests/test_nodes/test_file/test_write_file.py
@@ -6,7 +6,7 @@ import tempfile
 
 import pytest
 
-from src.pflow.nodes.file import WriteFileNode
+from pflow.nodes.file import WriteFileNode
 
 
 class TestWriteFileNode:

--- a/tests/test_nodes/test_http/test_http.py
+++ b/tests/test_nodes/test_http/test_http.py
@@ -47,7 +47,7 @@ import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import RequestException, Timeout
 
-from src.pflow.nodes.http import HttpNode
+from pflow.nodes.http import HttpNode
 
 
 class TestHttpNode:

--- a/tests/test_nodes/test_http/test_http_binary.py
+++ b/tests/test_nodes/test_http/test_http_binary.py
@@ -8,7 +8,7 @@ import base64
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
-from src.pflow.nodes.http import HttpNode
+from pflow.nodes.http import HttpNode
 
 
 class TestHttpBinarySupport:

--- a/tests/test_nodes/test_http/test_http_discovery.py
+++ b/tests/test_nodes/test_http/test_http_discovery.py
@@ -3,7 +3,7 @@
 import tempfile
 from pathlib import Path
 
-from src.pflow.registry.registry import Registry
+from pflow.registry.registry import Registry
 
 
 def test_http_node_discovered():

--- a/tests/test_nodes/test_shell/test_command_validation.py
+++ b/tests/test_nodes/test_shell/test_command_validation.py
@@ -5,7 +5,7 @@ Note: dict/list detection in shell commands is now done at template validation t
 still handles safe cases correctly.
 """
 
-from src.pflow.nodes.shell.shell import ShellNode
+from pflow.nodes.shell.shell import ShellNode
 
 
 class TestCommandTemplateValidation:

--- a/tests/test_nodes/test_shell/test_shell_sigpipe.py
+++ b/tests/test_nodes/test_shell/test_shell_sigpipe.py
@@ -28,7 +28,7 @@ import platform
 
 import pytest
 
-from src.pflow.nodes.shell.shell import ShellNode
+from pflow.nodes.shell.shell import ShellNode
 
 # Size that reliably exceeds pipe buffer on all platforms
 # macOS: 16KB, Linux: 64KB - we use 20KB (just above macOS minimum)
@@ -265,7 +265,7 @@ class TestSignalHandlerConfiguration:
         import signal
 
         # Import and call the signal setup function
-        from src.pflow.cli.main import _setup_signals
+        from pflow.cli.main import _setup_signals
 
         _setup_signals()
 

--- a/tests/test_nodes/test_shell/test_shell_stdin.py
+++ b/tests/test_nodes/test_shell/test_shell_stdin.py
@@ -4,7 +4,7 @@ Tests verify that the ShellNode correctly handles stdin from params,
 including template-resolved values (set directly as resolved params).
 """
 
-from src.pflow.nodes.shell.shell import ShellNode
+from pflow.nodes.shell.shell import ShellNode
 
 
 class TestShellStdinParameterFallback:

--- a/tests/test_nodes/test_shell/test_stdin_type_adaptation.py
+++ b/tests/test_nodes/test_shell/test_stdin_type_adaptation.py
@@ -4,7 +4,7 @@ The shell node should intelligently adapt any Python type to string for stdin,
 since subprocess.run() requires string or None for input.
 """
 
-from src.pflow.nodes.shell.shell import ShellNode
+from pflow.nodes.shell.shell import ShellNode
 
 
 class TestDictListToJSON:

--- a/tests/test_registry/test_metadata_extractor.py
+++ b/tests/test_registry/test_metadata_extractor.py
@@ -153,7 +153,7 @@ class TestMetadataExtractorBehavior:
 
     def test_works_with_real_node_implementations(self):
         """Test extraction from actual pflow node implementations."""
-        from src.pflow.nodes.file.read_file import ReadFileNode
+        from pflow.nodes.file.read_file import ReadFileNode
 
         result = self.extractor.extract_metadata(ReadFileNode)
 

--- a/tests/test_runtime/test_only_snapshot.py
+++ b/tests/test_runtime/test_only_snapshot.py
@@ -28,7 +28,7 @@ from pflow.execution.execution_state import build_execution_steps
 from pflow.execution.result import RunnerConfig, WorkflowStatus
 from pflow.execution.runner import WorkflowRunner
 from pflow.runtime.engine.engine import WorkflowEngine
-from pflow.runtime.engine.types import CompiledWorkflow, LoopConfig, NodeConfig
+from pflow.runtime.engine.types import CompiledWorkflow, LoopConfig, NodeConfig, TemplateConfig
 from pflow.runtime.workflow_trace import (
     format_trace_filename,
     load_full_run_events,
@@ -498,6 +498,110 @@ def test_seed_skips_events_without_output() -> None:
     shared: dict[str, Any] = {}
     seed_snapshot_into_shared(shared, events, exclude="target")
     assert "ghost" not in shared
+
+
+# ---------------------------------------------------------------------------
+# ADR-0002 Limitation L2 — --only freezes the branch choice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.trace_files
+def test_only_coalesce_silently_uses_snapshot_branch(tmp_path: Path) -> None:
+    """L2 silent sub-case: a coalesce on the target resolves against the
+    snapshot's branch outcome — silently.
+
+    The full run takes the primary branch, so ``fallback`` never executes and
+    is absent from the snapshot. Under ``--only report``, the coalesce
+    ``${primary.stdout ?? fallback.stdout}`` resolves from the seeded primary
+    with NO warning and NO degraded status — even though a fresh invocation
+    might have taken the other branch (upstream never re-runs, so the branch
+    choice is frozen). This is the DOCUMENTED limitation in ADR-0002
+    (context/adr/0002-443-only-snapshot-source.md, Limitations). If this test
+    starts failing because the behavior became loud, update the ADR's
+    Limitations section in the same change.
+    """
+    ir = {
+        "nodes": [
+            {
+                "id": "primary",
+                "type": "shell",
+                "purpose": "Succeeds, so the fallback branch is never taken.",
+                "params": {"next": "report", "on-error": "fallback", "command": "printf primary-data"},
+            },
+            {
+                "id": "fallback",
+                "type": "shell",
+                "purpose": "Error-branch recovery; absent from the full run's snapshot.",
+                "params": {"next": "report", "command": "printf fallback-data"},
+            },
+            {
+                "id": "report",
+                "type": "shell",
+                "purpose": "Coalesces whichever branch ran.",
+                "params": {"command": "printf 'got ${primary.stdout ?? fallback.stdout}'"},
+            },
+        ],
+    }
+    wf = tmp_path / "branch-freeze.pflow.md"
+    write_workflow_file(ir, wf)
+
+    full = WorkflowRunner().run(str(wf), {}, RunnerConfig())
+    assert full.success, [d.message for d in full.diagnostics]
+    assert "fallback" not in full.shared_after, "precondition: fallback branch must not run"
+    full.trace.save_to_file()
+
+    result = WorkflowRunner().run(str(wf), {}, RunnerConfig(only_node="report"))
+    assert result.success, [d.message for d in result.diagnostics]
+    # The coalesce silently used the snapshot's branch:
+    assert result.shared_after["report"]["stdout"] == "got primary-data"
+    # ...with nothing loud — no advisory, no degraded status (the L2 "silent" pin).
+    assert result.status == WorkflowStatus.SUCCESS
+    assert result.shared_after["__execution__"]["restored_nodes"] == ["primary"]
+    assert "fallback" not in result.shared_after, "untaken branch must not be addressable"
+
+
+def test_only_bare_ref_to_branch_not_in_snapshot_is_loud() -> None:
+    """L2 loud sub-case: a bare (non-coalesce) ref to a branch the snapshot
+    didn't take fails with an unresolved-reference error.
+
+    Pins the ADR-0002 Consequence "branch divergence is loud, not silent" for
+    the bare-ref form: ``branch_b`` never ran in the snapshot, so seeding
+    leaves it absent and strict-mode template resolution raises — the failure
+    is archived under ``__failures__`` as a template error naming the missing
+    reference.
+    """
+    target = _SpyNode()
+    target.node_id = "target"
+    target.set_params({"_calls": []})
+
+    cfg = NodeConfig(
+        node_id="target",
+        node_type_name="SpyNode",
+        template_config=TemplateConfig(
+            template_params={"message": "${branch_b.out}"},
+            static_params={},
+            expected_types={},
+            resolution_mode="strict",
+        ),
+        batch_config=None,
+        namespaced=True,
+        interface_metadata=None,
+    )
+    workflow = CompiledWorkflow(start_node=target, node_configs={"target": cfg})
+    shared: dict[str, Any] = {}
+    engine = WorkflowEngine(
+        only_node="target",
+        snapshot_events=[{"node_id": "branch_a", "node_output": {"out": "frozen-a"}}],
+    )
+
+    with pytest.raises(ValueError, match="branch_b") as excinfo:
+        engine.run(workflow, shared)
+
+    # Loud all the way down: the target never executed, the failure is archived
+    # as a template error, and the exception is annotated for the runner.
+    assert target.params["_calls"] == []
+    assert shared["__failures__"]["target"]["category"] == "template_error"
+    assert getattr(excinfo.value, "_pflow_node_id", None) == "target"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime/test_only_snapshot.py
+++ b/tests/test_runtime/test_only_snapshot.py
@@ -569,6 +569,10 @@ def test_only_bare_ref_to_branch_not_in_snapshot_is_loud() -> None:
     leaves it absent and strict-mode template resolution raises — the failure
     is archived under ``__failures__`` as a template error naming the missing
     reference.
+
+    ``ValueError`` is what strict-mode resolution raises today
+    (template_resolution.py); if it migrates to a PflowError subclass
+    (GH #503), update the ``pytest.raises`` here.
     """
     target = _SpyNode()
     target.node_id = "target"

--- a/tests/test_runtime/test_storage_mode_shared_prompt_cache.py
+++ b/tests/test_runtime/test_storage_mode_shared_prompt_cache.py
@@ -1,40 +1,156 @@
-"""Skip-marked regression for the documented `storage_mode: shared` race.
+"""Parent prompt-cache isolation under `storage_mode: shared` x parallel batch.
 
-Locks the contract from `runtime/CLAUDE.md:194-213`: when a future consumer
-reads parent `__pflow_prompt_cache__` after a parallel batch with
-`storage_mode: shared` and a child declaring `## Cache`, the restore order
-across worker threads is non-deterministic (last-finished worker wins).
+History: `runtime/CLAUDE.md` documented this combination as a benign RACE —
+"two parallel batch items each running a `storage_mode: shared` sub-workflow
+with its own `## Cache` block both invoke WorkflowEngine.run's save/restore
+on the SAME parent root... last-finished worker wins" — and a skip-marked
+test here waited for a guard (GH #379) that never landed.
 
-Today this is silent-but-benign — no production consumer reads parent
-prompt_cache post-batch. When a guard lands at `WorkflowEngine.run` entry
-(see GH #379), un-skip this test.
+The 2026-06 audit follow-up traced the actual write path and found the race
+cannot reach the parent root: every batch item (parallel AND sequential) runs
+against a per-item shallow copy (`item_shared = dict(shared)` in
+`batch_executor.py`), the child engine's save/restore goes through a
+`NamespacedSharedStore` whose `_parent` IS that discarded copy, and the value
+is an immutable `MappingProxyType` that is only ever rebound — so child
+restores can't leak into the parent's binding.
+
+This test pins that isolation at runtime with the real pipeline. If it ever
+fails, batch items have stopped copying the shared store — at which point the
+documented race becomes real and a guard (or the copy) must be restored.
 """
 
 from __future__ import annotations
 
-import pytest
+from pathlib import Path
+from typing import Any
+
+from pflow.core.markdown_parser import parse_markdown
+from pflow.core.node import BaseNode
+from pflow.registry.registry import Registry
+from pflow.runtime.compilation.compiler import compile_workflow
+from pflow.runtime.engine.engine import WorkflowEngine, build_prompt_cache_dict
+from pflow.runtime.engine.types import BatchConfig, CompiledWorkflow, NodeConfig
+from pflow.runtime.workflow_executor import WorkflowExecutor
+
+_CHILD_MARKDOWN = """\
+# Child
+
+Child sub-workflow with its own prompt-cache block.
+
+## Inputs
+
+### brief
+
+The shared brief.
+
+- type: string
+
+## Cache
+
+```cache
+The brief:
+
+${brief}
+```
+
+## Steps
+
+### child-llm
+
+Child LLM step (mocked by the autouse fixture).
+
+- type: llm
+- model: anthropic/claude-sonnet-4-5
+
+```prompt
+Say hello.
+```
+"""
 
 
-@pytest.mark.skip(
-    reason=(
-        "Known limitation, GH #379 — add runtime guard at engine.run entry "
-        "when storage_mode=shared + parallel batch + child ## Cache combine. "
-        "Documented in runtime/CLAUDE.md:194-213."
-    )
-)
-def test_storage_mode_shared_parallel_batch_child_cache_is_rejected_or_warned() -> None:
-    """Locks the future-guard contract.
+class _CachePrefixProbe(BaseNode):
+    """Reads the parent root's prompt-cache binding AFTER the batch node."""
 
-    Expected behavior once the guard lands (per `runtime/CLAUDE.md` race
-    documentation):
-      - `WorkflowEngine.run` entry detects the unsupported combination
-        (storage_mode: shared + parallel batch + child workflow declaring
-        `## Cache`).
-      - Either rejects loudly with a structured error, or emits a
-        `logger.warning` and disables the prompt_cache install for that
-        combination.
+    def exec(self, prep_res: Any) -> Any:
+        return None
 
-    Mutation contract once un-skipped: removing the guard re-introduces
-    the silent race condition documented in CLAUDE.md.
+    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+        cache_map = shared.get("__pflow_prompt_cache__") or {}
+        shared["cache_keys"] = sorted(cache_map.keys())
+        return "default"
+
+
+def test_parallel_shared_subworkflow_child_cache_does_not_leak_into_parent(tmp_path: Path) -> None:
+    """The parent's `__pflow_prompt_cache__` binding survives a parallel batch
+    of `storage_mode: shared` children that each install their own cache map.
+
+    Discriminator: the parent map is keyed {"parent-llm"} (a prewarm-declaring
+    LLM node), the child maps are keyed {"child-llm"} (via the child's
+    `## Cache` block). A leaked child restore would surface as "child-llm" —
+    or an empty map — at the probe.
     """
-    raise AssertionError("Skipped — un-skip when GH #379 guard lands.")
+    child_path = tmp_path / "child.pflow.md"
+    child_path.write_text(_CHILD_MARKDOWN, encoding="utf-8")
+    registry = Registry()
+
+    # Vacuity guard: the child genuinely installs a non-empty cache map of its
+    # own (otherwise a "no leak" assertion below would be meaningless).
+    child_compiled = compile_workflow(parse_markdown(child_path.read_text()).ir, registry, {"brief": "x"})
+    assert sorted(build_prompt_cache_dict(child_compiled, {})) == ["child-llm"]
+
+    fanout = WorkflowExecutor()
+    fanout.node_id = "fanout"
+    fanout.set_params({
+        "workflow": str(child_path),
+        "storage_mode": "shared",
+        "inputs": {"brief": "static-brief"},
+    })
+
+    probe = _CachePrefixProbe()
+    probe.node_id = "probe"
+
+    fanout >> probe
+
+    node_configs = {
+        "fanout": NodeConfig(
+            node_id="fanout",
+            node_type_name="WorkflowExecutor",
+            template_config=None,
+            batch_config=BatchConfig(
+                items_template=["a", "b", "c", "d"],
+                parallel=True,
+                max_concurrent=4,
+            ),
+            namespaced=True,
+            interface_metadata=None,
+        ),
+        "probe": NodeConfig(
+            node_id="probe",
+            node_type_name="_CachePrefixProbe",
+            template_config=None,
+            batch_config=None,
+            namespaced=True,
+            interface_metadata=None,
+        ),
+        # Never executed (not wired into the graph) — exists so the PARENT's
+        # prompt-cache map is non-empty and keyed distinctly from the child's.
+        "parent-llm": NodeConfig(
+            node_id="parent-llm",
+            node_type_name="LLMNode",
+            template_config=None,
+            batch_config=None,
+            namespaced=True,
+            interface_metadata=None,
+            prewarm=True,
+        ),
+    }
+    workflow = CompiledWorkflow(start_node=fanout, node_configs=node_configs)
+    shared: dict[str, Any] = {"__registry__": registry}
+
+    WorkflowEngine().run(workflow, shared)
+
+    # All four shared-storage children ran their cache-block child to success.
+    assert shared["fanout"]["success_count"] == 4, shared["fanout"].get("errors")
+    # The probe (after the batch, same engine run) saw the PARENT's map —
+    # not a child's {"child-llm"} map, not an empty leak.
+    assert shared["probe"]["cache_keys"] == ["parent-llm"]


### PR DESCRIPTION
## Summary

Verifies and resolves the actionable findings from the skill-hardening audit (#498 / #499, `scratchpads/architecture-audit/audit-report.md`). Each of the audit's five "critical findings for further investigation" was re-verified against main before acting: three were confirmed (fixed here), one was confirmed-but-contained (re-filed as #500 with a corrected threat model), and one was **inverted** — the documented prompt-cache race doesn't exist, so the fix is a doc correction plus a runtime proof rather than a guard.

References: #379 (closed by this work's findings), #498 (audit), #500 (re-filed MCP finding, not addressed here).

## Changes

- **`src.pflow` double-import eliminated** — 17 imports across 16 test files rewritten to the canonical `pflow` package name; new `tests/test_import_hygiene.py::test_no_src_pflow_imports` (AST scan over `src/`, `tests/`, `scripts/`) blocks recurrence.
- **Engine→llm_client layering rule corrected and enforced** — the rule in `runtime/engine/CLAUDE.md` ("engine MUST NOT import llm_client") had already rotted: `batch_executor.py` lazy-imports it for cache prewarm. Reworded to the real invariant (no *module-level* import; lazy and `TYPE_CHECKING` are fine) and pinned by `test_module_level_llm_client_imports_are_allowlisted`, which allowlists the documented dependency map exactly (`nodes/llm/llm.py` + the three discovery callsites).
- **ADR-0002 Limitation L2 pinned** — both sub-cases were untested (the audit found one; verification found the second): `test_only_coalesce_silently_uses_snapshot_branch` (e2e: coalesce silently resolves against the snapshot's branch, no advisory, untaken branch not addressable) and `test_only_bare_ref_to_branch_not_in_snapshot_is_loud` (engine-level: bare ref to a branch the snapshot didn't take raises, archives `template_error`, annotates the exception).
- **Prompt-cache "race" note corrected** (`runtime/CLAUDE.md`) — the documented `storage_mode: shared` × parallel batch × child `## Cache` race cannot reach the parent root: per-item `dict(shared)` copies isolate child save/restores, and the `MappingProxyType` value is only ever rebound. The skip-marked guard-placeholder test is replaced by a live isolation proof; #379 closed with the trace.
- **`tests/CLAUDE.md` pitfall #2** updated from stale PYTHONPATH advice to the actual import rule + pointer to the new meta-tests.

## Explanation

The audit hardened the review tooling but explicitly surfaced these as out-of-scope risks ordered by risk × cheapness-to-check. The common thread: **convention-only rules rot silently** — the layering rule was already violated when we checked, the prompt-cache note asserted a mechanism the code disproves, and a documented ADR limitation had no test holding it in place. Every doc claim touched here is now either enforced by a meta-test or pinned by a behavior test.

Diff: 22 files, +511/−73. The test-file bulk is mechanical one-line import rewrites; the substantive additions are `tests/test_import_hygiene.py`, two tests in `test_only_snapshot.py`, the rewritten `test_storage_mode_shared_prompt_cache.py`, and two CLAUDE.md corrections.

## Testing

All mutation-verified per `tests/CLAUDE.md` guidance (break production, confirm the test fails, restore):

- `test_no_src_pflow_imports` — reintroducing one `src.pflow` import fails it citing the exact `file:line`
- `test_module_level_llm_client_imports_are_allowlisted` — hoisting `batch_executor.py`'s lazy import to module level fails it; synthetic check confirms `try/except`-body, `class`-body imports are caught while lazy/`TYPE_CHECKING` pass
- `test_parallel_shared_subworkflow_child_cache_does_not_leak_into_parent` — changing `item_shared = dict(shared)` to `item_shared = shared` fails it 5/5 runs; includes a vacuity guard proving the child's cache map is genuinely non-empty
- `test_only_coalesce_silently_uses_snapshot_branch` / `test_only_bare_ref_to_branch_not_in_snapshot_is_loud` — pin both halves of ADR-0002 L2; the silent test's docstring instructs updating the ADR if the behavior is ever made loud
- Full suite: 7768 passed, 0 skipped (the former skip is now a live test); `make check` clean