### PR TITLE
chore: task 170 context, roadmap restructure (125 → 164 → 171), doc staleness fixes

### DIFF
--- a/.taskmaster/tasks/task_125/starting-context/braindump-2026-06-12-split-session.md
+++ b/.taskmaster/tasks/task_125/starting-context/braindump-2026-06-12-split-session.md
@@ -1,0 +1,45 @@
+# Braindump: the 2026-06-12 split session (short, tailored)
+
+Spec is current as of 2026-06-12 (blocking-only scope, dry-run parity section, parallel-batch
+escalation hard problem). This captures only what's NOT in it.
+
+## Why the spec looks the way it does
+
+- The user killed the old build-order sandwich (125-blocking → 164 → 125-durable) with one
+  line: *"im not sure I follow the order here... that doesnt make sense?"* The decider was
+  their convention: **"tasks are not implemented as separate prs though, its all one BIG pr."**
+  Durable went to Task 171. If you find yourself adding token/serialization code here, you're
+  re-merging the split — stop.
+- The "non-TTY + gate fails loudly" requirement only exists because of the split (the token
+  fallback used to absorb that case). It was never discussed beyond that — the error message
+  design is yours.
+
+## Standards the user will hold you to (their words, this session)
+
+- *"The bar isn't 'passing', it's 'passing the right thing'"* — they asked me to audit my own
+  tests for shallowness and will ask you. Mutation-verify the dry-run parity pin (recipe in
+  `task_164/starting-context/braindump-planner-mirror-session.md`).
+- *"Simplicity of the FINAL code... what would the top 10% of similar codebases implement"* —
+  with the explicit guard against overengineering.
+- Show expected output BEFORE implementing (the gate prompt UX is user-visible — mock it first).
+
+## Sequencing trap
+
+Branch AFTER PR #505 merges (planner-mirror refactor). Your `_classify` gate case lands in
+code #505 rewrote (it now dispatches on the shared `route_action`); pre-merge work = conflicts.
+
+## Not in the spec, might matter
+
+- CONSIDER: **MCP server is the non-TTY case in production.** `execution_service.execute_workflow`
+  on a gated workflow must hit the loud-error path; add it to the CLI/MCP parity tests
+  (`test_cli_mcp_parity.py`), not just a CLI test.
+- CONSIDER: **`--auto-approve` is a footgun on an agent-first CLI** — an agent that reflexively
+  passes it defeats the gate's entire purpose. Maybe it shouldn't exist, or should be
+  `--auto-approve=<node-id>` scoped. Never discussed; surface it to the user.
+- The plan-review pairing that paid off in this session's refactor: `review-silent-failures` +
+  `review-impact-completeness` on the implementation plan (caught a divergence five other
+  passes missed). Worth repeating.
+
+> **Note to next agent**: Read this fully, then task-125.md fully (especially "Dry-run parity
+> & engine placement" and Known Hard Problems). Confirm by summarizing key points before
+> proceeding.

--- a/.taskmaster/tasks/task_125/task-125.md
+++ b/.taskmaster/tasks/task_125/task-125.md
@@ -42,11 +42,7 @@ Both are faces of one primitive — a human-decision gate — and should share o
 
 A new `approval` parameter on any node that halts execution before the node runs, shows the user what's about to happen (resolved inputs), and waits for approval.
 
-Two modes:
-- **Interactive (TTY)**: Prompt directly in terminal, `[y/N]` style
-- **Non-interactive (token-based)**: Emit a durable resume token, exit. User resumes later with `pflow resume <token> --approve yes|no`
-
-Workflow state (completed node outputs, current position in execution) is serialized to disk at the pause point so resume doesn't re-execute completed nodes.
+**This task is the BLOCKING mode only** (split 2026-06-12, see Phasing): interactive TTY prompt, `[y/N]` style, human present during the run — pause in-process, decide live, continue. The non-interactive mode (durable resume token, answer hours later via `pflow resume <token>`) is **Task 171**, which rides Task 164's checkpoint→restore→continue substrate.
 
 ## Architecture: One Checkpoint/Resume Substrate, Three Triggers
 
@@ -86,25 +82,61 @@ The braindump (`starting-context/braindump-openclaw-discussion.md`) assumed a "w
 - **Node idempotency (failure-resume).** Re-running a node that *partially* side-effected (an http POST that sent but timed out on the response, an mcp tool that created a resource then dropped, a claude-code node that already committed) double-fires. Action-approval and escalation sidestep this (they stop *before* the node). **Reuse the existing side-effect taxonomy:** `_default_cache_for_node_type` already classifies which node types side-effect (only `llm` caches by default; `http`/`mcp`/`shell`/`claude-code` do not) — the same classification tells you which nodes are resume-safe vs. need a guard/confirm before re-running.
 - **Escalation calibration (the make-or-break).** The agent must escalate *only* genuine lasting-impact forks, never punt minor choices. Too eager defeats the autonomy that makes the harness worth having; too reluctant is the silent-bad-decision nightmare. Same discipline as Task 163's review adjudication ("a finding is a claim to be verified, not obeyed") — a prompt-design problem, not a mechanism problem.
 - **Lossy serialization.** The trace serializes with `json.dump(..., default=str)` (`workflow_trace.py:850`) — non-JSON-native values resurrect as their `str()`. Faithful resume needs lossless-enough state, or a documented constraint that resumable shared values must be JSON-native (the braindump's open serializability question, now concretely scoped).
-- **Nested / sub-workflow resume.** Dotted `--only parent.child` is rejected on every live path today (`_validate_only_target`, `engine.py:339-345` + `plan.py:458-481`); the child plumbing (`_pflow_child_only_node`) exists but is **dormant** (only write site is always passed `None`), parked under #443 as a deferred follow-up. Task 163 is a *tree* of sub-workflows, so pausing/escalating/resuming *inside* a child is real and not yet covered.
+- **Nested / sub-workflow resume.** Dotted `--only parent.child` is rejected on every live path today (post-PR #505: the shared `validate_only_target` in `engine.py`, called by both engine and planner); the child plumbing (`_pflow_child_only_node`) exists but is **dormant** (only write site is always passed `None`), parked under #443 as a deferred follow-up. Task 163 is a *tree* of sub-workflows, so pausing/escalating/resuming *inside* a child is real and not yet covered.
+- **Escalation raised inside a PARALLEL batch worker.** A sub-workflow child running as a parallel batch item executes on a worker thread whose progress events are **buffered** (per-worker transcript pattern, `batch_executor.py` — workers must not touch the real `OutputController`); a worker thread cannot prompt a TTY, and pausing one item while siblings run concurrently has no defined semantics. The spec's batch section below covers a *declared* gate on the batch node itself (whole-batch approval) — it does NOT cover an *agent-raised* escalation surfacing from inside a parallel item. v1: reject/define-away this combination explicitly at validation (e.g. escalation inside a parallel batch fails the item with a clear error) rather than handling it; sequential batch + top-level nodes are the supported v1 surface.
 
-## Phasing: Blocking (cheap, ship-gating) vs Durable (deferrable)
+## Dry-run parity & engine placement (added 2026-06-11 — from the planner-mirror refactor, issue #504 / PR #505)
 
-- **Blocking** — human present during the run. Gate fires (or agent escalates) → run pauses → human decides live (TTY now, web UI later) → continue. Needs the gate primitive + (for escalation) an agent-raised trigger + a decision payload. **No durable tokens or cross-process serialization.** This is the slice that gates shipping the agentic harness — and it is the cheap one.
-- **Durable** — answer hours/days later. Adds the persist-and-resume-across-processes machinery (the resume tokens / `~/.pflow/resume/` state described below). Genuinely useful, but the heavy, deferrable part.
+A gate is a new per-node walk outcome the dry-run planner must surface, or `--dry-run` lies
+about exactly the thing gates exist for ("this run performs no side effects without asking" —
+a plan that shows a gated node as plain `execute` is a parity lie). The drift record that
+motivated PR #505 (8–9 of 10 lockstep commits; 4 shipped parity bugs; the Task 162 under-report
+that passed the whole drift suite) says: design this in from day one, via the shared layer.
 
-Build blocking first.
+- **Put the gate in compile-time metadata so the planner sees it for free.** `approval:` lands
+  on `NodeConfig` (like `loop_config`/`cache_enabled`); anything `plan_node()` can read, the
+  planner inherits with zero `plan.py` work (Task 166 precedent — loop carry cost zero plan.py
+  edits because it landed behind the shared seam). Agent-raised escalation is runtime-only and
+  inherently unpredictable — the planner's job there is at most an annotation ("may escalate"),
+  not a prediction; record that asymmetry explicitly.
+- **Follow the documented planner extension recipe** (`execution/CLAUDE.md` → walker shape):
+  new `PlanEntry.status` (or annotation) → entry builder in `_plan_standard_node` → `_classify`
+  case → `_advance` match arm, in that order. `--dry-run` output shows "would pause for
+  approval" on gated nodes; add that to Verification.
+- **Do NOT model the pause as a `RouteKind`.** PR #505 extracted `route_action` as the pure
+  post-execution routing kernel (successor match > clean termination > routing error). A gate
+  fires *before* the node runs — same altitude as the loop guard, which matches the inline
+  `_execute_node` placement already specified in Implementation Notes. Keep the kernel pure.
+- **Gate bookkeeping goes in the shared layer.** Any new `__execution__` key (gate state; pause
+  position is Task 171's) extends `new_execution_state()` in `node_state.py` — the single source
+  PR #505 established; the planner's scratch store seeds via the same `initialize_execution_state`,
+  so a hand-mirrored literal is no longer possible *unless someone re-forks it. Don't.* (Applies
+  equally to Tasks 164/171.)
+- **Parity test first, mutation-verified**: when the gate status lands, add the drift-suite pin
+  ("plan says would-pause ⟺ engine pauses") and mutation-check it (re-fork one side, confirm it
+  fails) before trusting it — the PR #505 batch-shape test demonstrated 43 green tests can miss
+  a visibly drifted mirror.
+
+## Phasing → split into separate tasks (2026-06-12)
+
+The original phasing (blocking vs durable inside one task) implied a build-order sandwich
+(125-blocking → 164 → 125-durable) that contradicts the one-PR-per-task convention. Resolved
+by splitting:
+
+- **THIS task = blocking only** — human present during the run. Gate fires (or agent escalates) → run pauses → human decides live (TTY now, web UI later) → continue. Needs the gate primitive + (for escalation) an agent-raised trigger + a decision payload. **No durable tokens or cross-process serialization.** This is the slice that gates shipping the agentic harness — and it is the cheap one.
+- **Task 171 = durable** — answer hours/days later: resume tokens, `~/.pflow/resume/` state, non-TTY gates. Rides Task 164's substrate as a thin trigger. The durable design content originally drafted here now lives in `task-171.md`.
+
+Build order: **125 (this) → 164 → 171**.
 
 ## Design Decisions
 
 - **Parameter-level, not node-type-level**: `approval: required` is a parameter on any existing node type (`mcp`, `shell`, `http`, `llm`, etc.), not a separate `approval` node type. This keeps the node count unchanged and makes it composable — you add approval to an existing step, not insert a new step.
 - **Preview resolved inputs**: At the pause point, show the user the actual resolved template values (e.g., "About to send Slack message to #releases: 'v0.9.0 released with 3 features'"), not the raw template (`${create-summary.result}`). The user needs to approve *what will happen*, not the abstract definition.
-- **Resume tokens are self-contained**: Token encodes workflow identity, pause position, completed outputs, and a protocol version. A future session with no prior context can resume from the token alone.
-- **State goes to `~/.pflow/resume/`**: Serialized shared store at pause point. Resume tokens reference this state. Cleanup after successful resume or configurable TTL.
+- **Durable-token design moved to Task 171** (self-contained tokens, `~/.pflow/resume/` state, TTL/cleanup — see `task-171.md` Design Decisions).
 - **Engine integration is wrapper-free** (corrects the original "ApprovalWrapper in a wrapper chain" plan, now obsolete — Task 135/138 removed the wrapper chain): the pause/preview check belongs inline in `WorkflowEngine._execute_node`, after template resolution (so the preview shows resolved values) and before the node's `exec`, alongside the existing inline cache/trace/batch handling. Node implementations stay untouched. See Implementation Notes.
-- **General primitive, not approval-only**: design checkpoint → restore → continue once, with action-approval / decision-escalation / failure-resume as triggers over it (see Architecture). Approval-only-then-retrofit would rebuild the same substrate three times.
-- **One decision surface for CLI and UI**: the human-decision payload (action preview *or* decision + options + tradeoffs + recommendation) must render in both the terminal prompt and the planned web UI (Task 155 → visual gate). Design it as structured data, not a printed string.
-- **Blocking before durable**: ship the blocking gate (human present) first; durable resume tokens are a later phase (see Phasing).
+- **General primitive, not approval-only**: design checkpoint → restore → continue once, with action-approval / decision-escalation / failure-resume as triggers over it (see Architecture). Approval-only-then-retrofit would rebuild the same substrate three times. Post-split this means: the substrate is Task 164's; this task's gate primitive and decision payload must be designed so 171 can persist them unchanged.
+- **One decision surface for CLI and UI**: the human-decision payload (action preview *or* decision + options + tradeoffs + recommendation) must render in both the terminal prompt and the planned web UI (Task 155 → visual gate). Design it as structured data, not a printed string — this is also what makes Task 171's durable tokens a thin layer (it persists the same payload).
+- **Blocking before durable**: ship the blocking gate (human present) first; durable is Task 171 (see Phasing).
 
 ## Dependencies
 
@@ -112,7 +144,8 @@ Additive — no existing feature needs modification — but several relationship
 - **Reuses today's `--only` snapshot machinery** (`seed_snapshot_into_shared` / `load_snapshot_or_raise`, issue #443) as the reconstruction half of resume. See Reuse.
 - **Task 155 (Graph Model → web UI)** — the decision surface should render as a visual gate, not just a CLI prompt. Design the payload for both.
 - **Task 99 (Expose pflow Tools to Claude Code Node)** — the clean mechanism for an agent to *raise* an escalation is a pflow-provided tool (e.g. `escalate_to_human(...)`); under the hood it writes an escalation artifact + returns, fitting Task 163's fork model.
-- **Task 164 (Resume Workflow From a Failed Node)** — the sibling feature over the same substrate. Build order: 125-blocking → 164 (builds the substrate) → 125-durable. Prior art: **Task 73** (deprecated). See Architecture.
+- **Task 164 (Resume Workflow From a Failed Node)** — the sibling feature over the same substrate. Build order: **125 (this, blocking) → 164 (builds the substrate) → 171 (durable tokens/non-TTY gates)**. Prior art: **Task 73** (deprecated). See Architecture.
+- **Task 171 (Durable Resume Tokens & Non-TTY Gates)** — the durable phase carved out of this task (2026-06-12); persists this task's gate/decision payload across processes via 164's substrate. The decision payload designed here must survive serialization unchanged.
 - **Stale**: the original wrapper-chain integration plan predates the Task 135/138 engine redesign and is corrected in Reuse + Implementation Notes.
 
 ## Implementation Notes
@@ -123,22 +156,11 @@ The original plan slotted an `ApprovalWrapper` into an `InstrumentedWrapper → 
 
 So the gate is an **inline check in `_execute_node`**, placed *after* template resolution (so the preview shows resolved values — the actual Slack text, not `${...}`) and *before* the node's `exec`. The same hook serves both triggers: a declared `approval: required` (action-approval) and an agent-returned escalation marker (decision-escalation) both pause at this point. Confirm exact placement against the current `_execute_node` step order (the engine CLAUDE.md documents steps 1–17.6). Node implementations stay untouched either way.
 
-### State serialization
+### State serialization → Task 171
 
-At pause:
-1. Snapshot the shared store (all completed node outputs)
-2. Record the current node index (which node we're paused before)
-3. Record the workflow file path or saved name
-4. Record the original input parameters
-5. Write to `~/.pflow/resume/<execution-id>.json`
-6. Generate a compact resume token that references this state
-
-At resume:
-1. Decode token, load state from `~/.pflow/resume/`
-2. Reconstruct shared store from snapshot
-3. Skip to the paused node
-4. If approved: execute the paused node and continue
-5. If denied: exit with a clear message ("Workflow cancelled at step 'notify-slack'")
+The pause-time checkpoint (shared-store snapshot, pause position, `~/.pflow/resume/` state,
+token generation) and the token-resume flow moved to `task-171.md` (Solution + Requirements).
+This task's blocking gate holds state in-process only.
 
 ### Batch interaction
 
@@ -148,28 +170,24 @@ If a batch node has `approval: required`:
 
 ### Edge cases
 
-- **Workflow changed between pause and resume**: Hash the workflow definition at pause time. On resume, compare hashes. If different, warn but allow with `--force`.
-- **Multiple approval gates in one workflow**: Each gate pauses independently. After resuming gate 1, execution continues until gate 2 (or completion).
-- **Timeout**: No auto-cancel by default. Resume tokens are valid until explicitly cleaned up or TTL expires. Consider a `pflow resume list` command to show pending approvals.
+- **Multiple approval gates in one workflow**: Each gate pauses independently (in-process). After approving gate 1, execution continues until gate 2 (or completion).
+- **Non-TTY invocation with a gate present**: blocking mode cannot prompt. Until Task 171 ships tokens, this must fail loudly and immediately with an agent-actionable error (or honor `--auto-approve`) — never hang waiting for input that can't arrive.
+- Cross-process edge cases (workflow changed between pause and resume, token TTL, `pflow resume list`) → Task 171.
 
 ### CLI surface
 
 ```bash
-# Workflow with approval gates runs and pauses
+# Workflow with approval gate, human at TTY: pauses, prompts inline
 pflow my-workflow param=value
-# Output: Paused at 'notify-slack'. Resume token: pflow-resume-abc123
-# Run: pflow resume pflow-resume-abc123 --approve yes
-
-# Resume
-pflow resume pflow-resume-abc123 --approve yes
-pflow resume pflow-resume-abc123 --approve no
-
-# List pending
-pflow resume list
+# Paused at 'notify-slack'. About to send: "..." Approve? [y/N]
 
 # Auto-approve for CI/testing
 pflow my-workflow param=value --auto-approve
 ```
+
+Token-based resume (`pflow resume <token>`, `pflow resume list`) → Task 171. The `pflow resume`
+command name is shared with Task 164's failure-resume — resolve the surface jointly (flagged in
+both task-164.md and task-171.md).
 
 ### Markdown format
 
@@ -187,15 +205,17 @@ Post the release summary to Slack.
 ## Verification
 
 - **Basic gate**: Workflow with `approval: required` on a node halts before that node, displays preview, waits for input
-- **Resume flow**: Paused workflow resumes correctly from token without re-executing completed nodes
 - **Deny flow**: Denied approval exits cleanly with message, no side effects
-- **Multiple gates**: Workflow with 2+ approval gates pauses at each in sequence
+- **Multiple gates**: Workflow with 2+ approval gates pauses at each in sequence (in-process)
 - **Batch + approval**: Batch node with approval shows batch preview, not per-item prompts
 - **TTY mode**: Interactive prompt works in terminal
-- **Non-TTY mode**: Token emitted to stdout, parseable by calling process
-- **Stale resume**: Resuming after workflow definition changed shows warning
-- **Shared store integrity**: Resumed workflow has access to all outputs from nodes that completed before the pause
+- **Non-TTY + gate fails loudly**: a gate in a non-TTY run (pre-Task-171) errors immediately with an actionable message (or honors `--auto-approve`) — never hangs
 - **Validation**: `pflow --validate-only` recognizes `approval` as a valid parameter (no unknown-param warning)
+
+(Token resume flow, stale-resume warning, non-TTY token emission, post-resume shared-store
+integrity → Task 171 Verification.)
+- **Dry-run parity**: `--dry-run` shows gated nodes as "would pause for approval" (not plain execute); pinned by a drift-suite test ("plan says would-pause ⟺ engine pauses"), mutation-verified
+- **Parallel-batch escalation rejected loudly**: an escalation raised inside a parallel batch item produces the defined v1 error, never a hang or a silent skip
 
 ### Decision-escalation (new use case)
 

--- a/.taskmaster/tasks/task_164/starting-context/braindump-planner-mirror-session.md
+++ b/.taskmaster/tasks/task_164/starting-context/braindump-planner-mirror-session.md
@@ -1,0 +1,139 @@
+# Braindump: planner-mirror refactor session → what it means for Task 164
+
+Written 2026-06-12, at the end of the session that produced issue #504 / PR #505
+("lift the planner's engine-mirror into shared runtime functions") and the
+"Engine/planner parity plan" section now in `task-164.md`. The spec sections are
+written; this captures what is NOT written anywhere.
+
+## Where I Am
+
+PR #505 is **OPEN, not merged** (https://github.com/spinje/pflow/pull/505, closes #504,
+branch `refactor/planner-engine-shared-layer` cut from main). Task 164 work MUST start
+after it merges (or rebase onto it) — it moves/renames the exact functions 164 touches
+(`validate_only_target`, `route_action`, walk loop now `while curr is not None` dispatching
+on `RouteKind`). The `file:line` refs in task-164.md "Reuse"/"The delta" were verified
+pre-#505 and WILL be stale post-merge (caveat noted in spec, repeated here because it's
+the first trap).
+
+Also uncommitted on `chore/audit-followup-hardening` at session end: the new spec sections
+in task-164.md / task-125.md, the new task-171.md (durable tokens — split from 125's durable
+phase so each task is one PR), and the root CLAUDE.md roadmap reorder (build order
+125 → 164 → 171). If you don't see them, they weren't committed.
+
+## User's Mental Model (their words, load-bearing)
+
+- **"Prioritize simplicity of the FINAL code, not how easy it is to get there. When in
+  doubt ask: what's the right solution that the top 10% of codebases similar to this one
+  would implement — have we considered it yet?"** Immediately followed by the guard: this
+  does NOT mean overfitting to "top 10%" / overengineering — it's about **"simple code
+  that is optimized for AI agents to understand and add features to."** Apply this to the
+  Phase-0 helper design: the top-10% answer for "three walk modes over one graph" is
+  shared *rule* functions, not a walk-mode abstraction.
+- **"The bar isn't 'passing', it's 'passing the right thing'."** Said about tests. This led
+  to the mutation experiment (below) — the single highest-value discovery of the session.
+  The user explicitly does NOT want coverage-optimizing tests and asked me to audit my own
+  tests for shallowness; they will ask you the same.
+- **Tasks ship as ONE BIG PR.** Exact words: "tasks are not implemented as separate prs
+  though, its all one BIG pr." So "Phase 0" in the spec = first commits/milestone *inside*
+  the 164 PR, not a separate PR. (I had it wrong; user corrected.)
+- **Where knowledge lives**: design reasoning/phasing → task dirs; GH issues → closeable
+  problem statements **written at PR time** (user had me write #504 "as if written BEFORE
+  this implementation" when the work was done). For 164's PR, expect to write the issue
+  retroactively in the same style.
+- User cares about **branch hygiene** (chose a clean branch off main over piggybacking) and
+  wants the one-behavior-change-per-PR visible in history.
+
+## The Mutation Experiment (do this for 164, it's the whole point)
+
+The proof that motivated the spec's "parity test first": I re-forked the planner's batch
+shape into a drifted inline literal (`errors: None` — the exact #484 regression — plus 3
+dropped `batch_metadata` keys). **All 43 pre-existing batch/drift tests passed.** Only the
+new call-site parity test (`test_plan_batch_sub_workflow_output_shape_matches_engine`,
+in `test_plan_drift.py`, landed in #505) failed. Recipe to copy for walk-entry parity:
+write test → mutate one side (re-fork) → confirm fail → revert. The test's docstring
+documents the recipe and rationale — read it before writing 164's version.
+
+Key nuance: unit tests on a shared function CANNOT catch a re-fork (they test the function,
+not that callers use it). Only call-site parity tests do. Extraction A/B/D in #505 didn't
+need one (both callers invoke the same function on the same path); C did (different
+surrounding logic per caller). **164's walk-entry helper is a C-shaped case** — engine and
+planner will wrap it differently — so it needs the call-site parity pin, not just unit tests.
+
+## The Seam Shape I'd Start From (tacit — argued but not written down)
+
+Three consumers of "enter the walk mid-graph": `--only` = seed + run ONE node + stop;
+resume = seed + continue walking; planner `_resolve_walk_start` = seed + walk without
+executing. The shared part is **seed + locate-entry only**. The *continuation policy* is
+where they genuinely differ — do NOT try to share it (that's the walker-merge ADR-0001/0006
+forbids). If during design the helper starts growing a `mode` parameter or callbacks,
+that's the overengineering smell; back off to seed+locate.
+
+From the probe that mapped `create_planner_shared` (findings not persisted anywhere):
+the asymmetries that killed a fuller "walk environment" extraction were (1) engine does
+save/restore-in-place for nested sub-workflows while the planner builds a fresh store per
+child, (2) resource keys (`__trace_collector__`/`__mcp_pool__`/`__progress_callback__`)
+are deliberately absent on the plan path. Resume's helper will meet the same asymmetries —
+they're intentional, not accidents to "fix".
+
+## Dead Ends / Disproven Suspicions (don't re-derive)
+
+- **`clear_node_failure` for K is NOT needed (probably).** I suspected resume must clear
+  `__failures__[K]` (get_node_status checks failures first; visit-count reset means
+  `enforce_loop_guard`'s clear never fires for visit 1). Disproven: resume builds a FRESH
+  shared store and seeds only upstream `node_output`s from the trace — the old run's
+  failure record never enters the new store. NEEDS VERIFICATION once the resume loader
+  exists: if it ever seeds failure/warning state, this comes back.
+- **Cost-parity in the drift suite is a KNOWN blind spot, deliberately out of scope** of
+  #505 (it pins control flow, not cost — `task_162/task-review.md:30`; the Task 162
+  under-report passed the whole suite and was caught in a manual review session, NOT by
+  tests). If 164 adds `--dry-run --resume`, its cost predictions inherit this blind spot.
+- **`None` placeholders in batch `results` under parallel fail-fast** pass through
+  `build_batch_output` verbatim (documented in its docstring) — pre-existing, deliberately
+  preserved, one-line fix if ever wanted. Not 164's problem; just don't "fix" it in passing.
+
+## Hard-Won Trivia (cost me real time)
+
+- Hand-authoring `.pflow.md`: fences are ` ```shell command ` / ` ```yaml batch ` /
+  ` ```python code ` (info string = language + param name); code nodes are module-level
+  statements with annotated inputs (`n: int` on its own line) and `result: dict = ...` —
+  NOT a `def run()`. Loop `while:` must be a bare `${...}` truthiness template — comparisons
+  like `${x} < 3` are rejected by schema; compute the boolean inside the node.
+- `echo "EXIT=$?"` after a pipe captures `tail`'s exit code. Redirect to a file instead.
+- The review-agent pairing that paid off: `review-silent-failures` + `review-impact-completeness`
+  on the plan caught the `--only ""` engine/planner divergence that five other verification
+  passes missed. Every finding was confirmed (zero false positives). Worth repeating for
+  164's plan; the `--only ""` class to look for is "the two copies already disagree on an
+  edge — unification must pick one and the 'zero behavior change' claim breaks there."
+
+## Unexplored Territory
+
+- UNEXPLORED: **`--resume` × `--only` interaction.** Both are walk-entry modes; what does
+  `pflow wf --resume --only K2` mean? Probably reject loudly, but nobody has thought about it.
+- UNEXPLORED: **resume × loop nodes.** If failed node K has `loop_config`, what iteration
+  does resume re-enter at? `__iteration__`/`loop_counts` are not in the trace. Likely answer:
+  K restarts at iteration 1 (loop state is intentionally ephemeral) — but decide explicitly.
+- CONSIDER: **memo-cache interplay is mostly free** — restored upstream means K's resolved
+  params match the failed run, so K's memo lookup behaves as if mid-run. But the `--only`
+  limitation transfers: sanitized (binary/dunder) upstream values change K's cache_key vs
+  the live run (documented in ADR-0002 Limitations). Same caveat, new surface.
+- MIGHT MATTER: **Task 170 (template language) is the sibling refactor** likely to land in
+  the same window — it touches plan.py heavily. Coordinate merge order; expect conflicts in
+  plan.py imports/regions if both are in flight.
+
+## For the Next Agent
+
+1. Confirm PR #505 merged; rebase/branch from main after it. Re-verify spec line numbers.
+2. Read `task-164.md` fully — especially "Engine/planner parity plan" (the phasing) and
+   "Known Hard Problems". The spec is GOOD; the grilling gap is the snapshot-fidelity
+   decision (loud-caveat vs ADR-0002's dedicated-store escape hatch) — that's a USER
+   decision, get it before writing the implementation plan.
+3. Build order is fixed in root CLAUDE.md: 125 (blocking gates) ships first, then this task,
+   then 171 (durable tokens — your substrate's second consumer; its purpose-built checkpoint
+   file means your restore reader should handle two sources). Check whether 125 has shipped —
+   if it landed, its gate/pause code may have touched `_execute_node` placement you care about.
+4. The user will hold you to: final-code simplicity over implementation convenience,
+   mutation-verified tests over green tests, and showing expected output before implementing.
+
+> **Note to next agent**: Read this document fully before taking any action. When ready,
+> confirm you've read and understood by summarizing the key points, then state you're
+> ready to proceed.

--- a/.taskmaster/tasks/task_164/task-164.md
+++ b/.taskmaster/tasks/task_164/task-164.md
@@ -25,14 +25,15 @@ following successors to the end** — the missing "resume-and-continue" half of 
 `--only` snapshot machinery.
 
 ## Relationship to Task 125 (shared substrate)
-Task 125 (HITL gates) and this task are the **same primitive under different triggers**:
-checkpoint → restore → continue. See task-125.md "Architecture". The division of labour:
-- **Task 125 blocking gates** need NO substrate (verified: in-TTY in-place pause works) → independent, built first.
+Task 125 (HITL gates, blocking) and this task are the **same primitive under different
+triggers**: checkpoint → restore → continue. See task-125.md "Architecture". The division of
+labour (125's durable phase was split out as **Task 171** on 2026-06-12, so each task is one PR):
+- **Task 125 (blocking gates)** needs NO substrate (verified: in-TTY in-place pause works) → independent, built first.
 - **THIS task builds the checkpoint→restore→continue substrate** — it is the general,
   HITL-free exercise of it.
-- **Task 125 durable resume + non-TTY gates** then reuse this substrate as a thin trigger
-  (stop-at-a-gate instead of stop-at-a-failure).
-Build order: 125-blocking → 164 (this) → 125-durable.
+- **Task 171 (durable resume tokens + non-TTY gates)** then reuses this substrate as a thin
+  trigger (stop-at-a-gate instead of stop-at-a-failure), persisting 125's decision payload.
+Build order: **125 → 164 (this) → 171**.
 
 ## Reuse: what already exists (verified 2026-06)
 The reconstruction half ships, tested, via `--only` (issue #443):
@@ -59,6 +60,54 @@ The reconstruction half ships, tested, via `--only` (issue #443):
 5. Refine `restored_nodes` to mean "seeded AND not visited this run" — derive post-walk from
    `node_visit_counts` (`execution_state.py:144-145` is the one display-contract touchpoint).
 
+## Engine/planner parity plan (added 2026-06-11 — from the planner-mirror refactor, issue #504 / PR #505)
+
+The planner-mirror refactor (PR #505) made five engine/planner surfaces shared
+(`validate_only_target`, `route_action`, `new_execution_state`, `build_batch_output`,
+`build_snapshot_degraded_diagnostic`) and quantified the drift record this task walks into:
+8–9 of 10 post-dry-run commits touched `plan.py` in lockstep with engine changes, and the
+closest precedent to THIS task — the `--only` snapshot change (`ac479cfd`) — cost **+78 plan.py
+lines alongside +175 engine lines** because entry/seeding semantics are plan.py's mirror
+surface. Consequences for this task's implementation plan:
+
+1. **Phase 0 (first phase of this task's PR, pure refactor): extract the shared
+   "seed snapshot + resolve entry node" helper.** The composition exists twice today —
+   `engine._run_only_snapshot`'s prologue and `plan.py::_resolve_walk_start` — and the delta
+   above would add a third copy. Extract it into `runtime/` with both existing callers rewired
+   FIRST (parity suites as the safety net, zero behavior change), then build resume's engine
+   mode and any planner view as additional callers. Do not extract it before this task starts:
+   the helper's interface is shaped by resume's needs (continue-walking vs run-one-node,
+   failed-trace policy vs full-run policy) — designing it without the third consumer risks a
+   wrong seam (ADR-0006 doctrine: share rules/data, not traversal; the helper is a rule).
+   Task 166 is the payoff precedent: loop-carry landed behind `plan_node()` and cost zero
+   plan.py work.
+2. **Decide the dry-run story explicitly.** Does `--dry-run --resume` exist (planner predicts
+   the resumed tail's cache/cost)? If yes, the planner becomes the helper's fourth caller via
+   `_resolve_walk_start`. If no, record that as a scoped-out decision — don't leave it implicit,
+   or the planner silently lies about resume runs.
+3. **Write the parity test first, mutation-verified.** Before feature code, add a drift-suite
+   test pinning "engine's resume entry state == planner's walk-start state" (copy the recipe
+   from `test_plan_batch_sub_workflow_output_shape_matches_engine`, PR #505 — which demonstrated
+   a re-forked shape literal passes all 43 pre-existing batch/drift tests and is caught only by
+   a call-site parity pin). Mutation-check it by re-forking one side before trusting it.
+4. **Now-shared pieces to reuse directly:** `validate_only_target` is the validation pattern
+   (and likely the function) for the resume target K — note it now hard-errors on `""`;
+   `route_action` means "continue the walk after K" needs zero new routing logic;
+   `build_snapshot_degraded_diagnostic` is the template for a resume-scoped degraded/lossy-state
+   advisory (one builder, per-surface params); any new `__execution__` key resume needs goes in
+   `new_execution_state()` (`node_state.py`) — never a per-side literal.
+5. **Snapshot fidelity is a spec-gate, not an implementation detail.** The Lossy-serialization
+   bullet below understates the decision: `--only` accepted trace sanitization (bytes →
+   placeholder, dunder-drop, `default=str`) as an iteration-tool caveat, but resume is a
+   reliability feature — ADR-0002 explicitly reserves the "dedicated snapshot store" escape
+   hatch for when the trace coupling bites. Decide loud-caveat vs escape-hatch during spec
+   grilling, BEFORE Phase 0 (it changes what the shared helper reads).
+
+> Line-number caveat: the `file:line` refs in Reuse / The delta were verified pre-#505; that PR
+> touches `engine.py`/`plan.py` (e.g. `_validate_only_target` is now module-level
+> `validate_only_target`; the walk loop dispatches via `route_action`). Re-verify offsets at
+> implementation time.
+
 ## Known Hard Problems
 - **Node-K idempotency (the core problem).** K may have *partially* side-effected before
   failing (an http POST that sent but timed out on the response, an mcp tool that created a
@@ -82,13 +131,18 @@ The reconstruction half ships, tested, via `--only` (issue #443):
   — non-JSON-native values resurrect as `str()`. Either ensure resumable shared values are
   JSON-native or harden serialization. Shared with Task 125.
 
-## CLI Surface (open — coordinate with Task 125)
-`pflow resume` is a name Task 125 also wants (for resuming a paused gate). Decide whether one
-`pflow resume` serves both "resume a paused approval" and "resume a failed run", or whether
-this is `pflow <workflow> --resume` / `--from-failed`. Resolve jointly with 125.
+## CLI Surface (open — coordinate with Task 171)
+`pflow resume` is a name Task 171 also wants (for resuming a paused gate via token). Decide
+whether one `pflow resume` serves both "resume a paused approval" (token-addressed) and
+"resume a failed run" (workflow-addressed), or whether this is `pflow <workflow> --resume` /
+`--from-failed`. Resolve jointly with 171 (flagged in task-171.md Dependencies too).
 
 ## Dependencies
-- **Task 125** — shares the checkpoint/resume substrate; build order 125-blocking → this → 125-durable.
+- **Task 125** — shares the checkpoint/resume substrate; build order **125 → this → 171**.
+- **Task 171** — durable resume tokens / non-TTY gates (split from 125's durable phase,
+  2026-06-12); the second consumer of this task's substrate. Its checkpoint is a purpose-built
+  state file (controlled pause), NOT a failed-run trace — design this task's restore reader so
+  it can read both sources (see task-171.md Design Decisions).
 - **Task 73** (deprecated, "Checkpoint Persistence for External Agent Repair") — prior art;
   its side-effect/idempotency analysis still applies. Read `.taskmaster/tasks/task_73/`.
 - **`--only` machinery** (issue #443) — the reconstruction half this builds on.
@@ -102,6 +156,9 @@ this is `pflow <workflow> --resume` / `--from-failed`. Resolve jointly with 125.
 - `restored_nodes` shows upstream-of-K as not_executed; K-onward as executed.
 - No prior failed trace → clear error (`OnlySnapshotMissingError`-style), not a silent re-run.
 - Hard-kill case reported honestly as not-resumable (no trace).
+- Phase-0 extraction lands first with parity suites passing unmodified; the engine↔planner
+  walk-entry parity test exists and is mutation-verified (re-fork one side → test fails)
+  BEFORE resume feature code (see Engine/planner parity plan).
 
 ## References
 - **Verified capability facts (2026-06, with file:line):** see Reuse + The delta above.

--- a/.taskmaster/tasks/task_170/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_170/implementation/implementation-plan.md
@@ -1,0 +1,624 @@
+# Task 170 Implementation Plan — One Template Language (`core/templates`)
+
+## Context
+
+pflow's `${…}` template language has no owning module. Evidence (architecture review
+2026-06-11, recorded in `.taskmaster/tasks/task_170/task-170.md`): 7 regex families parse the
+syntax, 6+ independent path walkers exist (two near-duplicates *inside* `TemplateResolver`
+itself), the type-judgment rules are encoded 4×, 13 files split `??` operands themselves, and
+the static validator is a hand-written model of the runtime resolver kept in sync only by
+comments — ≥7 shipped drift bugs (#441, #460, #266, d5a1af8c, 6b7faf8f, 8535ed9b), zero parity
+tests. 15 `core/` files import the resolver from `runtime/` (layering inversion).
+
+This plan implements Task 170: one module `core/templates` owning grammar, value walk, and
+semantic rules; the validator keeps its own structure walk but consumes the same parsed
+segments and rules; three meta-tests make drift loud. The decided shape and the rejected
+alternatives (shared-walk World port, hand-written scanner, property-test generator) are
+recorded in `context/adr/0006-template-language-no-shared-walk.md` — do NOT re-open them.
+Vocabulary (Template, Reference, Coalesce, Operand) is fixed in `context/CONTEXT.md`.
+
+**Prime directive: zero user-facing behavior change in every phase.** The existing test suite
+is the freeze harness; phase 1's drift tests must pass against UNMODIFIED production code.
+
+## Phase structure (order is load-bearing)
+
+1. **Parity drift tests** — land the fence before touching production code.
+2. **One internal walk** — merge the duplicated traversal loops in `TemplateResolver`.
+3. **Relocate to `core/`** — fix the 16-file layering inversion; shim in `runtime/`.
+4. **Typed parse + drift-site migration** — the AST; migrate validation passes, data_flow,
+   engine resolution, error classification, cache chunking, scope.py.
+5. **Sweep and seal** — delete superseded machinery; grammar-uniqueness AST-scan meta-test.
+
+Each phase ends with `make test` + `make check` green and is a legitimate stopping point.
+
+## Frozen behaviors (the spec for every phase — violating any of these is a bug)
+
+- JSON auto-parse on traversal: containers only; numeric strings stay strings.
+- Simple templates (`${var}` exactly) preserve type; complex templates stringify via
+  `_convert_to_string` rules verbatim (None/""→"", False→"False", True→"True", 0→"0",
+  []→"[]", {}→"{}", dict/list→json.dumps ensure_ascii=False, else str()).
+- `$$` escape prevents resolution but does NOT strip the extra `$`.
+- `??` falls through on absent root OR absent field; literal operand always resolves and ends
+  the chain; literal-first classification (keyword literals beat same-spelled identifiers).
+- Literal grammar: no leading-zero numbers, no `??` inside strings, only `[]`/`{}` composites.
+- Identifiers allow hyphens (`[a-zA-Z_][\w-]*`).
+- Dynamic index `${a[${i}].x}` — VERIFIED truth table (run against live resolver; the naive
+  "left unchanged" description is WRONG for two of three cases):
+  | inner index | outer ref | today's output | strict-mode outcome |
+  |---|---|---|---|
+  | resolves to int | NOT resolvable | `${a[0].x}` — index SUBSTITUTED, rest unresolved | contains_unresolved=False → SILENT pass-through |
+  | resolves non-int (`"abc"`) | — | `${a[abc].x}` — inner SUBSTITUTED via complex-interpolation | logger.warning (resolver :147-150) + SILENT pass-through (pinned: tests/test_runtime/test_nested_templates.py:54-60) |
+  | inner var missing | — | text fully unchanged | contains_unresolved=True → strict error / permissive DEGRADED |
+  Phase-4 DynamicIndex resolution MUST reproduce all three rows (emit re-rendered source
+  text with resolved inner substitutions applied, outer wrapper intact; keep the non-int
+  logger.warning). Case 1 is pinned by NO existing test — phase 1 adds a pin row for it.
+- Unresolved templates remain textually unchanged; strict-mode erroring stays engine policy.
+- `output_resolver._is_all_absent_coalesce` keeps its stricter semantics — NOT absorbed.
+
+## Phase 1 — Parity drift tests
+
+**New file: `tests/test_runtime/test_template_drift.py`.** Pure in-process, no marker (runs in
+`make test`). Must pass against UNMODIFIED production code before any other phase starts.
+
+Follow the repo's established idioms exactly:
+
+- **Harness**: build workflow IR as inline dicts (`{"nodes": [{"id", "type", "params"}], "edges": []}`)
+  — the idiom of `tests/test_runtime/test_template_validation/test_validator.py:214-228`.
+  Define a file-local `create_mock_registry()` returning `Mock()` with
+  `get_nodes_metadata = Mock(side_effect=...)` serving
+  `{"interface": {"inputs": [...], "outputs": [{..., "structure": {...}}], "params": [], "actions": [...]}}`
+  per node type (copy the shape from `test_validator.py:12-127`). The package CLAUDE.md says
+  each file defines its own mock registry — do NOT extract to conftest.
+- **Validator side**: `tests/shared/diagnostic_helpers.split_template_diagnostics(workflow_ir, params, registry)`
+  → `(errors, warnings)` of typed `Diagnostic`s.
+- **Resolver side**: static calls, `TemplateResolver.resolve_nested(params, context)` — the
+  end-to-end precedent is `tests/test_runtime/test_template_feature_combinations.py:100-172`.
+- **Docstring contract**: module docstring "Drift-catcher tests: template validator vs runtime
+  resolver. If a test here fails, fix the divergence, never the test." Each test carries a
+  **Mutation:** clause naming the production change that would trip it — the
+  `test_plan_drift.py` convention (see its per-test docstrings, e.g. lines 320-331).
+
+Three test groups:
+
+**1a. Grammar-coherence table (pure regex assertions, no workflow).** One parametrized corpus
+(module-level list of ~80 rows: `(template_string, expectations)`) covering: hyphenated
+identifiers, `$${var}` escapes, single/multi bracket indices, nested dynamic index
+`${a[${i}].x}`, `??` chains (ref??ref, ref??literal, literal-only), every literal edge
+(leading-zero numbers must NOT match, `??` inside quoted strings must NOT split, `[]`/`{}`
+match, `[1,2]` must NOT, keywords vs `truthy_value`), malformed shapes (`${}`, `${a..b}`,
+unclosed `${a`), bash syntax (`${VAR:-x}`, `${#arr[@]}`), AND escaped-malformed shapes
+(`$${var}` → silent; `$${unclosed` and `$${}` → malformed ERROR today — pin these; no
+existing test covers `$$`+malformed), permissive-accepted/strict-rejected path shapes
+(`${a.0}`, `${a.}` — today: NOT malformed, surface as pass-5 path errors; pin that class),
+dynamic-index partial-substitution rows (pin the verified truth table from Frozen
+behaviors — especially case 1, `${results[${__index__}].field}` with `results` absent →
+`${results[0].field}` silent pass-through, pinned by NO existing test), and
+`extract_variables` expectations on dynamic-index forms
+(`extract_variables("${a[${i}].x}") == {"i"}` today — the outer ref is invisible to the
+strict pattern; the phase-4 facade must preserve this, NOT return `{"a[${i}].x"}`).
+Each corpus row carries a `mutation` field (the production change that would trip it —
+e.g. hyphen row ← "narrow `_PERM_VAR` to `\w`"; escape row ← "drop the `(?<!\$)`
+lookbehind"), since one parametrized test can't carry per-row Mutation docstrings.
+
+Also pin the PERMISSIVE∖STRICT grammar gap at the DIAGNOSTICS level (verified live, these
+are today's outcomes — the parser's two-tier rule must reproduce them):
+- `${first.stdout.}` (trailing dot, valid root) → silent at EVERY layer (validates clean,
+  ships literal text);
+- `${a..b}` → NOT malformed; pass-5 path error ("no valid source");
+- `${first.1x}` (digit-leading field) → NOT malformed; pass-5 error ("does not output '1x'");
+- `$${undefined.field}` → pass-5 ERROR today (permissive findall has no `$$` lookbehind, so
+  ESCAPED content is discovered by the validator even though runtime treats it as inert
+  text) — this is **characterization delta: escaped-visibility**: under the planned parser,
+  cleanly-escaped candidates are invisible to validation, so this flips ERROR→silent, and
+  an input referenced ONLY as `$${input}` flips used→unused-ERROR. Recommended: accept
+  (escaped = inert everywhere — today's behavior is itself validator/runtime drift), pin
+  the NEW behavior with tests, document in the PR. Never silent.
+
+Assert per row:
+- if `TEMPLATE_PATTERN` fully matches → `_PERMISSIVE_PATTERN` (import from
+  `pflow.runtime.template_validation.validator`) must also discover it (validator may never
+  call resolvable syntax malformed — the #266/8535ed9b class);
+- every `_LITERAL_PATTERN` full-match must round-trip `try_parse_json` (the resolver
+  docstring's prose invariant, mechanized). NOTE: this invariant cannot catch widening
+  toward valid JSON (e.g. accepting `[1,2]` round-trips fine) — the explicit
+  `[1,2]`-must-NOT-match row carries that load; keep both.
+Known decision this table forces: `_PERMISSIVE_PATTERN` has no `$$`-escape lookbehind, so
+`$${var}` content IS discovered at validation today. Pin CURRENT behavior with a comment
+(`# documented permissiveness — see template_validation/CLAUDE.md`), do not "fix" it.
+
+**1b. Soundness corpus (validator ⟺ resolver on the same artifact).** Parametrized rows of
+`(node_outputs_structure, template, conforming_context)` — declared structure for a producer
+node, a template referencing it, and a context whose shapes conform to the declaration.
+For each row: run `split_template_diagnostics` on a 2-node IR (producer → consumer with the
+template in consumer params); run `TemplateResolver.resolve_nested` against the conforming
+context. HARNESS MANDATES (each prevents a verified false-confidence trap):
+- Refs are NAMESPACED (`${producer.out…}`) and contexts are shared-store-shaped
+  (`{"producer": {"out": …}}`) — `extract_node_outputs` registers BOTH flat and namespaced
+  keys, and the flat legacy key validates against a context shape production never produces.
+- Consumer mock declares an `any`-typed input for the template param (prevents pass-6
+  type-matching noise contaminating rows) and the IR declares no unused inputs.
+- Use custom mock type names (`producer`/`consumer`), NOT real node types — `code` and
+  `workflow` hit special-cased branches in extract_node_outputs; only deliberate rows use
+  those.
+- ORACLE: each row carries `expected_value`; assert
+  `TemplateResolver.resolve_nested({"p": template}, context)["p"] == expected_value`
+  EXACTLY (rows are deterministic) and `errors == []` for the whole single-template
+  workflow. Do NOT use `result != template text` as the resolution oracle (fails on partial
+  resolution, None-valued simple templates, value-equals-text).
+- SCOPE: the no-ERROR assertion applies to grammar/path/existence diagnostics only.
+  Passes 6 (typed primitive sinks), 7 (shell safety: dict into `command` ERRORs while
+  runtime serializes fine), and 10 (loop checks) DELIBERATELY over-reject resolvable
+  templates — they are exempt by policy, named as such in the test docstring. Do NOT
+  assert the converse anywhere (the validator legitimately under-checks: user params,
+  `??` chains, unknown types).
+Rows must cover: nested dict paths, array indices, str-typed fields containing JSON
+(auto-parse), union types (`list|string`), `any`, batch shapes (`results` + item alias —
+the d5a1af8c/6b7faf8f class), `??` with literal fallbacks, dotted refs on batch outputs.
+
+**1c. Historical regressions (six named tests).** One test per drift bug, docstring citing
+issue/commit, encoding the exact scenario:
+- `test_441_coalesce_optional_field_not_field_checked` — `${ran_node.optional_field ?? "x"}`
+  validates clean and resolves to fallback. (Standard harness — verified writable.)
+- `test_460_generic_type_traversal` — HARNESS DEVIATION REQUIRED: the #460 mechanism is
+  `_runtime_base_type` in `engine/template_resolution.py:30-44`, which
+  `TemplateResolver.resolve_nested` never reaches (a resolve_nested-based test stays green
+  with the bug reverted). This test must call `build_type_cache(interface_metadata)` +
+  `resolve_templates(...)` from `pflow.runtime.engine.template_resolution` (import
+  precedent: `tests/test_runtime/test_null_defaults.py:8-12`) with a `list[str]`-declared
+  output whose value is a JSON-array STRING, and assert the resolved param `== ["a", "b"]`
+  (parsed list, not the string) AND the validator accepts.
+- `test_266_escaped_template_not_flagged` — `$${var}` produces no has-templates positive.
+- `test_d5a1af8c_batch_dotted_item_refs` — HARNESS DEVIATION REQUIRED: the d5a1af8c fix
+  lives in DATA_FLOW (`core/workflow/data_flow.py` — batch alias missing from
+  declared_inputs), which `validate_workflow_templates` never runs. Use
+  `split_validator_diagnostics` (`tests/shared/diagnostic_helpers.py:16`, runs the full
+  `WorkflowValidator.validate` including data_flow). `${item.field}` in a batch context →
+  no errors.
+- `test_6b7faf8f_batch_on_workflow_node` — the fix is in extract_node_outputs' workflow
+  branch (batch-on-workflow skipped batch-output registration). Write a real child
+  workflow to `tmp_path` and reference it by file path (the autouse `isolate_pflow_config`
+  means a NAMED child won't resolve); batch over it; `${node.results[0].field}` access
+  validates clean.
+- `test_8535ed9b_nested_index_coalesce_not_malformed` — CORRECTED POINTER: the fix is in
+  commit **4516cd72** (8535ed9b's diff does NOT contain the fix or template — verified).
+  Template: `${a[${i}] ?? b[${i}]}`, already validator-pinned at
+  `tests/test_runtime/test_template_validation/test_malformed.py:293-316`. The drift
+  version adds what that pin lacks: the RESOLVER side — against
+  `{"a": ["x"], "b": ["y"], "i": 0}` it resolves to `"x"`.
+
+Gate: full suite green (`make test`), file passes with zero production edits.
+
+## Phase 2 — One internal walk
+
+**File: `src/pflow/runtime/template_resolver.py` only. All public signatures unchanged.**
+
+Today there are two traversal loops in the class: `resolve_value` (:558-627, returns value or
+None) and `variable_exists` → `_traverse_path_part` → `_check_array_indices` (:453-556,
+returns bool — note `_traverse_path_part` returns the CONTAINER on the last segment, and
+`_check_array_indices` skips applying the final index: existence-only semantics). They share
+the same dot-split regex (:545/:579) and bracket regex (:498/:585). `resolve_coalesce`
+(:360-361) and `_resolve_complex_match` (:785+:780) each call BOTH — double traversal, and
+the two loops can in principle disagree.
+
+Change:
+1. Add private `_walk(var_name: str, context: Mapping) -> tuple[bool, Any]` — ONE traversal
+   returning `(found, value)`. Semantics: value side = today's `resolve_value` (applies all
+   indices, JSON auto-parse via `_get_dict_value`/`_try_parse_json_for_traversal`, OOB index
+   → not found, None mid-path → not found); found side = today's `variable_exists` truth
+   table (None/empty/0/False all EXIST; missing key / null parent do not — pinned by
+   `tests/test_runtime/test_null_defaults.py:20-49`).
+2. Reimplement: `variable_exists` = `_walk(...)[0]`; `resolve_value` = value where found else
+   None; `resolve_coalesce` = one `_walk` call per operand (replaces :360-361);
+   `_resolve_complex_match` = one call (replaces the :780/:785 pair).
+3. Delete `_traverse_path_part` and `_check_array_indices` (no external callers — verified;
+   `_get_dict_value` stays: `tests/test_runtime/test_template_resolver.py` imports it).
+
+**MUST-PRESERVE pin**: `tests/test_cli/test_workflow_output_handling.py:1522-1538` pins the
+missing-vs-None distinction by design ("a future refactor that uses just resolve_value and
+checks for None would fail this test"). `_walk`'s found flag is what keeps that working.
+
+**Do NOT touch the external exists-then-resolve pair callers** (`loop_control.py:150-153`,
+`workflow_output.py:182-183/:332-334`, `success_formatter.py:206-207`,
+`node_output_formatter.py:48/:52`, `cross_workflow.py:393-395`, `read_fields.py:61`,
+`field_service.py:74`): their behavior is pinned and their signatures are the public API.
+The only pair-caller that migrates later is `workflow_output._diagnose_path_failure`
+(phase 4 table). The rest stay on the pair permanently.
+
+Gate: full existing resolver suites pass unmodified (3,373 lines across 11 files — the
+freeze harness), especially `test_null_defaults.py`, `test_template_resolver_arrays.py`,
+and the consistency classes (`test_template_resolver_json_parsing.py:133`,
+`test_template_resolver_inline_object_parsing.py:311`). MANDATORY (not optional): extend
+the consistency class with edge rows — JSON-string mid-path, None mid-path, OOB index,
+dict-in-list, and the one genuinely UNPINNED disagreement surface:
+`${a[0] ?? "f"}` with `a = [None]` — today `variable_exists` True / `resolve_value` None /
+coalesce returns **None, not "f"** (the dict-field variant is pinned at
+test_template_coalesce.py:371-374; the array-element variant is pinned by NOTHING — a
+merged `_walk` deriving found from value-is-non-None flips it silently). Land these rows
+BEFORE the merge.
+
+## Phase 3 — Relocate to core/
+
+1. **Move** `src/pflow/runtime/template_resolver.py` → `src/pflow/core/templates.py`
+   verbatim (collision verified: nothing named `templates` exists in src/). Promote
+   `_VAR_NAME_PATTERN` → `VAR_NAME_PATTERN` and `_LITERAL_PATTERN` → `LITERAL_PATTERN`
+   (keep underscore class aliases until phase 5 — `template_validation/validator.py:27`
+   and tests import the privates).
+2. **Shim**: `runtime/template_resolver.py` becomes
+   `from pflow.core.templates import TemplateResolver  # noqa: F401` + a docstring pointing
+   at the new home. Patterns are class attributes, so the class re-export covers every
+   consumer.
+3. **Re-point ALL src importers** to `pflow.core.templates`. Regenerate the inventory
+   with BOTH greps (≈28 src files / 43 lines @ 9ebd6280 — trust the grep, not the count):
+   `grep -rn "runtime.template_resolver" src/ --include='*.py'` AND
+   `grep -rn "from \.\.template_resolver\|from \.template_resolver" src/ --include='*.py'`.
+   While re-pointing, fix the two private-pattern reaches to use the promoted constants:
+   `core/cache_overlap.py:32` and `core/workflow/data_flow.py:33` switch from
+   `TemplateResolver._VAR_NAME_PATTERN` to `VAR_NAME_PATTERN` (data_flow's `_PFLOW_VAR_RE`
+   dies entirely in phase 4, but must not reference a private meanwhile).
+   Traps:
+   - `runtime/engine/error_context.py:13` uses a RELATIVE import
+     (`from ..template_resolver import`) — absolute greps miss it.
+   - 13 lazy in-function imports across `core/prompt_cache_analysis/*` + `core/prompt_cache.py`,
+     `core/trace_report.py:482`, `core/workflow/graph/scope.py:28`, `nodes/llm/llm.py:543`.
+4. **Simplification that comes free** (do it — it deletes a workaround):
+   `core/prompt_cache_analysis/context.py:47-54`'s `template_resolver()` accessor and the
+   lazy-import pattern exist SOLELY because of the core→runtime layer violation (its
+   docstring says so). Delete the accessor, hoist all its call sites
+   (`stages/row_builder.py:916/:928`, `stages/discrepancy/predict.py:368-411`,
+   `stages/cross_workflow.py:393-395`, `stages/warnings.py:482-531`, `context.py` itself)
+   and the other core/ lazy imports to top-level
+   `from pflow.core.templates import TemplateResolver`. Same for the
+   `data_flow.py:1421-1424` lazy import + comment.
+5. **Test updates**: only 3 monkeypatch sites import lazily and need the new path
+   (`tests/test_core/test_cache_analysis_analyze.py:5800`,
+   `test_cache_analysis_token_estimation.py:501/:521` — they patch the CLASS object, safe
+   across the move once the import line is updated). Verified: ZERO string-path patch
+   targets, ZERO importlib strings, ZERO caplog pins on the resolver's logger name.
+6. **Layering meta-test**: add to `tests/test_core/` an AST-scan (mirror
+   `test_litellm_runtime.py:837-920` mechanics) asserting NO module under `src/pflow/core/`
+   imports `pflow.runtime.template_resolver` or `pflow.runtime.template_validation`
+   (empty allowlist). Scope it to template modules ONLY — core→runtime imports exist
+   elsewhere (trace_report→workflow_trace, prompt_cache→node_state, trace_loading→cache);
+   those are pre-existing and OUT OF SCOPE; a blanket test would fail today.
+7. **Doc updates**: `runtime/CLAUDE.md:14/:58`, `runtime/engine/CLAUDE.md:342`,
+   `template_validation/type_checker.py:32` (comment), `architecture/architecture.md:526`,
+   `architecture/reference/template-variables.md:158/:922`,
+   `architecture/core-concepts/data-type-coercion.md:73/:90` (these two cite line numbers —
+   replace with the new path, drop line numbers).
+
+Note: `runtime/template_validation/` does NOT move (it imports core — the allowed
+direction). Only the resolver moves.
+
+## Phase 4 — Typed parse + drift-site migration
+
+### 4.1 The module interface (`src/pflow/core/templates.py` — single file)
+
+```python
+# ── Grammar constants (the single definition; exported) ──
+VAR_NAME_PATTERN: str            # promoted from TemplateResolver._VAR_NAME_PATTERN
+LITERAL_PATTERN: str             # promoted from TemplateResolver._LITERAL_PATTERN
+TEMPLATE_PATTERN: re.Pattern     # strict (unchanged semantics, $$-lookbehind)
+TEMPLATE_EXTRACT_PATTERN: re.Pattern  # loose (unchanged semantics)
+
+# ── AST (frozen dataclasses, slots) ──
+@dataclass(frozen=True) class Index:        value: int
+@dataclass(frozen=True) class DynamicIndex: ref: "Ref"   # inner ${var} — plain Ref ONLY
+                                                          # (today's _BRACKET_INDEX_PATTERN
+                                                          # accepts only a simple var inside)
+@dataclass(frozen=True) class Field:
+    name: str
+    indices: tuple[Index | DynamicIndex, ...]             # a.b[0][1] → Field("b",(Index(0),Index(1)))
+@dataclass(frozen=True) class Ref:
+    segments: tuple[Field, ...]   # segments[0] is the root (root may carry indices: data[0])
+    raw: str                      # original operand text — display, dedup, set membership
+    @property def root(self) -> str: ...                  # segments[0].name
+@dataclass(frozen=True) class LiteralOperand:   # NOT "Literal" — collides with typing.Literal
+    raw: str
+    value: Any                    # via try_parse_json. MUTABILITY RULE: parse() is lru_cached,
+                                  # so a stored [] / {} would be ONE shared instance handed to
+                                  # every resolution process-wide (batch threads, loop
+                                  # iterations) — a node mutating it would corrupt the cached
+                                  # AST. Store the parsed value for immutable scalars only;
+                                  # re-parse (fresh object) composite literals ([], {}) at
+                                  # resolution time
+    valid: bool                   # looks-literal (coarse first-char check) but failed grammar
+Operand = Ref | LiteralOperand
+@dataclass(frozen=True) class Expr:
+    operands: tuple[Operand, ...] # len > 1 ⇔ coalesce chain
+    span: tuple[int, int]         # offsets of ${...} in the source string, inclusive of ${ }
+    raw: str                      # inner text
+    resolvable: bool              # TWO-TIER acceptance, load-bearing: Expr-acceptance uses
+                                  # the PERMISSIVE shape (so `${a.0}`/`${a.}` stay visible
+                                  # to pass 5 as path errors, as today — NOT malformed
+                                  # errors); resolvable=True only for the resolution grammar
+                                  # (strict + dynamic-index). resolve() acts ONLY on
+                                  # resolvable Exprs; the malformed pass errors ONLY on
+                                  # Issues. This reproduces today's split where the runtime
+                                  # silently ignores `${a.0}` while pass 5 reports a path
+                                  # error on it
+@dataclass(frozen=True) class Issue:
+    raw: str; span: tuple[int, int]
+    kind: Literal["malformed", "bad_literal"]  # ONLY kinds consumers branch on today:
+                                  # bad_literal = the _malformed_literal_operand_hint case
+@dataclass(frozen=True) class ParsedTemplate:
+    source: str
+    exprs: tuple[Expr, ...]       # grammar-valid templates (strict view)
+    issues: tuple[Issue, ...]     # ${-candidates that failed the grammar
+    @property def is_simple(self) -> bool                 # source is exactly one Expr
+
+@functools.lru_cache(maxsize=4096)
+def parse(source: str) -> ParsedTemplate   # pure, total, never raises on user input
+
+def parse_ref(path: str) -> Ref | None     # bare path WITHOUT ${…} wrapper ("node.field[0]")
+                                            # → Ref via full-match of the var grammar; None if
+                                            # not a valid ref. Required by two consumers that
+                                            # hold path strings, not templates: type_checker's
+                                            # infer_template_type (called with bare operands)
+                                            # and workflow_output's -o path diagnoser
+
+def strip_template_markers(text: str) -> str  # "${x} y ${z}" → "x y z"; today's loose
+                                               # display-stripping (mermaid.py:775 — strips
+                                               # even empty/escaped, [^}]* semantics). Moves
+                                               # here so the grammar-uniqueness scan stays
+                                               # clean; mermaid calls this helper
+
+# ── Value walk (built on phase 2's _walk) ──
+class LookupStatus(Enum): FOUND; ROOT_ABSENT; PATH_ABSENT
+def lookup(ref: Ref, context: Mapping) -> tuple[LookupStatus, Any]
+def resolve(value: Any, context: Mapping) -> Any          # = today's resolve_nested semantics
+
+# ── Semantic rules (the #460 drift class — REQUIRED, this is a stated purpose of the
+#    task; do not drop). One home for the judgment calls currently encoded twice: ──
+TYPE_COMPATIBILITY_MATRIX / is_type_compatible(source, target)  # moves from type_checker.py:38-115
+TRAVERSABLE_TYPES / TRUSTED_TYPES / STRING_TYPES                 # the lists at path_validation.py:327/:335/:342
+                                                                  # and the inline copy at :291
+def runtime_base_type(type_str: str) -> str   # = engine/template_resolution._runtime_base_type
+                                              # (:30-44, generics-stripping incl. the union
+                                              # exception) — engine imports it from HERE
+def to_string(value: Any) -> str              # _convert_to_string rules, verbatim
+# Consumers after phase 4: type_checker.py + path_validation.py + type_validation.py import
+# the sets/matrix; engine/template_resolution.py imports runtime_base_type + the auto-parse
+# eligibility set (("dict","list","object","array") literals at :347-354). Zero logic change
+# — same values, one home, pinned by test_460 + the 1b union rows.
+
+# ── Facade definitions that must be stated (silent-failure guards) ──
+# has_templates(source) == bool(parse(source).exprs)  — EXPRS ONLY, not exprs-or-issues.
+#   Today `${}`/`${a`/`${a..b}` have has_templates=False → split_params classifies them
+#   static → silent passthrough to the node. Counting issues would flip unvalidated dict-IR
+#   runs from silent passthrough to strict errors.
+# Permissive-tier segmentation must reproduce split_template_path: empty path segments are
+#   DROPPED (trailing-dot `${first.stdout.}` is silent at EVERY layer today — verified live:
+#   validates clean, has_templates False, literal text ships. Preserve exactly.)
+
+# ── TemplateResolver stays, as the permanent string-helper facade ──
+# All existing public methods keep their exact signatures, reimplemented over
+# parse()/lookup()/resolve(). The long tail (prompt_cache stack etc.) never migrates.
+```
+
+Parser implementation rules (regex-TOKENIZED — no hand scanner, per ADR-0006):
+- Scan for `${` candidates left-to-right. A `$$`-escaped candidate that PARSES CLEANLY
+  produces NOTHING (no Expr, no Issue) — resolution leaves its text untouched,
+  has_templates stays False for it, the malformed check stays silent (today: permissive
+  findall has no lookbehind, so `$${var}` counts 1-valid-of-1). BUT an escaped candidate
+  that is itself malformed (`$${unclosed`, `$${}`) still yields an Issue — today these
+  ERROR (count 1 `${`, permissive findall 0). The escape skip applies ONLY to
+  cleanly-parsing candidates. Phase-1 corpus rows pin both cases (no existing test covers
+  `$$`+malformed — verified).
+- A candidate matching the strict grammar (extended with dynamic-index brackets) → Expr.
+  A candidate that does not → Issue; kind="bad_literal" iff it contains `??` and some
+  operand passes `is_literal_operand` but fails `LITERAL_PATTERN` fullmatch (this is
+  exactly `_malformed_literal_operand_hint`, validator.py:628-657); else "malformed".
+- DynamicIndex parsing replaces `_PERMISSIVE_PATTERN`'s reason to exist: `${a[${i}].x}`
+  parses directly (inner = plain Ref, one level — reject nesting deeper, as today).
+- Literal-first operand classification (keyword literals beat identifiers) — preserved.
+- The phase-1 corpus is the acceptance test for all of the above. Where the parser's
+  natural behavior would differ from today's counting logic, TODAY WINS.
+
+### 4.2 Per-site migration (exact inventory; signatures verified @ 9ebd6280)
+
+Internal package signatures MAY change; `validate_workflow_templates(workflow_ir,
+available_params, registry) -> list[Diagnostic]` and `extract_node_outputs(...)` MUST NOT.
+
+| Site | Today (verified) | After |
+|---|---|---|
+| `template_validation/validator.py::_validate_malformed_templates` (:660-735) | counts `${` vs `_PERMISSIVE_PATTERN.findall` + nested-count crediting (:682-697); targeted literal msg via `_malformed_literal_operand_hint` | `p = parse(value)`; error iff `p.issues`; kind=="bad_literal" → the targeted message, else the generic one. Counting + crediting logic deleted (absorbed by parser). Scope unchanged: walks only `node.params` (NOT batch/loop fields) — preserve this quirk |
+| `validator.py::_operands_in_string` (:743-757) | `_PERMISSIVE_PATTERN.findall` + `split_coalesce_operands` + literal drop | `for expr in parse(value).exprs: for op in expr.operands: if isinstance(op, Ref): yield (op, len(expr.operands) > 1)` — now yields `Ref` objects |
+| `validator.py::_extract_all_templates` (:805) / `_extract_cache_templates_for_unused_check` (:827) | `set[str]` of operand text | UNCHANGED return type (`set[str]` via `ref.raw`) so `_validate_unused_inputs` and the :116 union are untouched |
+| `validator.py::_field_checkable_templates` (:815-824) | `set[str]`, filtered `not in_coalesce` | yields `Ref`s (dedup by `.raw`); Pass 5 consumes segments directly. #441 policy (coalesce operands excluded) stays HERE, unchanged |
+| `path_validation.py::validate_template_path` (:73-79) + `validate_namespaced_output` (:207, inline bracket parse :225-232) + `validate_nested_path` (:253) | `split_template_path` (:97,:386) + hand-rolled `output_part[:bracket_pos]` slicing | take `Ref`; `parts` = `ref.segments`; bracket slicing replaced by `Field.indices`. The structure-walk LOGIC (lookup keys `f"{base_var}.{base_output}"`, `_validate_array_access` dispatch) is UNCHANGED — but `check_type_allows_traversal`'s type lists (:327/:335/:342, plus the inline copy at :291) now IMPORT the shared rules sets from 4.1 (same values, one home) |
+| `type_checker.py::infer_template_type` (:118, splits :141/:145/:169/:231) | `template.split(".")` + 3× `re.sub(r"\[\d+\]","",…)` | NOTE: it receives BARE operand strings (no `${…}` wrapper) — use `parse_ref(template)`, not `parse()`. Consume `Ref.segments` (`Field.name`, `bool(field.indices)` replaces the indexed-access detection at :178). `parse_ref` returns None → keep today's fallthrough. `TYPE_COMPATIBILITY_MATRIX`/`is_type_compatible` (:38-115) MOVE to the 4.1 rules home (type_checker imports them); union split `:222` stays here (type-string policy) |
+
+| `runtime/engine/template_resolution.py` (:30-44 `_runtime_base_type`, :121-167 `validate_resolved_type`, :347-354 auto-parse type literals) | hand-mirrored copies of the validator's type rules — born from drift bug #460 | import `runtime_base_type` and the auto-parse eligibility set from the 4.1 rules home. ZERO logic change — same values, one home. This row is the #460 fence made structural; without it the rules stay two manually-synced encodings |
+| `batch_item_validation.py::_check_batch_item_ref` (:150-151), `_build_batch_item_nested_diagnostic` (:253-254), `_extract_item_field_refs` (:127-135) | `field_path.split(".")` + `.split("[")[0]` + startswith/slice | consume segments; prefix matching via `ref.root == item_alias` + `segments[1:]` |
+| `validator.py::_loop_declared_outputs` (:378) | `key[len(node_id)+1:].split(".",1)[0].split("[",1)[0]` over node_outputs keys | NOTE: operates on node_outputs KEYS (not templates) — keep as-is but switch the segment strip to a shared helper if trivial; do not force-fit the AST |
+| `core/workflow/data_flow.py::_check_param_value` (:778-800) | `TEMPLATE_EXTRACT_PATTERN.finditer` + `split_coalesce_operands` + `is_literal_operand` + `_PFLOW_VAR_RE` gate (:286) | `for expr in parse(value).exprs: for op in expr.operands:` skip `LiteralOperand`; ALSO skip any operand containing a `DynamicIndex` (today the extract pattern truncates at the inner `}` so dynamic-index templates are INVISIBLE to data_flow — checking them would add forward-ref errors and double diagnostics with pass 5; preserve invisibility). Pass `op.raw` to `_validate_template_reference` (signature unchanged). Issues skipped silently — replaces the `_PFLOW_VAR_RE` gate (bash → Issue → skipped, same outcome). KNOWN NARROWING (accept + note in PR): a coalesce mixing a valid ref with a bad literal (`${second.stdout ?? [1,2]}`) is one Issue, so data_flow stops checking the valid ref — today it errors at BOTH entry points; after, only the WorkflowValidator-side malformed pass reports (direct `compile_workflow()` callers lose the check; all CLI/MCP paths validate first). Delete `_PFLOW_VAR_RE` (:33). Dict/list recursion (:801-819) unchanged |
+| `engine/template_errors.py::classify_unresolved_references` (:126-187) | `TEMPLATE_PATTERN.finditer` + split + literal skip; per-operand `get_node_status` + `variable_exists` (:173,:176) | iterate `parse(template_str).exprs`/operands; replace the exists-call with `lookup(ref, context)` (status PATH_ABSENT ⇔ today's path_error branch). `get_node_status` root check stays (node-state policy). INVARIANT: the `"absent"` string status must continue to derive from `NodeStatus.ABSENT` (which checks `__failures__` first), NEVER from `LookupStatus.ROOT_ABSENT` — a FAILED node's data lives in `__failures__` so its root is absent from the lookup context; deriving "absent" from the walk would make `output_resolver._is_all_absent_coalesce` silently skip a declared output whose primary FAILED instead of raising (the regression runtime/CLAUDE.md flags). `_suggest_field_correction` (:320-322) path rebuild → segment-based. DYNAMIC-INDEX content rule: when a dynamic-index Expr's INNER ref is the unresolved one (truth-table case 3), the diagnostic must name the inner ref (`${i}`), as today — the strict pattern only ever saw the inner; naming the full outer ref is a message change |
+| `core/markdown_parser.py::_parse_cache_code_block` (:1716-1768) | `_CACHE_TEMPLATE_RE.finditer` (:166); prose = inter-match slice (:1733); chunk_line from `content.count("\n",0,match.start())` (:1739) | iterate `parse(content)` in span order; prose/lines from spans identically. CHUNK-BOUNDARY RULE: a boundary is an Expr OR an Issue whose candidate has a closing `}` and non-empty inner text (today's `[^}]+` shape) — unclosed `${a` and empty `${}` are NOT boundaries, preserving the "must contain at least one ${var}" error for a `${}`-only block. Add pin rows for `${}`/unclosed to test_cache_block_parser.py first. CHARACTERIZATION DELTA: `_CACHE_TEMPLATE_RE` has no `$$` lookbehind; `parse` skips cleanly-escaped. Before switching, add a test pinning current `$$`-in-cache-block behavior; surface the decision in the PR — do not change silently. Duplicate-name/zero-template/trailing-prose-discard behaviors unchanged (covered by tests/test_core/test_cache_block_parser.py, 21 tests) |
+| `core/workflow/graph/scope.py::source_refs_in` (:26-40) | `_BRACE_BLOCK_RE` + `_REF_IN_BLOCK_RE` (accepts digit-leading roots) | per Expr → per Ref → `(ref.root, segments[1].name if len(segments)>1 else None)`. TWO CHARACTERIZATION DELTAS, both test-pinned + PR-noted: (1) digit-leading roots no longer extracted (validator-rejected input anyway); (2) indexed roots — `${data[0].field}` today yields `("data", None)` (the `_REF_IN_BLOCK_RE` boundary class makes post-bracket `.field` unreachable), new code yields `("data", "field")`, changing the output_field label on DATA_FLOW graph edges in `pflow visualize`. Recommended: accept both as corrections; pin the NEW behavior with tests and document the delta — never silent |
+| `engine/engine.py::_diagnose_carry_ref` (:75-112) | `seg.split("[",1)[0] for seg in var.split(".")` | `parse(template)`; reuse `Ref.segments` for the dict walk; coalesce/complex defer rule (:96) unchanged |
+| `cli/workflow_output.py::_diagnose_path_failure` (:289-337) | `_PATH_SEGMENT_PATTERN.findall` + per-prefix `variable_exists` (O(n²)) | NOTE: receives a BARE `-o` path — use `parse_ref(key)`; None replaces the reconstruction guard (invalid chars → generic syntax hint, same behavior). Build prefix Refs from segments; one `lookup` per prefix. The `[N]`-bracket nudge behavior is pinned by an existing test — keep it |
+
+Order within phase 4: (1) build `parse()` + AST against the phase-1 corpus; (2) reimplement
+`TemplateResolver` methods over it (all existing resolver suites must pass UNMODIFIED — this
+is the freeze gate); (3) migrate sites in table order, running the relevant suite after
+each — EXCEPT rows 2–5 plus the path_validation row, which are ONE ATOMIC STEP: the chain
+`_operands_in_string` → `_iter_template_operands`/`_node_template_value_sources`
+(validator.py:760-802, the traversal pivot) → `_extract_all_templates`/
+`_field_checkable_templates` → `validate_template_paths` (path_validation.py:30, its
+`set[str]` parameter becomes `Ref`s) shares types end-to-end; making row 2 yield `Ref`s
+breaks downstream consumers until they migrate in the same change. The suite cannot be
+green between those rows — land them together.
+
+## Phase 5 — Sweep and seal
+
+**Deletions** (each only after grep confirms zero remaining users):
+- `template_validation/validator.py`: `_PERM_VAR`, `_PERM_OPERAND`, `_PERMISSIVE_PATTERN`
+  (:46-50), `_malformed_literal_operand_hint` (absorbed into parser), the counting logic
+- `template_validation/utils.py`: `split_template_path` (+ its re-exports in `__init__.py`;
+  update `tests/test_runtime/test_nested_templates.py` imports — its 8 cases move to the
+  parser's segment tests, same expectations)
+- `core/templates.py` (post-move resolver internals): `resolve_nested_index_templates` +
+  `_BRACKET_INDEX_PATTERN` (DynamicIndex made them dead), the second traversal loop
+  (already dead after phase 2)
+- `core/markdown_parser.py`: `_CACHE_TEMPLATE_RE` (:166)
+- `core/workflow/graph/scope.py`: `_BRACE_BLOCK_RE`, `_REF_IN_BLOCK_RE` (:11-12)
+- `core/workflow/data_flow.py`: `_PFLOW_VAR_RE` (:33) [if not already removed in phase 4]
+- `runtime/template_resolver.py` shim — 18 TEST files import it (all import only the
+  `TemplateResolver` class — verified), so "zero importers" will NOT hold unless tests are
+  re-pointed. DECIDE NOW: re-point the 18 test imports in phase 5 (mechanical,
+  `from pflow.core.templates import TemplateResolver`) and delete the shim. Do that.
+- type_checker's `re.sub` index-stripping sites (dead after segment migration)
+- `cli/workflow_output.py`: `_PATH_SEGMENT_PATTERN` (:286 — dead after the parse_ref
+  migration)
+- The underscore pattern aliases on `TemplateResolver` (`_VAR_NAME_PATTERN`,
+  `_LITERAL_PATTERN`) — all reaches were re-pointed in phase 3 (`cache_overlap`,
+  `data_flow`) or deleted in phase 4/5 (`validator.py:49` dies with `_PERMISSIVE_PATTERN`).
+  The private METHODS `_convert_to_string`/`_get_dict_value` are KEPT — they are the
+  declared direct-test surface of `tests/test_runtime/test_template_resolver.py`.
+
+**Two remaining `${…}` regexes need explicit treatment** (the meta-test fails otherwise):
+- `runtime/template_validation/type_validation.py:29` `_QUOTED_TEMPLATE_PATTERN`
+  (`r"'\$\{([^}]+)\}'"` — shell single-quote escape hatch): rebuild it FROM the exported
+  grammar — `re.compile(rf"'{TEMPLATE_EXTRACT_PATTERN.pattern}'")` — so the string literal
+  no longer restates `\$\{` (the scan checks literals, so derivation passes naturally) and
+  the grammar has one home. Behavior identical (same inner `[^}]+`).
+- `src/pflow/mcp/auth_utils.py:14` `ENV_VAR_PATTERN` (`${VAR:-default}` bash-style env
+  substitution in MCP configs): a FOREIGN grammar, not pflow templates — ALLOWLIST it in
+  the meta-test with a rationale comment at both sites.
+- `core/workflow/graph/renderers/mermaid.py:775` (`re.sub(r"\$\{([^}]*)\}", r"\1", text)`,
+  display-only marker stripping): replace with the `strip_template_markers` helper from
+  4.1 (behavior identical — loose `[^}]*`, strips escaped/empty too).
+- `core/workflow/graph/renderers/mermaid.py:821-828` `_strip_template` — a SECOND manual
+  stripper in the same file (`value[2:-1].strip()` after startswith/endswith checks, used
+  by `_loop_label`): migrate to `extract_simple_template_var` with a fallback to
+  `strip_template_markers` (it is looser than the strict grammar — accepts any inner
+  including coalesce; preserve that acceptance).
+- `core/prompt_cache_analysis/stages/warnings.py:485` and `:528` — `stripped[2:-1]`
+  immediately after an `is_simple_template` check: two-line migration to
+  `extract_simple_template_var`. Do it.
+
+**Accepted ad-hoc survivors** (named so the "one grammar home" seal is honest — these are
+string-helper-territory reimplementations, meta-test-blind by nature, accepted as-is; do
+NOT migrate them in this task): `core/cache_overlap.py:57-90 _canonicalize_path` (hand
+segment-walker over canonical path tuples — and note its OWN `_PFLOW_VAR_RE` at :32/:131
+stays alive on the promoted constant), `core/prompt_cache_analysis/sub_workflow_walker.py`
+:105/:113-123/:440-452 (root/tail extraction + `_extract_template_inner`),
+`core/prompt_cache_analysis/stages/suggestions.py:150/:526`, `core/prompt_refs.py:118-130`
+(`_split_head`/`_extract_template_inner`), `core/trace_report.py:504-531`
+(`_check_path_against_upstream`, display-only suggestion walker — no bracket handling,
+known-degraded for indexed paths). If any of these is touched for OTHER reasons later,
+migrate it then.
+
+**Phase-1 drift file update (sanctioned, pre-declared)**: 1a's permissive-side assertions
+import `_PERMISSIVE_PATTERN`, which this phase deletes. Re-target those assertions to
+`parse()` (strict full-match ⇒ Expr with no Issue; permissive-discovery ⇒ Expr-acceptance
+per the two-tier rule), keeping every Mutation clause. This is a sanctioned re-target — the
+implication becomes partly tautological once both sides derive from one parser; that is the
+consolidation working, and the grammar-uniqueness meta-test inherits the mutation target.
+
+**Grammar-uniqueness meta-test** — new test in `tests/test_core/test_template_grammar_seam.py`,
+mirroring `tests/test_core/test_litellm_runtime.py:837-920` exactly: module-level allowlist
+`frozenset({"core/templates.py", "mcp/auth_utils.py"})` (each with a why-comment),
+`_find_repo_root()` via pyproject.toml parents-walk, `sorted(src_root.rglob("*.py"))`, text
+prefilter `if "$" not in source` (NOT `"${"` — the violation spelling `\$\{` does not
+contain the contiguous substring `${`; the litellm precedent's prefilter works because
+"litellm" appears verbatim in violations, which doesn't transfer here), then `ast.parse` +
+walk for `re.compile`/`re.match`/`re.search`/`re.findall`/`re.finditer`/`re.sub`/`re.subn`/
+`re.split` calls whose first arg contains `\$\{` or `\${` — checking plain string
+constants, module-level string assignments, AND the constant fragments of JoinedStr
+(f-/rf-strings): that is what lets the sanctioned derivation
+`re.compile(rf"'{TEMPLATE_EXTRACT_PATTERN.pattern}'")` pass naturally (its constant
+fragments are just quotes) while a restated `rf"\$\{{…"` is caught. Deliberately OUT of
+the test's scope (note in its docstring): `core/ir_schema.py:87-187`'s five jsonschema
+`^\$\{.+\}$` pattern strings — dict values, not `re.*` calls; documented-loose by design
+(validator.py:259). Violations → `pytest.fail` with file:line list and a fix-hint pointing
+at `core/templates.py`. No marker (in-process).
+
+**Doc updates in passing**: `template_validation/CLAUDE.md` (delete the stale
+`compile_validation.py imports validate_workflow_templates` row; update the 3-regex-role
+table to point at core/templates), `runtime/CLAUDE.md` Template System section,
+`core/CLAUDE.md` (new module entry), create `core/templates` section documenting the AST.
+
+## Phase 4/5 addendum — facts from the consumer inventory
+
+- The **public surface** `TemplateResolver` must keep forever (union of all external use):
+  `has_templates, resolve_template, resolve_nested, resolve_value, variable_exists,
+  extract_variables, split_coalesce_operands, is_literal_operand, is_coalesce_expression,
+  is_simple_template, extract_simple_template_var, extract_root_node_id,
+  extract_first_field_segment, resolve_coalesce` + patterns `TEMPLATE_PATTERN,
+  TEMPLATE_EXTRACT_PATTERN, SIMPLE_TEMPLATE_PATTERN` (+ promoted `VAR_NAME_PATTERN`,
+  `LITERAL_PATTERN`).
+- `resolve_nested_index_templates` has ZERO external callers (verified) — make it private/
+  delete in phase 5 once DynamicIndex resolution replaces it internally.
+- Tests importing privates `_convert_to_string` (×12) and `_get_dict_value` (×1) live in
+  `tests/test_runtime/test_template_resolver.py` — keep those privates (they're the
+  declared direct-test surface) or update the tests in the same PR that moves them.
+- `tests/test_core/test_prompt_cache.py:190-203` pins TEMPLATE_PATTERN agreement with the
+  cache-prefix resolver — runs unchanged; do not break.
+
+## Verification
+
+**Per-phase gates** (every phase): `make test` and `make check` green; no existing test
+modified except where a phase explicitly says so (phase 3 import-path updates; phase 5
+`test_nested_templates.py` migration; phase 4/5 characterization deltas, each with an
+explicit decision recorded in the PR description).
+
+- **Phase 1**: new `tests/test_runtime/test_template_drift.py` passes against UNMODIFIED
+  production code. Run `uv run pytest tests/test_runtime/test_template_drift.py -x -q`.
+- **Phase 2**: `uv run pytest tests/test_runtime/ tests/test_cli/test_workflow_output_handling.py -q`
+  — all green with zero test edits. Grep confirms `_traverse_path_part`/`_check_array_indices`
+  gone.
+- **Phase 3**: full suite green; layering meta-test green; subprocess lazy-import test
+  (`tests/test_cli/test_lazy_imports.py`, e2e) still green —
+  `uv run pytest -m e2e tests/test_cli/test_lazy_imports.py` (the moved module must not
+  drag litellm into the CLI chain; it imports only stdlib + `core.json_utils`, so this is
+  a confirmation, not a risk).
+- **Phase 4**: after step (2) — resolver suites pass UNMODIFIED (the freeze gate). After
+  each table-row migration — that site's suite (`test_template_validation/`,
+  `test_core/test_cache_block_parser.py`, `test_core/test_graph_build.py` +
+  `test_core/test_mermaid.py` for scope.py, etc.). Phase-1 drift file green throughout.
+- **Phase 5**: grammar-uniqueness meta-test green; grep
+  `_PERMISSIVE_PATTERN|split_template_path|_CACHE_TEMPLATE_RE|_BRACKET_INDEX_PATTERN`
+  returns only historical references in docs/task files, and
+  `grep -rn _PFLOW_VAR_RE src/pflow/core/workflow/` returns nothing — NOTE:
+  `core/cache_overlap.py` has its OWN same-named `_PFLOW_VAR_RE` (:32, live use :131)
+  which deliberately survives on the promoted constant; do not let the grep claim trip
+  on it.
+
+**Final acceptance** (the task's Requirements, mechanized):
+1. `tests/test_runtime/test_template_drift.py` — soundness + grammar coherence + 6 named
+   historical regressions, all green.
+2. Grammar-uniqueness AST-scan green (exactly one `${…}` grammar home).
+3. Layering AST-scan green (core never imports runtime template modules).
+4. Full `make test` + `make check` + `make test-e2e` green.
+5. Behavioral spot-check (manual, end-to-end): run an example workflow exercising
+   templates+coalesce+batch (e.g. from `examples/`) before phase 1 and after phase 5;
+   outputs byte-identical. `uv run pflow <example>.pflow.md` — traces land in
+   `~/.pflow/debug/` for comparison.
+
+## Implementation guardrails
+
+- NEVER weaken a drift test to make a phase pass — fix the divergence (the
+  `test_plan_drift.py` contract).
+- When the parser's natural behavior differs from today's regex behavior, TODAY WINS;
+  any deliberate delta (the two characterization deltas in phase 4/5) needs its own test
+  + an explicit note, never a silent change.
+- Raise `PflowError` subclasses only (never vanilla exceptions) — though this plan should
+  add NO new raise sites: parse is total, resolve never raises, error policy stays with
+  existing callers.
+- Each phase is a separate commit series ending green; do not interleave phases.
+- If a phase reveals a behavior question this plan doesn't answer, the phase-1 corpus is
+  the arbiter; if it's not in the corpus, STOP and surface the question rather than guess
+  (epistemic manifesto: ambiguity is a stop signal).
+
+## Reference anchors (read before starting)
+
+- `.taskmaster/tasks/task_170/task-170.md` — the what/why, frozen-behavior list, scope
+- `context/adr/0006-template-language-no-shared-walk.md` — decided shape + rejected
+  alternatives (do not re-open: no World port, no hand scanner, no test generator)
+- `context/CONTEXT.md` — Template / Reference / Coalesce / Operand vocabulary
+- `src/pflow/runtime/template_resolver.py` — read in full first (884 lines)
+- `src/pflow/runtime/template_validation/CLAUDE.md` — pass map, 3-regex-role contract
+  (note: its claim that compile_validation imports validate_workflow_templates is STALE)
+- `tests/test_execution/test_plan_drift.py` — the drift-test idiom to mirror
+- `tests/test_core/test_litellm_runtime.py:837-920` — the AST-scan idiom to mirror

--- a/.taskmaster/tasks/task_170/starting-context/braindump-template-language-session.md
+++ b/.taskmaster/tasks/task_170/starting-context/braindump-template-language-session.md
@@ -1,0 +1,152 @@
+# Braindump: Task 170 — the session that produced the spec, ADR-0006, and the plan
+
+Written by the agent that ran the architecture review, the design exploration, and the plan
+authoring (2026-06-11). Everything procedural is in
+`implementation/implementation-plan.md` — this captures what is NOT written down.
+
+## Where I Am
+
+Plan approved by the user in plan mode, copied to
+`.taskmaster/tasks/task_170/implementation/implementation-plan.md`. Zero implementation has
+happened. ADR-0006 and the CONTEXT.md vocabulary (Template/Reference/Coalesce/Operand)
+already landed on branch `chore/audit-followup-hardening` (uncommitted as of this writing —
+check `git status` before assuming they're committed).
+
+## User's Mental Model — use their words
+
+- The whole task came from "find the biggest win possible" (architecture review). Candidate 2
+  (planner/engine parity) lost to this only on evidence-vs-cost; the user cares about
+  **leverage**, not completeness.
+- The directive that shaped every design decision, verbatim: *"We should prioritize
+  simplicity of the FINAL code, not how easy it is to get there. When in doubt we should ask
+  ourselves whats the right solution that the top 10% of codebases similar to this one would
+  implement, have we considered it yet?"* — and the qualifier: *"this is about more simple
+  code that is optimized for AI agents to understand and add features to"*, explicitly NOT
+  about impressing anyone with architecture.
+- Their closing priority, verbatim: *"the important thing is that we move in the right
+  direction and can extend later and that this will be high leverage for stopping bugs and
+  making the code more extendable and understandable for ai agents like you."* Translation I
+  operated under: **if forced to trade, choose drift-bug prevention and agent legibility over
+  scope completeness; stopping after an early phase is an acceptable outcome, shipping a
+  clever abstraction is not.**
+- Process preferences they stated: phases, NOT separate PRs ("we dont need to split it into
+  prs but it should be split into PHASES"); task spec is what/why only, plan owns the how;
+  use `pflow-codebase-searcher` subagents for verification, **never Explore** (they repeated
+  this — it's also in CLAUDE.md).
+- They grilled the "9 files → 1 edit site" claim and I conceded it was an overclaim. The
+  honest framing we settled on, which they accepted: **the win is that forgetting a consumer
+  becomes loud instead of silent**, not that edit counts drop to one. If you find yourself
+  justifying work by edit-count arithmetic, you're off their map.
+
+## Design genealogy the ADR doesn't capture
+
+Four competing interface designs were produced by parallel forks: A (minimal 3-entry-point),
+B (two-world ports & adapters with HIT/MISS/UNKNOWABLE), C (evolve-in-place staging),
+D (AST-as-interface). The final shape = D's AST + A's interface discipline + C's sequencing,
+with B **rejected entirely**. ADR-0006 records the rejection, but the argument that actually
+killed B — useful if anyone re-proposes sharing the walk: B's headline claim was
+"type-forced correspondence" (a new runtime capability forces a validator-side stance via
+the type system). We debunked it: a new behavior lands in one adapter's *body*; nothing in
+the types forces the other adapter to react. The drift protection was always coming from the
+shared AST + parity tests, which the chosen design keeps. Also: CEL (checker/interpreter),
+actionlint, and JMESPath were the "top 10%" precedents — all share the AST and conformance
+tests, none share the walk.
+
+C's lasting contribution: tests land BEFORE production changes, and it corrected two of my
+own claims (the "private reaches" actually *import* the attribute, so they auto-sync; the
+double-walk is worse than I'd said — `_resolve_complex_match` pays it too).
+
+## Hard-won knowledge / things that surprised me
+
+- **Reviewers who EXECUTED code beat reviewers who read code.** Five review agents ran over
+  the plan (1 structural + 4 lenses). The highest-value findings came from live execution:
+  my DynamicIndex "leaves text unchanged" description was flat wrong (2 of 3 failure modes
+  partially SUBSTITUTE text and pass through silently); `${first.stdout.}` is silent at
+  every layer today. **When you hit a behavior question during implementation, run the
+  resolver in a REPL — do not reason from the regexes.** Several "obvious" descriptions in
+  earlier drafts were wrong.
+- Three of the six historical regression tests as originally specced would have been green
+  with their bugs reverted (test_460 wrong code path, test_d5a1af8c wrong validator,
+  test_8535ed9b wrong commit — it's 4516cd72). The plan now has the corrections, but the
+  meta-lesson stands: **for each 1c test, first revert-check mentally: "would this fail if
+  the fix were undone?"**
+- The `resolvable: bool` two-tier rule on Expr (permissive-shaped acceptance, strict
+  resolvability) is MY synthesis to resolve a real conflict found late (the permissive∖strict
+  grammar gap: `${a..b}` must stay a pass-5 path error, not become a malformed error). It is
+  specified in the plan but was never prototyped. NEEDS VERIFICATION: that the
+  empty-segment-dropping rule reproduces `split_template_path` exactly for the gap shapes —
+  the phase-1 corpus rows are the arbiter.
+- Counts drifted between searcher passes (33 vs 28 importer files, 16 vs 15 core files).
+  The plan now says "trust the grep, not the count" — take that seriously.
+
+## Assumptions & Uncertainties
+
+- ASSUMPTION: implementation happens on a fresh branch off `main`, not on
+  `chore/audit-followup-hardening`. The ADR/CONTEXT/spec/plan files in the task folder need
+  to ride along (they may still be uncommitted — verify, and ask the user where to commit
+  them if unclear; remember the project rule: NEVER commit without explicit instruction).
+- ASSUMPTION (unconfirmed by user): `lru_cache(maxsize=4096)` is fine because workflows hold
+  a few dozen distinct template strings. Never measured. Don't optimize; just don't shrink it.
+- UNCLEAR: whether the user wants the root `CLAUDE.md` updated (Task 170 isn't in its
+  roadmap list, and the list still carries the stale Task 133 "Unified Per-Node Storage"
+  title — flagged twice in the session, never fixed). Surface it at the end, don't do it
+  unprompted mid-task.
+- NEEDS VERIFICATION at phase 4: the cache_analysis tests monkeypatch
+  `TemplateResolver.resolve_template` as a CLASS attribute (3 sites, listed in the plan).
+  The facade reimplementation must keep those methods as the genuine call path for the
+  analysis stack, or the monkeypatches silently stop intercepting (the patch would hit a
+  method nothing calls). Check this when reimplementing the facade.
+
+## Unexplored Territory
+
+- UNEXPLORED: `architecture/reference/template-variables.md` (922+ lines) likely documents
+  template behaviors with examples nobody cross-checked against the phase-1 corpus. Cheap
+  win: skim it while building the corpus; it may contain documented edge cases the session
+  never surfaced — and it needs path updates in phase 3 anyway.
+- CONSIDER: the corpus rows that pin "silent garbage pass-through" (dynamic-index case 1,
+  trailing-dot) are pinning behavior that is arguably BAD. The user never saw those
+  specific cases. If during implementation one feels intolerable to pin, that's a legitimate
+  stop-and-ask — frame it as "pin or sanctioned delta #N", same mechanism the plan already
+  uses for the scope.py/escaped-visibility deltas.
+- MIGHT MATTER: `make check` runs ruff/mypy — the new module is the first heavily
+  frozen-dataclass + pattern-matching code in `core/`; if the repo's Python floor (3.10)
+  matters for `match` exhaustiveness checking via mypy, verify early rather than after
+  writing all interpreters.
+
+## What I'd Tell Myself
+
+- Phase 1 is the whole ballgame. Budget real care there; everything after is mechanical
+  BECAUSE phase 1 is good. If a corpus row's expected value surprises you, that's signal,
+  not friction.
+- Resist every "while I'm here" improvement. The plan's accepted-survivors list and the
+  do-NOT-touch pair-caller list exist because reviewers kept (correctly) finding adjacent
+  mess — the user explicitly scoped it out. The sanctioned deltas are enumerated; the count
+  is closed. Anything new = stop and surface.
+- The guardrail hierarchy when instructions seem to conflict: phase-1 corpus > "TODAY WINS"
+  > plan prose. The plan was edited many times by review findings; if two sentences disagree,
+  the corpus + the verified truth tables win, and the conflict is worth reporting back.
+
+## Relevant Files & References
+
+- `implementation/implementation-plan.md` — THE document; read fully before anything.
+- `task-170.md`, `context/adr/0006-template-language-no-shared-walk.md`,
+  `context/CONTEXT.md` (new terms near the Retry cluster).
+- Review idioms to mirror: `tests/test_execution/test_plan_drift.py` (mutation docstrings),
+  `tests/test_core/test_litellm_runtime.py:837-920` (AST scan),
+  `tests/test_runtime/test_template_validation/test_validator.py:12-127` (mock registry).
+- The session's architecture review HTML lived in $TMPDIR — ephemeral, nothing load-bearing
+  in it that isn't in the task spec.
+
+## For the Next Agent
+
+Start by reading the plan end-to-end, then `template_resolver.py` end-to-end (884 lines),
+THEN write the phase-1 corpus — in that order. Don't parallelize phase 1 across subagents;
+the corpus's value is one mind holding all the edge cases at once. Use
+`pflow-codebase-searcher` (never Explore) for verification questions, `test-writer-fixer`
+for test-file authoring with the corpus handed over as data, `code-implementer` only for
+the mechanical phases (3, parts of 5). The user reads progress through behavior: show
+expected before/after output when a decision point arises, per CLAUDE.md.
+
+> **Note to next agent**: Read this document fully before taking any action. When ready,
+> confirm you've read and understood by summarizing the key points, then state you're ready
+> to proceed.

--- a/.taskmaster/tasks/task_170/task-170.md
+++ b/.taskmaster/tasks/task_170/task-170.md
@@ -1,0 +1,220 @@
+# Task 170: One Template Language — consolidate `${…}` into core/templates
+
+## Description
+
+Give the `${…}` template language a single owning module: one parser producing a typed
+structure, one value walk, one home for the semantic judgment calls — with the validator
+consuming the same parsed segments and rules instead of re-implementing them. This closes the
+codebase's worst drift seam (validation-time vs runtime template behavior) and makes the
+language one small, typed thing an agent can load whole.
+
+## Status
+
+not started
+
+## Priority
+
+high
+
+## Problem
+
+The template language has no owner. An architecture review (2026-06-11) found, with file:line
+evidence:
+
+- **7 regex families** parse `${…}` (canonical 3-role contract in `TemplateResolver`, plus
+  uncontracted copies in `markdown_parser._CACHE_TEMPLATE_RE`, `graph/scope.py` — which accepts
+  digit-leading roots the canonical grammar rejects — and ad-hoc one-liners).
+- **6+ independent path walkers** for `a.b[0].c` — including two near-identical loops *inside*
+  `TemplateResolver` itself (`resolve_value` vs `variable_exists`/`_traverse_path_part`), which
+  can disagree (exists=True, resolve=None) and which `resolve_coalesce` AND
+  `_resolve_complex_match` each call twice per operand.
+- **4 encodings of the type rules** (the str-auto-parses-as-JSON judgment is re-stated in ≥4
+  places; the validator's compatibility matrix documents itself as a hand-maintained mirror of
+  runtime coercion).
+- **13 files split `??` operands themselves.**
+- The static validator is a hand-written model of the resolver, held in sync only by comments:
+  **≥7 shipped drift bugs** (#441 coalesce field-check, #460 generic-type drift, #266 `$${var}`
+  escape, d5a1af8c batch dotted refs, 6b7faf8f batch-on-workflow, 8535ed9b malformed false
+  positive, plus the historical save-vs-compile drift) and **no parity test** (verified: no test
+  file exercises both `validate_workflow_templates` and resolver resolution).
+- **Layering is inverted**: 16 `core/` files import `pflow.runtime.template_resolver` (core must
+  not import runtime), two of them via private attributes.
+- The strict/permissive grammar split is partly an artifact: `${a[${i}].x}` is valid language
+  the strict regex can't express, so runtime grew a string-rewrite pre-pass
+  (`resolve_nested_index_templates`) and validation grew a second grammar
+  (`_PERMISSIVE_PATTERN`).
+
+The failure mode is silent: a forgotten consumer is a regex that quietly stops matching, so
+validation silently skips templates — the shape of several of the bugs above.
+
+## Solution
+
+One module, `core/templates` (single file initially; split only if it grows), owning:
+
+- **One error-tolerant parse** (regex-*tokenized* internally — reuse the battle-tested
+  patterns, no hand-written scanner) producing an immutable typed structure: template segments
+  (text / expression), expressions with operands (reference or literal), references with path
+  segments (field / index / **dynamic index** — first-class, retiring both the rewrite pre-pass
+  and the permissive second grammar), parse issues as data (not exceptions), and source spans
+  (needed by cache-block chunking). Parse results are cached (`lru_cache`) — engine, planner,
+  and validator share one parse with no invalidation story.
+- **One value walk** (`lookup`/`resolve`): JSON auto-parse, `??` fall-through, index bounds,
+  stringification — the single home for resolution semantics.
+- **One home for the judgment calls** that drifted historically: stringification rules,
+  traversability ("which types may be walked into"), type compatibility (the #460 class).
+- **String-in/string-out helpers stay public permanently** (`extract_root_node_id`-style),
+  backed by `parse()` internally — the lasting interface for the long tail of callers whose
+  question is genuinely string-shaped. The long tail (e.g. `prompt_cache_analysis` one-liners)
+  is NOT migrated to the AST.
+
+The **validator keeps its own direct structure-walk** over the same parsed segments, consuming
+the shared rules — deliberately NOT unified with the runtime walk behind an abstraction (see
+ADR-0006). Validator policy (namespacing, batch index-blocking, coalesce field-check exemption,
+diagnostic wording) stays in `template_validation/` — the module hides the language, not its
+callers' judgments.
+
+Drift becomes loud through three meta-tests (pflow's native mechanism):
+1. **Parity drift tests** — fixed table corpus + the historical bugs as named fixtures
+   (mirrors `test_plan_drift.py`: "fix the divergence, never the test").
+2. **Grammar-uniqueness AST-scan** — no regex containing `\$\{` compiled outside
+   `core/templates` (same shape as the litellm seam test).
+3. **Core-does-not-import-runtime** pin once the module moves (closes the 16-file inversion).
+
+### Phases (each a legitimate resting point, in this order)
+
+1. **Parity drift tests first** — land the corpus + historical fixtures + grammar-coherence
+   assertions against the *current* code, before any production change. Pure bug-stopping at
+   zero risk; everything after executes under its protection.
+2. **One internal walk** — merge the duplicated traversal loops inside `TemplateResolver`
+   behind a single found/value walk; coalesce and complex-match resolution stop walking twice.
+3. **Relocate to `core/`** — module moves, `runtime/template_resolver.py` becomes a shim,
+   16 core importers point the right way, layering meta-test lands.
+4. **Typed parse + drift-site migration** — the AST and `parse()`; migrate the sites where
+   drift actually lived: validation passes, `data_flow` operand loop, engine resolution,
+   `template_errors` classification, cache-block chunking, `graph/scope.py`.
+5. **Sweep and seal** — delete `split_template_path`, `_PERMISSIVE_PATTERN` machinery, the
+   rewrite pre-pass, ad-hoc regex copies and the shim's dead halves; grammar-uniqueness
+   AST-scan lands. Net LOC returns to ~baseline or below.
+
+## Design Decisions
+
+- **Separate walks, shared AST + rules — no World/port abstraction**: a fully worked
+  ports-and-adapters design (ValueWorld/StructureWorld) was rejected via the deletion test;
+  top-tier analogues (CEL checker/interpreter, actionlint, JMESPath) share the AST and
+  conformance tests, not the walk. Recorded as **ADR-0006** — do not re-litigate.
+- **Regex-tokenized parser, not a hand scanner**: the scanner was the riskiest part of the
+  AST design for zero interface payoff; the existing regexes become the tokenizer.
+- **Table corpus, not a property-test generator**: generation rejected as premature — the
+  table covers every observed failure; build a generator only if a drift escapes the table.
+- **Dynamic index as an AST node**: earns its place by *deleting* two existing hacks (rewrite
+  pre-pass + second grammar) — not by hypothetical future syntax.
+- **Speculative vocabulary trimmed**: an AST node or issue-kind exists only when a consumer
+  branches on it (e.g. no `Escaped` node if `Text` suffices; issue kinds defined by actual
+  consumers during implementation).
+- **Partial migration is the end state, not a compromise**: drift sites move to the AST;
+  string helpers remain the permanent public interface for everyone else.
+- **Phases, not parallel work**: order is load-bearing (tests before production change);
+  each phase leaves the codebase strictly better and is independently stoppable.
+- **Module home `core/`**: forced by the 16-file inversion; precedent `core/trace_io.py`.
+- Vocabulary fixed in `context/CONTEXT.md`: **Template, Reference, Coalesce, Operand**.
+
+## Dependencies
+
+None.
+
+## Requirements
+
+### Behavior freeze (no user-facing change anywhere in this task)
+- JSON auto-parse on traversal: containers only; numeric strings stay strings (the
+  Discord-snowflake rule).
+- Simple templates preserve type; complex templates stringify via the exact
+  `_convert_to_string` rules.
+- `$$` escape: prevents resolution, does NOT strip the extra `$` (frozen partial behavior).
+- `??` falls through on absent root OR absent field (#441); a literal operand always resolves
+  and ends the chain; literal-first matching (keyword literals win over same-spelled
+  identifiers).
+- Literal grammar constraints: no leading-zero numbers, no `??` inside strings, composite
+  literals excluded — must remain exactly aligned with what `try_parse_json` +
+  operand-splitting can handle at runtime.
+- Hyphens allowed in identifiers; nested bracket index (`${a[${i}].x}`) resolves to the same
+  observable outcomes as today's pre-pass (non-int or unresolved inner → whole ref unresolved,
+  template text unchanged).
+- Unresolved templates remain textually unchanged in output; strict-mode error policy stays
+  with the engine.
+- Complex-template interpolation: write a characterization test for today's sequential
+  `str.replace` behavior (resolved values containing `${…}`-like text) BEFORE changing
+  interpolation; any diff is a frozen-behavior decision, not a silent improvement.
+- `output_resolver._is_all_absent_coalesce` keeps its deliberately stricter semantics —
+  consumes parsed operands but is NOT absorbed.
+
+### Parity (the point of the task)
+- One-way soundness: for templates over declared structure with conforming data, runtime
+  resolves ⟹ validator emitted no ERROR (the validator may under-check, never over-reject).
+- The six historical drift bugs exist as named regression fixtures citing issue/commit.
+- Grammar coherence: every strictly-valid template is also discoverable by the loose/
+  validation views; every literal-grammar match round-trips `try_parse_json`.
+- Existence and resolution cannot disagree (single walk: found ⟺ value produced).
+
+### Structure
+- Exactly one place in `src/` compiles a `${…}` grammar (mechanically enforced).
+- `core/` no longer imports `runtime` for template functionality; no private-attribute
+  reaches across the module's interface remain.
+- Validation passes, `data_flow`, engine resolution, error classification, and cache chunking
+  consume parsed segments/operands — no `str.split(".")`-style re-segmentation at those sites.
+- The module is importable without `litellm` entering `sys.modules` (repo invariant).
+- Parse is pure, total (never raises on user input), and cached; malformedness is data.
+
+### Out of scope
+- Any new template syntax or semantics.
+- Unifying the validator's structure walk with the value walk (ADR-0006).
+- Migrating the string-helper long tail to the AST.
+- The type-compatibility matrix's *content* (only its home consolidates).
+
+## Implementation Notes
+
+- Phase 4 is roughly half the total effort; the validation-pass migration
+  (`path_validation.py` is the heaviest consumer) dominates it. Whole task ≈ a focused week;
+  phases 1–3 ≈ two days and capture most of the bug value.
+- Net size: ~400–500 LOC module replacing ~450 LOC of scattered patterns/splitters/duplicate
+  walks — approximately LOC-neutral after phase 5.
+- Phase 3 prep: grep for importlib string paths, monkeypatch tuples, and caplog logger names
+  before moving symbols (Task 160's silent-failure lesson).
+- Known behavior deltas to test-gate in phase 5: `_CACHE_TEMPLATE_RE` lacks the `$$`
+  lookbehind the canonical extractor has; `graph/scope.py` accepts digit-leading roots
+  (validator-rejected input anyway). Each replacement needs a characterization test and an
+  explicit decision.
+- `_PERMISSIVE_PATTERN` has no `$$`-escape handling — the phase-1 corpus will force an
+  explicit decision (carve-out vs documented permissiveness).
+- Stale docs to fix in passing: `template_validation/CLAUDE.md` claims `compile_validation.py`
+  imports `validate_workflow_templates` (false — template passes run only in
+  `WorkflowValidator`); update the consumer table when touching the package.
+- The two "private reaches" (`data_flow.py:33`, `cache_overlap.py:32`) import the attribute
+  (auto-sync) — hygiene, not a live drift risk; fix by exporting, don't treat as urgent.
+
+## Verification
+
+- `make test` and `make check` green after every phase (each phase is shippable).
+- Phase 1's drift-test file passes against unmodified production code (proves the corpus
+  encodes current behavior, not aspirations).
+- Phase 2 gated by a differential test (old vs new walk over a path×context corpus), deleted
+  with the second loop.
+- All Requirements→Parity properties hold continuously from phase 1 onward; all
+  Requirements→Structure properties hold by end of phase 5, each pinned by a meta-test.
+- The existing resolver/validation suites pass unmodified through phases 2–4 (they are the
+  behavior-freeze harness; the markdown/scope characterization deltas in phase 5 are the only
+  sanctioned test changes, each with an explicit decision recorded).
+
+## References
+
+- `context/adr/0006-template-language-no-shared-walk.md` — the decided shape + rejected
+  alternatives (created with this task)
+- `context/CONTEXT.md` — Template / Reference / Coalesce / Operand vocabulary
+- `src/pflow/runtime/template_resolver.py` — current canonical grammar + the duplicated walk
+- `src/pflow/runtime/template_validation/` (+ its CLAUDE.md: 3-regex-role contract, pass map)
+- `src/pflow/core/workflow/data_flow.py` (operand loop ~:779; `_PFLOW_VAR_RE` :33)
+- `src/pflow/core/markdown_parser.py` :166, `src/pflow/core/workflow/graph/scope.py` :11-13,
+  `src/pflow/runtime/engine/template_resolution.py`, `template_errors.py` — drift-site
+  consumers for phase 4
+- `tests/test_execution/test_plan_drift.py` — the in-repo precedent for seam-pinning drift
+  tests; `tests/test_core/test_litellm_runtime.py` — precedent for the AST-scan meta-test
+- Drift rap sheet: #441, #460 (PR #461), #266, commits d5a1af8c, 6b7faf8f, 8535ed9b

--- a/.taskmaster/tasks/task_171/starting-context/braindump-2026-06-12-split-session.md
+++ b/.taskmaster/tasks/task_171/starting-context/braindump-2026-06-12-split-session.md
@@ -1,0 +1,38 @@
+# Braindump: how this task was born (short, tailored)
+
+task-171.md says WHAT; this says how much to trust it and what was never decided.
+
+## Trust calibration — read this first
+
+**This spec is a carve, not a grilled design.** It was distilled (2026-06-12) from Task 125's
+durable phase + session insights, with NO dedicated codebase verification pass — unlike
+task-125.md and task-164.md, whose claims carry verified `file:line` refs. Treat every
+mechanism claim here as "ASSUMED from the 125 spec"; re-verify against code at start. And by
+the time you read this, Task 164's task-review will exist — **read it before this spec's
+Implementation Notes**; the substrate's real shape beats my predictions.
+
+## Assertions of mine the user never confirmed
+
+- ASSUMPTION: **"one restore reader, two state sources"** (164 reads a sanitized trace, this
+  task reads its own faithful checkpoint file; both feed one seed path). I'm ~85% sure it's
+  the right shape; it's my design call, echoed into 164's Dependencies, but no human approved
+  it. If 164 implemented restore differently, follow 164.
+- ASSUMPTION: the **distinct exit code for "paused, token emitted"** requirement — I invented
+  it (agent-UX reasoning: callers must distinguish paused from failed). Plausible, unreviewed.
+- UNDECIDED (the user never weighed in): **token security** (sign/encrypt vs trust local fs)
+  and the **`pflow resume` CLI surface collision** with 164. Both are flagged in the spec as
+  open — they are genuinely open, not rhetorically open. Get user decisions.
+
+## Context that shaped the scope
+
+- The split exists because of the user's one-big-PR-per-task convention; this task must stay
+  a THIN trigger over 164's substrate. The spec's "design smell" warning (a parallel
+  serialization/walk-entry path growing here) is the failure mode I'd bet on — the session
+  that created this task spent a week's effort un-forking exactly that kind of duplication
+  (issue #504 / PR #505).
+- CONSIDER: **this task is what unlocks gates for the MCP server** (MCP can't prompt; 125
+  just fails loudly there). The token needs to surface in `execution_service`'s structured
+  result, not only CLI stdout — nobody has designed that surface.
+
+> **Note to next agent**: Read this fully, then 164's task-review, then task-171.md. Confirm
+> by summarizing key points before proceeding.

--- a/.taskmaster/tasks/task_171/task-171.md
+++ b/.taskmaster/tasks/task_171/task-171.md
@@ -1,0 +1,168 @@
+# Task 171: Durable Resume Tokens & Non-TTY Gates
+
+## Description
+
+The durable half of human-in-the-loop gates: when a gate fires (or an agent escalates) and
+no human is at the TTY, persist the run's state to disk, emit a self-contained resume token,
+and exit — the human answers hours or days later with `pflow resume <token> --approve yes|no`
+and the run continues without re-executing completed nodes. Carved out of Task 125's
+"durable phase" (2026-06-12) so each task ships as one PR; it is a thin trigger over the
+checkpoint→restore→continue substrate Task 164 builds.
+
+## Status
+
+not started
+
+## Priority
+
+medium
+
+## Problem
+
+Task 125's blocking gates require a human present during the run — the pause lives in-process
+and dies with it. That excludes the contexts where gates matter most: CI, scheduled/cron runs,
+long-running agent harnesses where the human checks in asynchronously, and any non-TTY caller
+(MCP, pipes). Without durability, a gate in an unattended run is a hang or a hard stop, and
+the decision the human owed the workflow is lost with the process.
+
+## Solution
+
+At an unanswerable gate (non-TTY, or `--no-block`-style policy TBD):
+
+1. Checkpoint: serialize the shared store (completed node outputs), the pause position, the
+   workflow identity (path/name + definition hash), and the original input params to
+   `~/.pflow/resume/<execution-id>.json`.
+2. Emit a compact, self-contained resume token referencing that state; exit cleanly with a
+   parseable message.
+3. `pflow resume <token> --approve yes|no` loads the state, reconstructs the shared store,
+   and — via Task 164's restore+continue substrate — runs the gated node and everything after
+   (approve) or exits with a clear cancellation message (deny).
+
+The gate trigger and the structured decision payload come from Task 125; the
+restore-and-continue mechanics come from Task 164; this task adds only the durable seam:
+the checkpoint writer, the token, the resume-state lifecycle, and the `pflow resume` CLI.
+
+## Design Decisions
+
+- **Why this is its own task (2026-06-12):** the original build order was a sandwich
+  (125-blocking → 164 → 125-durable), which contradicts the one-PR-per-task convention —
+  half a task shipping twice. Decision: split. Build order is now **125 → 164 → 171**.
+- **Thin trigger over 164's substrate, not its own machinery:** restore-and-continue is built
+  exactly once (Task 164); this task must not grow a second serialization/walk-entry path.
+  If implementation pressure pushes toward a parallel mechanism, that's a design smell — stop
+  and revisit with 164's substrate.
+- **Resume tokens are self-contained** (carried from 125): token encodes workflow identity,
+  pause position, completed outputs reference, and a protocol version. A future session with
+  no prior context resumes from the token alone.
+- **State goes to `~/.pflow/resume/`** (carried from 125): serialized shared store at the
+  pause point; tokens reference this state; cleanup after successful resume or configurable TTL.
+- **The checkpoint is a purpose-built state file, NOT the debug trace.** This is the key
+  structural difference from Task 164: 164 restores from a *failed run's trace* (sanitized:
+  bytes → placeholder, `default=str`), because failure is uncontrolled. A gate pause is
+  CONTROLLED — the checkpoint is written deliberately at a clean point (before the gated node
+  runs), so this task can write faithful state and avoid the trace's lossy-serialization
+  caveats. The *restore* side should still share 164's seed semantics (one restore reader,
+  two state sources) — coordinate the format with 164's snapshot-fidelity decision so the
+  substrate's restore half reads both.
+- **One decision surface** (carried from 125): the persisted decision payload is the same
+  structured data the blocking gate renders — parseable for CLI prompt and the planned web UI
+  (Task 155), never a printed string.
+
+## Dependencies
+
+- **Task 164: Resume Workflow From a Failed Node** — builds the restore+continue substrate
+  (shared walk-entry helper, resume-scoped seeding) this task triggers. Also owns the
+  snapshot-fidelity decision the checkpoint format must coordinate with.
+- **Task 125: Human-in-the-Loop Approval Gates (blocking)** — the gate primitive
+  (`approval:` on NodeConfig), the agent-escalation trigger, and the structured decision
+  payload this task persists.
+- **CLI surface — resolve jointly with 164:** `pflow resume` must serve BOTH "resume a paused
+  gate" (this task, token-addressed) and "resume a failed run" (164, workflow-addressed).
+  Decide one coherent surface (e.g. `pflow resume <token>` vs `pflow <workflow> --resume`)
+  before either task ships its CLI. Flagged unresolved in both sibling specs.
+
+## Requirements
+
+### Checkpoint & token
+- A gate firing in a non-TTY context emits a resume token to stdout in a parseable form and
+  exits with a distinct, documented exit code (not the failure exit code).
+- The checkpoint contains everything resume needs: shared store snapshot, pause position,
+  workflow path/name + definition hash, original input params, protocol version.
+- Checkpoint write is atomic (no torn state file on kill mid-write).
+
+### Resume
+- `pflow resume <token> --approve yes` continues from the gated node without re-executing
+  completed nodes; final outputs match an uninterrupted approved run.
+- `pflow resume <token> --approve no` exits cleanly with a message naming the cancelled step
+  ("Workflow cancelled at step 'notify-slack'"); no side effects fire.
+- Workflow definition changed between pause and resume (hash mismatch): warn and require
+  `--force` to proceed.
+- Multiple gates: resuming past gate 1 runs until gate 2 pauses again (each gate is an
+  independent checkpoint/token).
+- Unknown/expired/cleaned-up token: clear, agent-actionable error — never a silent fresh run.
+
+### Lifecycle
+- `pflow resume list` shows pending checkpoints (workflow, gated step, age).
+- Cleanup after successful resume; configurable TTL for abandoned checkpoints; no auto-cancel
+  by default.
+
+### Security (decide, don't default silently)
+- Token/state tamper-resistance was raised in the original discussion (signed/encrypted
+  tokens — `task_125/starting-context/braindump-openclaw-discussion.md`) and never resolved.
+  The state file approves real-world actions; at minimum make an explicit, recorded decision
+  on whether v1 trusts the local filesystem (likely fine — single-user CLI) or signs tokens.
+
+### Out of scope (v1)
+- Resuming into a sub-workflow child (same dotted-path limitation as 164/`--only`; child
+  plumbing dormant under #443).
+- Escalation raised inside a parallel batch item (rejected loudly per task-125 v1 scoping).
+- Hard-kill recovery (no checkpoint exists if the process was SIGKILLed before a gate fired).
+
+## Implementation Notes
+
+- The pause point is 125's inline gate check in `WorkflowEngine._execute_node` (after template
+  resolution, before exec) — this task adds the "can't block → checkpoint and exit" branch.
+- Restore should reuse 164's seed semantics (`seed_snapshot_into_shared`-shaped) reading the
+  resume-state file instead of a trace. One restore reader, two sources — do not fork the
+  seeding logic (the planner-mirror lesson, issue #504: re-forked copies drift; PR #505's
+  mutation experiment showed 43 green tests missing a visibly drifted fork).
+- Dry-run parity: `--dry-run` on a resume should be consistent with whatever 164 decided for
+  `--dry-run --resume` (recorded decision in task-164.md "Engine/planner parity plan" §2).
+- Original durable-phase notes (state serialization steps, edge cases, CLI sketch) were
+  drafted in task-125.md pre-split — preserved here in Requirements/Solution; the CLI sketch:
+
+```bash
+pflow my-workflow param=value
+# Output: Paused at 'notify-slack'. Resume token: pflow-resume-abc123
+pflow resume pflow-resume-abc123 --approve yes
+pflow resume pflow-resume-abc123 --approve no
+pflow resume list
+```
+
+## Verification
+
+- **Resume flow**: paused workflow resumes from token without re-executing completed nodes;
+  shared-store integrity verified (all pre-pause outputs addressable post-resume).
+- **Non-TTY mode**: token emitted to stdout, parseable by a calling process; distinct exit code.
+- **Deny flow**: denied approval exits cleanly with the named step; no side effects.
+- **Stale resume**: definition changed → warning; `--force` proceeds; without it, refusal.
+- **Multiple gates**: 2+ gates checkpoint/resume in sequence.
+- **Durable escalation**: an agent-raised escalation in a non-TTY run produces a token whose
+  payload carries the structured decision (options/tradeoffs/recommendation); answering it
+  continues from the decision.
+- **Lifecycle**: `pflow resume list` shows pending; TTL cleanup removes abandoned state;
+  resumed token is consumed (second resume of the same token errors clearly).
+
+## References
+
+- **Origin spec**: `.taskmaster/tasks/task_125/task-125.md` — Architecture (the three-trigger
+  substrate), Phasing (blocking vs durable — the split this task formalizes).
+- **Substrate**: `.taskmaster/tasks/task_164/task-164.md` — Reuse, The delta, Engine/planner
+  parity plan (Phase-0 shared walk-entry helper; snapshot-fidelity decision).
+- **Braindumps**: `task_125/starting-context/braindump-escalation-and-resume-substrate.md`
+  (CLI collision, token security, nested escalation — lines ~170-182),
+  `task_164/starting-context/braindump-planner-mirror-session.md` (parity discipline,
+  mutation-test recipe).
+- **Prior art**: `.taskmaster/tasks/task_73/` (deprecated checkpoint persistence; idempotency
+  analysis), ADR-0002 (`context/adr/0002-443-only-snapshot-source.md` — trace-vs-store
+  tradeoffs the checkpoint format must answer differently).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ MVP feature-complete. Published to PyPI (initial release v0.8.0; current version
 **Refactors:**
 - Task 117: Subcommand JSON Error Output
 - Task 120: Strict Input Type Validation
+- Task 170: One Template Language
 
 **Later:**
 - Task 124: Code Node Dependency Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,9 +230,10 @@ MVP feature-complete. Published to PyPI (initial release v0.8.0; current version
 
 ### Planned Features (in order of priority)
 
-**Next?**
-- Task 125: Human-in-the-Loop Approval Gates
-- Task 164: Resume Workflow From a Failed Node
+**Next?** (in build order)
+1. Task 125: Human-in-the-Loop Approval Gates
+2. Task 164: Resume Workflow From a Failed Node
+3. Task 171: Durable Resume Tokens & Non-TTY Gates
 
 **v0.14.0**
 - Task 142: Explore Function-Based Code Node Syntax

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ MVP feature-complete. Published to PyPI (initial release v0.8.0; current version
 
 - Task 78: Save User Request History
 - Task 88: MCPMark Benchmarking
-- Task 133: Unified Per-Node Storage for Trace and Cache
+- Task 133: Trace/Cache Storage Architecture
 
 **v1.0.0 - Security & Sandboxing:**
 - Task 87: Sandboxed Execution Runtime

--- a/context/CONTEXT.md
+++ b/context/CONTEXT.md
@@ -35,6 +35,21 @@ feedback, recurrence, state-threading.
 produced output. From round 2 on, the Carry supplies the value. A role, not a separate field —
 a carried input's ordinary input value *is* its Seed. _Avoid_: initial, default, base.
 
+**Template** — a string in a Step's params containing `${…}` expressions, resolved against the
+shared store at runtime and checked against declared output structure at validation — one parse
+serves both surfaces. _Avoid_: placeholder, interpolation, substitution.
+
+**Reference** — a path inside a template expression — a root (step, input, or batch alias) plus
+field/index segments — naming data in the shared store. _Avoid_: variable, pointer, path
+(unqualified).
+
+**Coalesce** — the `??` operator in a template expression: Operands tried left to right, the
+first present one wins; an absent root *or* an absent field falls through. _Avoid_: fallback,
+default, or-else.
+
+**Operand** — one alternative in a Coalesce chain: a Reference or a JSON literal. A literal
+always resolves, ending the chain. _Avoid_: argument, branch.
+
 **Retry** — re-running a *single step's own work* after a **transient** failure, capped by a
 maximum attempt count, same inputs each time. A *deterministic* failure (e.g. bad config) is
 not retried. A retry that eventually succeeds leaves no trace — the run is a clean Success.

--- a/context/adr/0002-443-only-snapshot-source.md
+++ b/context/adr/0002-443-only-snapshot-source.md
@@ -59,6 +59,10 @@ The snapshot needs the last full run's output for **every** upstream node, as a 
   memo cache a subset, so building `--only` on the trace today means it rides that consolidation
   naturally — the snapshot reader repoints at the merged artifact — rather than being orphaned.
   The dedup the merge must solve is the same repetition that makes a dedicated store tempting.
+  *(Update 2026-06: Task 133 evaluated and **rejected** the merge — trace/cache overlap is small
+  relative to total volume, and the subsystems stay separate. The trace remains the snapshot
+  source; the size problem was instead addressed by blob interning (Task 165, format 2.5.0).
+  The "dedicated snapshot store" escape hatch above stands unchanged.)*
 
 ## Limitations (v1, FLAT `--only` only)
 

--- a/context/adr/0006-template-language-no-shared-walk.md
+++ b/context/adr/0006-template-language-no-shared-walk.md
@@ -1,0 +1,35 @@
+# The template language is one parser/AST with separate runtime and validator walks — no shared-traversal abstraction
+
+Status: accepted
+
+The `${…}` template language consolidates into one module (`core/templates`): a single
+error-tolerant parser producing a typed AST (expressions, Operands, path segments — dynamic
+indices first-class, which retires both the string-rewrite pre-pass and the second
+"permissive" grammar), one value-walk evaluator, and one home for the semantic judgments
+that have historically drifted (stringification, traversability, type compatibility —
+issue #460). The validator keeps its **own direct structure-walk** over the same AST
+segments; the two walks are deliberately NOT unified behind a World/port abstraction,
+although a fully worked ports-and-adapters design (ValueWorld/StructureWorld over a
+two-method protocol with HIT/MISS/UNKNOWABLE outcomes) was on the table.
+
+Rejected because the port fails the deletion test: deleting it yields two single-purpose
+~60-line walks, each simpler to read than a generic loop + two adapters + a three-valued
+outcome algebra — the adapters would hold all the real semantics anyway. Its claimed
+type-forced correspondence also doesn't hold: a new traversal behavior lands in one
+adapter's body, and nothing in the types forces the other adapter to react. Top-tier
+implementations of the same two-worlds problem (CEL's checker/interpreter, actionlint,
+JMESPath) share the AST and conformance tests, not the walk.
+
+Drift protection instead comes from three places: both walks consume the same parsed
+segments (segmentation cannot drift — the d5a1af8c class), both consume the shared rules
+(judgment calls cannot drift — the #460 class), and parity drift tests pin the remainder
+(a fixed table corpus plus the historical bugs as named fixtures — #441, #460, #266,
+d5a1af8c, 8535ed9b, 6b7faf8f; a grammar-uniqueness AST-scan meta-test keeps new `${…}`
+regexes from appearing outside the module). Property-test *generation* was also rejected
+as premature — the table corpus covers every observed failure; build a generator only if
+a drift ever escapes the table.
+
+Recorded so a future architecture review does not re-suggest unifying the two walks (or
+read the validator's separate walk as an unfinished consolidation violating the "shared
+layers, not parallel logic" doctrine — the shared layers here are the AST and the rules,
+deliberately not the loop).

--- a/src/pflow/runtime/template_validation/CLAUDE.md
+++ b/src/pflow/runtime/template_validation/CLAUDE.md
@@ -65,8 +65,8 @@ validator.py (orchestrator)
 
 | File | What it imports |
 |------|----------------|
-| `runtime/compilation/compile_validation.py` | `validate_workflow_templates`, `extract_node_outputs` |
-| `core/workflow/validator.py` | `validate_workflow_templates` (lazy) |
+| `runtime/compilation/compile_validation.py` | `extract_node_outputs` only — the template passes do NOT run at compile time |
+| `core/workflow/validator.py` | `validate_workflow_templates` (lazy) — the ONLY production caller of the template passes |
 | `execution/formatters/node_output_formatter.py` | `flatten_output_structure` |
 | `execution/executor_service.py` | `MAX_DISPLAYED_FIELDS` (lazy) |
 


### PR DESCRIPTION
## Summary

Task-planning and documentation follow-through from the planner-mirror refactor session (#504 / #505). Three commits:

- `c603c8e9` **task 170 context** — Task 170 spec (One Template Language), implementation plan, session braindump, ADR-0006, CONTEXT.md/CLAUDE.md updates
- `bb3ac309` **new tasks** — roadmap restructure: Task 125's durable phase carved into new **Task 171** (Durable Resume Tokens & Non-TTY Gates) so each task ships as one PR; build order now linear **125 → 164 → 171**; task-164 gains the "Engine/planner parity plan" (phase-0 shared walk-entry extraction, parity-test-first discipline); task-125 gains dry-run parity requirements + the parallel-batch escalation hard problem; tailored handoff braindumps for 125/164/171
- `e1230382` **doc fixes** — three stale claims found during the session: root CLAUDE.md's Task 133 title (merge premise was rejected; now "Trace/Cache Storage Architecture"), ADR-0002's merge consequence (dated update note: Task 133 rejected the merge; blob interning addressed size instead), and `template_validation/CLAUDE.md`'s consumer table (the compiler imports `extract_node_outputs` only — template passes run solely in `WorkflowValidator`)

No code changes — `.taskmaster/`, `context/`, and CLAUDE.md files only, plus the test/docs content in the task-170 context commit.

## Related (no closing keywords — context only)

- #504 / #505 — the refactor session that produced these insights
- #506 — cost-parity blind spot filed from the same session; referenced by the new task specs

## Review note

Branch rebased onto main post-creation: the two commits already merged via #501's squash were dropped, so the diff is exactly the 3 commits / 14 files above. ADR-0002's Consequences note (this branch) and #505's line-36 change (main) are disjoint regions — already cleanly combined by the rebase.

---
Implemented by Claude (Session: e127fea8-6a39-4845-8e99-329817fd5d04)
