### PR TITLE
fix: frame large pflow guide output with read-completeness header + end-marker (#509)

### DIFF
--- a/src/pflow/guide/__init__.py
+++ b/src/pflow/guide/__init__.py
@@ -7,6 +7,15 @@ from pathlib import Path
 GUIDE_DIR = Path(__file__).parent
 PROMPT_CACHING_TOPIC = "prompt-caching"
 
+# Topic output gets the read-completeness header + end-marker only when it's
+# large enough that a calling tool might truncate it. Small fetches (a single
+# small topic) are not truncated in practice, so framing them is pure overhead.
+# 20KB sits above every single small topic and below `core` and all multi-topic
+# output — the failure class where an agent silently misses a whole section.
+# Tunable risk dial: lower = safer against aggressive truncators, higher = less
+# overhead on mid-size output.
+_FRAME_THRESHOLD_BYTES = 20_000
+
 # Backward-compatible topic aliases. Keep aliases out of auto-detection and
 # menu text so generated guide pointers use the clearest public topic name.
 _TOPIC_ALIASES: dict[str, str] = {
@@ -91,7 +100,37 @@ def compose_guide(args: list[str]) -> str:
 
         parts.append(content)
 
-    return "\n\n---\n\n".join(parts) + "\n"
+    body = "\n\n---\n\n".join(parts)
+    if len(body) < _FRAME_THRESHOLD_BYTES:
+        return body + "\n"
+    return _frame_topics(body, len(topics))
+
+
+def _frame_topics(body: str, n: int) -> str:
+    """Frame composed topic content with a read-completeness header and end-marker.
+
+    Only called for output large enough to risk truncation (see
+    ``_FRAME_THRESHOLD_BYTES``). The header goes at the very top because calling
+    tools that truncate large output keep the *start* and drop the *end* — a
+    trailing reminder would be in the region that gets cut. It tells the agent that
+    a preview means the tool has preserved the full text elsewhere (file/pagination)
+    to be read there rather than re-fetched, and points at the end-marker as the
+    completeness check. The marker's absence proves the output was truncated.
+
+    ``marker`` is computed once so the header's claim and the trailing line cannot
+    drift on pluralization.
+    """
+    sections = "section" if n == 1 else "sections"
+    marker = f"⟨END OF GUIDE — {n} {sections}⟩"
+    header = (
+        f"> **{n} guide {sections} below, split by `---`. Read each to the END before building** "
+        "— they're condensed, so skimming means wrong format rules.\n"
+        "> Output is long: if you see only a **preview**, the full text is preserved elsewhere "
+        "(a file your tool names, or pagination) — open and read it there. "
+        "Don't build from the preview, and don't re-run this command.\n"
+        f"> Done only when you reach the last line `{marker}` — if you're not there, you haven't read it all."
+    )
+    return f"{header}\n\n{body}\n\n---\n\n{marker}\n"
 
 
 def list_topics() -> list[str]:

--- a/tests/test_cli/test_guide.py
+++ b/tests/test_cli/test_guide.py
@@ -202,6 +202,97 @@ def test_compose_separator_between_chunks() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Read-completeness header + end-marker (topic path only)
+# ---------------------------------------------------------------------------
+
+
+def _end_marker(n: int) -> str:
+    return f"⟨END OF GUIDE — {n} section{'' if n == 1 else 's'}⟩"
+
+
+# Framing only fires above _FRAME_THRESHOLD_BYTES (20KB). `core` (~33KB) is the
+# smallest single topic that exceeds it; small topics like `http` stay unframed.
+
+
+def test_large_topic_output_starts_with_header() -> None:
+    """Large topic output leads with the read-completeness header (survives
+    preview truncation, which keeps the start)."""
+    result = compose_guide(["core"])
+    assert result.startswith("> **1 guide section below")
+    assert "Read each to the END before building" in result
+    # Advises reading the preserved full output, not re-fetching.
+    assert "don't re-run this command" in result
+    assert "the full text is preserved" in result
+
+
+def test_large_topic_output_ends_with_marker() -> None:
+    result = compose_guide(["core"])
+    assert result.rstrip().endswith(_end_marker(1))
+
+
+def test_small_topic_output_is_not_framed() -> None:
+    """A single small topic stays below the truncation-risk threshold and gets
+    no header/marker — framing it would be pure overhead."""
+    result = compose_guide(["http"])
+    assert not result.startswith(">")
+    assert "END OF GUIDE" not in result
+    assert "Read each to the END" not in result
+    # Real content is still present and intact.
+    assert "# HTTP Node" in result
+
+
+def test_marker_count_is_section_count_despite_interface_divider() -> None:
+    """A node topic injects its own ``---`` divider for the dynamic interface, so
+    a naive divider count over-counts. The marker count must be the resolved topic
+    count, proving completeness is divider-independent. ``core http`` exceeds the
+    framing threshold and ``http`` contributes an extra interface divider."""
+    result = compose_guide(["core", "http"])
+    # Dividers: core↔http join + http's interface + the pre-marker divider ≥ 3.
+    assert result.count("\n\n---\n\n") >= 3
+    # ...but the section count is the number of topics (2), not dividers.
+    assert _end_marker(2) in result
+    assert _end_marker(3) not in result
+
+
+def test_multi_topic_marker_count_matches_resolved_topics() -> None:
+    result = compose_guide(["core", "http", "llm"])
+    assert result.startswith("> **3 guide sections below")
+    assert result.rstrip().endswith(_end_marker(3))
+
+
+def test_marker_count_uses_deduped_topic_count() -> None:
+    """Count is the deduped topic count — a repeated topic doesn't inflate it."""
+    result = compose_guide(["core", "core"])
+    assert result.startswith("> **1 guide section below")
+    assert result.rstrip().endswith(_end_marker(1))
+
+
+def test_header_appears_within_first_kilobyte() -> None:
+    """The header must fit inside a typical preview window."""
+    result = compose_guide(["core"])
+    assert _end_marker(1) in result[:1024]
+
+
+def test_header_and_marker_pluralization_agree() -> None:
+    """The marker text quoted in the header equals the actual trailing line —
+    they're generated from one local, so they can't drift on plural."""
+    for topics, n in (["core"], 1), (["core", "http"], 2):
+        result = compose_guide(topics)
+        marker = _end_marker(n)
+        # Header quotes the exact marker as the completeness check.
+        assert f"reach the last line `{marker}`" in result
+        assert result.rstrip().endswith(marker)
+
+
+def test_no_args_output_has_no_header_or_marker() -> None:
+    """The entry path (no args / ``pflow --help``) is untouched."""
+    result = compose_guide([])
+    assert result == render_entry_content()
+    assert "END OF GUIDE" not in result
+    assert "Read each to the END" not in result
+
+
+# ---------------------------------------------------------------------------
 # Dynamic node interface injection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
`pflow guide <topics…>` carried no instruction to read its output completely. The one read-completeness reminder lived in `entry.md` — rendered only for `pflow guide` (no args) and `pflow --help`, never on the topic content an agent actually consumes. Large multi-topic output gets truncated to a preview by calling tools, so agents built from the preview and silently missed whole sections (e.g. concluded "branching docs are missing" when the section was just in the unread remainder).

This adds a surviving header + end-marker to large topic output. Because truncation keeps the *start* and drops the *end*, the reminder is a **header** (not a footer), and an end-marker sentinel makes truncation detectable: if the agent never reaches it, the output was cut off.

Fixes #509

## Changes
- `compose_guide()` now frames topic output with a read-completeness header (top) and an `⟨END OF GUIDE — N section(s)⟩` end-marker, via a single helper `_frame_topics(body, n)`.
- Framing is gated on size (`_FRAME_THRESHOLD_BYTES = 20_000`): only output large enough to risk truncation is framed; small single topics (`http`, `branching`, `loop`) stay clean to avoid overhead.
- The marker string is computed once inside `_frame_topics`, so the header's quoted "ends with…" claim and the trailing line cannot drift on pluralization.
- The entry path (`pflow guide` no-args / `pflow --help`) is untouched.

## Explanation
Three design points worth calling out:

1. **Header, not footer.** Truncation preserves the beginning of output, so a trailing reminder would be in exactly the region that gets cut. The header sits in the surviving region and tells the agent: the full text has been *preserved by the tool* (file/pagination) — open and read it there, do **not** re-fetch.
2. **End-marker, not divider count.** Node topics inject their own `---` separator for the dynamic interface, so the number of `---` dividers ≠ the number of topics. A single end-marker line keyed to `len(topics)` is the divider-independent completeness signal.
3. **Size gate at 20KB.** The reported failure truncated a 63.8KB output; the "2KB" in that report was the *preview size*, not the truncation *threshold*. Small outputs are not truncated in practice, so framing them is pure overhead. 20KB sits above every single small topic and below `core` (~33KB) and all multi-topic output — the failure class where an agent silently misses a whole section. It's a documented, tunable risk dial.

Files: `src/pflow/guide/__init__.py`, `tests/test_cli/test_guide.py`.

## Testing
- `test_large_topic_output_starts_with_header` / `test_large_topic_output_ends_with_marker` — `core` output begins with the header (correct count, recovery advice) and ends with the marker.
- `test_small_topic_output_is_not_framed` — `http` (2.7KB) stays unframed, content intact (pins the size gate).
- `test_marker_count_is_section_count_despite_interface_divider` — `core http` has ≥3 `---` dividers but the marker count is 2, proving completeness is divider-independent.
- `test_multi_topic_marker_count_matches_resolved_topics` / `test_marker_count_uses_deduped_topic_count` — count equals the resolved, deduped topic count.
- `test_header_appears_within_first_kilobyte` — header survives a typical preview window.
- `test_header_and_marker_pluralization_agree` — header's quoted marker equals the trailing line for n=1 and n=2.
- `test_no_args_output_has_no_header_or_marker` — entry path unchanged.
- Full suite: `make test` → 7805 passed; `make check` clean (ruff, mypy, deptry). The guide-example extractor test (`test_guide_example_validation.py`) is unaffected — it reads source `.md` files, which the runtime framing never touches.
- Manual: `pflow guide core` is framed; `pflow guide http` is clean.