### PR TITLE
fix: treat code-node annotated assignments as locals, not undeclared inputs (#331)

### DIFF
--- a/src/pflow/guide/nodes/code.md
+++ b/src/pflow/guide/nodes/code.md
@@ -60,7 +60,7 @@ result: dict = {
 **Code node rules:**
 - Templates go in `- inputs:` param, NEVER in the `python code` block (code is literal Python, not a template)
 - All inputs and `result` MUST have type annotations: `data: list`, `result: dict = ...`
-- The reverse also holds: a top-level `name: type` IS read as an input declaration, so do NOT annotate locals — write `total = ...`, not `total: int = ...`. Only declared inputs plus `result`/`next` take annotations.
+- Bare vs valued annotations: a top-level **bare** `name: type` (no value) is read as an input declaration and needs a matching `inputs:` entry. An annotated assignment `name: type = value` is a local — so type your intermediates freely (`total: int = sum(...)`). `result`/`next` are the declared output/routing.
 - Upstream JSON is auto-parsed before your code runs — if source is JSON, declare `dict`/`list` not `str`
 - Use `Any` as the type when you don't want type validation (see syntax table below — auto-injected, no import needed)
 - Single output via `result` variable — use dict for structured output
@@ -74,17 +74,20 @@ Three code-node input errors are caught at validate time (`pflow
 1. **Input bound, annotation missing** — `inputs: {x: ${ref}}` with no `x:
    <type>` in code. The suggestion uses the upstream's declared type when
    known (`Add an annotation (in params.code): x: str  (inferred from ...)`).
-2. **Annotation declared, no input bound** — the fix depends on whether the
-   name is assigned in the body:
-   - **assigned** (`all_items: list = ...`) → it's a local, so removing the
-     annotation is safe. Offers both, local first: `Remove the annotation
-     'all_items: list' — '...' is assigned in the code, so it's a local
-     variable` *or* `add 'all_items' to the inputs dict` (if it was meant as
-     an input).
-   - **read but not assigned** (`y: list` + `len(y)`) → removing would leave
+2. **Bare annotation declared, no input bound** — a top-level `name: type` with
+   no value and no matching `inputs:` entry. (An annotated assignment `name: type
+   = value` is a local and is never flagged — issue #331.) The fix depends on
+   whether the name is also bound in the body:
+   - **bound elsewhere** (a later `helper = ...` or `def helper(): ...`) → the
+     bare annotation is redundant, so removing it is safe. Offers both, local
+     first: `Remove the annotation 'helper: Any' — 'helper' is assigned in the
+     code, so it's a local variable` *or* `add 'helper' to the inputs dict` (if
+     it was meant as an input). To keep a type on a local, use the value form
+     (`helper: Any = ...`).
+   - **read but not bound** (`y: list` + `len(y)`) → removing would leave
      `y` unbound, so the only fix is `Add 'y' to the inputs dict` (or `Rename
      the annotation to 'items'` for a fuzzy-matched typo).
-   - **neither read nor assigned** → dead annotation: `Remove the annotation
+   - **neither read nor bound** → dead annotation: `Remove the annotation
      'y: list' — it is never read in the code`.
 3. **Type mismatch** — `x: dict` bound to `${upstream.result}` that declares
    `list`:

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -195,10 +195,11 @@ def extract_code_annotation_type(code: str, key: str) -> Optional[str]:
 
     Returns None as a skip-check signal when the code is malformed, the key is
     not annotated at module scope, or the annotation resolves to an
-    unknown/non-S1 type. Uses top-level extraction — a function-local
-    ``y: int`` does not shadow a missing or different top-level ``y`` binding.
+    unknown/non-S1 type. Uses top-level *input* extraction — a function-local
+    ``y: int`` does not shadow a missing or different top-level ``y`` binding,
+    and a local ``y: int = ...`` is not an input whose type we'd check.
     """
-    annotations = extract_top_level_annotations(code)
+    annotations = extract_top_level_input_annotations(code)
     type_str = annotations.get(key)
     if type_str is None:
         return None
@@ -206,15 +207,23 @@ def extract_code_annotation_type(code: str, key: str) -> Optional[str]:
     return _get_outer_type_name(type_str)
 
 
-def extract_top_level_annotations(code: str) -> dict[str, str]:
-    """Like ``_extract_annotations`` but scoped to module-level names only.
+def extract_top_level_input_annotations(code: str) -> dict[str, str]:
+    """Module-level **bare** annotations — a code node's input declarations.
 
-    ``_extract_annotations`` uses ``ast.walk`` which descends into function
-    and class bodies. For Pass 9's boundary checks (missing-input, orphan
-    annotation) we want ONLY the module-level annotations — a helper function
-    like ``def helper(): y: int = 1`` is a legitimate local variable, not a
-    candidate code-node input. Treating it as one produces spurious orphan
-    errors that block valid workflows.
+    Two filters narrow ``ast.AnnAssign`` to exactly the input-declaration
+    candidates that Pass 9's boundary checks (missing-input, orphan annotation)
+    care about:
+
+    1. **Bare only** (``node.value is None``). A *bare* annotation ``x: T`` is an
+       unbound name whose value the engine injects from ``inputs:`` — that is an
+       input declaration. An *annotated assignment* ``x: T = expr`` binds its own
+       value, so it is a local variable (issue #331), NOT an input. ``result``
+       and ``next`` are likewise annotated assignments and so are excluded here;
+       they are outputs/routing, checked separately via ``_extract_annotations``.
+
+    2. **Module scope only**. ``_extract_annotations`` uses ``ast.walk`` and
+       descends into function/class bodies; we don't — a helper-local like
+       ``def helper(): y: int`` is not a candidate code-node input.
 
     Scope boundaries (skipped, not descended into):
     ``FunctionDef``, ``AsyncFunctionDef``, ``ClassDef``, ``Lambda``.
@@ -236,7 +245,7 @@ def extract_top_level_annotations(code: str) -> dict[str, str]:
         node = stack.pop()
         if isinstance(node, _SCOPE_BOUNDARIES):
             continue  # Don't descend into new scopes.
-        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        if isinstance(node, ast.AnnAssign) and node.value is None and isinstance(node.target, ast.Name):
             annotations[node.target.id] = ast.unparse(node.annotation)
         stack.extend(ast.iter_child_nodes(node))
     return annotations

--- a/src/pflow/nodes/python/python_code.py
+++ b/src/pflow/nodes/python/python_code.py
@@ -195,11 +195,12 @@ def extract_code_annotation_type(code: str, key: str) -> Optional[str]:
 
     Returns None as a skip-check signal when the code is malformed, the key is
     not annotated at module scope, or the annotation resolves to an
-    unknown/non-S1 type. Uses top-level *input* extraction — a function-local
-    ``y: int`` does not shadow a missing or different top-level ``y`` binding,
-    and a local ``y: int = ...`` is not an input whose type we'd check.
+    unknown/non-S1 type. Uses module-level extraction (bare OR valued) so a
+    valued-annotated input (``x: dict = ...``) is still type-checked — matching
+    runtime's ``_check_input_types`` — while a function-local ``y: int`` does not
+    shadow a missing or different top-level ``y`` binding.
     """
-    annotations = extract_top_level_input_annotations(code)
+    annotations = extract_top_level_annotations(code)
     type_str = annotations.get(key)
     if type_str is None:
         return None
@@ -207,32 +208,45 @@ def extract_code_annotation_type(code: str, key: str) -> Optional[str]:
     return _get_outer_type_name(type_str)
 
 
+def extract_top_level_annotations(code: str) -> dict[str, str]:
+    """All module-level annotations — bare ``x: T`` AND valued ``x: T = expr``.
+
+    The "does this name carry a type annotation at all" view. It mirrors what
+    runtime's ``_check_input_annotations`` / ``_check_input_types`` treat as
+    annotated, so validate-time input checks that must agree with runtime —
+    missing-annotation and type-match — stay aligned. For the narrower
+    *input-declaration* view (bare annotations only), use
+    ``extract_top_level_input_annotations``.
+
+    Scoped to module level (descends ``If``/``For``/``While``/``With``/``Try``,
+    skips ``FunctionDef``/``AsyncFunctionDef``/``ClassDef``/``Lambda``). Returns
+    an empty dict on SyntaxError.
+    """
+    return _walk_top_level_annotations(code, bare_only=False)
+
+
 def extract_top_level_input_annotations(code: str) -> dict[str, str]:
     """Module-level **bare** annotations — a code node's input declarations.
 
-    Two filters narrow ``ast.AnnAssign`` to exactly the input-declaration
-    candidates that Pass 9's boundary checks (missing-input, orphan annotation)
-    care about:
+    A *bare* annotation ``x: T`` is an unbound name whose value the engine injects
+    from ``inputs:`` — that is an input declaration. An *annotated assignment*
+    ``x: T = expr`` binds its own value, so it is a local variable (issue #331),
+    NOT an input; ``result`` and ``next`` are likewise valued assignments and so
+    are excluded here. Used by the orphan-annotation check, which flags input
+    *declarations* with no matching binding.
 
-    1. **Bare only** (``node.value is None``). A *bare* annotation ``x: T`` is an
-       unbound name whose value the engine injects from ``inputs:`` — that is an
-       input declaration. An *annotated assignment* ``x: T = expr`` binds its own
-       value, so it is a local variable (issue #331), NOT an input. ``result``
-       and ``next`` are likewise annotated assignments and so are excluded here;
-       they are outputs/routing, checked separately via ``_extract_annotations``.
+    Same module-scope rules as ``extract_top_level_annotations`` (skips
+    function/class/lambda bodies). Returns an empty dict on SyntaxError.
+    """
+    return _walk_top_level_annotations(code, bare_only=True)
 
-    2. **Module scope only**. ``_extract_annotations`` uses ``ast.walk`` and
-       descends into function/class bodies; we don't — a helper-local like
-       ``def helper(): y: int`` is not a candidate code-node input.
 
-    Scope boundaries (skipped, not descended into):
-    ``FunctionDef``, ``AsyncFunctionDef``, ``ClassDef``, ``Lambda``.
+def _walk_top_level_annotations(code: str, *, bare_only: bool) -> dict[str, str]:
+    """Shared module-scope annotation walk; ``bare_only`` drops valued assignments.
 
-    Non-scope structures (descended into) include ``If``, ``For``, ``While``,
-    ``With``, ``Try`` — annotations inside these are still module-scoped per
-    Python's scoping rules (only the four types above introduce new scopes).
-
-    Returns an empty dict on SyntaxError (matches ``_extract_annotations``).
+    Descends into non-scope structures (``If``/``For``/``While``/``With``/``Try``)
+    but not into ``FunctionDef``/``AsyncFunctionDef``/``ClassDef``/``Lambda`` —
+    only those four introduce new scopes, so their locals aren't module names.
     """
     try:
         tree = ast.parse(code)
@@ -245,7 +259,11 @@ def extract_top_level_input_annotations(code: str) -> dict[str, str]:
         node = stack.pop()
         if isinstance(node, _SCOPE_BOUNDARIES):
             continue  # Don't descend into new scopes.
-        if isinstance(node, ast.AnnAssign) and node.value is None and isinstance(node.target, ast.Name):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and not (bare_only and node.value is not None)
+        ):
             annotations[node.target.id] = ast.unparse(node.annotation)
         stack.extend(ast.iter_child_nodes(node))
     return annotations

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -465,20 +465,22 @@ def _build_orphan_code_annotation_diagnostics(
     assigned_names: set[str],
     batch_alias: Optional[str],
 ) -> list[Diagnostic]:
-    """Build diagnostics for annotations with no matching input binding.
+    """Build diagnostics for *bare* annotations with no matching input binding.
 
-    The fix depends on whether the orphan name is *assigned* a value in the body,
+    Only bare annotations (``x: T``) reach here — a valued annotated assignment
+    (``x: T = expr``) is a local and is filtered out upstream (issue #331). The
+    fix for a bare orphan depends on whether the name is *also bound* in the body,
     because that decides which fixes are even safe:
 
-    - Orphan key is assigned (``x: T = ...`` / ``x = ...``) → it's a local. BOTH
-      fixes are valid: drop the annotation (it stays a working local) or, if it
-      was meant as an input, bind it. We list both, leading with the more-likely
-      local reading.
-    - Orphan key is read but never assigned (``ast.Name(ctx=Load())`` only) → the
+    - Orphan key is bound elsewhere (a plain ``x = ...`` / ``def x`` / ``class x``)
+      → it's a local. BOTH fixes are valid: drop the bare annotation (the name
+      stays bound) or, if it was meant as an input, bind it. We list both, leading
+      with the more-likely local reading.
+    - Orphan key is read but never bound (``ast.Name(ctx=Load())`` only) → the
       author expected it bound at runtime. Removing the annotation would leave the
       name unbound, so the only valid fix is "Add to the inputs dict" (or "Rename"
       for a typo-level fuzzy match against an existing input key).
-    - Orphan key is neither read nor assigned → dead annotation; the fix is
+    - Orphan key is neither read nor bound → dead annotation; the fix is
       "Remove the annotation".
 
     ``batch_alias`` (when present) narrows the "add to inputs" suggestion to
@@ -500,10 +502,10 @@ def _build_orphan_code_annotation_diagnostics(
         }
 
         if is_assigned and not (batch_alias and key == batch_alias):
-            # The author binds this name to a value, so it's a local, not an
-            # injected input. Removing the annotation is safe (it stays a working
-            # local); binding it is also valid if it was meant as an input. Offer
-            # both, local first.
+            # The author also binds this name in the body, so it's a local, not an
+            # injected input. Removing the bare annotation is safe (it stays a
+            # working local); binding it is also valid if it was meant as an input.
+            # Offer both, local first.
             #
             # The batch alias is excluded: it is NOT injected into code exec
             # (only into template resolution), so removing its annotation would
@@ -512,7 +514,8 @@ def _build_orphan_code_annotation_diagnostics(
             # `alias: ${alias}` binding.
             fixes = [
                 f"Remove the annotation '{key}: {annotation_str}' — '{key}' is assigned in the code, "
-                f"so it's a local variable (only declared inputs and result/next take annotations).",
+                f"so it's a local variable, not an input. To keep the type on a local, annotate the "
+                f"assignment itself: '{key}: {annotation_str} = ...'.",
                 f"Or add '{key}' to the inputs dict (in params.inputs): {key}: ${{<source>}} "
                 f"— if it's a workflow input.",
             ]
@@ -774,7 +777,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         _get_outer_type,
         extract_code_assigned_names,
         extract_code_load_references,
-        extract_top_level_annotations,
+        extract_top_level_input_annotations,
     )
 
     diagnostics: list[Diagnostic] = []
@@ -794,17 +797,25 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         # Skip Pass 9 entirely when the code has a SyntaxError — runtime
         # surfaces a clean line-numbered error and Pass 9 emitting extra
         # "missing annotation" / "orphan" diagnostics on top only obscures
-        # the real issue. `extract_top_level_annotations` fails open with
+        # the real issue. `extract_top_level_input_annotations` fails open with
         # `{}`, so without this check Pass 9 would proceed and over-report.
         try:
             _ast.parse(code)
         except SyntaxError:
             continue
 
-        # Module-level annotations only — function/class locals are not
-        # candidate code-node inputs. Using ``_extract_annotations`` here
-        # would flag every ``def helper(): y: int = 1`` as an orphan.
-        annotations = extract_top_level_annotations(code)
+        # Module-level BARE annotations only — these are the input declarations.
+        # An annotated assignment (``deliberation: str = ...``) binds its own
+        # value, so it is a local, not an input (issue #331); function/class
+        # locals are excluded too. Using ``_extract_annotations`` (walk, all
+        # values) here would flag every typed local as an orphan input.
+        #
+        # Edge case — a name bound in ``inputs:`` AND written as a valued local
+        # (``x: dict = {}`` while ``x`` is also an input): ``x`` is absent here,
+        # so the missing-annotation check below reports it. That is correct —
+        # the engine injects inputs before the code runs (``namespace.update``),
+        # so the ``= {}`` clobbers the injected value: the input binding is dead.
+        annotations = extract_top_level_input_annotations(code)
 
         # Mirror the two prep-time checks in ``python_code.py::prep`` at
         # validate-time:

--- a/src/pflow/runtime/template_validation/type_validation.py
+++ b/src/pflow/runtime/template_validation/type_validation.py
@@ -777,6 +777,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         _get_outer_type,
         extract_code_assigned_names,
         extract_code_load_references,
+        extract_top_level_annotations,
         extract_top_level_input_annotations,
     )
 
@@ -804,18 +805,24 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         except SyntaxError:
             continue
 
-        # Module-level BARE annotations only — these are the input declarations.
-        # An annotated assignment (``deliberation: str = ...``) binds its own
-        # value, so it is a local, not an input (issue #331); function/class
-        # locals are excluded too. Using ``_extract_annotations`` (walk, all
-        # values) here would flag every typed local as an orphan input.
+        # Two module-level annotation views feed three checks (issue #331):
         #
-        # Edge case — a name bound in ``inputs:`` AND written as a valued local
-        # (``x: dict = {}`` while ``x`` is also an input): ``x`` is absent here,
-        # so the missing-annotation check below reports it. That is correct —
-        # the engine injects inputs before the code runs (``namespace.update``),
-        # so the ``= {}`` clobbers the injected value: the input binding is dead.
-        annotations = extract_top_level_input_annotations(code)
+        #   * ``input_annotations`` — BARE annotations only (``x: T``, no value).
+        #     These are the input *declarations*. The orphan check uses this: an
+        #     annotated assignment (``deliberation: str = ...``) binds its own
+        #     value, so it's a local, not an undeclared input.
+        #   * ``annotations`` — ALL module-level annotations (bare + valued). The
+        #     missing-annotation and type-match checks use this, because they ask
+        #     "does this input carry a type annotation at all" — and they must
+        #     agree with runtime, which reads valued annotations too
+        #     (``_check_input_annotations`` / ``_check_input_types`` walk all
+        #     values). A normalized input like ``text: str = text.strip()`` (with
+        #     ``text`` in ``inputs:``) reads the injected value before reassigning,
+        #     runs clean, and must NOT be flagged "missing annotation".
+        #
+        # Both are module-scope only — function/class locals are never inputs.
+        annotations = extract_top_level_annotations(code)
+        input_annotations = extract_top_level_input_annotations(code)
 
         # Mirror the two prep-time checks in ``python_code.py::prep`` at
         # validate-time:
@@ -892,7 +899,10 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
         # fails with "Undefined variable 'item'". Pass 9 correctly flags the
         # missing binding as Class 2 (orphan annotation with Load reference →
         # "Add 'item' to the inputs dict").
-        annotation_keys = {key for key in annotations if key not in {"result", "next"}}
+        # `annotated_keys` (all annotations) drives the missing/type checks;
+        # `bare_keys` (input declarations) drives the orphan check.
+        annotated_keys = {key for key in annotations if key not in {"result", "next"}}
+        bare_keys = {key for key in input_annotations if key not in {"result", "next"}}
         # Load references disambiguate orphan annotations: a name read in the
         # body signals "add to inputs"; an unused annotation is dead code.
         load_refs = extract_code_load_references(code)
@@ -906,12 +916,12 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
 
         diagnostics.extend(
             _build_missing_code_annotation_diagnostics(
-                node_id, input_keys, annotation_keys, inputs, workflow_ir, node_outputs
+                node_id, input_keys, annotated_keys, inputs, workflow_ir, node_outputs
             )
         )
         diagnostics.extend(
             _build_orphan_code_annotation_diagnostics(
-                node_id, input_keys, annotation_keys, annotations, load_refs, assigned_names, batch_alias
+                node_id, input_keys, bare_keys, input_annotations, load_refs, assigned_names, batch_alias
             )
         )
         diagnostics.extend(
@@ -922,7 +932,7 @@ def validate_code_node_input_annotations(workflow_ir: dict[str, Any], node_outpu
                 code,
                 inputs,
                 annotations,
-                annotation_keys,
+                annotated_keys,
             )
         )
 

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -18,6 +18,7 @@ from pflow.nodes.python.python_code import (
     extract_code_assigned_names,
     extract_code_load_references,
     extract_optional_input_keys,
+    extract_top_level_annotations,
     extract_top_level_input_annotations,
     s1_type_to_python_display,
 )
@@ -534,8 +535,10 @@ class TestAnnotationExtractionHelper:
         assert _get_outer_type('"dict"') is dict
         assert _get_outer_type("'list[dict]'") is list
 
-    def test_top_level_annotations_excludes_function_locals(self):
-        """Function-local annotations must not surface at module scope."""
+    # --- extract_top_level_annotations: ALL module-level annotations (bare + valued) ---
+
+    def test_top_level_annotations_includes_valued_excludes_function_locals(self):
+        """All module-level annotations (bare AND valued); function locals excluded."""
         code = """
 def helper():
     y: int = 1
@@ -544,20 +547,11 @@ def helper():
 x: dict
 result: int = helper()
 """
-        annotations = extract_top_level_input_annotations(code)
-        # Only the bare module-level annotation `x: dict` is an input declaration.
-        # `y` is a function local; `result: int = ...` is a valued assignment
-        # (an output, not an input) — both excluded.
-        assert annotations == {"x": "dict"}
+        annotations = extract_top_level_annotations(code)
+        # Valued `result: int = ...` IS included (it's a module-level annotation —
+        # runtime reads valued annotations too); function-local `y` is a new scope.
+        assert annotations == {"x": "dict", "result": "int"}
         assert "y" not in annotations
-        assert "result" not in annotations
-
-    def test_top_level_annotations_excludes_valued_assignments(self):
-        """Annotated assignments (`x: T = expr`) are locals, not inputs (issue #331)."""
-        code = "rewrite_output: str\nseen: set = set()\ncandidates: list = []\nresult: dict = {}"
-        annotations = extract_top_level_input_annotations(code)
-        # Only the bare `rewrite_output: str` declares an input.
-        assert annotations == {"rewrite_output": "str"}
 
     def test_top_level_annotations_excludes_class_body(self):
         """Class body annotations must not surface at module scope."""
@@ -568,30 +562,57 @@ class Config:
 
 x: dict
 """
-        annotations = extract_top_level_input_annotations(code)
-        assert annotations == {"x": "dict"}
-        assert "timeout" not in annotations
-        assert "name" not in annotations
+        assert extract_top_level_annotations(code) == {"x": "dict"}
 
     def test_top_level_annotations_includes_if_scoped(self):
         """Non-scope structures (if/for/while) don't hide module-level annotations."""
         code = """
 import os
 if os.environ.get("FLAG"):
-    y: int
+    y: int = 1
 else:
-    y: str
+    y: str = "2"
 
 x: dict
 """
-        annotations = extract_top_level_input_annotations(code)
-        # `y` appears twice at module scope (one branch of `if`); last-write wins.
-        # The important fact: `y` (a bare annotation) is included because `if`
-        # is not a scope boundary.
+        annotations = extract_top_level_annotations(code)
+        # `if` is not a scope boundary, so `y` surfaces (valued is fine here).
         assert "x" in annotations
         assert "y" in annotations
 
     def test_top_level_annotations_malformed_returns_empty(self):
+        assert extract_top_level_annotations("x: dict =") == {}
+
+    # --- extract_top_level_input_annotations: BARE annotations = input declarations ---
+
+    def test_top_level_input_annotations_excludes_valued_assignments(self):
+        """Annotated assignments (`x: T = expr`) are locals, not inputs (issue #331)."""
+        code = "rewrite_output: str\nseen: set = set()\ncandidates: list = []\nresult: dict = {}"
+        # Only the bare `rewrite_output: str` declares an input.
+        assert extract_top_level_input_annotations(code) == {"rewrite_output": "str"}
+
+    def test_top_level_input_annotations_excludes_function_and_class_locals(self):
+        """Bare input view also excludes function/class-scoped annotations."""
+        code = """
+def helper():
+    y: int
+    return 1
+
+class C:
+    z: int
+
+x: dict
+"""
+        assert extract_top_level_input_annotations(code) == {"x": "dict"}
+
+    def test_top_level_input_annotations_includes_bare_if_scoped(self):
+        """A bare annotation inside `if` (not a scope boundary) is still an input decl."""
+        code = "import os\nif os.environ.get('F'):\n    y: int\nelse:\n    y: str\nx: dict"
+        annotations = extract_top_level_input_annotations(code)
+        assert "x" in annotations
+        assert "y" in annotations
+
+    def test_top_level_input_annotations_malformed_returns_empty(self):
         assert extract_top_level_input_annotations("x: dict =") == {}
 
     def test_python_to_s1_canonical_is_injective(self):

--- a/tests/test_nodes/test_python/test_python_code.py
+++ b/tests/test_nodes/test_python/test_python_code.py
@@ -18,7 +18,7 @@ from pflow.nodes.python.python_code import (
     extract_code_assigned_names,
     extract_code_load_references,
     extract_optional_input_keys,
-    extract_top_level_annotations,
+    extract_top_level_input_annotations,
     s1_type_to_python_display,
 )
 
@@ -544,9 +544,20 @@ def helper():
 x: dict
 result: int = helper()
 """
-        annotations = extract_top_level_annotations(code)
-        assert annotations == {"x": "dict", "result": "int"}
+        annotations = extract_top_level_input_annotations(code)
+        # Only the bare module-level annotation `x: dict` is an input declaration.
+        # `y` is a function local; `result: int = ...` is a valued assignment
+        # (an output, not an input) — both excluded.
+        assert annotations == {"x": "dict"}
         assert "y" not in annotations
+        assert "result" not in annotations
+
+    def test_top_level_annotations_excludes_valued_assignments(self):
+        """Annotated assignments (`x: T = expr`) are locals, not inputs (issue #331)."""
+        code = "rewrite_output: str\nseen: set = set()\ncandidates: list = []\nresult: dict = {}"
+        annotations = extract_top_level_input_annotations(code)
+        # Only the bare `rewrite_output: str` declares an input.
+        assert annotations == {"rewrite_output": "str"}
 
     def test_top_level_annotations_excludes_class_body(self):
         """Class body annotations must not surface at module scope."""
@@ -557,7 +568,7 @@ class Config:
 
 x: dict
 """
-        annotations = extract_top_level_annotations(code)
+        annotations = extract_top_level_input_annotations(code)
         assert annotations == {"x": "dict"}
         assert "timeout" not in annotations
         assert "name" not in annotations
@@ -567,20 +578,21 @@ x: dict
         code = """
 import os
 if os.environ.get("FLAG"):
-    y: int = 1
+    y: int
 else:
-    y: str = "2"
+    y: str
 
 x: dict
 """
-        annotations = extract_top_level_annotations(code)
+        annotations = extract_top_level_input_annotations(code)
         # `y` appears twice at module scope (one branch of `if`); last-write wins.
-        # The important fact: `y` is included because `if` is not a scope boundary.
+        # The important fact: `y` (a bare annotation) is included because `if`
+        # is not a scope boundary.
         assert "x" in annotations
         assert "y" in annotations
 
     def test_top_level_annotations_malformed_returns_empty(self):
-        assert extract_top_level_annotations("x: dict =") == {}
+        assert extract_top_level_input_annotations("x: dict =") == {}
 
     def test_python_to_s1_canonical_is_injective(self):
         """Reverse mapping from S1 to Python requires injectivity.

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1480,12 +1480,13 @@ class TestCodeNodeInputAnnotationValidation:
         assert any("Add 'y' to the inputs dict" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
         assert not any("Remove" in s for s in diagnostic.suggestions or []), diagnostic.suggestions
 
-    def test_orphan_annotation_assigned_suggests_remove_or_add(self, test_registry):
-        """Orphan annotation that is ALSO assigned is a local — offer remove (lead) or add.
+    def test_annotated_assignment_local_is_not_flagged_as_orphan(self, test_registry):
+        """A typed local (`x: T = expr`) is not an input declaration — no orphan error (#331).
 
-        Removing the annotation is safe because the name carries a value, so both
-        fixes are valid. Contrast with the read-but-unassigned case above, where
-        removing would leave the name unbound and only "add" is offered.
+        ``all_items: list = [x]`` binds its own value, so it is a local variable,
+        not an injected input. Only a BARE annotation (``x: T``) declares an input,
+        so the validator must leave valued assignments alone. Contrast with the
+        bare-orphan cases above, which still error.
         """
         workflow_ir = {
             "nodes": [
@@ -1493,7 +1494,7 @@ class TestCodeNodeInputAnnotationValidation:
                     "id": "consumer",
                     "type": "code",
                     "params": {
-                        # all_items is annotated AND assigned -> a local, not an input.
+                        # all_items is an annotated assignment -> a local, not an input.
                         "code": "x: dict\nall_items: list = [x]\nresult: int = len(all_items)",
                         "inputs": {"x": "literal_value"},
                     },
@@ -1503,16 +1504,41 @@ class TestCodeNodeInputAnnotationValidation:
         }
 
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
-        annotation_errors = [
-            d for d in errors if "has no corresponding entry in 'inputs'" in d.message and "all_items" in d.message
-        ]
-        assert len(annotation_errors) == 1
-        suggestions = annotation_errors[0].suggestions or []
-        # Both fixes present...
-        assert any("Remove the annotation 'all_items" in s and "local variable" in s for s in suggestions), suggestions
-        assert any("add 'all_items' to the inputs dict" in s.lower() for s in suggestions), suggestions
-        # ...and the local reading leads.
-        assert "Remove" in suggestions[0], suggestions
+        annotation_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
+        assert annotation_errors == [], [d.message for d in annotation_errors]
+
+    def test_typed_locals_not_in_inputs_are_not_flagged(self, test_registry):
+        """Issue #331 repro — typed intermediates produce zero validation errors.
+
+        The original failure: every ``name: type = expr`` intermediate was flagged
+        ``has no corresponding entry in 'inputs'``. Here ``rewrite_output`` is the
+        only real input (bare); ``deliberation`` / ``lyrics`` are typed locals and
+        ``result`` is the output. The whole node must validate clean.
+        """
+        code = (
+            "rewrite_output: str\n"
+            "lines = rewrite_output.split('\\n')\n"
+            "deliberation: str = '\\n'.join(lines[:1]).strip()\n"
+            "lyrics: str = '\\n'.join(lines[1:]).strip()\n"
+            'result: dict = {"deliberation": deliberation, "lyrics": lyrics}'
+        )
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "split",
+                    "type": "code",
+                    "params": {
+                        "code": code,
+                        "inputs": {"rewrite_output": "some text"},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        orphan_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
+        assert orphan_errors == [], [d.message for d in orphan_errors]
 
     def test_orphan_annotation_conditional_assignment_is_not_safe_local(self, test_registry):
         """Orphan assigned only inside `if` may be unbound at runtime — add, don't lead with remove (C1)."""
@@ -1579,6 +1605,10 @@ class TestCodeNodeInputAnnotationValidation:
         suggestions = ann[0].suggestions or []
         assert any("Remove the annotation 'helper" in s and "local variable" in s for s in suggestions), suggestions
         assert "Remove" in suggestions[0], suggestions
+        # #331: the suggestion must not claim locals can't be annotated, and should
+        # point to the typed-local value form instead.
+        assert not any("take annotations" in s for s in suggestions), suggestions
+        assert any("helper: Any = ..." in s for s in suggestions), suggestions
 
     def test_orphan_batch_alias_assigned_preserves_alias_suggestion(self, test_registry):
         """An assigned batch alias still needs `item: ${item}` — the alias isn't injected into exec (C3)."""

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -1540,6 +1540,37 @@ class TestCodeNodeInputAnnotationValidation:
         orphan_errors = [d for d in errors if "has no corresponding entry in 'inputs'" in d.message]
         assert orphan_errors == [], [d.message for d in orphan_errors]
 
+    def test_input_normalized_in_place_is_not_flagged_missing(self, test_registry):
+        """A valued annotation on an INPUT key (`text: str = text.strip()`) validates clean.
+
+        The RHS reads the injected value before reassigning, so the input is used,
+        not dead — it runs fine at runtime. The missing-annotation check must treat
+        a valued annotation as satisfying the input's type-annotation requirement
+        (matching runtime's ``_check_input_annotations``), not flag "missing".
+        Regression guard for the over-narrowing caught in deep review.
+        """
+        workflow_ir = {
+            "nodes": [
+                {
+                    "id": "norm",
+                    "type": "code",
+                    "params": {
+                        "code": "text: str = text.strip()\nresult: str = text.upper()",
+                        "inputs": {"text": "  hello  "},
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+        # No "missing annotation" and no "orphan" error — the node is valid.
+        relevant = [
+            d
+            for d in errors
+            if "missing a type annotation" in d.message or "has no corresponding entry in 'inputs'" in d.message
+        ]
+        assert relevant == [], [d.message for d in relevant]
+
     def test_orphan_annotation_conditional_assignment_is_not_safe_local(self, test_registry):
         """Orphan assigned only inside `if` may be unbound at runtime — add, don't lead with remove (C1)."""
         workflow_ir = {


### PR DESCRIPTION
## Summary

The code-node validator flagged annotated assignments (`name: type = expr`) as undeclared inputs, requiring an `inputs:` entry for what are really local variables. Only **bare** annotations (`name: type`, no `=`) declare an input — a valued assignment binds its own value and is a local. This was the most recurring code-node friction in real use (every node with typed intermediates).

Fixes #331

## Changes

- `src/pflow/nodes/python/python_code.py` — gate the validate-time annotation extractor on `node.value is None` so only bare annotations are returned; renamed `extract_top_level_annotations` → `extract_top_level_input_annotations` to encode the narrowed contract.
- `src/pflow/runtime/template_validation/type_validation.py` — consume the renamed helper; document the name-collision edge case; **fix a false claim in the orphan-suggestion text** ("(only declared inputs and result/next take annotations)") that #331 overturns — it now points to the typed-local value form. Updated the orphan-builder docstring accordingly.
- `src/pflow/guide/nodes/code.md` — the agent guide previously told agents "do NOT annotate locals"; rewritten to explain bare-vs-valued and that typed intermediates are fine.
- Tests — flipped the test that codified the bug; added issue-repro + bare-only extractor tests; pinned the corrected suggestion messaging.

## Explanation

Root cause: `extract_top_level_annotations()` collected every module-level `ast.AnnAssign` regardless of `node.value`, so the validator's orphan check (`annotation_keys - input_keys`) flagged typed locals. `result`/`next` only escaped via a by-name exclusion — not because the validator understood the bare-vs-valued distinction. The fix makes that distinction the single source of truth: bare = input declaration, valued = local.

Runtime is untouched — it uses the separate `_extract_annotations` (AST-walk variant) for input/result type checks, so only validate-time behavior changed. Verified injection order (`namespace.update(inputs)` runs before the code), which confirms a valued module-level assignment always shadows an injected input — so the rare "input key also written as `x: T = ...`" case is a genuinely dead binding and is correctly reported as a missing annotation (documented in a code comment).

131 insertions / 66 deletions across 5 files.

## Testing

- `test_typed_locals_not_in_inputs_are_not_flagged` — issue repro: typed intermediates (`deliberation`/`lyrics`) produce zero validation errors.
- `test_annotated_assignment_local_is_not_flagged_as_orphan` — flipped from the bug-codifying test: `all_items: list = [x]` is now a clean local, no diagnostic.
- `test_top_level_annotations_excludes_valued_assignments` — extractor returns only bare annotations.
- `test_orphan_annotation_on_def_name_suggests_remove` — extended to pin the corrected messaging (no "take annotations" claim; suggests the `name: type = ...` value form).
- Existing bare-orphan tests (unused / read-but-unbound / conditional / augmented / batch-alias) still pass — bare annotations are still validated.
- Manual: `pflow --validate-only` on the issue's repro now reports `✓ Workflow is valid`; a bare orphan (`ghost: list`) still errors; the assigned-orphan case renders the corrected suggestion.
- Full suite: 7807 passed; `make check` clean (ruff, mypy on 230 files, deptry, MDX fence check).