### PR TITLE
fix: JSON-string result unwrap bypasses MCP-only gate (#508)

### DIFF
--- a/src/pflow/runtime/engine/api_warning_detector.py
+++ b/src/pflow/runtime/engine/api_warning_detector.py
@@ -138,15 +138,17 @@ def unwrap_mcp_response(output: Any, *, inspect_result: bool = True) -> Optional
     if not isinstance(output, dict):
         return None
 
-    # Try to unwrap MCP JSON string result
-    parsed = _parse_mcp_json_result(output)
-    if parsed is not None:
-        return parsed
+    # Canonical MCP ``result`` wrapper — JSON-string or dict form. Both are
+    # gated on ``inspect_result`` so this unwrapping stays limited to MCP nodes
+    # (a non-MCP node's ``result`` is payload data, not an API response).
+    if inspect_result:
+        parsed = _parse_mcp_json_result(output)
+        if parsed is not None:
+            return parsed
 
-    # Handle canonical MCP node output: {"result": {...}}.
-    if inspect_result and isinstance(output.get("result"), dict):
-        result = output["result"]
-        return _unwrap_successful_data(result) or result
+        if isinstance(output.get("result"), dict):
+            result = output["result"]
+            return _unwrap_successful_data(result) or result
 
     # Handle MCP dict with nested data
     data = _unwrap_successful_data(output)

--- a/tests/test_execution/test_api_warning_system.py
+++ b/tests/test_execution/test_api_warning_system.py
@@ -157,6 +157,21 @@ class TestCriticalAPIWarningScenarios:
 
         assert warning is None
 
+    def test_json_string_result_not_unwrapped_for_non_mcp_nodes(self):
+        """GH #508: a JSON-string ``result`` is payload, not an API response.
+
+        The string arm of ``unwrap_mcp_response`` used to bypass the MCP-only
+        gate, so a successful code node returning a JSON failure report (e.g. a
+        verdict ``{"ok": false}``) was misclassified as a failed API call. This
+        pins the string case to match the dict case above — both stay payload
+        for non-MCP nodes.
+        """
+        shared = {"calc": {"result": json.dumps({"ok": False, "violations": ["x"]})}}
+
+        warning = detect_api_warning("calc", shared, node_type_name="PythonCodeNode")
+
+        assert warning is None
+
     def test_top_level_explicit_failure_flags_remain_type_agnostic(self):
         shared = {"calc": {"status": "error", "message": "Invalid input format"}}
 


### PR DESCRIPTION
## Summary
A successful non-MCP node (e.g. a `code` node) whose `result` is a JSON **string** containing an explicit failure flag (`ok: false`, `success: false`, …) was misclassified as a failed API call and failed with the misleading `API error: API request failed` — exit 1. The node's real output was only recoverable from the trace blob.

Fixes #508

## Changes
- `unwrap_mcp_response` (`api_warning_detector.py`): both `result`-wrapper arms — JSON-string (`_parse_mcp_json_result`) and dict — now sit under a single `if inspect_result:` gate.
- Added `test_json_string_result_not_unwrapped_for_non_mcp_nodes` — the string mirror of the existing `test_result_wrapper_not_unwrapped_for_non_mcp_nodes` dict-case guard.

## Explanation
This is a **drift bug**: the dict `result` arm was gated on `inspect_result` (True only for MCP / unknown callers), but the JSON-string arm ran **unconditionally** before the gate. Identical data, different serialization, opposite outcome:

```python
# code node, result as a dict → SAFE (gate blocks unwrapping)
detect_api_warning("calc", {"calc": {"result": {"ok": False}}}, node_type_name="PythonCodeNode")  # → None
# code node, the SAME data json.dumps'd → FAILED
detect_api_warning("calc", {"calc": {"result": '{"ok": false}'}}, node_type_name="PythonCodeNode")  # → "API error: API request failed"
```

Rather than the smallest diff (adding a second parallel guard), both arms are consolidated under **one** gate block. They are the single concern `inspect_result` exists to gate — unwrapping the canonical MCP `result` wrapper in either serialization — so the gate becomes structural and a future third arm can't re-introduce the drift. The `_parse_mcp_json_result` / `_unwrap_successful_data` helpers are left untouched (they have a subtly different `successful: true` + non-dict-`data` edge case that unifying would silently change).

The deeper design tension the issue flags (the detector reinterpreting a node's data output as execution status, with no per-node opt-out) is intentionally **out of scope** here — that overlaps with #301 and would be a detector-scoping redesign, not a surgical gate fix.

`2 files changed, 26 insertions(+), 9 deletions(-)`.

## Testing
- `test_json_string_result_not_unwrapped_for_non_mcp_nodes` — new regression: non-MCP node with a JSON-string `{"ok": false}` `result` → `None` (was `"API error: API request failed"`).
- Both issue-pinned behaviors verified intact: `test_slack_mcp_channel_not_found` (MCP keeps full string-result inspection) and `test_top_level_explicit_failure_flags_remain_type_agnostic` (top-level flags stay type-agnostic).
- Full suite: **7821 passed**; `make check` clean (ruff, ruff-format, mypy 230 files, deptry).
- **Manual end-to-end** through the real `pflow` CLI on a workflow with a `code` node returning `json.dumps({"ok": False, "violations": [...]})`:
  - Post-fix: exit **0**, `✓ completed`, verdict preserved in output.
  - Pre-fix (same workflow, fix stashed): exit **1**, `❌ API error: API request failed` — confirms the symptom and that this change is the fix.
  - Regression direction confirmed: MCP JSON-string `ok:false` → still flagged (`channel_not_found`); MCP dict `status:error` → still flagged; unknown caller (`node_type_name=None`) → still flagged.