### PR TITLE
fix: core-node refresh no longer wipes synced MCP tools (#462)

### DIFF
--- a/src/pflow/mcp/registrar.py
+++ b/src/pflow/mcp/registrar.py
@@ -259,6 +259,7 @@ class MCPRegistrar:
             "class_name": "MCPNode",
             "module": "pflow.nodes.mcp.node",
             "file_path": "virtual://mcp",  # Virtual path for MCP nodes
+            "type": "mcp",  # Mirrors core/user nodes — keeps the data self-describing
             "interface": {
                 "description": tool.get("description", f"MCP tool from {server_name}"),
                 "inputs": [],  # MCP tools don't read from shared store, only from params

--- a/src/pflow/mcp/types.py
+++ b/src/pflow/mcp/types.py
@@ -75,15 +75,6 @@ class InterfaceSchema(TypedDict, total=False):
     mcp_metadata: dict[str, Any]
 
 
-class RegistryEntry(TypedDict):
-    """Registry entry for MCP nodes."""
-
-    class_name: str
-    module: str
-    file_path: str
-    interface: InterfaceSchema
-
-
 # JSON Schema types
 JSONSchemaType = str | list[str]  # Can be string or union type like ["string", "null"]
 JSONSchemaValue = None | bool | int | float | str | list | dict[str, Any]

--- a/src/pflow/registry/registry.py
+++ b/src/pflow/registry/registry.py
@@ -462,9 +462,23 @@ class Registry:
             return False
 
     def _refresh_core_nodes(self, nodes: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
-        """Refresh core nodes while preserving user and MCP nodes."""
-        # Preserve non-core nodes
-        preserved = {name: data for name, data in nodes.items() if data.get("type") in ("user", "mcp")}
+        """Refresh core nodes while preserving every non-core node.
+
+        The refresh re-discovers core nodes, so everything that isn't core (user,
+        mcp, or an untyped legacy entry) must survive. Keyed on "not core" rather
+        than an allowlist of known types so it fails safe: an entry we don't
+        recognize is kept, never silently dropped. This also self-heals MCP
+        entries synced before they were stamped with type="mcp" — their absent
+        type is not "core", so they're preserved.
+
+        Freshly-discovered core metadata wins on a name collision: preserved
+        entries are merged *under* the fresh scan, not over it. So a stale entry
+        sharing a core node's name (e.g. an untyped "shell" left by the removed
+        `registry scan` CLI) can neither resurrect nor shadow a core node — the
+        broadened predicate can only add non-core names, never override core ones.
+        """
+        # Preserve every non-core node (see docstring: fail-safe, self-healing).
+        preserved = {name: data for name, data in nodes.items() if data.get("type") != "core"}
 
         # Re-discover core nodes — _auto_discover_core_nodes stamps
         # last_core_scan with a PRE-scan timestamp (race-safe).
@@ -473,8 +487,11 @@ class Registry:
         # Reload — populates self._registry_last_scan from the pre-scan stamp.
         refreshed = self._load_from_file()
 
-        # Merge preserved nodes back in
-        refreshed.update(preserved)
+        # Merge preserved nodes UNDER the fresh core scan: setdefault adds a
+        # preserved entry only when its name is free, so fresh core metadata
+        # always wins a name collision (see docstring).
+        for name, data in preserved.items():
+            refreshed.setdefault(name, data)
 
         # Save the merged result, propagating the pre-scan timestamp so the
         # race-safety is preserved through the final merge write. Without this,

--- a/tests/test_mcp/test_mcp_discovery_critical.py
+++ b/tests/test_mcp/test_mcp_discovery_critical.py
@@ -141,6 +141,8 @@ class TestMCPRegistrarCritical:
             assert entry["class_name"] == "MCPNode"
             assert entry["module"] == "pflow.nodes.mcp.node"
             assert entry["file_path"] == "virtual://mcp"
+            # type="mcp" so the entry survives core-node refresh (issue #462)
+            assert entry["type"] == "mcp"
 
             # Interface MUST have these exact fields
             interface = entry["interface"]

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -559,11 +559,13 @@ class TestRegistryVersionRefresh:
                 assert registry2._core_nodes_outdated(nodes) is True
 
     def test_refresh_preserves_user_nodes(self):
-        """When core nodes are refreshed, user and MCP nodes must survive.
+        """When core nodes are refreshed, every non-core node must survive.
 
-        We write a registry containing both core nodes and user/MCP nodes,
-        then call _refresh_core_nodes. The returned dict must still contain
-        the user and MCP entries.
+        We write a registry containing core nodes plus user/MCP nodes, then
+        call _refresh_core_nodes. The returned dict must still contain the
+        user and MCP entries — including a legacy MCP entry with NO type field
+        (synced before issue #462's fix stamped type="mcp"), which the fail-safe
+        "preserve everything that isn't core" predicate must self-heal.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             registry_path = Path(tmpdir) / "registry.json"
@@ -586,6 +588,13 @@ class TestRegistryVersionRefresh:
                     "class_name": "McpNode",
                     "type": "mcp",
                 },
+                # Legacy MCP entry as the registrar built it BEFORE the fix:
+                # no "type" field, identified only by the virtual path.
+                "mcp-legacy-tool": {
+                    "module": "pflow.nodes.mcp.node",
+                    "class_name": "MCPNode",
+                    "file_path": "virtual://mcp",
+                },
             }
             registry._save_with_metadata(mixed_nodes)
 
@@ -601,10 +610,54 @@ class TestRegistryVersionRefresh:
             assert refreshed["my-custom-node"]["type"] == "user"
             assert "mcp-tool" in refreshed
             assert refreshed["mcp-tool"]["type"] == "mcp"
+            # Untyped legacy MCP entry must self-heal through the refresh,
+            # with its payload intact (the merge must not mutate it).
+            assert "mcp-legacy-tool" in refreshed
+            assert refreshed["mcp-legacy-tool"] == mixed_nodes["mcp-legacy-tool"]
 
             # Core nodes should be present (from real auto-discovery)
             core_nodes = {name: data for name, data in refreshed.items() if data.get("type") == "core"}
             assert len(core_nodes) > 0, "Refresh should have discovered core nodes"
+
+    def test_refresh_does_not_shadow_core_node_with_untyped_entry(self):
+        """A stale untyped entry sharing a core node's name must not shadow it.
+
+        The fail-safe denylist preserves untyped entries, but fresh core metadata
+        must win on a name collision (issue #462 review): a legacy untyped "shell"
+        entry (e.g. left by the removed `registry scan` CLI) must be overridden by
+        the freshly-discovered core node, never resurrected over it. A non-colliding
+        untyped entry must still self-heal.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry.json"
+            registry = Registry(registry_path)
+
+            stale_nodes = {
+                # Untyped entry colliding with a real core node name.
+                "shell": {
+                    "module": "stale.shell",
+                    "class_name": "StaleShellNode",
+                    "file_path": "/stale/shell.py",
+                },
+                # Untyped MCP entry that does NOT collide — must self-heal.
+                "mcp-legacy-tool": {
+                    "module": "pflow.nodes.mcp.node",
+                    "class_name": "MCPNode",
+                    "file_path": "virtual://mcp",
+                },
+            }
+            registry._save_with_metadata(stale_nodes)
+
+            registry2 = Registry(registry_path)
+            nodes = registry2._load_from_file()
+            refreshed = registry2._refresh_core_nodes(nodes)
+
+            # Fresh core "shell" wins — the stale untyped entry must not shadow it.
+            assert refreshed["shell"]["type"] == "core"
+            assert refreshed["shell"]["module"] == "pflow.nodes.shell.shell"
+            assert refreshed["shell"]["class_name"] == "ShellNode"
+            # Non-colliding untyped entry still self-heals through the refresh.
+            assert "mcp-legacy-tool" in refreshed
 
 
 class TestRegistrySourceMtimeRefresh:


### PR DESCRIPTION
## Summary

Every synced MCP tool was silently dropped from the registry whenever pflow's core-node auto-refresh fired. The refresh *intended* to preserve MCP nodes (it kept `type in ("user", "mcp")`), but **MCP entries were never stamped with a `type`**, so the preservation filter skipped them and wiped them. User nodes survived (they're stamped `type="user"`); MCP nodes didn't.

The refresh triggers on any change to node source-file mtimes, so anyone **developing pflow** (editing node files, switching branches/worktrees, `uv` reinstalls) lost all MCP tools on the next command and had to re-run `pflow mcp sync --all`.

Fixes #462

## Changes

- **`src/pflow/mcp/registrar.py`** — stamp `"type": "mcp"` on MCP registry entries in `_create_registry_entry`, mirroring how core (`type="core"`) and user (`type="user"`) nodes are stamped.
- **`src/pflow/registry/registry.py`** — change `_refresh_core_nodes` preservation from an allowlist to the fail-safe denylist `data.get("type") != "core"`, plus a docstring/comment explaining the rationale.
- **`tests/test_mcp/test_mcp_discovery_critical.py`** — assert the registrar now stamps `type="mcp"`.
- **`tests/test_registry/test_registry.py`** — add an untyped legacy `virtual://mcp` entry to the refresh-preservation test and assert it self-heals.

```
 src/pflow/mcp/registrar.py                    |  1 +
 src/pflow/registry/registry.py                | 14 +++++++++++---
 tests/test_mcp/test_mcp_discovery_critical.py |  2 ++
 tests/test_registry/test_registry.py          | 19 +++++++++++++++----
 4 files changed, 29 insertions(+), 7 deletions(-)
```

## Explanation

There were two ways to harden the preservation, and the denylist was chosen deliberately over the more obvious "add a `virtual://mcp` sentinel clause to the allowlist":

The original allowlist (`type in ("user", "mcp")`) failed **unsafe** — it silently dropped anything it didn't recognize, which is exactly what caused this bug. `_refresh_core_nodes` re-discovers *core* nodes, so the true intent is simply "keep everything that isn't core." Expressed as `type != "core"`, the predicate:

- fails **safe** — an unrecognized entry is preserved, never silently dropped (fixes the failure *mode*, not just this instance);
- **self-heals** legacy registries — MCP entries synced before this fix have no `type`, and `None != "core"`, so they survive with no re-sync needed;
- is the simplest final code — one condition, no magic string, no migration crutch to remove later.

Stamping `type="mcp"` is then complementary: it isn't required for the fix (the denylist preserves typed and untyped entries alike), but it makes the registry data self-describing — every node category carries an explicit `type`, so the next reader doesn't have to learn that "MCP is the typeless category identified by a `virtual://mcp` path." This also makes the existing `registry/CLAUDE.md` "Node Types" table (which already documented MCP getting `type` from the registrar) accurate.

## Testing

- `test_create_registry_entry_structure` — extended to assert `entry["type"] == "mcp"`, locking the registrar stamp.
- `test_refresh_preserves_user_nodes` — extended with an untyped legacy `virtual://mcp` entry (the exact shape that was being wiped); asserts it survives a real `_refresh_core_nodes`, locking the denylist self-heal.
- Full suite: **7820 passed, 0 failed**; `make check` clean (ruff, mypy on 230 files, deptry).
- **Manual, real CLI, real mtime trigger path** (isolated `$HOME`, version matched so `_source_newer_than_scan` is what fires):
  - Old code, 2 untyped MCP entries → `pflow mcp list` shows `0 total across 0 servers` (bug reproduced).
  - New code, identical seed → `pflow mcp list` shows `2 total across 1 servers` (fixed). Disk inspection confirmed the refresh genuinely ran (`last_core_scan` moved off `2020`, 11 core nodes re-discovered) and both untyped entries persisted.
  - A normal workflow (`pflow <wf>.pflow.md`) still compiles, executes, and outputs correctly against the refreshed registry.