### PR TITLE
fix: shield ${...} templates in flow-style YAML so unquoted inline maps parse (#482)

### DIFF
--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -16,6 +16,7 @@ src/pflow/core/
 ├── ir_schema.py             # IR schema definition and validation
 ├── types.py                 # TypeSpec, CANONICAL_TYPES, PYTHON_ALIASES_AT_S1 — single source of truth for S1 vocabulary
 ├── json_utils.py            # Shared JSON parsing (try_parse_json, parse_json_or_original)
+├── yaml_utils.py            # safe_load_preserving_templates — YAML load that shields ${...} templates (issue #482)
 ├── llm_config.py            # LLM model resolution, env injection, provider detection
 ├── llm_client.py            # pflow LiteLLM adapter (single seam for all LLM calls)
 ├── llm_providers.py         # Canonical provider metadata (prefixes, env vars)
@@ -178,6 +179,8 @@ Returns `MarkdownParseResult(ir, title, description, metadata, source)`.
 
 **Parameter parsing** (`_parse_yaml_items`): Two parsing paths based on syntax. Single-line items use `_coerce_yaml_scalar` (raw string + YAML-like scalar coercion for bools, ints, floats, null, quoted strings, flow-style `{}`/`[]`). Multi-line items (indented continuations) use `yaml.safe_load()`. This eliminates YAML structural bugs (`: ` splitting, `#` comment stripping) while preserving type coercion. Intentionally diverges from PyYAML for edge cases (octal, hex, dates, scientific notation). Unterminated quotes error; inline `#` comments are NOT stripped.
 
+**Template shielding in flow-style YAML** (issue #482): every site that YAML-parses author content that can carry `${...}` templates — `_coerce_yaml_scalar` (single-line flow values), `_parse_multiline_yaml_item`, the fenced `yaml`-config blocks in `_validate_code_blocks`/`_route_code_blocks_to_node`, plus `file_resolver`/`dependency_discovery` for external files — goes through `yaml_utils.safe_load_preserving_templates`, NOT raw `yaml.safe_load`. PyYAML reads the `{` in an unquoted `${...}` as a nested flow mapping, so `{ x: ${y} }` would otherwise fail where block/quoted forms parse. The helper masks templates → parses → restores, so inline ≡ block ≡ quoted everywhere. Frontmatter (`markdown_parser`/`manager`) stays on raw `yaml.safe_load` — it carries system metadata, never templates. New author-content YAML sites must use the shared helper or they reopen the bug.
+
 **Multi-line item continuation**: a line continues the current `- key:` item if it is **blank OR indented ≥ the bullet's content column**. Blank lines are preserved verbatim so `|`/`>` block scalars with internal blank-line separators round-trip correctly through `yaml.safe_load`. Termination is only: dedented non-blank line, new `- ` bullet, heading, code-fence, or EOF. `_flush_yaml_item` strips trailing blanks before joining so single-line items stay on the `_coerce_yaml_scalar` fast path (preserving the PyYAML divergences noted above).
 
 **Routing syntax**: `- next: node-id` (static routing), `- next: end` (terminal), `- on-error: node-id` (error routing). These are extracted from params into routing metadata during `_build_node_dict()` and used by `_build_edges()` to generate edges with action fields. Python code blocks are AST-scanned for `next: str = "literal"` assignments to generate additional routing edges.
@@ -327,7 +330,7 @@ Detects file path references in node params and batch items, reads the files, an
 
 **Detection heuristic**: starts with `./` or `../`, or contains `/` with recognized extension (.md, .txt, .py, .sh, .yaml, .yml, .json). Must not contain `${`, newlines, or `://` (URLs excluded).
 
-**YAML-parsed params**: batch, output_schema, headers — file content is `yaml.safe_load()`'d. All other params get raw text content.
+**YAML-parsed params**: batch, output_schema, headers — file content is parsed with `yaml_utils.safe_load_preserving_templates` (shields `${...}` in flow style — issue #482). All other params get raw text content.
 
 **Batch handling**: `node["batch"]` is at the node top level (NOT in params). If it's a string file reference, reads and YAML-parses. If it's a dict with inline items, walks items for file references in their values.
 

--- a/src/pflow/core/file_resolver.py
+++ b/src/pflow/core/file_resolver.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import yaml
+from pflow.core.yaml_utils import safe_load_preserving_templates
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,9 @@ def resolve_file_references(ir_dict: dict[str, Any], base_dir: Path) -> dict[str
     Walks all node params and batch items. When a value matches the
     file reference heuristic and the file exists, reads the file and
     substitutes its content. For YAML params (batch, output_schema,
-    headers), the file content is parsed with yaml.safe_load().
+    headers), the file content is parsed with
+    ``yaml_utils.safe_load_preserving_templates`` so unquoted ``${...}``
+    templates in flow style parse like block form (issue #482).
 
     Args:
         ir_dict: The workflow IR dict (modified in place)
@@ -143,7 +145,7 @@ def resolve_file_references(ir_dict: dict[str, Any], base_dir: Path) -> dict[str
             if is_file_reference(value):
                 content = _read_file(value, base_dir, node_id, key)
                 if key in YAML_PARSED_PARAMS:
-                    params[key] = yaml.safe_load(content)
+                    params[key] = safe_load_preserving_templates(content)
                 else:
                     params[key] = content
                 node.setdefault("_source_files", {})[key] = value
@@ -173,7 +175,7 @@ def _resolve_batch_file_references(
     if isinstance(batch, str) and is_file_reference(batch):
         original_value = batch
         content = _read_file(batch, base_dir, node_id, "batch")
-        node["batch"] = yaml.safe_load(content)
+        node["batch"] = safe_load_preserving_templates(content)
         node.setdefault("_source_files", {})["batch"] = original_value
         logger.debug(f"Resolved file reference: node '{node_id}', batch <- {original_value}")
         batch = node["batch"]  # Update local var for B2 fall-through
@@ -190,7 +192,7 @@ def _resolve_batch_file_references(
                         if is_file_reference(value):
                             content = _read_file(value, base_dir, node_id, f"batch.items[{i}].{key}")
                             if key in YAML_PARSED_PARAMS:
-                                item[key] = yaml.safe_load(content)
+                                item[key] = safe_load_preserving_templates(content)
                             else:
                                 item[key] = content
                             provenance_key = f"batch.items[{i}].{key}"

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -27,6 +27,7 @@ from pflow.core.cache_ttl import cache_ttl_syntax_hint, is_valid_cache_ttl
 from pflow.core.diagnostic import Diagnostic, Severity
 from pflow.core.exceptions import MarkdownParseError
 from pflow.core.suggestion_utils import find_similar_items
+from pflow.core.yaml_utils import safe_load_preserving_templates
 
 # --- Result dataclass ---
 
@@ -932,10 +933,11 @@ def _coerce_yaml_scalar(value: str) -> Any:
         quote_type = "double" if value[0] == '"' else "single"
         raise ValueError(f"Unterminated {quote_type}-quoted string: {value}")
 
-    # Flow-style YAML mapping or sequence → parse with yaml.safe_load
+    # Flow-style YAML mapping or sequence → parse with yaml.safe_load, shielding
+    # ``${...}`` templates so unquoted ones parse like block form.
     # Let yaml.YAMLError propagate — caller converts to MarkdownParseError
     if value.startswith(("{", "[")):
-        return yaml.safe_load(value)
+        return safe_load_preserving_templates(value)
 
     # Null
     if value in _YAML_NULL:
@@ -959,7 +961,7 @@ def _coerce_yaml_scalar(value: str) -> Any:
 def _parse_multiline_yaml_item(item: str, entity: _Entity, merged: dict[str, Any]) -> str | None:
     """Parse a multi-line YAML item and merge results into ``merged``."""
     try:
-        parsed = yaml.safe_load(item)
+        parsed = safe_load_preserving_templates(item)
     except yaml.YAMLError as exc:
         raise _enhance_yaml_error(exc, entity) from exc
 
@@ -1124,10 +1126,10 @@ def _validate_code_blocks(entity: _Entity) -> None:
                     suggestion=f"Fix the Python syntax in the code block starting at line {block.start_line}.",
                 ) from exc
 
-        # YAML config validation
+        # YAML config validation (shielding ${...} templates — same as param values)
         if block.is_yaml_config:
             try:
-                yaml.safe_load(block.content)
+                safe_load_preserving_templates(block.content)
             except yaml.YAMLError as exc:
                 raise MarkdownParseError(
                     f"YAML syntax error in '{block.tag}' block: {exc}",
@@ -1184,16 +1186,16 @@ def _route_code_blocks_to_node(entity: _Entity, node: dict[str, Any], params: di
     for block in entity.code_blocks:
         if block.param_name == "batch":
             if block.is_yaml_config:
-                node["batch"] = yaml.safe_load(block.content)
+                node["batch"] = safe_load_preserving_templates(block.content)
             else:
                 node["batch"] = block.content
         elif block.param_name == "loop":
             # `loop:` is a top-level node field (sibling to `batch`), not a param.
             # Always YAML-parse — a loop block is a `while:`/`max_iterations:` mapping.
-            node["loop"] = yaml.safe_load(block.content) if block.is_yaml_config else block.content
+            node["loop"] = safe_load_preserving_templates(block.content) if block.is_yaml_config else block.content
         elif block.param_name:
             if block.is_yaml_config:
-                params[block.param_name] = yaml.safe_load(block.content)
+                params[block.param_name] = safe_load_preserving_templates(block.content)
             else:
                 params[block.param_name] = block.content
                 # Carry source line so runtime errors can reference the .pflow.md file.

--- a/src/pflow/core/workflow/dependency_discovery.py
+++ b/src/pflow/core/workflow/dependency_discovery.py
@@ -15,6 +15,7 @@ import yaml
 from pflow.core.exceptions import MarkdownParseError
 from pflow.core.file_resolver import FILE_RESOLVABLE_PARAMS, is_file_reference, is_workflow_file_reference
 from pflow.core.markdown_parser import parse_markdown
+from pflow.core.yaml_utils import safe_load_preserving_templates
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +171,7 @@ def _collect_batch_deps(
         # Parse batch YAML to find file refs in items
         try:
             batch_content = resolved.read_text(encoding="utf-8")
-            batch_data = yaml.safe_load(batch_content)
+            batch_data = safe_load_preserving_templates(batch_content)
             if isinstance(batch_data, dict):
                 _collect_batch_item_deps(batch_data, base_dir, node_id, deps)
         except yaml.YAMLError:

--- a/src/pflow/core/yaml_utils.py
+++ b/src/pflow/core/yaml_utils.py
@@ -21,9 +21,15 @@ from typing import Any
 
 import yaml
 
-# A ``${...}`` template, tolerating one level of nested ``{}`` so coalesce operands
-# with object/array literals (e.g. ``${a ?? {}}``) are captured whole — the same
-# extent the runtime TemplateResolver accepts. We only shield braces from YAML's
+# A ``${...}`` template, tolerating one level of nested ``{}`` so a coalesce operand
+# with an object/array literal (e.g. ``${a ?? {}}``) is captured whole rather than
+# truncated at its first ``}``. This is *at least* the extent the runtime
+# TemplateResolver accepts, and deliberately a bit broader: it also captures content
+# the runtime rejects (e.g. ``${a ?? {"k": 1}}`` — only empty ``{}``/``[]`` are valid
+# operands there). Over-capturing is harmless because the mask/restore round-trip is
+# verbatim. Deeper-than-one-level nesting (``${a ?? {"k": {...}}}``) is NOT matched,
+# so its ``{`` reaches YAML and surfaces as a normal YAML error — acceptable, since
+# those aren't valid runtime templates either. We only shield braces from YAML's
 # flow tokenizer, so there is no ``$$`` escape handling here (a literal ``$${y}``
 # still needs its ``{`` protected just the same).
 _TEMPLATE_RE = re.compile(r"\$\{(?:[^{}]|\{[^{}]*\})*\}")

--- a/src/pflow/core/yaml_utils.py
+++ b/src/pflow/core/yaml_utils.py
@@ -1,0 +1,106 @@
+"""Shared YAML parsing for author-supplied content that may carry templates.
+
+pflow layers its own ``${...}`` template syntax on top of YAML. PyYAML knows
+nothing about templates: it reads the ``{`` in an unquoted ``${...}`` as the
+start of a nested flow mapping, so a flow-style value like ``{ x: ${y} }`` fails
+to parse even though the block form ``x: ${y}`` and the quoted form
+``{ x: "${y}" }`` both succeed.
+
+Every site that ``yaml.safe_load``s author content capable of containing
+templates must go through :func:`safe_load_preserving_templates`, so an unquoted
+template parses the same way everywhere — single-line param, multi-line param,
+fenced YAML code block, or external file. Splitting this across ad-hoc call sites
+is how the inline form ends up working in one place and breaking in another.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+from typing import Any
+
+import yaml
+
+# A ``${...}`` template, tolerating one level of nested ``{}`` so coalesce operands
+# with object/array literals (e.g. ``${a ?? {}}``) are captured whole — the same
+# extent the runtime TemplateResolver accepts. We only shield braces from YAML's
+# flow tokenizer, so there is no ``$$`` escape handling here (a literal ``$${y}``
+# still needs its ``{`` protected just the same).
+_TEMPLATE_RE = re.compile(r"\$\{(?:[^{}]|\{[^{}]*\})*\}")
+
+
+def safe_load_preserving_templates(text: str) -> Any:
+    """``yaml.safe_load`` author content, shielding ``${...}`` templates from YAML.
+
+    Masks each template with a unique placeholder, parses, then restores the
+    original template text in the result — and in any error message — so an
+    unquoted template inside a flow map/sequence parses like the block form.
+
+    Raises:
+        yaml.YAMLError: For content malformed independently of its templates
+            (e.g. ``{invalid: [unclosed``). The error text shows the author's
+            original ``${...}``, never the internal placeholder.
+    """
+    placeholders: dict[str, str] = {}
+    # A per-call nonce keeps the placeholder un-guessable, so authored content can
+    # never collide with it — a collision would silently corrupt the parsed value.
+    nonce = secrets.token_hex(4)
+
+    def _mask(match: re.Match[str]) -> str:
+        key = f"__pflow_tpl_{nonce}_{len(placeholders)}__"
+        placeholders[key] = match.group(0)
+        return key
+
+    masked = _TEMPLATE_RE.sub(_mask, text)
+    if not placeholders:
+        return yaml.safe_load(masked)
+    try:
+        parsed = yaml.safe_load(masked)
+    except yaml.YAMLError as exc:
+        # De-mask in place before surfacing so the error quotes the author's ${...},
+        # never the internal placeholder; bare re-raise keeps the original traceback.
+        _demask_error(exc, placeholders)
+        raise
+    return _restore(parsed, placeholders)
+
+
+def _restore(obj: Any, placeholders: dict[str, str]) -> Any:
+    """Recursively swap masked placeholders back to their ``${...}`` templates."""
+    if isinstance(obj, str):
+        return _restore_str(obj, placeholders)
+    if isinstance(obj, list):
+        return [_restore(item, placeholders) for item in obj]
+    if isinstance(obj, dict):
+        return {_restore(k, placeholders): _restore(v, placeholders) for k, v in obj.items()}
+    return obj
+
+
+def _restore_str(text: str, placeholders: dict[str, str]) -> str:
+    """Replace each masked placeholder in ``text`` with its original template."""
+    for key, template in placeholders.items():
+        text = text.replace(key, template)
+    return text
+
+
+def _demask_error(exc: yaml.YAMLError, placeholders: dict[str, str]) -> yaml.YAMLError:
+    """Restore templates in a YAML error in place so it quotes the author's source.
+
+    PyYAML renders — and truncates — its source snippet from the masked buffer, so
+    de-masking the already-formatted string can leave a split placeholder fragment
+    (a long line truncated mid-placeholder). Instead we restore the templates in the
+    structured marks and re-derive the pointer, so the snippet renders from author
+    text with a correctly-placed caret. Placeholders carry no newlines, so a mark's
+    line index is unchanged; only its column shifts.
+    """
+    for attr in ("context_mark", "problem_mark"):
+        mark = getattr(exc, attr, None)
+        if mark is None or mark.buffer is None:
+            continue
+        mark.pointer = len(_restore_str(mark.buffer[: mark.pointer], placeholders))
+        mark.buffer = _restore_str(mark.buffer, placeholders)
+        mark.column = mark.pointer - (mark.buffer.rfind("\n", 0, mark.pointer) + 1)
+    for attr in ("problem", "context", "note"):
+        text = getattr(exc, attr, None)
+        if isinstance(text, str):
+            setattr(exc, attr, _restore_str(text, placeholders))
+    return exc

--- a/src/pflow/core/yaml_utils.py
+++ b/src/pflow/core/yaml_utils.py
@@ -21,18 +21,27 @@ from typing import Any
 
 import yaml
 
-# A ``${...}`` template, tolerating one level of nested ``{}`` so a coalesce operand
-# with an object/array literal (e.g. ``${a ?? {}}``) is captured whole rather than
-# truncated at its first ``}``. This is *at least* the extent the runtime
-# TemplateResolver accepts, and deliberately a bit broader: it also captures content
-# the runtime rejects (e.g. ``${a ?? {"k": 1}}`` — only empty ``{}``/``[]`` are valid
-# operands there). Over-capturing is harmless because the mask/restore round-trip is
-# verbatim. Deeper-than-one-level nesting (``${a ?? {"k": {...}}}``) is NOT matched,
-# so its ``{`` reaches YAML and surfaces as a normal YAML error — acceptable, since
-# those aren't valid runtime templates either. We only shield braces from YAML's
-# flow tokenizer, so there is no ``$$`` escape handling here (a literal ``$${y}``
-# still needs its ``{`` protected just the same).
-_TEMPLATE_RE = re.compile(r"\$\{(?:[^{}]|\{[^{}]*\})*\}")
+# Scans author text for the spans we must treat specially before handing it to YAML:
+#   - A double- or single-quoted YAML scalar is left UNTOUCHED. YAML already parses
+#     quotes correctly (including unescaping ``\"``), and a ``${...}`` inside quotes
+#     never breaks the flow tokenizer — masking it would strip YAML's escape
+#     processing and corrupt e.g. ``"${a ?? \"x\"}"``. Quoted scalars are YAML's job.
+#   - A *bare* (unquoted) ``${...}`` template (group 1) is what we mask. It tolerates
+#     one level of nested ``{}`` so a coalesce operand with an object/array literal
+#     (``${a ?? {}}``) is captured whole rather than truncated at its first ``}``.
+#     This is *at least* the extent the runtime TemplateResolver accepts, and a bit
+#     broader (it also captures content the runtime rejects, e.g. ``${a ?? {"k": 1}}``);
+#     over-capturing is harmless because the mask/restore round-trip is verbatim.
+#     Deeper-than-one-level nesting (``${a ?? {"k": {...}}}``) is NOT matched, so its
+#     ``{`` reaches YAML and surfaces as a normal YAML error — acceptable, since those
+#     aren't valid runtime templates either.
+# There is no ``$$`` escape handling here (a literal ``$${y}`` still needs its ``{``
+# protected just the same).
+_SCAN_RE = re.compile(
+    r'"(?:\\.|[^"\\])*"'  # double-quoted YAML scalar — left untouched
+    r"|'(?:''|[^'])*'"  # single-quoted YAML scalar — left untouched
+    r"|(\$\{(?:[^{}]|\{[^{}]*\})*\})"  # (group 1) a bare ${...} template — masked
+)
 
 
 def safe_load_preserving_templates(text: str) -> Any:
@@ -53,11 +62,16 @@ def safe_load_preserving_templates(text: str) -> Any:
     nonce = secrets.token_hex(4)
 
     def _mask(match: re.Match[str]) -> str:
+        template = match.group(1)
+        if template is None:
+            # A quoted scalar — leave it for YAML to (un)escape; only bare templates
+            # break the flow tokenizer. (Masking inside quotes would corrupt `\"`.)
+            return match.group(0)
         key = f"__pflow_tpl_{nonce}_{len(placeholders)}__"
-        placeholders[key] = match.group(0)
+        placeholders[key] = template
         return key
 
-    masked = _TEMPLATE_RE.sub(_mask, text)
+    masked = _SCAN_RE.sub(_mask, text)
     if not placeholders:
         return yaml.safe_load(masked)
     try:

--- a/tests/test_core/test_file_resolver.py
+++ b/tests/test_core/test_file_resolver.py
@@ -159,6 +159,19 @@ class TestResolveFileReferences:
         assert batch["parallel"] is True
         assert ir["nodes"][0]["_source_files"]["batch"] == "./batch.yaml"
 
+    def test_batch_file_flow_style_unquoted_template(self, tmp_path: Path) -> None:
+        """Issue #482: an external batch file using flow-style with an unquoted template parses.
+
+        Previously raised a YAML error because the `{` in `${candidate}` was read as a
+        nested flow mapping — the same bug as inline params, now fixed at this surface too.
+        """
+        (tmp_path / "batch.yaml").write_text("items:\n  - { contender: ${candidate} }\n")
+
+        ir = _make_ir([{"id": "n1", "type": "llm", "batch": "./batch.yaml", "params": {}}])
+        resolve_file_references(ir, tmp_path)
+
+        assert ir["nodes"][0]["batch"]["items"] == [{"contender": "${candidate}"}]
+
     def test_batch_items_resolution(self, tmp_path: Path) -> None:
         """File references inside inline batch items resolved."""
         prompts_dir = tmp_path / "prompts"

--- a/tests/test_core/test_markdown_parser.py
+++ b/tests/test_core/test_markdown_parser.py
@@ -4990,6 +4990,92 @@ class TestRawStringParsing:
         assert node["params"]["inputs"]["text"] == "${fetch.stdout}"
         assert node["params"]["inputs"]["count"] == 10
 
+    def test_flow_style_dict_unquoted_template_parsed(self) -> None:
+        """Issue #482: an inline flow map with an *unquoted* ${...} template parses.
+
+        Previously raised ``MarkdownParseError`` ("expected ',' or '}', but got '{'")
+        because PyYAML read the ``{`` in ``${...}`` as a nested flow mapping. The
+        inline form must now behave exactly like the block and quoted forms.
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### run
+
+            Runs code.
+
+            - type: code
+            - inputs: { contenders: ${candidates} }
+
+            ```python code
+            print(inputs["contenders"])
+            ```
+        """)
+        result = parse_markdown(content)
+        node = result.ir["nodes"][0]
+        assert node["params"]["inputs"] == {"contenders": "${candidates}"}
+
+    def test_flow_style_nested_template_in_multiline_item_parsed(self) -> None:
+        """Issue #482: an unquoted ${...} inside a nested flow map in a multi-line item parses."""
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### run
+
+            Runs code.
+
+            - type: code
+            - inputs:
+                data: { x: ${y} }
+
+            ```python code
+            print(inputs["data"])
+            ```
+        """)
+        result = parse_markdown(content)
+        node = result.ir["nodes"][0]
+        assert node["params"]["inputs"] == {"data": {"x": "${y}"}}
+
+    def test_yaml_config_code_block_with_unquoted_template_parsed(self) -> None:
+        """Issue #482: a ```yaml batch``` block with an unquoted template parses.
+
+        The fenced YAML-config surface (batch/stdin/loop/output_schema/headers) is
+        routed through the same shielding helper as inline param values.
+        """
+        content = _md("""\
+            # Test
+
+            A test.
+
+            ## Steps
+
+            ### run
+
+            Runs a command per item.
+
+            - type: shell
+
+            ```yaml batch
+            items:
+              - { contender: ${candidate} }
+            ```
+
+            ```shell command
+            echo hello
+            ```
+        """)
+        result = parse_markdown(content)
+        node = result.ir["nodes"][0]
+        assert node["batch"] == {"items": [{"contender": "${candidate}"}]}
+
     def test_flow_style_list_parsed(self) -> None:
         """Flow-style YAML lists on single lines are parsed as lists."""
         content = _md("""\
@@ -5188,6 +5274,14 @@ class TestCoerceYamlScalar:
     def test_flow_style_list(self) -> None:
         result = _coerce_yaml_scalar("[x, y, z]")
         assert result == ["x", "y", "z"]
+
+    def test_flow_style_dict_with_unquoted_template(self) -> None:
+        """Issue #482: coerce routes flow values through template-shielding.
+
+        Exhaustive mechanism coverage lives in test_yaml_utils.py; this pins that
+        ``_coerce_yaml_scalar`` delegates flow-style values to the shielding helper.
+        """
+        assert _coerce_yaml_scalar("{ x: ${y} }") == {"x": "${y}"}
 
     def test_unterminated_double_quote_raises(self) -> None:
         """Unterminated double-quoted string raises ValueError."""

--- a/tests/test_core/test_yaml_shielding_hygiene.py
+++ b/tests/test_core/test_yaml_shielding_hygiene.py
@@ -1,0 +1,66 @@
+"""Guard: author-content YAML must go through safe_load_preserving_templates (issue #482).
+
+PyYAML can't see pflow's ``${...}`` templates — it reads the ``{`` in an unquoted
+template as a nested flow mapping — so any raw ``yaml.safe_load`` on author content
+reopens issue #482 (unquoted templates in flow style fail to parse). This test fails
+if a new raw ``yaml.safe_load`` / ``yaml.load`` call appears outside the legitimate
+exemptions, mirroring tests/test_import_hygiene.py. It scans the AST (not text), so
+docstrings and comments mentioning ``yaml.safe_load`` don't trip it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# yaml_utils.py IS the shielding implementation — raw safe_load is its job there.
+_ALLOWED_FILES = frozenset({"src/pflow/core/yaml_utils.py"})
+_RAW_LOADERS = frozenset({"safe_load", "load", "full_load"})
+# Frontmatter parsing carries system metadata (timestamps/exec stats), never templates.
+# Both frontmatter sites call yaml.safe_load(fm_text); allowlist by that argument so a
+# new author-content call (any other argument) is still caught, even in the same file.
+_ALLOWED_ARGS = frozenset({"fm_text"})
+
+
+def _raw_yaml_load_calls(py_file: Path, rel: str) -> list[str]:
+    """Return ``rel:lineno`` for each non-exempt ``yaml.<loader>(...)`` call in the file."""
+    tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        func = getattr(node, "func", None)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(func, ast.Attribute)
+            and func.attr in _RAW_LOADERS
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "yaml"
+        ):
+            first_arg = node.args[0] if node.args else None
+            arg_name = first_arg.id if isinstance(first_arg, ast.Name) else None
+            if arg_name not in _ALLOWED_ARGS:
+                hits.append(f"{rel}:{node.lineno}")
+    return hits
+
+
+def test_author_content_yaml_uses_shielding_helper() -> None:
+    src_root = Path(__file__).resolve().parents[2] / "src" / "pflow"
+    repo_root = src_root.parents[1]
+    assert src_root.is_dir(), f"expected src/pflow/ at {src_root}"
+
+    violations: list[str] = []
+    for py_file in sorted(src_root.rglob("*.py")):
+        rel = py_file.relative_to(repo_root).as_posix()
+        if rel in _ALLOWED_FILES:
+            continue
+        violations.extend(_raw_yaml_load_calls(py_file, rel))
+
+    if violations:
+        pytest.fail(
+            "Raw yaml.safe_load/yaml.load on (possibly) author content found. Author "
+            "content can carry ${...} templates that PyYAML mis-parses (issue #482).\n"
+            "Use pflow.core.yaml_utils.safe_load_preserving_templates instead — or, if "
+            "this parses system metadata only (e.g. frontmatter), add its argument to "
+            "_ALLOWED_ARGS with a reason.\n\n" + "\n".join(violations)
+        )

--- a/tests/test_core/test_yaml_shielding_hygiene.py
+++ b/tests/test_core/test_yaml_shielding_hygiene.py
@@ -64,3 +64,48 @@ def test_author_content_yaml_uses_shielding_helper() -> None:
             "this parses system metadata only (e.g. frontmatter), add its argument to "
             "_ALLOWED_ARGS with a reason.\n\n" + "\n".join(violations)
         )
+
+
+def _aliased_or_from_yaml_imports(py_file: Path, rel: str) -> list[str]:
+    """Return ``rel:lineno`` for yaml imports the call-based guard above can't see."""
+    tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        # `from yaml import safe_load` / `load` / `full_load`
+        from_yaml = (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "yaml"
+            and any(alias.name in _RAW_LOADERS for alias in node.names)
+        )
+        # `import yaml as y`
+        aliased = isinstance(node, ast.Import) and any(
+            alias.name == "yaml" and alias.asname is not None for alias in node.names
+        )
+        if from_yaml or aliased:
+            hits.append(f"{rel}:{node.lineno}")
+    return hits
+
+
+def test_no_aliased_or_from_yaml_imports() -> None:
+    """The call-based guard keys on ``yaml.<loader>(...)`` attribute calls.
+
+    ``from yaml import safe_load`` or ``import yaml as y`` would bypass it — exactly
+    the regression it exists to prevent — so forbid those import forms entirely.
+    Author-content callers must use the shielding helper; the few frontmatter
+    callers use plain ``import yaml``.
+    """
+    src_root = Path(__file__).resolve().parents[2] / "src" / "pflow"
+    repo_root = src_root.parents[1]
+
+    violations: list[str] = []
+    for py_file in sorted(src_root.rglob("*.py")):
+        rel = py_file.relative_to(repo_root).as_posix()
+        violations.extend(_aliased_or_from_yaml_imports(py_file, rel))
+
+    if violations:
+        pytest.fail(
+            "Aliased or from-imports of yaml found. These bypass the call-based "
+            "yaml-shielding guard (which keys on `yaml.<loader>(...)`). Use plain "
+            "`import yaml` (frontmatter) or pflow.core.yaml_utils."
+            "safe_load_preserving_templates.\n\n" + "\n".join(violations)
+        )

--- a/tests/test_core/test_yaml_utils.py
+++ b/tests/test_core/test_yaml_utils.py
@@ -52,10 +52,13 @@ class TestNoOpForTemplateFreeContent:
 
 
 class TestBraceAwareTemplates:
-    """C2: coalesce operands with object/array literals are captured whole.
+    """C2: a coalesce operand with an object/array literal is captured whole.
 
-    These are valid templates per TemplateResolver, so the inline flow form must
-    parse them — not truncate at the first ``}``.
+    This is parser-level capture only — the masking regex tolerates one level of
+    nested ``{}`` so the inline flow form parses these rather than truncating at the
+    first ``}``. ``${a ?? {}}`` / ``${a ?? []}`` are valid runtime templates;
+    ``${a ?? {"k": 1}}`` is captured here but rejected at runtime as a malformed
+    literal operand (the regex is intentionally broader than the resolver grammar).
     """
 
     def test_empty_object_literal_operand(self) -> None:
@@ -65,6 +68,8 @@ class TestBraceAwareTemplates:
         assert load("{ x: ${a ?? []} }") == {"x": "${a ?? []}"}
 
     def test_object_literal_operand_with_content(self) -> None:
+        # Captured whole at parse time (broader than the runtime grammar); the
+        # resolver rejects it later as a malformed literal operand.
         assert load('{ x: ${a ?? {"k": 1}} }') == {"x": '${a ?? {"k": 1}}'}
 
     def test_inline_matches_block_for_object_operand(self) -> None:

--- a/tests/test_core/test_yaml_utils.py
+++ b/tests/test_core/test_yaml_utils.py
@@ -51,6 +51,31 @@ class TestNoOpForTemplateFreeContent:
         assert load(text) == yaml.safe_load(text)
 
 
+class TestQuotedScalarEscaping:
+    """Issue #518 review (finding A): templates inside quoted scalars are NOT masked.
+
+    Masking inside a quoted scalar strips YAML's escape processing, so
+    ``"${a ?? \\"x\\"}"`` would restore with literal backslashes and the resolver
+    would reject it. Quoted scalars are YAML's job — leave them alone.
+    """
+
+    def test_escaped_string_literal_in_quoted_flow_value(self) -> None:
+        # Outer double-quotes force ``\"``; YAML must unescape so the resolver sees a
+        # valid coalesce string literal (``"DEF"``), not ``\"DEF\"``.
+        assert load('{ fb: "${a ?? \\"DEF\\"}" }') == {"fb": '${a ?? "DEF"}'}
+
+    def test_quoted_equals_unquoted_for_escaped_literal(self) -> None:
+        assert load('{ fb: "${a ?? \\"DEF\\"}" }') == load('{ fb: ${a ?? "DEF"} }')
+
+    def test_quoted_scalar_alongside_bare_template(self) -> None:
+        # The quoted scalar (with a ``:`` that would otherwise confuse flow parsing)
+        # is left for YAML; the bare template is still shielded.
+        assert load('{ a: "hi: there", b: ${y} }') == {"a": "hi: there", "b": "${y}"}
+
+    def test_single_quoted_template_preserved(self) -> None:
+        assert load("{ fb: '${a ?? 1}' }") == {"fb": "${a ?? 1}"}
+
+
 class TestBraceAwareTemplates:
     """C2: a coalesce operand with an object/array literal is captured whole.
 

--- a/tests/test_core/test_yaml_utils.py
+++ b/tests/test_core/test_yaml_utils.py
@@ -1,0 +1,110 @@
+"""Tests for safe_load_preserving_templates (issue #482).
+
+The helper shields pflow ``${...}`` templates from PyYAML's flow tokenizer so an
+unquoted template inside a flow map/sequence parses like the block form. These
+unit tests own the mechanism; integration through the parser and file_resolver is
+covered in test_markdown_parser.py and test_file_resolver.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from pflow.core.yaml_utils import safe_load_preserving_templates as load
+
+
+class TestHappyPath:
+    def test_unquoted_template_in_flow_map(self) -> None:
+        assert load("{ x: ${y} }") == {"x": "${y}"}
+
+    def test_unquoted_template_in_flow_sequence(self) -> None:
+        assert load("[${a}, ${b}, literal]") == ["${a}", "${b}", "literal"]
+
+    def test_multiple_templates(self) -> None:
+        assert load("{ a: ${one}, b: ${two} }") == {"a": "${one}", "b": "${two}"}
+
+    def test_template_embedded_in_scalar(self) -> None:
+        assert load("{ url: ${base}/path/${id} }") == {"url": "${base}/path/${id}"}
+
+    def test_nested_flow_collections(self) -> None:
+        assert load("{ n: { deep: ${v} }, l: [${i}] }") == {"n": {"deep": "${v}"}, "l": ["${i}"]}
+
+    def test_template_as_key(self) -> None:
+        assert load("{ ${k}: v }") == {"${k}": "v"}
+
+    def test_quoted_and_unquoted_are_equivalent(self) -> None:
+        assert load("{ x: ${y} }") == load('{ x: "${y}" }')
+
+    def test_block_form_unchanged(self) -> None:
+        assert load("x: ${y}\nz: 3") == {"x": "${y}", "z": 3}
+
+
+class TestNoOpForTemplateFreeContent:
+    """No template → identical to a plain yaml.safe_load (no masking happens)."""
+
+    def test_scalars_still_coerce(self) -> None:
+        assert load("{ a: 1, b: true, c: hi, d: null }") == {"a": 1, "b": True, "c": "hi", "d": None}
+
+    def test_matches_plain_safe_load(self) -> None:
+        text = "{ list: [1, 2, 3], nested: { k: v } }"
+        assert load(text) == yaml.safe_load(text)
+
+
+class TestBraceAwareTemplates:
+    """C2: coalesce operands with object/array literals are captured whole.
+
+    These are valid templates per TemplateResolver, so the inline flow form must
+    parse them — not truncate at the first ``}``.
+    """
+
+    def test_empty_object_literal_operand(self) -> None:
+        assert load("{ x: ${a ?? {}} }") == {"x": "${a ?? {}}"}
+
+    def test_empty_array_literal_operand(self) -> None:
+        assert load("{ x: ${a ?? []} }") == {"x": "${a ?? []}"}
+
+    def test_object_literal_operand_with_content(self) -> None:
+        assert load('{ x: ${a ?? {"k": 1}} }') == {"x": '${a ?? {"k": 1}}'}
+
+    def test_inline_matches_block_for_object_operand(self) -> None:
+        assert load("{ x: ${a ?? {}} }") == load("x: ${a ?? {}}")
+
+
+class TestCollisionResistance:
+    """W1: authored text that looks like a placeholder must not be corrupted."""
+
+    def test_literal_placeholder_text_is_preserved(self) -> None:
+        # The 'a' value literally spells an old-style placeholder; it must survive
+        # untouched even though the same value also contains a real template.
+        assert load("{ a: __pflow_tpl_0__, b: ${y} }") == {"a": "__pflow_tpl_0__", "b": "${y}"}
+
+
+class TestErrorDeMasking:
+    """C1: a YAML error must quote the author's ${...}, never the placeholder."""
+
+    def test_malformed_template_bearing_flow_shows_source_not_placeholder(self) -> None:
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            load("{ x: ${y}")  # missing closing brace
+        message = str(excinfo.value)
+        assert "__pflow_tpl_" not in message
+        assert "${y}" in message
+
+    def test_long_line_truncation_does_not_leak_placeholder(self) -> None:
+        """A long/indented malformed flow must not leak a truncated placeholder.
+
+        PyYAML truncates its error snippet (``...``) around the error column; the
+        placeholder is longer than ``${...}``, so a realistically-indented line gets
+        truncated *through* a placeholder. De-masking the formatted string alone would
+        leave a fragment (``__pflow_tpl_ab12 ...``) — de-masking the structured marks
+        renders the snippet from author text, so no fragment can survive.
+        """
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            load("  - { contender: ${candidate}")  # unclosed flow map, indented
+        message = str(excinfo.value)
+        assert "pflow_tpl" not in message
+        assert "${candidate}" in message
+
+    def test_malformed_template_free_flow_still_raises(self) -> None:
+        with pytest.raises(yaml.YAMLError):
+            load("{invalid: [unclosed")


### PR DESCRIPTION
## Summary
Unquoted `${...}` templates inside an inline YAML flow map/sequence — e.g. `- inputs: { x: ${y} }` — failed to parse. PyYAML reads the `{` in `${...}` as the start of a nested flow mapping, so the natural compact inline form an agent reaches for broke at authoring time, even though the block form (`inputs:` then `  x: ${y}`) and the quoted form (`{ x: "${y}" }`) both parsed.

Fixes #482

## Changes
- New shared module `src/pflow/core/yaml_utils.py` → `safe_load_preserving_templates(text)`: masks each `${...}` with a per-call-nonce placeholder, `yaml.safe_load`s, then recursively restores the original template text — and de-masks any error so it quotes the author's `${...}`, never the placeholder.
- Routed all author-content YAML parse sites through the helper: single-line + multi-line params and the fenced `yaml`-config blocks (`_validate_code_blocks`, `_route_code_blocks_to_node`) in `markdown_parser.py`; external `batch`/`headers`/`output_schema` files in `file_resolver.py`; and the batch-file dependency scan in `dependency_discovery.py`. Frontmatter stays on raw `yaml.safe_load` (system metadata, never templates).
- Brace-aware template regex `\$\{(?:[^{}]|\{[^{}]*\})*\}` so coalesce operands with `{}`/`[]` literals (`${a ?? {}}`) — a real TemplateResolver form — are captured whole.
- Added an AST-based hygiene guard test that fails if a new raw `yaml.safe_load` on author content bypasses the helper.

## Explanation
pflow layers its own `${...}` template syntax on top of YAML, and PyYAML knows nothing about templates. The fix treats a template as opaque to YAML: mask → parse → restore. It is parse-position-agnostic (whole-value, embedded, sequences, nested maps, keys) and a no-op for template-free or already-quoted content, so there is zero behavior change for existing workflows.

The change started as a 2-site private helper; review (impact-completeness, agent-ux, simplicity) found it (a) missed 5 other author-content YAML sites — reopening the same bug in external files and code blocks — and (b) leaked the internal placeholder into PyYAML's truncated error snippets. Both are addressed: the helper is now a single shared chokepoint, and errors are de-masked via the structured PyYAML marks so the snippet renders from author text with a correct caret.

9 files changed, +412/−15.

## Testing
- `tests/test_core/test_yaml_utils.py` — owns the mechanism: happy path (map/seq/embedded/nested/keys), quoted≡unquoted equivalence, template-free no-op, brace-aware `${a ?? {}}`, collision resistance (nonce), and error de-masking incl. `test_long_line_truncation_does_not_leak_placeholder` (the truncated-snippet regression).
- `test_flow_style_dict_unquoted_template_parsed`, `test_flow_style_nested_template_in_multiline_item_parsed`, `test_yaml_config_code_block_with_unquoted_template_parsed` (markdown_parser) — wiring at each parser surface.
- `test_batch_file_flow_style_unquoted_template` (file_resolver) — external flow-style batch file.
- `test_author_content_yaml_uses_shielding_helper` (new hygiene guard) — AST scan preventing a future raw `yaml.safe_load` on author content.
- Full suite: 7852 passed; `make check` clean (mypy / ruff / deptry).
- Manual CLI verification (12 adversarial `.pflow.md` workflows): auto-JSON-parse parity quoted-vs-unquoted, type preservation, coalesce incl. colon/comma literals, malformed-flow error UX (no placeholder leak in text or JSON output), save→reload→run round-trip, external flow-style batch + nested file-ref discovery, and the auto-parse escape hatch. No regressions; every inline form behaves identically to block form.