### PR TITLE
fix: surface structured sub-workflow failures at the parent boundary (#233, #252)

### DIFF
--- a/src/pflow/core/diagnostic_render.py
+++ b/src/pflow/core/diagnostic_render.py
@@ -147,6 +147,11 @@ def _format_error_diagnostic(
     # can grep on the id without parsing JSON. Diagnostics without an ``id``
     # (every pflow diagnostic pre-Task-159) render unchanged.
     title = diagnostic.title or CATEGORY_TITLES.get(context.get("category", ""), "Error")
+    # NOTE: `execution/formatters/batch_errors.py::_format_child_failure_lines`
+    # strips this title line by matching the "Error:"/"Warning:"/"Info:" prefix so
+    # a nested batch sub-workflow diagnostic doesn't double-render its title. If this
+    # prefix format changes (e.g. the numbered "Error N:" form leaks into that
+    # single-arg call site), update that consumer too.
     prefix = f"Error {error_number}" if error_number is not None else "Error"
     if diagnostic.id:
         lines.append(f"{prefix}: {title} [{diagnostic.id}]")

--- a/src/pflow/execution/executor_service.py
+++ b/src/pflow/execution/executor_service.py
@@ -8,9 +8,16 @@ agent-friendly error dicts.
 
 import json
 import logging
+from dataclasses import replace
 from typing import Any, Optional
 
-from pflow.core.diagnostic import CATEGORY_TITLES, Diagnostic, Severity, normalize_runtime_warning
+from pflow.core.diagnostic import (
+    CATEGORY_TITLES,
+    Diagnostic,
+    Severity,
+    format_child_provenance,
+    normalize_runtime_warning,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +65,20 @@ def build_error_list(success: bool, action_result: Optional[str], shared_store: 
     if success:
         return []
 
+    # A failed sub-workflow node carries the child's structured failure state
+    # forward in its archived data (`child_failure` bundle, written by
+    # WorkflowExecutor.post()). Reconstruct the child's diagnostics recursively
+    # and wrap them with parent provenance instead of collapsing to the
+    # generic one-line "WorkflowExecutor failed" message (issues #233/#252).
+    # Checked BEFORE the generic path so the rich reconstruction wins.
+    from pflow.runtime.node_state import get_node_output
+
+    failed_node = _get_failed_node(shared_store)
+    if failed_node:
+        node_output = get_node_output(shared_store, failed_node)
+        if isinstance(node_output, dict) and isinstance(node_output.get("child_failure"), dict):
+            return build_subworkflow_diagnostics(node_output["child_failure"], failed_node)
+
     error_info = _extract_error_info(action_result, shared_store)
     category = determine_error_category(error_info["message"] or "")
 
@@ -94,6 +115,60 @@ def build_error_list(success: bool, action_result: Optional[str], shared_store: 
             context=context,
         )
     ]
+
+
+def build_subworkflow_diagnostics(bundle: dict[str, Any], parent_step_id: str) -> list[Diagnostic]:
+    """Rebuild a failed sub-workflow child's diagnostics, wrapped with parent provenance.
+
+    The runtime layer (``WorkflowExecutor``) ferries a JSON-able ``child_failure``
+    bundle across the parent boundary — it cannot import this module without an
+    import cycle. Here we reconstruct the child's structured diagnostics by
+    reusing ``build_error_list`` so a nested failure renders byte-identical to a
+    top-level one (shell ``exit_code``/``command``/``stderr``, HTTP status, MCP
+    details, template ``unresolved_references``), then prefix each message via
+    ``format_child_provenance``. Nesting recurses naturally: the reconstructed
+    child shape's failed-node data may itself carry a ``child_failure`` bundle,
+    which ``build_error_list`` detects and dispatches back here, so provenance
+    chains outermost-first across arbitrary depth.
+
+    Used by ``build_error_list`` (non-batch sub-workflow failures) and the batch
+    error formatter (per-item sub-workflow failures).
+    """
+    workflow_ref = bundle.get("workflow_path")
+
+    template_diagnostic = bundle.get("template_diagnostic")
+    if isinstance(template_diagnostic, dict):
+        # Strict-mode template failure: the rich Diagnostic (unresolved_references,
+        # peer suggestions) lives only on the child exception — captured verbatim
+        # into the bundle, never present in the child's archived failure record.
+        inner: list[Diagnostic] = [Diagnostic.from_dict(template_diagnostic)]
+    else:
+        child_shape: dict[str, Any] = {
+            "__execution__": {"failed_node": bundle.get("failed_node")},
+            "__failures__": bundle.get("failures") or {},
+        }
+        if bundle.get("error"):
+            child_shape["error"] = bundle["error"]
+        inner = build_error_list(False, "error", child_shape)
+
+    wrapped: list[Diagnostic] = []
+    for d in inner:
+        # Mirror the provenance contract of `_propagate_child_parser_warnings`
+        # exactly (message via the shared helper, node_id fallback, setdefault
+        # context keys) — see core/diagnostic.py::format_child_provenance.
+        context = dict(d.context or {})
+        context.setdefault("sub_workflow_step", parent_step_id)
+        if isinstance(workflow_ref, str) and workflow_ref:
+            context.setdefault("sub_workflow_path", workflow_ref)
+        wrapped.append(
+            replace(
+                d,
+                message=format_child_provenance(parent_step_id, d.message),
+                node_id=d.node_id or parent_step_id,
+                context=context,
+            )
+        )
+    return wrapped
 
 
 def determine_error_category(error_message: str) -> str:

--- a/src/pflow/execution/executor_service.py
+++ b/src/pflow/execution/executor_service.py
@@ -65,19 +65,22 @@ def build_error_list(success: bool, action_result: Optional[str], shared_store: 
     if success:
         return []
 
-    # A failed sub-workflow node carries the child's structured failure state
-    # forward in its archived data (`child_failure` bundle, written by
-    # WorkflowExecutor.post()). Reconstruct the child's diagnostics recursively
-    # and wrap them with parent provenance instead of collapsing to the
-    # generic one-line "WorkflowExecutor failed" message (issues #233/#252).
-    # Checked BEFORE the generic path so the rich reconstruction wins.
-    from pflow.runtime.node_state import get_node_output
+    from pflow.runtime.node_state import get_node_failure, get_node_output
 
+    # A failed sub-workflow node carries the child's structured failure state
+    # forward in its archived data (the reserved `_pflow_child_failure` bundle,
+    # written by WorkflowExecutor.post()). Reconstruct the child's diagnostics
+    # recursively and wrap them with parent provenance instead of collapsing to
+    # the generic one-line message (issues #233/#252). Checked BEFORE the generic
+    # path so the rich reconstruction wins. The reserved `_pflow_` key is written
+    # only by WorkflowExecutor.post() (collision-proof); even so, reconstruction
+    # degrades gracefully on a malformed bundle (empty `failures` → generic
+    # "Workflow execution failed").
     failed_node = _get_failed_node(shared_store)
     if failed_node:
         node_output = get_node_output(shared_store, failed_node)
-        if isinstance(node_output, dict) and isinstance(node_output.get("child_failure"), dict):
-            return build_subworkflow_diagnostics(node_output["child_failure"], failed_node)
+        if isinstance(node_output, dict) and isinstance(node_output.get("_pflow_child_failure"), dict):
+            return build_subworkflow_diagnostics(node_output["_pflow_child_failure"], failed_node)
 
     error_info = _extract_error_info(action_result, shared_store)
     category = determine_error_category(error_info["message"] or "")
@@ -90,8 +93,6 @@ def build_error_list(success: bool, action_result: Optional[str], shared_store: 
     # Extract rich error data from namespaced node output
     failed_node = error_info.get("failed_node")
     if failed_node:
-        from pflow.runtime.node_state import get_node_failure, get_node_output
-
         node_output = get_node_output(shared_store, failed_node) or {}
         if isinstance(node_output, dict):
             _enrich_error_from_node_output(context, node_output, category)

--- a/src/pflow/execution/formatters/batch_errors.py
+++ b/src/pflow/execution/formatters/batch_errors.py
@@ -32,6 +32,9 @@ def format_batch_errors_section(steps: list[dict[str, Any]]) -> list[str]:
             item_summary = format_batch_item_summary(err)
             if item_summary:
                 lines.append(f"      item: {item_summary}")
+            child_failure = err.get("child_failure")
+            if isinstance(child_failure, Mapping):
+                lines.extend(_format_child_failure_lines(dict(child_failure), node_id))
 
         if truncated > 0:
             lines.append(f"  ...and {truncated} more errors")
@@ -68,7 +71,39 @@ def compact_batch_error_detail(error_detail: Mapping[str, Any]) -> dict[str, Any
     if "item" in error_detail:
         compact["has_full_item"] = True
 
+    # Preserve the structured child-failure bundle (#252) so JSON/MCP consumers
+    # get the child's per-node category + data, not a flattened string. The bundle
+    # holds child failure records (never the raw batch item), so it is API-safe.
+    child_failure = error_detail.get("child_failure")
+    if isinstance(child_failure, Mapping):
+        compact["child_failure"] = dict(child_failure)
+
     return compact
+
+
+def _format_child_failure_lines(child_failure: dict[str, Any], node_id: str) -> list[str]:
+    """Render a failed batch sub-workflow item's reconstructed child diagnostics (indented).
+
+    Reuses the same reconstruction primitive (``build_subworkflow_diagnostics``) and
+    renderer (``format_diagnostic``) the non-batch path uses, so a batched
+    sub-workflow failure shows the same rich, provenance-wrapped block.
+    """
+    from pflow.core.diagnostic_render import format_diagnostic
+    from pflow.execution.executor_service import build_subworkflow_diagnostics
+
+    lines: list[str] = []
+    for diagnostic in build_subworkflow_diagnostics(child_failure, node_id):
+        rendered = format_diagnostic(diagnostic).splitlines()
+        # Drop the top-level title frame ("Error: <title>" + its trailing blank line).
+        # The "[idx] ..." line above is already the item's headline, so the title
+        # would read as a second, separate error. format_diagnostic always emits the
+        # severity-prefixed title first (diagnostic_render._format_error_diagnostic).
+        if rendered and rendered[0].startswith(("Error:", "Warning:", "Info:")):
+            rendered = rendered[1:]
+            while rendered and not rendered[0].strip():
+                rendered.pop(0)
+        lines.extend(f"      {line}" if line.strip() else "" for line in rendered)
+    return lines
 
 
 def compact_batch_output_value(value: Any) -> Any:

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -410,6 +410,15 @@ def _run_batch_item_once(
 
     duration_ms = (time.perf_counter() - start_time) * 1000
     error_info = _build_batch_error(idx, item, error_msg, None) if error_msg else None
+    if error_info is not None:
+        # Carry a failed sub-workflow item's structured child-failure bundle into
+        # the error record so the parent can reconstruct rich per-item diagnostics
+        # (#252). Read from the per-item result here (the worker body) — step 17.5
+        # never fires per item, so item_shared[node_id] still holds it, and this
+        # runs inside the worker so parallel items stay isolated.
+        child_failure = result.get("child_failure")
+        if isinstance(child_failure, dict):
+            error_info["child_failure"] = child_failure
     _capture_item_trace(
         parent_shared,
         config.node_id,

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -413,10 +413,11 @@ def _run_batch_item_once(
     if error_info is not None:
         # Carry a failed sub-workflow item's structured child-failure bundle into
         # the error record so the parent can reconstruct rich per-item diagnostics
-        # (#252). Read from the per-item result here (the worker body) — step 17.5
-        # never fires per item, so item_shared[node_id] still holds it, and this
-        # runs inside the worker so parallel items stay isolated.
-        child_failure = result.get("child_failure")
+        # (#252). Read the reserved namespace key from the per-item result here (the
+        # worker body) — step 17.5 never fires per item, so item_shared[node_id]
+        # still holds it, and this runs inside the worker so parallel items stay
+        # isolated. (Stored under the display key `child_failure` on the record.)
+        child_failure = result.get("_pflow_child_failure")
         if isinstance(child_failure, dict):
             error_info["child_failure"] = child_failure
     _capture_item_trace(

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -423,16 +423,18 @@ class WorkflowExecutor(BaseNode):
             shared["error"] = error_msg
             error_action = self.params.get("error_action", "error")
             action = str(error_action) if error_action else "error"
-            # Carry the child's structured failure forward so the execution layer
-            # can reconstruct rich diagnostics with provenance (#233/#252). Only on
-            # a real failure route: step 17.5 archives error-actions, so a custom
-            # non-error route (e.g. `error_action: continue`) must NOT write the
-            # bundle — it would linger in the success namespace and leak as
-            # ${node.child_failure}. Non-dunder key → namespaced into
-            # shared[node_id] → archived to __failures__[node_id].data.child_failure.
+            # Carry the child's structured failure forward so the execution layer can
+            # reconstruct rich diagnostics with provenance (#233/#252). The reserved
+            # `_pflow_` key is namespaced into shared[node_id] (→ archived to
+            # __failures__[node_id].data on an error route, where build_error_list
+            # reconstructs it) AND filtered from agent-visible output / never exposed
+            # as a child output — so it is written unconditionally without leaking.
+            # That unconditional write matters for a batched sub-workflow with a
+            # non-error `error_action` (e.g. `continue`): the batch still records the
+            # item as failed and must surface its structured child failure (#252).
             child_failure = exec_res.get("child_failure")
-            if child_failure is not None and action.startswith("error"):
-                shared["child_failure"] = child_failure
+            if child_failure is not None:
+                shared["_pflow_child_failure"] = child_failure
             return action
 
         self._expose_child_outputs(shared, prep_res, exec_res)
@@ -547,11 +549,24 @@ class WorkflowExecutor(BaseNode):
         # When a specific child node is identified, the structured summary (names the
         # node + its real error) beats a generic exception string. Fall back to the
         # exception text only when no node was archived (e.g. an engine-level error).
+        # Reuse the bundle's already-computed summary when present (mapped mode) so
+        # the summary isn't built twice.
         failed_node = child_storage.get("__execution__", {}).get("failed_node")
         if failed_node or fallback_summary is None:
-            summary = self._summarize_child_failure(child_storage, workflow_path, failed_node)
+            summary = (
+                bundle["error"]
+                if bundle is not None
+                else self._summarize_child_failure(child_storage, workflow_path, failed_node)
+            )
         else:
             summary = fallback_summary
+        # Keep the bundle's reconstruction summary in sync with the chosen summary:
+        # build_error_list prefers the bundle over the parent failure record, so
+        # without this an exception with no archived child node (e.g. a child
+        # output-resolution failure) would surface the generic "returned error
+        # action" instead of the real exception text.
+        if bundle is not None:
+            bundle["error"] = summary
         return {
             "success": False,
             "error": summary,
@@ -581,10 +596,21 @@ class WorkflowExecutor(BaseNode):
         reference-shared across parallel batch items and would mis-attribute.
         """
         failed_node = child_storage.get("__execution__", {}).get("failed_node")
+        failures = WorkflowExecutor._jsonable(child_storage.get("__failures__") or {})
+        # A failed child node that is itself a batch archives the full batch output,
+        # including each error record's RAW item input. Honor the same display-safety
+        # compaction the top-level batch path applies (compact_batch_error_detail) so
+        # raw child batch inputs don't leak into the parent's trace / JSON output.
+        # (Lazy import of a leaf formatter — no module-level deps, so no import cycle.)
+        from pflow.execution.formatters.batch_errors import compact_batch_output_value
+
+        for record in failures.values():
+            if isinstance(record, dict) and isinstance(record.get("data"), dict):
+                record["data"] = compact_batch_output_value(record["data"])
         bundle: dict[str, Any] = {
             "workflow_path": str(workflow_path),
             "failed_node": failed_node,
-            "failures": WorkflowExecutor._jsonable(child_storage.get("__failures__") or {}),
+            "failures": failures,
             "error": WorkflowExecutor._summarize_child_failure(child_storage, workflow_path, failed_node),
         }
         if template_diagnostic is not None:

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -395,33 +395,45 @@ class WorkflowExecutor(BaseNode):
 
             # Detect sub-workflow failure via action string
             if isinstance(result, str) and result.startswith("error"):
-                error_msg = self._extract_child_error(child_storage, workflow_path)
-                return {
-                    "success": False,
-                    "error": error_msg,
-                    "workflow_path": workflow_path,
-                    "child_storage": child_storage,
-                }
+                return self._child_failure_result(prep_res, child_storage, workflow_path)
 
             return {"success": True, "result": result, "child_storage": child_storage, "storage_mode": storage_mode}
         except Exception as e:
             if child_trace and child_trace.events:
                 self._child_trace_events = child_trace.events
-            return {
-                "success": False,
-                "error": f"Sub-workflow execution failed: {e!s}",
-                "workflow_path": workflow_path,
-                "child_storage": child_storage,
-            }
+            # A strict-mode template failure carries its structured Diagnostic
+            # (unresolved_references, peer suggestions) ONLY on the exception — it
+            # is never in child_storage — so capture it here for full fidelity.
+            return self._child_failure_result(
+                prep_res,
+                child_storage,
+                workflow_path,
+                template_diagnostic=getattr(e, "_pflow_template_diagnostic", None),
+                fallback_summary=f"Sub-workflow execution failed: {e!s}",
+            )
 
     def post(self, shared: dict[str, Any], prep_res: dict[str, Any], exec_res: dict[str, Any]) -> str:
         """Auto-expose child outputs and update parent storage."""
         if not exec_res.get("success", False):
+            # The summary already reads "Sub-workflow failed at <path> (node 'X'): ..."
+            # (or the exception text) — don't re-wrap it with "WorkflowExecutor failed
+            # at <path>:" which double-states the path and leaks the internal class
+            # name into agent-facing text.
             error_msg = exec_res.get("error", "Unknown error")
-            workflow_path = exec_res.get("workflow_path", "<unknown>")
-            shared["error"] = f"WorkflowExecutor failed at {workflow_path}: {error_msg}"
+            shared["error"] = error_msg
             error_action = self.params.get("error_action", "error")
-            return str(error_action) if error_action else "error"
+            action = str(error_action) if error_action else "error"
+            # Carry the child's structured failure forward so the execution layer
+            # can reconstruct rich diagnostics with provenance (#233/#252). Only on
+            # a real failure route: step 17.5 archives error-actions, so a custom
+            # non-error route (e.g. `error_action: continue`) must NOT write the
+            # bundle — it would linger in the success namespace and leak as
+            # ${node.child_failure}. Non-dunder key → namespaced into
+            # shared[node_id] → archived to __failures__[node_id].data.child_failure.
+            child_failure = exec_res.get("child_failure")
+            if child_failure is not None and action.startswith("error"):
+                shared["child_failure"] = child_failure
+            return action
 
         self._expose_child_outputs(shared, prep_res, exec_res)
 
@@ -511,16 +523,79 @@ class WorkflowExecutor(BaseNode):
             if WorkflowExecutor.is_exposable_child_key(key, child_input_keys):
                 shared[key] = value
 
-    @staticmethod
-    def _extract_child_error(child_storage: dict[str, Any], workflow_path: str) -> str:
-        """Extract a meaningful error message from child storage after sub-workflow failure.
+    def _child_failure_result(
+        self,
+        prep_res: dict[str, Any],
+        child_storage: dict[str, Any],
+        workflow_path: str,
+        *,
+        template_diagnostic: Diagnostic | None = None,
+        fallback_summary: str | None = None,
+    ) -> dict[str, Any]:
+        """Build the ``success=False`` exec_res for a child failure, carrying a structured bundle.
 
-        When a sub-workflow's Flow returns "error" action (not an exception), the actual
-        error message is namespaced under the failed node's ID in child_storage.
+        The ``child_failure`` bundle is built ONLY for ``storage_mode: mapped`` (the
+        default). In ``shared`` mode the child store *is* the parent store, so the
+        child's ``__failures__`` already live in the parent (issue #254 territory,
+        out of scope here) and bundling would be self-referential. The guard reads
+        ``prep_res`` (always present after prep) — ``exec_res`` lacks ``storage_mode``
+        on the failure path.
         """
+        bundle: dict[str, Any] | None = None
+        if prep_res.get("storage_mode") == "mapped":
+            bundle = self._extract_child_failure(child_storage, workflow_path, template_diagnostic=template_diagnostic)
+        # When a specific child node is identified, the structured summary (names the
+        # node + its real error) beats a generic exception string. Fall back to the
+        # exception text only when no node was archived (e.g. an engine-level error).
+        failed_node = child_storage.get("__execution__", {}).get("failed_node")
+        if failed_node or fallback_summary is None:
+            summary = self._summarize_child_failure(child_storage, workflow_path, failed_node)
+        else:
+            summary = fallback_summary
+        return {
+            "success": False,
+            "error": summary,
+            "child_failure": bundle,
+            "workflow_path": workflow_path,
+            "child_storage": child_storage,
+        }
+
+    @staticmethod
+    def _extract_child_failure(
+        child_storage: dict[str, Any],
+        workflow_path: str,
+        *,
+        template_diagnostic: Diagnostic | None = None,
+    ) -> dict[str, Any]:
+        """Capture a child sub-workflow's failure state as a JSON-able bundle.
+
+        Replaces the former string flattening (issues #233/#252). Carries exactly
+        what the execution-layer reconstructor reads: the child ``__failures__``
+        records (each with its per-node ``category`` + ``data``), the failed-node
+        pointer, a one-line summary, and — for a strict-mode template failure — the
+        rich Diagnostic that lives only on the child exception. Plain dicts only
+        (Diagnostics → ``to_dict``) so it survives trace + JSON serialization once
+        archived in ``__failures__[id].data``. Child node IDs stay nested inside the
+        bundle, never promoted to parent ``__failures__`` keys (no #254 regression).
+        Sourced from ``__failures__`` / node output — never ``__warnings__``, which is
+        reference-shared across parallel batch items and would mis-attribute.
+        """
+        failed_node = child_storage.get("__execution__", {}).get("failed_node")
+        bundle: dict[str, Any] = {
+            "workflow_path": str(workflow_path),
+            "failed_node": failed_node,
+            "failures": WorkflowExecutor._jsonable(child_storage.get("__failures__") or {}),
+            "error": WorkflowExecutor._summarize_child_failure(child_storage, workflow_path, failed_node),
+        }
+        if template_diagnostic is not None:
+            bundle["template_diagnostic"] = template_diagnostic.to_dict()
+        return bundle
+
+    @staticmethod
+    def _summarize_child_failure(child_storage: dict[str, Any], workflow_path: str, failed_node: str | None) -> str:
+        """One-line human summary of a child failure (the legacy flat message, reused for shared["error"])."""
         from pflow.runtime.node_state import get_node_failure, get_node_output
 
-        failed_node = child_storage.get("__execution__", {}).get("failed_node")
         if failed_node:
             failure = get_node_failure(child_storage, failed_node)
             if failure and failure.get("error"):
@@ -535,6 +610,24 @@ class WorkflowExecutor(BaseNode):
                 message, _context = normalize_runtime_warning(warning)
                 return f"Sub-workflow failed at {workflow_path} (node '{failed_node}'): {message}"
         return f"Sub-workflow failed at {workflow_path} (returned error action)"
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        """Deep-convert a value to JSON-serializable form for the carry bundle.
+
+        Converts any ``Diagnostic`` to its dict shape and stringifies stray
+        exceptions, so the archived bundle never holds objects that the trace or
+        MCP/JSON serializers would drop or coerce lossily.
+        """
+        if isinstance(value, Diagnostic):
+            return value.to_dict()
+        if isinstance(value, BaseException):
+            return str(value)
+        if isinstance(value, dict):
+            return {k: WorkflowExecutor._jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [WorkflowExecutor._jsonable(v) for v in value]
+        return value
 
     def _record_child_workflow_path(self, parent_shared: dict[str, Any], workflow_path: str) -> None:
         if not workflow_path or workflow_path == "<inline>":

--- a/tests/test_cli/test_agent_ux_fixes.py
+++ b/tests/test_cli/test_agent_ux_fixes.py
@@ -328,7 +328,7 @@ def test_extract_child_error_includes_node_id() -> None:
         error="Command failed with exit code 127",
     )
 
-    message = WorkflowExecutor._extract_child_error(child_storage, "./child.pflow.md")
+    message = WorkflowExecutor._extract_child_failure(child_storage, "./child.pflow.md")["error"]
 
     assert "my-shell-node" in message
     assert "Command failed with exit code 127" in message
@@ -341,7 +341,7 @@ def test_extract_child_error_fallback_without_failed_node() -> None:
         "__execution__": {},
     }
 
-    message = WorkflowExecutor._extract_child_error(child_storage, "./child.pflow.md")
+    message = WorkflowExecutor._extract_child_failure(child_storage, "./child.pflow.md")["error"]
 
     assert "./child.pflow.md" in message
     assert "returned error action" in message
@@ -357,7 +357,7 @@ def test_extract_child_error_fallback_no_error_in_node_data() -> None:
     }
     mark_node_failed(child_storage, "some-node", category=FAILURE_CATEGORY_EXCEPTION)
 
-    message = WorkflowExecutor._extract_child_error(child_storage, "./workflow.pflow.md")
+    message = WorkflowExecutor._extract_child_failure(child_storage, "./workflow.pflow.md")["error"]
 
     assert "returned error action" in message
 

--- a/tests/test_integration/test_failed_node_invariant.py
+++ b/tests/test_integration/test_failed_node_invariant.py
@@ -1532,7 +1532,7 @@ def test_subworkflow_shell_failure_propagates_structured_to_parent(tmp_path):
     assert "inner" not in failures, "child node IDs must stay nested (no #254 regression)"
 
     # Structured child failure carried in the executor's archived data.
-    child_failure = failures["sub"]["data"]["child_failure"]
+    child_failure = failures["sub"]["data"]["_pflow_child_failure"]
     assert child_failure["failed_node"] == "inner"
     assert child_failure["failures"]["inner"]["category"] == "shell_failure"
 
@@ -1563,7 +1563,7 @@ def test_subworkflow_failure_state_is_json_serializable(tmp_path):
 
     failures = result.shared_after.get("__failures__", {})
     dumped = json.dumps(failures)  # raises TypeError if a Diagnostic/Exception leaked
-    assert "child_failure" in dumped
+    assert "_pflow_child_failure" in dumped
     # Result diagnostics serialize cleanly too (no dataclass repr fallbacks).
     diag_json = json.dumps([d.to_dict() for d in result.errors])
     assert "Diagnostic(" not in diag_json
@@ -1729,11 +1729,22 @@ def test_subworkflow_error_action_continue_does_not_leak_child_failure(tmp_path)
 
     result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
 
-    # The run continued past the failure (not archived as an error).
+    from pflow.runtime.workflow_executor import WorkflowExecutor
+
+    # The run continued past the handled failure (continue route, not archived).
     assert "sub" not in result.shared_after.get("__failures__", {})
     sub_namespace = result.shared_after.get("sub", {})
     assert isinstance(sub_namespace, dict)
-    assert "child_failure" not in sub_namespace, "bundle must not leak into the success namespace"
+    # The carry rides a reserved `_pflow_` key so it is filtered from agent-visible
+    # output and never exposed as a ${sub.child_failure} workflow output. Any key
+    # carrying the bundle in the (succeeded-via-continue) namespace must be
+    # non-exposable — never the plain `child_failure` key.
+    assert "child_failure" not in sub_namespace
+    for key in sub_namespace:
+        if "child_failure" in key:
+            assert not WorkflowExecutor.is_exposable_child_key(key, set()), (
+                f"child_failure carried on exposable key {key!r} would leak as a workflow output"
+            )
 
 
 def test_storage_mode_shared_skips_child_failure_bundle(tmp_path):
@@ -1851,7 +1862,7 @@ def test_subworkflow_failure_trace_json_has_no_diagnostic_repr(tmp_path):
     with patch("pathlib.Path.home", return_value=tmp_path):
         trace_path = result.trace.save_to_file()
     raw = trace_path.read_text()
-    assert "child_failure" in raw, "structured child failure must reach the saved trace"
+    assert "_pflow_child_failure" in raw, "structured child failure must reach the saved trace"
     assert "Diagnostic(" not in raw, "no Diagnostic object may be stringified into the trace"
 
 
@@ -1900,7 +1911,7 @@ echo "${producer.stdout}"
 
     assert result.status == WorkflowStatus.FAILED
     # The strict-mode template Diagnostic was captured from the child exception.
-    cf = result.shared_after["__failures__"]["sub"]["data"]["child_failure"]
+    cf = result.shared_after["__failures__"]["sub"]["data"]["_pflow_child_failure"]
     assert "template_diagnostic" in cf
     # ...and reconstructed with unresolved_references + provenance at the parent.
     assert len(result.errors) == 1
@@ -1929,3 +1940,78 @@ def test_jsonable_converts_diagnostic_and_exception():
     assert out["c"]["nested"] == diag.to_dict()
     assert out["plain"] == "s"
     assert out["n"] == 7
+
+
+def test_child_batch_failure_strips_raw_item_from_carried_bundle(tmp_path):
+    """Review (codex A) — when the failed child node is itself a batch, the carried
+    bundle must NOT expose raw child batch item inputs in the parent's archived data;
+    it honors the same display-safety compaction the top-level batch path applies."""
+    child = tmp_path / "child.pflow.md"
+    child.write_text(
+        """\
+# Child
+
+Child whose batch step fails per item with sensitive inputs.
+
+## Steps
+
+### faninner
+
+Fail per item so the child batch archives raw item inputs.
+
+- type: shell
+- batch:
+    items: ["SENSITIVE-AAA", "SENSITIVE-BBB"]
+    as: it
+    error_handling: continue
+
+```shell command
+echo "${it}"; exit 1
+```
+""",
+        encoding="utf-8",
+    )
+    parent_ir = {"ir_version": "0.1.0", "nodes": [_subworkflow_node(child)], "start_node": "sub"}
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    bundle = result.shared_after["__failures__"]["sub"]["data"]["_pflow_child_failure"]
+    inner_errors = bundle["failures"]["faninner"]["data"]["errors"]
+    assert inner_errors
+    # The raw `item` input is stripped (replaced by the display-safe summary +
+    # has_full_item), exactly as the top-level batch compaction does — so raw child
+    # batch inputs don't ride into the parent's trace / JSON output.
+    assert "item" not in inner_errors[0], "raw child batch item leaked into the carried bundle"
+    assert inner_errors[0].get("has_full_item") is True
+    assert "item_summary" in inner_errors[0]
+    json.dumps(bundle)  # still JSON-serializable
+
+
+def test_batch_subworkflow_continue_route_still_carries_structured_failure(tmp_path):
+    """Review (codex C) — a batched sub-workflow with a non-error `error_action`
+    (e.g. `continue`) is still recorded as a failed item by the batch, so its
+    structured child failure must survive (not regress to a flat string)."""
+    child = _write_child_shell_fail(tmp_path, command='echo "x"; exit 5')
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "fan",
+                "type": "workflow",
+                "purpose": "Batch a continue-routed failing child once per item.",
+                "params": {"workflow": str(child), "error_action": "continue"},
+                "batch": {"items": ["a", "b"], "as": "item", "error_handling": "continue"},
+            }
+        ],
+        "start_node": "fan",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    errors = result.shared_after["__failures__"]["fan"]["data"]["errors"]
+    assert len(errors) == 2
+    for err in errors:
+        cf = err.get("child_failure")
+        assert cf is not None, "continue-routed batch item must still carry structured child failure"
+        assert cf["failures"]["inner"]["category"] == "shell_failure"
+        assert cf["failures"]["inner"]["data"]["exit_code"] == 5

--- a/tests/test_integration/test_failed_node_invariant.py
+++ b/tests/test_integration/test_failed_node_invariant.py
@@ -1464,3 +1464,468 @@ def test_routing_failure_on_custom_action_propagates_to_trace():
         "did not literally start with 'error'. This was the GH #250 bug."
     )
     assert "custom_route" in (event.get("error") or "")
+
+
+# ===========================================================================
+# PR 1: failure-archival invariant across the sub-workflow boundary (#252 + #233)
+#
+# A failed sub-workflow must reach the parent's __failures__ with the child's
+# STRUCTURED per-node failure (category + data) and provenance, not a flattened
+# string — across the non-batch, batch, and nested boundaries — while never
+# leaking child node IDs into the parent's top-level __failures__ keys (#254).
+# ===========================================================================
+
+
+def _write_child_shell_fail(tmp_path, name="child.pflow.md", *, command='echo "boom" >&2; exit 7'):
+    """Write a child workflow whose single shell step always fails. Returns the path."""
+    path = tmp_path / name
+    path.write_text(
+        f"""\
+# Child
+
+A child workflow whose inner shell step always fails.
+
+## Steps
+
+### inner
+
+Run a shell command that always fails.
+
+- type: shell
+
+```shell command
+{command}
+```
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _subworkflow_node(child_path, *, node_id="sub", **extra):
+    node = {
+        "id": node_id,
+        "type": "workflow",
+        "purpose": "Delegate to a child workflow that fails.",
+        "params": {"workflow": str(child_path), **extra},
+    }
+    return node
+
+
+def test_subworkflow_shell_failure_propagates_structured_to_parent(tmp_path):
+    """#233 — a non-batch sub-workflow shell failure surfaces the child's structured
+    record (category, command, exit_code, stderr) at the parent, with provenance, and
+    NO child node ID leaks into the parent's top-level __failures__ (#254)."""
+    child = _write_child_shell_fail(tmp_path, command='echo "out"; echo "err" >&2; exit 1')
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [_subworkflow_node(child)],
+        "start_node": "sub",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    assert result.status == WorkflowStatus.FAILED
+    failures = result.shared_after.get("__failures__", {})
+    # The executor node is archived; the child's inner node is NOT a top-level key.
+    assert "sub" in failures
+    assert "inner" not in failures, "child node IDs must stay nested (no #254 regression)"
+
+    # Structured child failure carried in the executor's archived data.
+    child_failure = failures["sub"]["data"]["child_failure"]
+    assert child_failure["failed_node"] == "inner"
+    assert child_failure["failures"]["inner"]["category"] == "shell_failure"
+
+    # The reconstructed diagnostic renders byte-identical to a top-level shell
+    # failure, wrapped with provenance.
+    assert len(result.errors) == 1
+    diag = result.errors[0]
+    assert diag.node_id == "inner"
+    assert diag.message.startswith("In step 'sub' sub-workflow:")
+    ctx = diag.context or {}
+    assert ctx.get("sub_workflow_step") == "sub"
+    assert ctx.get("shell_exit_code") == 1
+    assert "exit 1" in (ctx.get("shell_command") or "")
+    rendered = format_diagnostic(diag)
+    assert "In step 'sub' sub-workflow:" in rendered
+    assert "Shell details:" in rendered
+    assert "err" in rendered  # child stderr survives to the parent's rendered error
+    assert "__failures__" not in rendered  # no internal-vocabulary leak
+
+
+def test_subworkflow_failure_state_is_json_serializable(tmp_path):
+    """The carried bundle must be plain JSON (no Diagnostic/Exception objects) so it
+    survives the trace + MCP/JSON serialization paths (review W-b)."""
+    child = _write_child_shell_fail(tmp_path)
+    parent_ir = {"ir_version": "0.1.0", "nodes": [_subworkflow_node(child)], "start_node": "sub"}
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    failures = result.shared_after.get("__failures__", {})
+    dumped = json.dumps(failures)  # raises TypeError if a Diagnostic/Exception leaked
+    assert "child_failure" in dumped
+    # Result diagnostics serialize cleanly too (no dataclass repr fallbacks).
+    diag_json = json.dumps([d.to_dict() for d in result.errors])
+    assert "Diagnostic(" not in diag_json
+
+
+def test_batch_subworkflow_shell_failure_carries_structured_per_item(tmp_path):
+    """#252 — a sub-workflow run as a batch item carries the child's structured
+    failure into the parent batch node's errors[], not just a flat string."""
+    child = _write_child_shell_fail(tmp_path)  # exit 7
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "fan",
+                "type": "workflow",
+                "purpose": "Run the failing child once per batch item.",
+                "params": {"workflow": str(child)},
+                "batch": {"items": ["a"], "as": "item"},
+            }
+        ],
+        "start_node": "fan",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    assert result.status == WorkflowStatus.FAILED
+    failures = result.shared_after.get("__failures__", {})
+    assert "fan" in failures
+    assert "inner" not in failures  # no #254 regression through the batch path
+    errors = failures["fan"]["data"]["errors"]
+    assert len(errors) == 1
+    child_failure = errors[0]["child_failure"]
+    assert child_failure["failed_node"] == "inner"
+    inner = child_failure["failures"]["inner"]
+    assert inner["category"] == "shell_failure"
+    assert inner["data"]["exit_code"] == 7
+
+
+def test_parallel_batch_subworkflow_failures_attributed_per_item(tmp_path):
+    """Review W-c — in a PARALLEL batch, each item's child failure must be attributed
+    to its own item (the bundle is sourced from per-item-isolated __failures__, never
+    the reference-shared __warnings__)."""
+    child = tmp_path / "child.pflow.md"
+    child.write_text(
+        """\
+# Child
+
+Echo the per-item message, then fail.
+
+## Inputs
+
+### msg
+
+The per-item message.
+
+- type: string
+
+## Steps
+
+### inner
+
+Echo the message and fail so the value is captured in the failure record.
+
+- type: shell
+
+```shell command
+echo "got:${msg}"; exit 3
+```
+""",
+        encoding="utf-8",
+    )
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "fan",
+                "type": "workflow",
+                "purpose": "Fan a failing child over distinguishable items in parallel.",
+                "params": {"workflow": str(child), "inputs": {"msg": "${item}"}},
+                "batch": {
+                    "items": ["alpha", "beta"],
+                    "as": "item",
+                    "error_handling": "continue",
+                    "parallel": True,
+                },
+            }
+        ],
+        "start_node": "fan",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    failures = result.shared_after.get("__failures__", {})
+    errors = failures["fan"]["data"]["errors"]
+    assert len(errors) == 2
+    # Map each item's index → the stdout captured in ITS OWN child failure record.
+    by_item = {}
+    for err in errors:
+        cf = err["child_failure"]
+        stdout = cf["failures"]["inner"]["data"].get("stdout", "")
+        by_item[str(err["item"])] = stdout
+    assert "got:alpha" in by_item["alpha"], by_item
+    assert "got:beta" in by_item["beta"], by_item
+
+
+def test_nested_subworkflow_failure_chains_provenance(tmp_path):
+    """Nested >1 level — provenance chains outermost-first across depth, and the
+    reconstructed diagnostic names the deepest failing node."""
+    grandchild = _write_child_shell_fail(tmp_path, "grandchild.pflow.md", command="exit 1")
+    child = tmp_path / "child.pflow.md"
+    child.write_text(
+        f"""\
+# Child
+
+A child whose only step is a deeper sub-workflow that fails.
+
+## Steps
+
+### subsub
+
+Delegate to the grandchild workflow.
+
+- type: workflow
+- workflow: {grandchild}
+""",
+        encoding="utf-8",
+    )
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [_subworkflow_node(child, node_id="sub")],
+        "start_node": "sub",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    assert result.status == WorkflowStatus.FAILED
+    assert len(result.errors) == 1
+    diag = result.errors[0]
+    # Outermost-first chain: parent step 'sub' wraps child step 'subsub' wraps inner.
+    assert diag.message.startswith("In step 'sub' sub-workflow: In step 'subsub' sub-workflow:")
+    assert diag.node_id == "inner"  # deepest failing node
+
+
+def test_subworkflow_error_action_continue_does_not_leak_child_failure(tmp_path):
+    """Review W-d — a custom non-error route (error_action: continue) is NOT archived
+    by step 17.5, so the child_failure bundle must NOT be written (it would linger in
+    the success namespace and leak as ${node.child_failure})."""
+    child = _write_child_shell_fail(tmp_path)
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [
+            _subworkflow_node(child, node_id="sub", error_action="continue"),
+            {
+                "id": "after",
+                "type": "shell",
+                "purpose": "Continue past the failed sub-workflow.",
+                "params": {"command": 'echo "after"'},
+            },
+        ],
+        "edges": [{"from": "sub", "to": "after", "action": "continue"}],
+        "start_node": "sub",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    # The run continued past the failure (not archived as an error).
+    assert "sub" not in result.shared_after.get("__failures__", {})
+    sub_namespace = result.shared_after.get("sub", {})
+    assert isinstance(sub_namespace, dict)
+    assert "child_failure" not in sub_namespace, "bundle must not leak into the success namespace"
+
+
+def test_storage_mode_shared_skips_child_failure_bundle(tmp_path):
+    """Review W-a — storage_mode: shared aliases child storage to the parent, so the
+    carry is guarded off (bundling would be self-referential / #254 territory). No
+    failure record may carry a child_failure bundle in shared mode."""
+    child = _write_child_shell_fail(tmp_path, command="exit 1")
+    parent_ir = {
+        "ir_version": "0.1.0",
+        "nodes": [_subworkflow_node(child, node_id="sub", storage_mode="shared")],
+        "start_node": "sub",
+    }
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    failures = result.shared_after.get("__failures__", {})
+    for record in failures.values():
+        data = record.get("data") or {}
+        assert "child_failure" not in data, "shared mode must not build a child_failure bundle"
+
+
+def test_child_template_diagnostic_survives_reconstruction():
+    """A strict-mode child template error carries its structured Diagnostic
+    (unresolved_references, peer suggestions) only on the child exception. Pin that it
+    round-trips through the bundle and reconstruction with provenance, fields intact."""
+    from pflow.execution.executor_service import build_subworkflow_diagnostics
+
+    template_diag = Diagnostic(
+        severity=Severity.ERROR,
+        source="runtime",
+        message="Template error: '${ghost.value}' could not be resolved",
+        node_id="inner",
+        context={
+            "category": "template_error",
+            "unresolved_references": [{"var": "ghost.value", "status": "absent"}],
+        },
+    )
+    bundle = {
+        "workflow_path": "./child.pflow.md",
+        "failed_node": "inner",
+        "failures": {"inner": {"data": {}, "category": "template_error", "error": "Template error"}},
+        "template_diagnostic": template_diag.to_dict(),
+    }
+
+    diags = build_subworkflow_diagnostics(bundle, "sub")
+
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.message == "In step 'sub' sub-workflow: Template error: '${ghost.value}' could not be resolved"
+    assert d.node_id == "inner"
+    assert (d.context or {}).get("unresolved_references") == [{"var": "ghost.value", "status": "absent"}]
+    assert (d.context or {}).get("sub_workflow_step") == "sub"
+    assert (d.context or {}).get("sub_workflow_path") == "./child.pflow.md"
+
+
+def test_real_mcp_node_protocol_error_archived_as_mcp_failure():
+    """#253 end-to-end: a REAL MCPNode hitting a transport error flows through
+    exec_fallback → post → engine step 17.5 and is archived as mcp_failure, with
+    get_node_status reporting FAILED (never SUCCEEDED).
+
+    #491 fixed and tested the ROUTING with a BaseNode mock that mimics MCPNode.post();
+    this drives the real node through its own exec_fallback path — the integration gap
+    the issue flagged ("zero MCP integration tests for the failure archival path").
+    """
+    from unittest.mock import patch
+
+    from pflow.nodes.mcp.node import MCPNode
+    from pflow.runtime.engine import CompiledWorkflow, NodeConfig, WorkflowEngine
+    from pflow.runtime.node_state import NodeStatus, get_node_failure, get_node_status
+
+    node = MCPNode()
+    node.node_id = "call_tool"
+    node.set_params({"__mcp_server__": "demo", "__mcp_tool__": "do_thing"})
+
+    async def boom(_prep_res):
+        raise ConnectionError("connection refused")
+
+    configs = {
+        "call_tool": NodeConfig(
+            node_id="call_tool",
+            node_type_name="MCPNode",
+            template_config=None,
+            batch_config=None,
+            namespaced=True,
+            interface_metadata=None,
+        )
+    }
+    workflow = CompiledWorkflow(start_node=node, node_configs=configs)
+    shared: dict = {}
+
+    with (
+        patch.object(MCPNode, "_load_server_config", return_value={"command": "x"}),
+        patch.object(MCPNode, "_exec_async", side_effect=boom),
+    ):
+        result = WorkflowEngine().run(workflow, shared)
+
+    assert result == "error"
+    failure = get_node_failure(shared, "call_tool")
+    assert failure is not None
+    assert failure["category"] == "mcp_failure"
+    assert get_node_status(shared, "call_tool") == NodeStatus.FAILED
+
+
+@pytest.mark.trace_files
+def test_subworkflow_failure_trace_json_has_no_diagnostic_repr(tmp_path):
+    """Review W-b — the saved trace serializes via _sanitize_for_json + default=str
+    (no Diagnostic-aware converter). Assert the trace JSON for a failed sub-workflow
+    carries the structured child_failure as data, never a stringified 'Diagnostic('."""
+    child = _write_child_shell_fail(tmp_path, command='echo "boom" >&2; exit 1')
+    parent_ir = {"ir_version": "0.1.0", "nodes": [_subworkflow_node(child)], "start_node": "sub"}
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    assert result.trace is not None
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        trace_path = result.trace.save_to_file()
+    raw = trace_path.read_text()
+    assert "child_failure" in raw, "structured child failure must reach the saved trace"
+    assert "Diagnostic(" not in raw, "no Diagnostic object may be stringified into the trace"
+
+
+def test_strict_template_error_in_child_surfaces_unresolved_references(tmp_path):
+    """Review W1 (test-fidelity) — a RUNTIME strict-mode template error inside a child
+    (a failed-node reference, which the validator can't catch statically) carries its
+    structured Diagnostic only on the child exception. Pin the full capture chain:
+    child raises → `_pflow_template_diagnostic` → bundle → reconstruction, so
+    `unresolved_references` survive to the parent with provenance."""
+    child = tmp_path / "tmpl-child.pflow.md"
+    child.write_text(
+        """\
+# Template Child
+
+A child where a recovered node references a failed node's output at runtime.
+
+## Steps
+
+### producer
+
+Fail by design so its output is unavailable at runtime.
+
+- type: shell
+- on-error: consumer
+
+```shell command
+exit 1
+```
+
+### consumer
+
+Reference the failed producer's stdout — unresolved at runtime in strict mode.
+
+- type: shell
+- next: end
+
+```shell command
+echo "${producer.stdout}"
+```
+""",
+        encoding="utf-8",
+    )
+    parent_ir = {"ir_version": "0.1.0", "nodes": [_subworkflow_node(child)], "start_node": "sub"}
+
+    result = WorkflowRunner().run(parent_ir, {}, RunnerConfig(cache_enabled=False))
+
+    assert result.status == WorkflowStatus.FAILED
+    # The strict-mode template Diagnostic was captured from the child exception.
+    cf = result.shared_after["__failures__"]["sub"]["data"]["child_failure"]
+    assert "template_diagnostic" in cf
+    # ...and reconstructed with unresolved_references + provenance at the parent.
+    assert len(result.errors) == 1
+    diag = result.errors[0]
+    assert diag.message.startswith("In step 'sub' sub-workflow:")
+    ctx = diag.context or {}
+    assert ctx.get("category") == "template_error"
+    assert ctx.get("unresolved_references"), "structured per-reference detail must survive the boundary"
+    assert ctx.get("sub_workflow_step") == "sub"
+
+
+def test_jsonable_converts_diagnostic_and_exception():
+    """Review S1 — `_jsonable` is the serialization isolation boundary for the carry
+    bundle: it must convert Diagnostic → dict and Exception → str (recursively) so the
+    archived bundle never holds objects the trace / MCP-JSON serializers would drop."""
+    from pflow.runtime.workflow_executor import WorkflowExecutor
+
+    diag = Diagnostic(severity=Severity.ERROR, source="x", message="m", context={"k": "v"})
+    value = {"a": diag, "b": [ValueError("boom")], "c": {"nested": diag}, "plain": "s", "n": 7}
+
+    out = WorkflowExecutor._jsonable(value)
+
+    json.dumps(out)  # must not raise — proves no Diagnostic/Exception object survived
+    assert out["a"] == diag.to_dict()
+    assert out["b"][0] == "boom"
+    assert out["c"]["nested"] == diag.to_dict()
+    assert out["plain"] == "s"
+    assert out["n"] == 7

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor.py
@@ -352,15 +352,20 @@ class TestExecErrorActionDetection:
             category=FAILURE_CATEGORY_EXCEPTION,
             error="HTTP 503 Service Unavailable",
         )
-        msg = WorkflowExecutor._extract_child_error(child_storage, "deploy.pflow.md")
+        bundle = WorkflowExecutor._extract_child_failure(child_storage, "deploy.pflow.md")
+        msg = bundle["error"]
 
         assert "HTTP 503 Service Unavailable" in msg
         assert "deploy.pflow.md" in msg
+        # The bundle carries the child's structured failure forward (#233/#252):
+        # the failed-node pointer and its per-node failure record (with category).
+        assert bundle["failed_node"] == "api_call"
+        assert bundle["failures"]["api_call"]["category"] == FAILURE_CATEGORY_EXCEPTION
 
     def test_extract_child_error_without_failed_node(self):
         """When __execution__ has no failed_node, return generic fallback message."""
         child_storage: dict = {"__execution__": {}}
-        msg = WorkflowExecutor._extract_child_error(child_storage, "deploy.pflow.md")
+        msg = WorkflowExecutor._extract_child_failure(child_storage, "deploy.pflow.md")["error"]
 
         assert "returned error action" in msg
         assert "deploy.pflow.md" in msg
@@ -374,7 +379,7 @@ class TestExecErrorActionDetection:
             "step1": {"stdout": "some output", "exit_code": 1},
         }
         mark_node_failed(child_storage, "step1", category=FAILURE_CATEGORY_EXCEPTION)
-        msg = WorkflowExecutor._extract_child_error(child_storage, "build.pflow.md")
+        msg = WorkflowExecutor._extract_child_failure(child_storage, "build.pflow.md")["error"]
 
         assert "returned error action" in msg
         assert "build.pflow.md" in msg
@@ -394,7 +399,7 @@ class TestExecErrorActionDetection:
             category=FAILURE_CATEGORY_ROUTING,
             warning="Node 'router' returned action 'banana' but no successor edge matches.",
         )
-        msg = WorkflowExecutor._extract_child_error(child_storage, "child.pflow.md")
+        msg = WorkflowExecutor._extract_child_failure(child_storage, "child.pflow.md")["error"]
 
         assert "banana" in msg
         assert "no successor edge matches" in msg
@@ -419,7 +424,7 @@ class TestExecErrorActionDetection:
         }
         mark_node_failed(child_storage, "router", category=FAILURE_CATEGORY_ROUTING)
 
-        msg = WorkflowExecutor._extract_child_error(child_storage, "child.pflow.md")
+        msg = WorkflowExecutor._extract_child_failure(child_storage, "child.pflow.md")["error"]
 
         assert "router: declared cache did not fire" in msg
         assert "Diagnostic(" not in msg

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
@@ -562,8 +562,13 @@ class TestWorkflowExecutorComprehensive:
         exec_res = node.exec(prep_res)
 
         assert exec_res["success"] is False
-        assert "Sub-workflow execution failed" in exec_res["error"]
+        # An exception-path child failure now surfaces the structured summary that
+        # names the failing child node (#233/#252), not a generic
+        # "Sub-workflow execution failed" string.
+        assert "node 'fail'" in exec_res["error"]
         assert "Execution failed as expected" in exec_res["error"]
+        # The structured child-failure bundle is carried forward (mapped mode).
+        assert exec_res["child_failure"]["failed_node"] == "fail"
 
     # --- Test 16: auto-outputs with declared outputs ---
 


### PR DESCRIPTION
## Summary

A failed child sub-workflow's rich failure state was flattened to a one-line string at the parent boundary, so agents debugging a nested failure got strictly less than a top-level one — losing the child's per-node category, shell `exit_code`/`command`/`stderr`, source line, and template `unresolved_references`. The batch path was worse: child `__failures__` were never read during aggregation, so a batched sub-workflow failure surfaced only a flattened string per item.

This makes **every real failure reach the parent's `__failures__` structured, across every boundary** — the failure-archival invariant that Task 164 (resume), Task 125 (gates), and Task 171 build on.

Fixes #233, fixes #252. Closes #253.

## Changes

- **`workflow_executor.py`** — `_extract_child_error` (returns `str`) → `_extract_child_failure` (returns a JSON-able **bundle**: the child's `__failures__` records with per-node `category`+`data`, the failed-node pointer, a summary, and — for strict-mode template errors — the structured `Diagnostic` that lives only on the child exception). `post()` carries it forward only on a real error route, scoped to `storage_mode: mapped`; its `shared["error"]` summary no longer leaks the `WorkflowExecutor` class name or double-states the path.
- **`executor_service.py`** — one recursive primitive `build_subworkflow_diagnostics()` rebuilds the child's diagnostics by **reusing `build_error_list`** (so a nested failure renders byte-identical to a top-level one) and wraps each with `format_child_provenance`. `build_error_list` short-circuits to it when a failed node carries a `child_failure` bundle.
- **`batch_executor.py`** — carries the per-item bundle inside the worker body (parallel-safe).
- **`batch_errors.py`** — preserves the structured `child_failure` through compaction (JSON/MCP parseable), and renders it in text (without a redundant title frame).

## Explanation

Layering forces the shape: `runtime/` cannot import `execution/build_error_list` without an import cycle. So the **runtime layer ferries raw JSON-able failure state**, and the **execution layer reconstructs diagnostics recursively** and provenance-wraps them. The bundle rides via a non-dunder key on the executor node's namespace → archived into `__failures__[id].data` by engine step 17.5 → read back via `get_node_output`. Child node IDs stay **nested inside** that record, never as top-level `__failures__` keys, so this does **not** reintroduce #254 (`storage_mode: shared` is left to a separate PR). Nesting falls out for free: the reconstructed child shape's failed-node data may itself carry a `child_failure`, which `build_error_list` re-detects — so provenance chains outermost-first across arbitrary depth.

#253's MCP protocol-error routing was already fixed by #491 (the node returns `"error"`, step 17.5 archives it as `mcp_failure`); this PR adds the end-to-end regression test (real `MCPNode` through `exec_fallback`) that was its flagged "zero MCP integration tests for the failure archival path" gap — hence `Closes #253`.

Diff: 8 files, +719/-32 (≈230 production, the rest tests). Plan- and code-reviewed via multi-agent batteries (14 review agents across both stages); all findings addressed.

## Testing

`make check` clean; `make test` **7909 → 7921 passed, 9 skipped, 0 failed** (+12 new tests, 0 regressions). New integration tests in `tests/test_integration/test_failed_node_invariant.py`:

- `test_subworkflow_shell_failure_propagates_structured_to_parent` — #233: child `shell_failure` block (command/exit_code/stderr) + provenance reaches the parent; `inner` is **not** a top-level `__failures__` key (#254 guard)
- `test_batch_subworkflow_shell_failure_carries_structured_per_item` — #252: each batch item's structured child record (category, exit_code) survives
- `test_parallel_batch_subworkflow_failures_attributed_per_item` — parallel: ≥2 items failing the same child node are attributed to their own item (sourced from per-item `__failures__`, never the reference-shared `__warnings__`)
- `test_nested_subworkflow_failure_chains_provenance` — outermost-first provenance chaining, deepest node named
- `test_strict_template_error_in_child_surfaces_unresolved_references` — runtime strict template error in a child → `unresolved_references` survive to the parent
- `test_subworkflow_error_action_continue_does_not_leak_child_failure` — a custom non-error route doesn't leak `${node.child_failure}`
- `test_storage_mode_shared_skips_child_failure_bundle` — shared mode builds no bundle (#254 territory, out of scope)
- `test_subworkflow_failure_state_is_json_serializable` / `test_subworkflow_failure_trace_json_has_no_diagnostic_repr` — bundle is plain JSON in both result and saved-trace paths
- `test_real_mcp_node_protocol_error_archived_as_mcp_failure` — #253 e2e
- `test_jsonable_converts_diagnostic_and_exception` — the serialization isolation boundary
- Migrated 9 existing `_extract_child_error` tests to the new `_extract_child_failure` bundle shape (strengthened, not weakened)
- Manual: ran both reproducers via `uv run pflow` — non-batch and batch now render the rich `Shell details` block with `In step 'sub' sub-workflow:` provenance