### PR TITLE
feat: agent↔browser interaction channel — point & watch for the workflow viewer (Task 169)

### DIFF
--- a/.taskmaster/tasks/task_169/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_169/implementation/implementation-plan.md
@@ -56,6 +56,13 @@ CLI verb (httpx)  --GET /api/activity-->  hub ring                          Grap
   existing `sameRef` machinery. Flat ids (`n3`/`g2`/`e7`) are positional, unstable across rebuilds, and
   the server's render won't match the browser's — only structural identity is valid between two
   independent renders. **One parser (Python, fully unit-testable).**
+- **Apply model — two rules, no acknowledgment (detailed under "Apply model" below).** The server
+  validates the target against the current workflow file and either returns a **great error**
+  (not-found / ambiguous / 0 windows — all server-knowable) or broadcasts it; the browser then
+  **always reveals** a target that exists in its view. The command reports *resolution + which live
+  windows it was sent to + each window's visible/backgrounded state* — it does **not** claim or
+  confirm "shown", and there is **no browser→server apply-ack**. Confirmation is the human in the
+  loop (it's a conversation).
 
 ---
 
@@ -92,7 +99,7 @@ class _Hub:
     def unregister(self, conn_id) -> None: ...
     def set_visibility(self, conn_id, visibility) -> None: ...
     def windows_for(self, workflow_key) -> list[_Conn]: ...
-    def broadcast(self, workflow_key, message) -> list[_Conn]:   # put_nowait each match; ret delivered
+    def broadcast(self, workflow_key, message) -> list[_Conn]:   # put_nowait each match; ret conns queued to
     def record(self, event) -> None: ...
     def activity(self, workflow_key=None) -> list[dict]: ...      # filtered, newest-first
 ```
@@ -156,18 +163,19 @@ mismatch is visible to the agent.
    with a body naming the required header). Body `{workflow, type: "focus"|"frame"|"clear", target?}`.
    - Normalize the workflow → `_workflow_key`. If `None` (unknown name) → 404-style actionable
      not-found with fuzzy `list_names()` suggestions (do not broadcast).
-   - `type=="clear"`: `hub.broadcast(key, {"type":"clear"})`; return delivery report.
+   - `type=="clear"`: `hub.broadcast(key, {"type":"clear"})`; return the dispatch report (below).
    - `type in ("focus","frame")`: build the graph + resolve the target (below). On
      `WorkflowGraphValidationError` → 422 with diagnostics (mirror `graph` handler `server.py:106`).
-     - **0 matches** → `{"resolved":{"matched":0,"suggestions":[...fuzzy node-ids...]}, "delivered":0}`
-       (no broadcast).
-     - **>1 match** → `{"resolved":{"matched":N,"qualify":[<fully-qualified addrs>]}, "delivered":0}`
+     - **0 matches** → `{"resolved":{"matched":0,"suggestions":[...fuzzy node-ids...]}, "sent_to":0}`
+       (a great error, no broadcast).
+     - **>1 match** → `{"resolved":{"matched":N,"qualify":[<fully-qualified addrs>]}, "sent_to":0}`
        (no broadcast — never point at a guess; the agent re-points with a qualified address).
        **Each `qualify` entry MUST resolve to exactly 1 element** (test it — the self-correcting loop
        must converge).
      - **1 match** → `hub.broadcast(key, {"type":type, "target":<descriptor>})`; return
-       `{"resolved":{"matched":1,"address":<addr>}, "delivered":len(conns),
+       `{"resolved":{"matched":1,"address":<addr>}, "sent_to":len(conns),
        "windows":[{"visibility":c.visibility} for c in conns], "workflow_key":key}`.
+       `sent_to` = queued to N live windows, NOT confirmed-shown (see "Apply model").
 
 3. **`POST /api/interaction`** — Watch report (fire-and-forget). Require JSON. Body
    `{workflow, type, target?, view_state}`. `hub.record({..., "workflow_key":_workflow_key(workflow),
@@ -179,6 +187,26 @@ mismatch is visible to the agent.
 5. **`GET /api/activity?workflow=<name|path optional>`** — Watch read (a **snapshot**, not a stream).
    Return `{"events": [...], "workflow_key": <resolved or null>}`, newest-first, each event annotated
    with `age_seconds = time.time() - ev["ts"]` (single clock — CLI + server share localhost).
+
+### Apply model — validate → reveal → report; NO apply-acknowledgment
+
+The command's report tells the agent *resolution + which live windows it was sent to + each window's
+visible/backgrounded state*. It deliberately does **not** report "did the browser actually show it",
+and there is **no browser→server ack channel**. Two rules make that honest, not lossy:
+
+1. **The server validates before sending** (it builds the graph from the current file). A bad target
+   never gets broadcast — it returns a **great error**: not-found + fuzzy suggestions, ambiguous +
+   qualified scopes, or 0-windows. All server-knowable.
+2. **The browser always reveals a resolvable target** (total apply — see the frontend section: focus
+   expands collapsed ancestors; edge focus expands both endpoints + un-hides; frame expands + moves
+   camera). So "exists in the window's view → shown" holds without confirmation.
+
+The only residual gap is a **stale browser view**: in the ~1.5s after the user edits the `.pflow.md`,
+the server already sees the new target but a window hasn't auto-refreshed yet, so a just-validated
+target isn't in *that* window's view → nothing visible. It **self-heals** on the next Auto-update
+poll, and the **human in the loop** ("see it?" → "no") prompts a re-point. A transient, not a failure
+mode worth a protocol. A programmatic apply-ack is a deferred fast-follow, only worth it for
+autonomous/no-human flows or the run-overlay (which would define its own).
 
 ### Target resolution (`src/pflow/ui/targets.py` — new module, pure, unit-tested)
 
@@ -258,8 +286,9 @@ Resolve `{source, source_field, target, input_name}`: `flatIdForRef` each ref, t
 by its **`data.from`/`data.to`** (the original contract endpoints the focus-reveal styling keys on,
 `GraphView.tsx:288`, `flow.ts:1075-1076`) — **NOT** `edge.source`/`edge.target` (renderAnchor-resolved;
 they differ exactly when an endpoint is suppressed/re-anchored). Pin the chosen mapping with a
-`flow.test.ts` assertion. Collapsed endpoint → re-anchored, discrete edge absent → return an explicit
-"endpoint collapsed; focus an endpoint node instead" outcome (no silent no-op).
+`flow.test.ts` assertion. Collapsed endpoint → re-anchored, discrete edge absent → **expand both
+endpoints' collapsed ancestors first** so the discrete edge appears, then highlight it (the apply path
+reveals; it does not report a failure back to the agent).
 
 ### `web/src/views/GraphView.tsx` wiring
 
@@ -267,18 +296,16 @@ On mount `subscribe(workflow, handlers)` (unsubscribe on unmount / workflow chan
 server-resolved descriptor onto the **existing** entry points — no new focus mechanics:
 - `focus` + node: `flatIdForRef` → `RFNode` → **`onSelectNode(node)`** (`GraphView.tsx:390` — already
   expands collapsed ancestors + focus + select + pan).
-- `focus` + edge: edge-by-endpoints lookup → `setFocus(edgeId)` + `setSelectedId(edgeId)` (mirrors
-  `onEdgeClick`, `:237`). **Must reveal a default-hidden data edge in beautiful** — a data edge is
-  `hidden:true` in compact density (`flow.ts:1090`), revealed only on incident focus. Verify
-  `onEdgeClick`/`applyFocus` un-hides a directly-focused edge; if it doesn't, the handler clears
-  `hidden` on that edge, else `focus "a.x -> b.y"` delivers-but-shows-nothing in the default density.
-- `frame` + node/edge: resolve to the **visible on-canvas representative** via
-  `resolveEndpointFlatId`/`nodeRepresentativeId` (`viewParams.ts:111/132` — returns the nearest visible
-  ancestor when the target is collapsed), then `useReactFlow().fitView({nodes:[{id}], padding:0.45,
-  maxZoom:1.2, duration:300})` (recipe `useCameraNavigation.ts:102/143`; expose a focus-free variant).
-  **Never `fitView` a flat id that exists structurally but is hidden in a collapsed container** (large
-  workflows >60 nodes open fully collapsed → `fitView` on an off-canvas id is a silent no-op while the
-  command falsely reports `delivered>0`). If unresolvable to anything on-canvas, the browser reports it.
+- `focus` + edge: **total apply** — expand both endpoints' collapsed ancestors so the (otherwise
+  re-anchored) discrete edge exists, then `setFocus(edgeId)` + `setSelectedId(edgeId)` (mirrors
+  `onEdgeClick`, `:237`), AND un-hide it in beautiful (a data edge is `hidden:true` in compact density,
+  `flow.ts:1090`, revealed only on focus — verify `applyFocus` un-hides a directly-focused edge; if
+  not, the handler clears `hidden`). So a resolvable edge is *always* revealed, never a shown-nothing
+  no-op.
+- `frame` + node/edge: **total apply, camera-only** — expand collapsed ancestors to reveal the target
+  (same as focus), then `useReactFlow().fitView({nodes:[{id}], padding:0.45, maxZoom:1.2,
+  duration:300})` (recipe `useCameraNavigation.ts:102/143`; expose a focus-free variant) WITHOUT
+  setting focus/selection. Reveal-then-frame the actual target; never `fitView` an off-canvas id.
 - `clear`: `onPaneClick()` (`:261`).
 
 Wire `reportInteraction` into the deliberate handlers ONLY (never hover/pan/zoom): `onNodeClick`,
@@ -350,12 +377,12 @@ body and return; else the text render below. **JSON mode exposes the per-window 
 not just an aggregate, so an agent can reason "all backgrounded → tell the user to switch tabs".
 
 - **`pflow ui focus <workflow> <target> [--open] [--json] [--port]`** → `POST /api/command` `focus`.
-  `--open` when `delivered==0`: non-edge target → open `?workflow=<wf>&focus=<target>` (load-time
+  `--open` when `sent_to==0`: non-edge target → open `?workflow=<wf>&focus=<target>` (load-time
   `?focus=` resolves node/container/IO); **edge target** → open `?workflow=<wf>` then re-POST every
-  ~0.25s until `delivered>0` or a 15s timeout (the load-time `?focus=` can't parse `from -> to`). On
+  ~0.25s until `sent_to>0` or a 15s timeout (the load-time `?focus=` can't parse `from -> to`). On
   **timeout**, print a DISTINCT message: "opened a window but it didn't connect within 15s — re-run
   `pflow ui focus …` now that it may be up" (never the plain `0 windows` report — that's misleading
-  after an open). `--open` gates strictly on `delivered==0` (never duplicates a backgrounded window).
+  after an open). `--open` gates strictly on `sent_to==0` (never duplicates a backgrounded window).
 - **`pflow ui frame <workflow> <target> [--json] [--port]`** → `frame`.
 - **`pflow ui clear-focus <workflow> [--json] [--port]`** → `clear`.
 - **`pflow ui user-activity [workflow] [--json] [--port]`** → `GET /api/activity`; newest-first with
@@ -366,9 +393,9 @@ not just an aggregate, so an agent can reason "all backgrounded → tell the use
 ### Text report shapes (agent-first; the `--json` payload is the server body verbatim)
 
 ```
-focus 'fetch-data' in 'my-wf':  resolved 1 (fetch-data) · delivered to 2 windows (1 visible, 1 backgrounded)
+focus 'fetch-data' in 'my-wf':  resolved 1 (fetch-data) · sent to 2 windows (1 visible, 1 backgrounded)
   workflow key: /abs/.../my-wf.pflow.md
-focus 'gen' in 'my-wf':  ambiguous — 2 matches, not delivered. Qualify with one of:
+focus 'gen' in 'my-wf':  ambiguous — 2 matches, not sent. Qualify with one of:
     create-songs.gen
     remix.gen
 focus 'fetchdata' in 'my-wf':  not found. did you mean: fetch-data, fetch-config?   # FUZZY, not substring
@@ -412,13 +439,18 @@ untouched (the `?watch` param is an internal CLI↔frontend contract).
   hub.unregister` → next command reports the corrected count.
 - **Mid-edit-invalid source:** `/api/command` → 422 diagnostics (CLI renders via `format_diagnostic`,
   not a traceback); `/api/activity`/`/api/visibility` unaffected.
-- **Ambiguous target:** not delivered; qualify list of fully-qualified addresses, each resolving to 1.
+- **Ambiguous target:** not sent; qualify list of fully-qualified addresses, each resolving to 1.
 - **IO in/out + body-name collision; batched sub-workflow interiors:** addresses carry `in:`/`out:`
   and `[batch_index]` so the qualify list is distinct + actionable.
-- **Collapsed node/frame target (large auto-collapsed workflow):** resolve via the visible
-  representative; never frame an off-canvas id; report if unresolvable.
-- **Collapsed edge endpoint:** re-anchored → explicit "endpoint collapsed" outcome.
-- **Default-density (beautiful) data-edge focus:** the focus must un-hide the edge.
+- **Collapsed node / edge / frame target (large workflows auto-collapse):** the apply path EXPANDS
+  collapsed ancestors so a target that exists in the current graph is **always revealed** (edges
+  expand both endpoints; frame expands + moves camera without highlighting). Never `fitView` an
+  off-canvas id.
+- **Default-density (beautiful) data-edge focus:** the focus also un-hides the edge.
+- **Stale browser view (mid-edit, ~1.5s):** a just-validated target may not exist in a window's
+  not-yet-refreshed view → nothing visible; **self-heals** on the next Auto-update poll, and the
+  human-in-the-loop re-points. The command does **not** confirm apply — no browser ack, by design
+  (see "Apply model").
 - **Name vs path Viewer split:** `_workflow_key` normalizes both to the resolved entry path (symlinks
   included); the key is echoed.
 - **Unknown workflow name:** actionable not-found with fuzzy suggestions (not a silent 0-window).
@@ -439,7 +471,7 @@ untouched (the `?watch` param is an internal CLI↔frontend contract).
   literal batch (N>4) of a sub-workflow; input+output sharing a name; a data edge. Assert
   node/container/IO/edge resolution, scoped + `in:`/`out:` + `[i]` disambiguation, 0→fuzzy suggestions,
   and that **every emitted `qualify` address resolves to exactly 1 element**.
-- **Endpoint integration** via `TestClient(create_app())`: `/api/command` delivery counts, 415 on
+- **Endpoint integration** via `TestClient(create_app())`: `/api/command` sent_to counts, 415 on
   non-JSON, 422 on invalid source, the unknown-workflow not-found; `/api/activity` shape + empty case.
 - **CLI tests** (`CliRunner`): bare serve preserved (`test_ui.py:593/628` green; patch
   `_port_available`/`uvicorn.run`/`webbrowser.open`); subcommand dispatch; `httpx.ConnectError` →
@@ -454,11 +486,11 @@ untouched (the `?watch` param is an internal CLI↔frontend contract).
 ## End-to-end verification (the originating scenario)
 
 1. `pflow ui my-wf` (browser opens). Second terminal: `pflow ui focus my-wf fetch-data` → the window
-   focuses/reveals it, no reload; output `delivered to 1 window (1 visible)`.
+   focuses/reveals it, no reload; output `sent to 1 window (1 visible)`.
 2. Second window same workflow → re-run → `2 windows`.
 3. Background the tab → report says `backgrounded`. Close it (incl. a hard close) → next focus reports
    the corrected count.
-4. No window → `0 windows` + hint; `--open` opens focused (node) or opens+delivers-once-connected
+4. No window → `0 windows` + hint; `--open` opens focused (node) or opens+sends-once-connected
    (edge); a backgrounded window present → `--open` does NOT duplicate.
 5. `pflow ui focus my-wf "gen.response -> summarize.prompt"` → the data line lights (even in beautiful).
 6. Click a node → `pflow ui user-activity my-wf` shows it with the right `node_id` + view state +
@@ -485,7 +517,9 @@ untouched (the `?watch` param is an internal CLI↔frontend contract).
 
 Standalone body-row targets (need a field-level descriptor beyond `RFRef`); control/branch edges;
 `user-activity --follow` livestream (same bus, "when a consumer exists"); SSE replacing the Auto-update
-poll; any run-event schema (Task 133 boundary — envelope stays vocabulary-agnostic).
+poll; **programmatic apply-acknowledgment** (browser confirming "shown" back to the agent — unneeded
+while a human is in the loop; revisit only for autonomous/no-human flows or the run-overlay); any
+run-event schema (Task 133 boundary — envelope stays vocabulary-agnostic).
 
 ---
 
@@ -503,8 +537,10 @@ poll; any run-event schema (Task 133 boundary — envelope stays vocabulary-agno
 - **Async-only hub INVARIANT comment names the specific failure** — review-concurrency W3.
 - **`_workflow_key` gates on `exists()` + `.resolve()`; unknown name → fuzzy not-found** — review-plan
   W1 (dead `try/except`; phantom-path → silent 0 windows) + review-feature-interactions (symlink).
-- **`frame`/focus resolve via the visible representative; never frame an off-canvas id** —
-  review-feature-interactions (auto-collapse silent false-delivery).
+- **Total apply: focus/edge/frame expand collapsed ancestors so a resolvable target is always
+  revealed; never frame an off-canvas id** — review-feature-interactions (auto-collapse silent
+  false-delivery) + the apply-model simplification (no browser ack; the server validates, the browser
+  always reveals; the report says "sent", not "shown").
 - **Edge lookup keyed on `data.from`/`data.to`; beautiful-density edge un-hide** —
   review-feature-interactions (+ review-plan W3: pin with a `flow.test.ts` assertion).
 - **`--json` flag + structured passthrough; per-window visibility in JSON** — review-agent-ux C1.

--- a/.taskmaster/tasks/task_169/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_169/implementation/implementation-plan.md
@@ -1,0 +1,518 @@
+# Task 169 — Agent↔Browser Interaction Channel (Point & Watch)
+
+> Implementation plan for an agent executing in isolation. Every file:line anchor was verified by
+> codebase search (2026-06-18/19) and hardened by a 4-agent deep-review (plan / concurrency /
+> agent-ux / feature-interactions) — see "Review hardening" at the end for what each fix traces to.
+> Re-confirm a line number if a file has moved. Vocabulary is fixed in `context/CONTEXT.md`
+> (**Viewer, Point, Watch, Auto-update**).
+
+## Context — why this exists
+
+The `pflow ui` viewer (Task 168) is one-way: the server answers read-only GETs, and an AI agent can
+only *see* the user's canvas via its own headless-browser screenshots — it cannot act in the
+**user's** window. Observed trigger: while discussing the UI, the user said *"I can't find it"* about
+a node the agent was describing, with no way to point at it.
+
+This adds a bidirectional channel: the agent can **Point** (focus/frame/clear a target in every open
+Viewer showing a workflow, reusing the exact selection a user click produces) and **Watch** (read a
+snapshot of the user's recent deliberate interactions). It also builds the **SSE push transport** the
+deferred live-run overlay (Task 133) will ride — this task owns the *channel + a vocabulary-agnostic
+envelope*, NOT any run-event schema.
+
+Outcome: with a workflow open in a real browser, `pflow ui focus <wf> <target>` focuses/reveals it
+without a reload; the command reports how many windows received it and whether each is visible or
+backgrounded; `pflow ui user-activity <wf>` shows what the user just clicked, newest-first, with
+relative ages.
+
+## Scope (decided with the user)
+
+**v1 Point targets:** node, container (sub-workflow / batch box), workflow/sub-workflow IO port, and
+**data edge** (`from -> to`). **Watch** covers deliberate interactions only.
+
+**Deferred (documented fast-follows):** standalone body-row targets (pointing at `gen.response`
+*alone*, not as an edge endpoint — `RFRef` has no field-level identity); control/branch edges
+(no `${ref}` to name them by); a `--follow` activity livestream; replacing the Auto-update poll with
+an SSE push.
+
+---
+
+## Architecture overview
+
+```
+CLI verb (httpx)  --POST /api/command-->  Server hub  --SSE /api/events-->  Browser (events.ts)
+                                              |                                    |
+Browser  --POST /api/interaction / /api/visibility-->  hub ring + conn registry    |
+CLI verb (httpx)  --GET /api/activity-->  hub ring                          GraphView focus/camera
+```
+
+- **Transport:** SSE (server→browser commands) + plain JSON POST/GET. No WebSocket.
+- **Envelope (the overlay's seam — keep generic):** every SSE frame is
+  `data: {"type": "<str>", ...payload}\n\n`. v1 defines `connected`, `focus`, `frame`, `clear`. The
+  future overlay adds run-event `type`s over the same pipe; do NOT define any run-event schema here.
+- **The server resolves; the browser is a dumb display; flat ids never cross the wire.** The server
+  parses the agent's target string, resolves it against the freshly-built `RFGraph` to a **structural**
+  identity (`RFRef = {node_id, ancestor_path, port}`; an edge = a pair of those + `input_name`), and
+  broadcasts that. The browser maps the structural identity to its *own* current flat id via the
+  existing `sameRef` machinery. Flat ids (`n3`/`g2`/`e7`) are positional, unstable across rebuilds, and
+  the server's render won't match the browser's — only structural identity is valid between two
+  independent renders. **One parser (Python, fully unit-testable).**
+
+---
+
+## Server (`src/pflow/ui/server.py`)
+
+### The hub (first stateful, in-memory, per-app-instance)
+
+Add a `_Hub` class; attach one instance to `app.state.hub` in `create_app()`. Handlers read
+`request.app.state.hub`.
+
+```python
+_ACTIVITY_MAX = 200
+_KEEPALIVE_S = 15
+
+# INVARIANT (load-bearing — keep this exact comment at _Hub AND at the route list):
+# Every handler that touches the hub MUST be `async def`. Starlette runs async handlers on the
+# event loop and sync `def` handlers in a threadpool thread. asyncio.Queue is loop-affine and NOT
+# thread-safe — a sync handler calling put_nowait / mutating the deque would race the loop with no
+# lock. Do NOT add a sync hub-touching handler. (The 4 existing sync GET handlers never touch it.)
+
+@dataclass
+class _Conn:
+    conn_id: str
+    workflow_key: str
+    queue: asyncio.Queue          # of dict (envelopes)
+    visibility: str               # "visible" | "hidden"
+
+class _Hub:
+    def __init__(self) -> None:
+        self._conns: dict[str, _Conn] = {}
+        self._activity: deque[dict] = deque(maxlen=_ACTIVITY_MAX)
+        self._counter = itertools.count(1)        # conn-id source (deterministic for tests)
+    def register(self, workflow_key, visibility) -> _Conn: ...   # mints conn_id + Queue
+    def unregister(self, conn_id) -> None: ...
+    def set_visibility(self, conn_id, visibility) -> None: ...
+    def windows_for(self, workflow_key) -> list[_Conn]: ...
+    def broadcast(self, workflow_key, message) -> list[_Conn]:   # put_nowait each match; ret delivered
+    def record(self, event) -> None: ...
+    def activity(self, workflow_key=None) -> list[dict]: ...      # filtered, newest-first
+```
+
+`create_app()` (`server.py:263-288`): build `app = Starlette(routes=...)`, set `app.state.hub = _Hub()`,
+`return app`. Add the five new `Route(...)` **before** the static `Mount`/catch-all (the
+`/api/*`-before-catch-all rule, `server.py:266-278`). The hub is **per-app-instance**: the 28
+`TestClient(create_app())` sites get isolated hubs automatically; the single `uvicorn.run(app)`
+process has exactly one. Do NOT use a module-level singleton.
+
+### Workflow-key normalization (groups name-opened and path-opened Viewers together)
+
+```python
+def _workflow_key(value: str) -> str | None:
+    p = Path(value)
+    if p.suffix == ".pflow.md" or p.exists():
+        return str(p.resolve())
+    wm = WorkflowManager()
+    if wm.exists(value):                                  # manager.py:366 — REAL fs check
+        return str(Path(wm.get_path(value)).resolve())    # .resolve() so a symlinked library path
+                                                          # matches the catalog's resolved path
+    return None                                           # unknown name → caller reports actionably
+```
+
+`get_path` does NOT raise — it returns a phantom path for any string (`manager.py:304/62`), so the
+prior `try/except` was dead code and a typo'd name silently mapped to a never-matching key. The
+`exists()` gate is load-bearing. On `None`, the command handler returns an actionable not-found:
+`find_similar_items(value, WorkflowManager().list_names(), method="fuzzy")` → "no workflow 'X'; did
+you mean: …". The command response also **echoes the resolved key** so a residual name-vs-path
+mismatch is visible to the agent.
+
+### Endpoints (all `async def` — see the hub INVARIANT; all new; before the static mount)
+
+1. **`GET /api/events?workflow=<name|path>&visibility=<visible|hidden>`** — SSE subscribe.
+   `async def` → `StreamingResponse(gen(), media_type="text/event-stream")`:
+   ```python
+   async def gen():
+       conn = hub.register(key, visibility)
+       try:
+           yield f'data: {json.dumps({"type":"connected","conn_id":conn.conn_id})}\n\n'
+           while True:
+               try:
+                   msg = await asyncio.wait_for(conn.queue.get(), timeout=_KEEPALIVE_S)
+                   yield f"data: {json.dumps(msg)}\n\n"
+               except asyncio.TimeoutError:
+                   yield ": keepalive\n\n"      # forces a periodic send() → see below
+       finally:
+           hub.unregister(conn.conn_id)
+   ```
+   **The periodic keepalive yield is load-bearing for disconnect cleanup, not optional.** A generator
+   blocked forever on `queue.get()` is NOT woken on a silently-dropped tab when `StreamingResponse`
+   runs under ASGI `spec_version >= 2.4` (httptools / `uvicorn[standard]` / a uvicorn bump) — it only
+   notices a dead socket when it next `send()`s. The keepalive `yield` forces a periodic `send()`, so
+   a dead socket surfaces (`ClientDisconnect`/`OSError`) on EITHER ASGI version, firing `finally`. Do
+   NOT substitute `request.is_disconnected()`: on the spec<2.4 path `StreamingResponse` already
+   consumes `receive()` via its own disconnect listener, and a second `receive()` consumer is
+   undefined. (Today's stack — uvicorn 0.35 h11 = spec 2.3 — works either way; the keepalive makes it
+   version-independent and also defeats idle-proxy timeouts.)
+
+2. **`POST /api/command`** — the agent's Point. **Require `Content-Type: application/json`** (else 415
+   with a body naming the required header). Body `{workflow, type: "focus"|"frame"|"clear", target?}`.
+   - Normalize the workflow → `_workflow_key`. If `None` (unknown name) → 404-style actionable
+     not-found with fuzzy `list_names()` suggestions (do not broadcast).
+   - `type=="clear"`: `hub.broadcast(key, {"type":"clear"})`; return delivery report.
+   - `type in ("focus","frame")`: build the graph + resolve the target (below). On
+     `WorkflowGraphValidationError` → 422 with diagnostics (mirror `graph` handler `server.py:106`).
+     - **0 matches** → `{"resolved":{"matched":0,"suggestions":[...fuzzy node-ids...]}, "delivered":0}`
+       (no broadcast).
+     - **>1 match** → `{"resolved":{"matched":N,"qualify":[<fully-qualified addrs>]}, "delivered":0}`
+       (no broadcast — never point at a guess; the agent re-points with a qualified address).
+       **Each `qualify` entry MUST resolve to exactly 1 element** (test it — the self-correcting loop
+       must converge).
+     - **1 match** → `hub.broadcast(key, {"type":type, "target":<descriptor>})`; return
+       `{"resolved":{"matched":1,"address":<addr>}, "delivered":len(conns),
+       "windows":[{"visibility":c.visibility} for c in conns], "workflow_key":key}`.
+
+3. **`POST /api/interaction`** — Watch report (fire-and-forget). Require JSON. Body
+   `{workflow, type, target?, view_state}`. `hub.record({..., "workflow_key":_workflow_key(workflow),
+   "ts": time.time()})`; return `204`.
+
+4. **`POST /api/visibility`** — Require JSON. Body `{conn_id, visibility}`. `hub.set_visibility(...)`;
+   return `204`.
+
+5. **`GET /api/activity?workflow=<name|path optional>`** — Watch read (a **snapshot**, not a stream).
+   Return `{"events": [...], "workflow_key": <resolved or null>}`, newest-first, each event annotated
+   with `age_seconds = time.time() - ev["ts"]` (single clock — CLI + server share localhost).
+
+### Target resolution (`src/pflow/ui/targets.py` — new module, pure, unit-tested)
+
+Generate the canonical address(es) of every addressable element and match the target against them —
+this sidesteps parse ambiguity (the server *generates* from real metadata, so it knows which dotted
+segment is a field vs a scope host). **The agent-facing address string MUST carry everything `RFRef`
+carries — it drops nothing — or two in-scope target classes become un-disambiguatable (an input
+`data` and output `data` both stringify to `data`; batch items 0 and 1 both stringify to `fanout.gen`,
+yielding a useless qualify list of identical strings).**
+
+```python
+def resolve_target(rf: RFGraph, target: str) -> TargetResolution:
+    # Build (canonical_addresses: set[str], descriptor) for every addressable element.
+    # scope_prefix(ancestor_path) = "".join(step.node_id + (f"[{i}]" if step.batch_index==i else "") + "."
+    #                                        for step in ancestor_path)
+    #  - node (port=None):  bare = node_id ; scoped = scope_prefix + node_id   (e.g. "fanout[0].gen")
+    #                       descriptor = {"kind":"node","ref": ref_dict}
+    #  - IO port (port in {"in","out"}):  PREFIX THE SIDE -> "in:" + addr / "out:" + addr
+    #                       (so input "data" and output "data" are DISTINCT addresses)
+    #                       descriptor = {"kind":"node","ref": ref_dict}
+    #  - container:  via its host node (RFGroup.host -> RFNode.id -> .ref); same addrs as host node.
+    #  - data edge (kind=="data_flow" only):  f"{src_ep} -> {tgt_ep}"
+    #        src_ep = <src node addr> + ("."+output_field) + ("."+".".join(output_path) if any)
+    #        tgt_ep = <tgt node addr> + ("."+input_name)
+    #        descriptor = {"kind":"edge","source":src_ref,"source_field":output_field,
+    #                      "target":tgt_ref,"input_name":input_name}
+    # RFEdge.source/target are FLAT node ids (react_flow.py:339) -> first build {flat_id: RFNode} to
+    # recover each endpoint's .ref. Restrict to kind=="data_flow".
+    # Match (normalize whitespace around "->"): matched = [e for e in elements if target in e.addresses]
+    #   0  -> suggestions = find_similar_items(target, bare_node_ids, method="fuzzy")   # NOT substring
+    #   1  -> resolve + broadcast
+    #   >1 -> qualify = [most-qualified (scoped) addr of each match]  (each resolves to exactly 1)
+```
+
+Match against the **`RFGraph`** (what's on the canvas — batch truncation keeps ≤2 representatives, so
+hidden items aren't addressable, which is correct). The broadcast **descriptor is the full `RFRef`**
+(already carries `port` + `ancestor_path[batch_index]`); only the agent-facing STRING needed the
+port/batch_index fix. Reused: `resolve_validate_build(workflow, max_depth=_MAX_DEPTH)`
+(`graph_service.py:50`) → `render_react_flow(model)` (`react_flow.py:172`); `find_similar_items(...,
+method="fuzzy")` + `format_did_you_mean` (`suggestion_utils.py:14/77`).
+
+### Security (extend the comment at `server.py:279-287`)
+
+Keep binding `127.0.0.1`, keep **no CORS**. Extend to cover the new endpoints: the mutating POSTs
+**require `Content-Type: application/json`** → a cross-origin page is forced into a CORS preflight
+that fails → unreachable cross-origin (do NOT use `navigator.sendBeacon` for the interaction report —
+it sends a CORS-safelisted type and bypasses this). `GET /api/events` streams commands; a cross-origin
+`EventSource` can't read the body without CORS headers. Worst case if a write lands: focusing a node in
+the user's own Viewer — no file/system effect.
+
+---
+
+## Frontend (`web/`)
+
+### New: `web/src/api/events.ts` (mirror `client.ts` — relative paths, `ApiError` shape)
+
+- `subscribe(workflow, handlers)`: `new EventSource("/api/events?workflow=…&visibility="+document.visibilityState)`.
+  Store `conn_id` from the `connected` message; dispatch others by `msg.type`; add a
+  `visibilitychange` listener POSTing `/api/visibility {conn_id, visibility}`. Return an unsubscribe
+  that closes the source + removes the listener. **Validate** each message shape before dispatch
+  (`client.ts:60-68` discipline).
+- `reportInteraction(workflow, event)`: `fetch("/api/interaction", {method:"POST", keepalive:true,
+  headers:{"Content-Type":"application/json"}, body: JSON.stringify({workflow, ...event})}).catch(()=>{})`
+  — fire-and-forget; never throws into the UI.
+
+### New helper in `web/src/graph/remap.ts`: `flatIdForRef`
+
+```ts
+export function flatIdForRef(graph: RFGraph, ref: RFRef): string | null {
+  return graph.nodes.find((n) => sameRef(n.ref, ref))?.id ?? null;   // sameRef exists, remap.ts:16
+}
+```
+
+### Edge-by-endpoints lookup (the one substantial new mapping; code marks it "deferred", `useCameraNavigation.ts:78`)
+
+Resolve `{source, source_field, target, input_name}`: `flatIdForRef` each ref, then find the FlowEdge
+by its **`data.from`/`data.to`** (the original contract endpoints the focus-reveal styling keys on,
+`GraphView.tsx:288`, `flow.ts:1075-1076`) — **NOT** `edge.source`/`edge.target` (renderAnchor-resolved;
+they differ exactly when an endpoint is suppressed/re-anchored). Pin the chosen mapping with a
+`flow.test.ts` assertion. Collapsed endpoint → re-anchored, discrete edge absent → return an explicit
+"endpoint collapsed; focus an endpoint node instead" outcome (no silent no-op).
+
+### `web/src/views/GraphView.tsx` wiring
+
+On mount `subscribe(workflow, handlers)` (unsubscribe on unmount / workflow change). Map a
+server-resolved descriptor onto the **existing** entry points — no new focus mechanics:
+- `focus` + node: `flatIdForRef` → `RFNode` → **`onSelectNode(node)`** (`GraphView.tsx:390` — already
+  expands collapsed ancestors + focus + select + pan).
+- `focus` + edge: edge-by-endpoints lookup → `setFocus(edgeId)` + `setSelectedId(edgeId)` (mirrors
+  `onEdgeClick`, `:237`). **Must reveal a default-hidden data edge in beautiful** — a data edge is
+  `hidden:true` in compact density (`flow.ts:1090`), revealed only on incident focus. Verify
+  `onEdgeClick`/`applyFocus` un-hides a directly-focused edge; if it doesn't, the handler clears
+  `hidden` on that edge, else `focus "a.x -> b.y"` delivers-but-shows-nothing in the default density.
+- `frame` + node/edge: resolve to the **visible on-canvas representative** via
+  `resolveEndpointFlatId`/`nodeRepresentativeId` (`viewParams.ts:111/132` — returns the nearest visible
+  ancestor when the target is collapsed), then `useReactFlow().fitView({nodes:[{id}], padding:0.45,
+  maxZoom:1.2, duration:300})` (recipe `useCameraNavigation.ts:102/143`; expose a focus-free variant).
+  **Never `fitView` a flat id that exists structurally but is hidden in a collapsed container** (large
+  workflows >60 nodes open fully collapsed → `fitView` on an off-canvas id is a silent no-op while the
+  command falsely reports `delivered>0`). If unresolvable to anything on-canvas, the browser reports it.
+- `clear`: `onPaneClick()` (`:261`).
+
+Wire `reportInteraction` into the deliberate handlers ONLY (never hover/pan/zoom): `onNodeClick`,
+`onEdgeClick`, `focusPort`, the clear in `onPaneClick`, `changeDensity`, `changeDirection`, and the
+workflow open/switch in `App.tsx`. Report the **structural** target
+(`graph.nodes.find(n=>n.id===flatId)?.ref` → `{node_id, ancestor_path}`; for an edge, both endpoint
+identities) + `view_state = {density: DENSITY_TO_PARAM[density], direction, focus:<current focus →
+node_id|null>}`. **Export `DENSITY_TO_PARAM`** (`viewParams.ts:43`, currently unexported) so events
+carry agent-facing words (`advanced`/`beautiful`), not code words (`detailed`/`compact`).
+
+---
+
+## CLI (`src/pflow/cli/commands/ui.py`)
+
+### Restructure: a CUSTOM `UiGroup(click.Group)` — NOT a plain `@click.group`
+
+A plain `@click.group(invoke_without_command=True)` with a positional `WORKFLOW` **cannot coexist with
+subcommands** in Click (reproduced: `pflow ui focus <wf> <target>` → "No such command 'my-wf'";
+`pflow ui <wf> --no-open` → "No such command '--no-open'"). The working idiom is the repo's own
+`PflowCLI` (`main.py:18-49`, documented in `cli/CLAUDE.md` "How routing works"): a `click.Group`
+subclass with `ignore_unknown_options = True` and a custom `resolve_command` that routes a
+non-subcommand first arg to a hidden default command.
+
+Mirror it exactly:
+- `class UiGroup(click.Group): ignore_unknown_options = True`, and `resolve_command(ctx, args)`: if
+  `not args` OR `args[0]` is not a known subcommand → route to the hidden `serve` command
+  (`return "serve", self.get_command(ctx,"serve"), args`); else normal dispatch.
+- `ui_cmd = @click.group(cls=UiGroup, name="ui", invoke_without_command=True)`; registration unchanged
+  (`main.py:151/168`, `cli.add_command(ui_cmd)`).
+- Hidden `@ui_cmd.command(name="serve", hidden=True, context_settings={"ignore_unknown_options": True})`
+  with the `WORKFLOW` arg + `--port`/`--no-open`/`--no-auto-update`, holding **today's serve body
+  verbatim** (`ui.py:89-142`). **Keep the `create_app`/`uvicorn`/`starlette` imports INSIDE `serve`**
+  (the lazy-import boundary test `test_ui.py:664` asserts `pflow.ui.server` isn't imported by importing
+  the command module). New subcommands import only `httpx` (core dep) — safe to import eagerly.
+
+Result: `pflow ui` / `pflow ui <wf>` / `pflow ui <wf> --no-open --port N` all reach `serve` (so the
+existing tests `test_ui.py:593/628` pass unchanged); `pflow ui focus|frame|clear-focus|user-activity`
+dispatch to subcommands. Name-collision: a saved workflow named `focus`/`frame`/`clear-focus`/
+`user-activity` is reachable via the path form `pflow ui ./focus.pflow.md` (document in `--help`).
+**Add a test for subcommand dispatch AND for the preserved bare-serve forms.**
+
+### Four thin-client subcommands (`@ui_cmd.command()`), all `httpx`, all with a `--json` flag
+
+Shared helper handles BOTH connection and HTTP-status errors (neither pattern exists in the repo yet):
+```python
+def _request(ctx, port, method, path, **kw):
+    import httpx
+    try:
+        r = httpx.request(method, f"http://127.0.0.1:{port}{path}", timeout=5, **kw)
+        r.raise_for_status()
+        return r.json()
+    except httpx.ConnectError:
+        click.echo(f"No pflow ui server on port {port}.\n→ start one: pflow ui {workflow}", err=True)
+        ctx.exit(1)
+    except httpx.HTTPStatusError as e:
+        body = e.response.json() if "json" in e.response.headers.get("content-type","") else {}
+        if e.response.status_code == 422:                 # mid-edit-invalid source
+            for d in body.get("errors", []):
+                click.echo(format_diagnostic(d), err=True)   # the diagnostic the CLI already renders
+        elif e.response.status_code == 415:
+            click.echo("Server requires Content-Type: application/json (client bug).", err=True)
+        else:
+            click.echo(f"Server error {e.response.status_code}: {body}", err=True)
+        ctx.exit(1)
+```
+Each subcommand: `--json` boolean flag (the `list.py` idiom — there is no `--output-format` convention
+for subcommands); when set, `click.echo(json.dumps(payload, indent=2))` of the server's structured
+body and return; else the text render below. **JSON mode exposes the per-window `visibility` array**,
+not just an aggregate, so an agent can reason "all backgrounded → tell the user to switch tabs".
+
+- **`pflow ui focus <workflow> <target> [--open] [--json] [--port]`** → `POST /api/command` `focus`.
+  `--open` when `delivered==0`: non-edge target → open `?workflow=<wf>&focus=<target>` (load-time
+  `?focus=` resolves node/container/IO); **edge target** → open `?workflow=<wf>` then re-POST every
+  ~0.25s until `delivered>0` or a 15s timeout (the load-time `?focus=` can't parse `from -> to`). On
+  **timeout**, print a DISTINCT message: "opened a window but it didn't connect within 15s — re-run
+  `pflow ui focus …` now that it may be up" (never the plain `0 windows` report — that's misleading
+  after an open). `--open` gates strictly on `delivered==0` (never duplicates a backgrounded window).
+- **`pflow ui frame <workflow> <target> [--json] [--port]`** → `frame`.
+- **`pflow ui clear-focus <workflow> [--json] [--port]`** → `clear`.
+- **`pflow ui user-activity [workflow] [--json] [--port]`** → `GET /api/activity`; newest-first with
+  relative ages + addressing notation; ALWAYS print an explicit count line; echo the resolved
+  `workflow_key`; distinguish "server up, no interactions recorded" from "none for workflow key X
+  (is a window open on it?)".
+
+### Text report shapes (agent-first; the `--json` payload is the server body verbatim)
+
+```
+focus 'fetch-data' in 'my-wf':  resolved 1 (fetch-data) · delivered to 2 windows (1 visible, 1 backgrounded)
+  workflow key: /abs/.../my-wf.pflow.md
+focus 'gen' in 'my-wf':  ambiguous — 2 matches, not delivered. Qualify with one of:
+    create-songs.gen
+    remix.gen
+focus 'fetchdata' in 'my-wf':  not found. did you mean: fetch-data, fetch-config?   # FUZZY, not substring
+focus 'fetch-data' in 'my-wf':  resolved 1 · 0 windows open.
+  → re-run with --open, or run `pflow ui my-wf`
+user-activity 'my-wf' (0 events)  — server up, no interactions recorded yet.
+```
+(Run `review-agent-ux` once more on the final strings.)
+
+### Rename `--no-watch` → `--no-auto-update` (flag only; keep the internal `?watch=0` URL param)
+
+Rename: `ui.py` option/help/param/docstrings (`:57/60/63/72-73/83`); the URL builder keeps emitting
+`watch=0` (`:123-124`). Docs: `docs/reference/cli/index.mdx:493`,
+`src/pflow/guide/features/visualization.md:28`, `src/pflow/ui/CLAUDE.md:116/123`. Also update the stale
+description string `(pflow ui --no-watch)` in `web/src/utils/viewParams.test.ts:23` (won't fail — it
+tests the `watch` URL param, unchanged — but it's agent-facing drift). Leave the rest of `web/`
+untouched (the `?watch` param is an internal CLI↔frontend contract).
+
+---
+
+## Implementation order (phases)
+
+0. **Write the ADR amendment FIRST** (`context/adr/`, amending/citing ADR-0005): the UI server gains
+   its first stateful, push-capable layer (SSE + in-memory registry); it carries UI-interaction
+   vocabulary and is the transport the deferred run-overlay rides, but does NOT define a run-event
+   schema. This reopens a recorded "read-only, stateless, no side effects" decision (`server.py:279`,
+   `ui/CLAUDE.md`) — pin it before code or a validation-consistency reviewer treats the stateful
+   server as an unjustified regression.
+1. **Server hub + 5 endpoints + `targets.py` + security comment.** Pure-Python, browser-free. The
+   overlay's transport seam; land first.
+2. **Frontend `events.ts` + `flatIdForRef` + edge-lookup + GraphView wiring + focus-free `frame`
+   camera + interaction reporting.** `make ui-build` (output → `src/pflow/ui/static/`, gitignored).
+3. **CLI `UiGroup` restructure + hidden `serve` + 4 subcommands + `--open` + `--no-watch` rename.**
+4. **Docs:** `src/pflow/ui/CLAUDE.md` (endpoints, the hub + per-app-instance/no-persistence note,
+   security extension, name-collision, the async-only INVARIANT), `web/CLAUDE.md` (`events.ts` exists).
+   Flip Task 169 → ✅ in root `CLAUDE.md`.
+
+## Edge cases to handle (verified)
+
+- **Dropped tab (incl. silent drop):** the keepalive-yield SSE loop surfaces the dead socket → `finally:
+  hub.unregister` → next command reports the corrected count.
+- **Mid-edit-invalid source:** `/api/command` → 422 diagnostics (CLI renders via `format_diagnostic`,
+  not a traceback); `/api/activity`/`/api/visibility` unaffected.
+- **Ambiguous target:** not delivered; qualify list of fully-qualified addresses, each resolving to 1.
+- **IO in/out + body-name collision; batched sub-workflow interiors:** addresses carry `in:`/`out:`
+  and `[batch_index]` so the qualify list is distinct + actionable.
+- **Collapsed node/frame target (large auto-collapsed workflow):** resolve via the visible
+  representative; never frame an off-canvas id; report if unresolvable.
+- **Collapsed edge endpoint:** re-anchored → explicit "endpoint collapsed" outcome.
+- **Default-density (beautiful) data-edge focus:** the focus must un-hide the edge.
+- **Name vs path Viewer split:** `_workflow_key` normalizes both to the resolved entry path (symlinks
+  included); the key is echoed.
+- **Unknown workflow name:** actionable not-found with fuzzy suggestions (not a silent 0-window).
+- **`--open` duplicate / backgrounded-only / zero windows / edge-open timeout:** each a distinct
+  message (see CLI).
+
+## Test strategy
+
+- **Hub unit tests** (`tests/test_ui/test_hub.py`, new): register/broadcast/`windows_for`/visibility/
+  ring bound+newest-first+age. **Cleanup MUST be tested here** (register→unregister→count drops) —
+  see the next bullet.
+- **SSE cleanup CANNOT be tested via `TestClient`** — its `receive()` never emits `http.disconnect`
+  for an infinite generator, so a `client.stream(...)` "cleanup" test passes green WITHOUT exercising
+  cleanup (false confidence). Test cleanup via (a) the `_Hub` unit tests above and (b) a raw-ASGI scope
+  driving `gen()` with an injected `http.disconnect`. Use `client.stream(...)` only to assert the
+  `connected` frame + one broadcast frame.
+- **`targets.py` unit tests** (new): flat workflow; nested sub-workflow with duplicate `node_id`;
+  literal batch (N>4) of a sub-workflow; input+output sharing a name; a data edge. Assert
+  node/container/IO/edge resolution, scoped + `in:`/`out:` + `[i]` disambiguation, 0→fuzzy suggestions,
+  and that **every emitted `qualify` address resolves to exactly 1 element**.
+- **Endpoint integration** via `TestClient(create_app())`: `/api/command` delivery counts, 415 on
+  non-JSON, 422 on invalid source, the unknown-workflow not-found; `/api/activity` shape + empty case.
+- **CLI tests** (`CliRunner`): bare serve preserved (`test_ui.py:593/628` green; patch
+  `_port_available`/`uvicorn.run`/`webbrowser.open`); subcommand dispatch; `httpx.ConnectError` →
+  actionable hint + exit 1; `httpx.HTTPStatusError` 422 → rendered diagnostics (not traceback);
+  `--json` payload; `--open` dedup gating + edge-timeout message.
+- **Frontend** (jsdom — state/transform only): `flatIdForRef`, the edge-by-endpoints lookup keyed on
+  `data.from`/`data.to` (pinned in `flow.test.ts`), the flat-id↔node_id reporting map. Visual
+  focus/reveal + the beautiful-density edge un-hide → real browser via
+  `.claude/skills/screenshot-pflow-web-ui`.
+- **All Task 168 server tests stay green** (four `/api/graph` arms, catalog, static, 503, lazy-import).
+
+## End-to-end verification (the originating scenario)
+
+1. `pflow ui my-wf` (browser opens). Second terminal: `pflow ui focus my-wf fetch-data` → the window
+   focuses/reveals it, no reload; output `delivered to 1 window (1 visible)`.
+2. Second window same workflow → re-run → `2 windows`.
+3. Background the tab → report says `backgrounded`. Close it (incl. a hard close) → next focus reports
+   the corrected count.
+4. No window → `0 windows` + hint; `--open` opens focused (node) or opens+delivers-once-connected
+   (edge); a backgrounded window present → `--open` does NOT duplicate.
+5. `pflow ui focus my-wf "gen.response -> summarize.prompt"` → the data line lights (even in beautiful).
+6. Click a node → `pflow ui user-activity my-wf` shows it with the right `node_id` + view state +
+   relative age; hover/pan produce nothing. `pflow ui focus my-wf --json …` emits a parseable body.
+
+## Reused functions / anchors (do not re-implement)
+
+- `resolve_validate_build` `graph_service.py:50` · `render_react_flow` `react_flow.py:172` ·
+  `WorkflowGraphValidationError` `graph_service.py:33` · `_json` `server.py:64` · `create_app`
+  `server.py:263` · `WorkflowManager.{exists:366, get_path:304, list_names:315}` ·
+  `find_similar_items(method="fuzzy")` + `format_did_you_mean` `suggestion_utils.py:14/77` ·
+  `format_diagnostic` (CLI diagnostic render).
+- `RFRef/RFNode/RFEdge/RFGroup` `react_flow.py:36/88/126/147`; `(node_id, ancestor_path, port)` unique
+  key (`model.py:18`); `RFEdge.source/target` are flat ids (`react_flow.py:339`).
+- `sameRef` `remap.ts:16` · `onSelectNode` `GraphView.tsx:390` · `onEdgeClick` `:237` · `onPaneClick`
+  `:261` · `focusPort` `:274` · `resolveEndpointFlatId`/`nodeRepresentativeId` `viewParams.ts:111/132` ·
+  `fitView` recipe `useCameraNavigation.ts:102` · `DENSITY_TO_PARAM` `viewParams.ts:43` ·
+  `data.from`/`data.to` keying `flow.ts:1075`, `GraphView.tsx:288` · `client.ts` (`ApiError`) `:9`.
+- CLI: serve body `ui.py:89-142` · helpers `ui.py:17/28` · `PflowCLI` idiom `main.py:18-49` +
+  `cli/CLAUDE.md` "How routing works" · registration `main.py:151/168` · `--json` idiom `list.py:15-46`
+  · `httpx` core dep `pyproject.toml:36`.
+
+## Out of scope / fast-follows (state in `ui/CLAUDE.md`)
+
+Standalone body-row targets (need a field-level descriptor beyond `RFRef`); control/branch edges;
+`user-activity --follow` livestream (same bus, "when a consumer exists"); SSE replacing the Auto-update
+poll; any run-event schema (Task 133 boundary — envelope stays vocabulary-agnostic).
+
+---
+
+## Review hardening (deep-review, 4 agents) — what each fix traces to
+
+- **CLI group is a custom `UiGroup` (not a plain group)** — review-plan C1 (reproduced: plain
+  group+positional+subcommands breaks both the headline command and existing tested serve forms).
+- **Address string carries `port` (`in:`/`out:`) + `batch_index` (`[i]`)** — review-feature-interactions
+  (the scheme was lossier than `RFRef`; IO-name collisions and batched interiors gave identical
+  un-disambiguatable qualify entries).
+- **SSE keepalive-yield (not bare `try/finally`, not `is_disconnected()`)** — review-concurrency W1
+  (cleanup silently breaks on ASGI spec≥2.4; `is_disconnected` double-consumes `receive()` on spec<2.4).
+- **SSE cleanup tested via `_Hub` + raw-ASGI, not `TestClient`** — review-concurrency W2 (TestClient
+  can't deliver `http.disconnect` to an infinite generator → false-green).
+- **Async-only hub INVARIANT comment names the specific failure** — review-concurrency W3.
+- **`_workflow_key` gates on `exists()` + `.resolve()`; unknown name → fuzzy not-found** — review-plan
+  W1 (dead `try/except`; phantom-path → silent 0 windows) + review-feature-interactions (symlink).
+- **`frame`/focus resolve via the visible representative; never frame an off-canvas id** —
+  review-feature-interactions (auto-collapse silent false-delivery).
+- **Edge lookup keyed on `data.from`/`data.to`; beautiful-density edge un-hide** —
+  review-feature-interactions (+ review-plan W3: pin with a `flow.test.ts` assertion).
+- **`--json` flag + structured passthrough; per-window visibility in JSON** — review-agent-ux C1.
+- **Fuzzy `not-found` suggestions (not substring)** — review-agent-ux C2 (the substring example was
+  impossible).
+- **`_request` handles 422/415, not just `ConnectError`; ConnectError echoes the real workflow** —
+  review-agent-ux W1/W2/S2.
+- **`user-activity` explicit empty line + echo key; `--open` edge-timeout distinct message** —
+  review-agent-ux W3/W4.
+- **ADR written FIRST** — review-plan S1. **`viewParams.test.ts:23` in the rename checklist** —
+  review-plan W2.

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -1,0 +1,148 @@
+# Task 169 — Progress Log (design & planning)
+
+> **What this file is:** the tacit knowledge from the design + planning process — *why* decisions
+> landed where they did, what was tried and rejected, and what nearly bit us. It is the complement
+> to the other three artifacts; it deliberately does **not** restate them:
+> - `task-169.md` — the spec (what/why, requirements).
+> - `implementation/implementation-plan.md` — the how (endpoints, resolver, phases, tests, anchors).
+> - `context/CONTEXT.md` — the glossary (Viewer, Point, Watch, Auto-update).
+>
+> Read those for *what to build*. Read this for *why it's shaped this way and where the bodies are
+> buried*. Status as of this entry: **planned + deep-reviewed, not yet implemented.**
+
+---
+
+## 2026-06-19 — Planning & design session (no code yet)
+
+### The one decision a future agent will most want explained: resolution lives in the SERVER
+
+The plan says "the server parses the target → resolves to a structural `RFRef` → the browser maps it
+via `sameRef`." That is **not** the obvious choice, and we arrived at it by reversing an earlier one.
+The journey, so nobody re-treads it:
+
+1. **First instinct:** validate the node server-side (build the graph, check it exists).
+2. **Rejected → "resolve in the frontend only":** the frontend already has `resolveNodeFlatId`/
+   `sameRef`; re-implementing node addressing in Python would be a *second source of truth* that
+   drifts — exactly the validation-vs-runtime drift this codebase hunts for. So: server stays a dumb
+   pipe, broadcasts the opaque target string, the browser resolves. Agent learns the result by
+   *screenshot* (the "see" leg already exists).
+3. **Reversed → "resolve in the server, to a structural `RFRef`":** the frontend-only design forces
+   the agent to screenshot-and-eyeball to learn "did it hit? how many matched?". For an agent-first
+   tool that's worse than a structured answer. The key unlock: the server resolves the *agent's text*
+   to a **structural identity** (`node_id`+`ancestor_path`+`port`), and the browser maps *that* to its
+   on-screen flat id via its **existing** `sameRef` — so there is still only **one notation parser**
+   (Python), no drift, the report is **synchronous + structured**, and the parser is unit-testable
+   without a browser. The browser became a dumb display after all, just keyed on structure not text.
+
+**Load-bearing principle that fell out of this:** flat ids (`n3`/`g2`/`e7`) are positional and
+unstable, and the server's fresh render ≠ the browser's live render. **Only structural identity is
+valid currency between two independently-rendered views.** If you ever find a flat id crossing the
+SSE wire, that's a bug.
+
+### The insight the deep-review forced (and the lesson for the deferred work)
+
+The agent-facing **address string was lossier than the `RFRef` it described** — it dropped `port`
+(IO in/out) and `batch_index`. Consequence: an input `data` and an output `data` both stringified to
+`data`; batch items 0 and 1 both stringified to `fanout.gen`. The "ambiguous → here are the qualified
+scopes → re-point" loop then dead-ends, because the qualify list is *identical strings*. Fixed in the
+plan (`in:`/`out:`, `[batch_index]`).
+
+**Reusable lesson (applies to every deferred fast-follow too):** an agent-facing identity string must
+carry **everything** the structural identity carries, or self-correction can't converge. When you add
+standalone-row or control-edge addressing later, re-check this invariant first.
+
+### The design philosophy that drove half the small decisions: the self-correcting loop
+
+The user articulated it as *"agents see this happening and can prefix with the subworkflow name if
+they need to."* The agent doesn't have to be precise on the first point — it points, observes (the
+structured report's qualified scopes, or a screenshot), and re-points. This single idea decided:
+- **ambiguous → report, never guess** (a wrong point is worse than no point);
+- the **qualify list must round-trip** (each entry resolves to exactly 1 — now a required test);
+- **structured/parseable output** matters more than a pretty point, because the *report* is the
+  feedback channel that closes the loop.
+
+### Scope calls and the reasoning the spec doesn't carry
+
+- **Edges are in v1 by the user's explicit choice, against my recommendation to defer.** Verification
+  showed edges are the costliest target (no field-level structural identity; a frontend edge-by-
+  endpoints lookup the existing code deliberately marked *"deferred"*; and a collapse/re-anchor case
+  where the discrete edge doesn't exist). I recommended shipping nodes+containers+IO and fast-
+  following edges; the user chose to include edges. So the cost is **known and accepted**, not
+  overlooked — budget for the real-browser verification of the `data.from`/`data.to` keying.
+- **Why standalone body-rows are deferred (not just "later"):** `RFRef` has no field-level identity —
+  it reaches node + in/out side, not "the `prompt` row of `summarize`." Addressing a row *alone* needs
+  a richer descriptor. (Rows are still reachable *as edge endpoints* — that's why edges work but
+  standalone rows don't.)
+- **Why control/branch edges are deferred:** they have no `${ref}` to name them by, and they hit the
+  same collapse/re-anchor fragility. The `data_flow`-only restriction is coherent, not arbitrary.
+- **Per-window visibility is full (not count-only)** because it serves the *originating* "I can't find
+  it" moment directly — "it's in a backgrounded tab, switch over" is the actual help. The cost is one
+  conn-id + a tiny visibility POST, which we needed for registry cleanup anyway.
+- **Watch buffer is one global tagged ring, not a per-workflow dict** (the spec says "per workflow").
+  Observably equivalent, less structure; supports the "what did the user just touch, anywhere" case.
+
+### The concurrency landmine (most important thing for whoever writes the SSE endpoint)
+
+The "all handlers async → single loop → no locks" claim is **correct for the design and the shipped
+stack**, verified at ASGI level. But the disconnect cleanup has a **latent, version-dependent trap**:
+
+- A bare `try/finally` around `await queue.get()` only fires on a silently-dropped tab when
+  `StreamingResponse` runs under ASGI **`spec_version < 2.4`**. Today's stack (plain `uvicorn` 0.35,
+  h11 → spec 2.3) takes that branch, so it *works today*.
+- The moment anyone installs `httptools` / `uvicorn[standard]` / bumps uvicorn to a 2.4+ path, the
+  generator blocks on `queue.get()` forever and **connections leak** — silently inflating the very
+  delivery counts this feature exists to report. The `>=0.30` floor does **not** pin this.
+- Fix (in the plan): a periodic **keepalive `yield`**, which forces a `send()` so a dead socket
+  surfaces on *either* ASGI version. **Do not "simplify" it to `request.is_disconnected()`** — on the
+  spec<2.4 path `StreamingResponse` already consumes `receive()`, and a second consumer is undefined.
+- **Testing trap:** Starlette's `TestClient` **cannot** deliver `http.disconnect` to an infinite SSE
+  generator, so a `client.stream(...)` "cleanup" test passes **green without testing cleanup**. Test
+  cleanup via `_Hub` units + a raw-ASGI disconnect injection. (This is exactly the kind of
+  synthetic-fixture-matches-happy-path false confidence to avoid.)
+
+And the future-facing one: the no-locks invariant is **unenforced**. A later "stats" endpoint written
+as a sync `def` that reads `app.state.hub` would run in a threadpool and race the loop. The plan puts
+a hard comment naming this failure at `_Hub` and the route list — keep it.
+
+### Spec-vs-code discrepancies found (trust boundary — don't trust the spec's specifics blindly)
+
+The spec is directionally right but had stale specifics. Verified against code:
+- "no-CORS security comment ~line 126" → actually **`server.py:279-287`** (line 126 is an unrelated
+  400 branch). And that comment *already* anticipated "any mutating/live-run endpoint must revisit
+  this" — it foresaw us.
+- "the `?focus=` URL param exists" → yes in the **frontend**, but the **CLI never emits it** today;
+  `--open` adds it.
+- "focus produces incoming/outgoing edge highlighting" → imprecise. Focus does **symmetric** incident
+  reveal/dim + a per-edge source/target *fade hint*, not separate in/out edge sets. Substance (the
+  connected edges light up) holds.
+- A `--no-watch` serve flag existed that the spec never mentioned — found during exploration, now
+  renamed `--no-auto-update`.
+- `WorkflowManager.get_path(name)` does **not** raise on a bad name — it returns a *phantom* resolved
+  path for any string. Gate name→key normalization with `exists()`, or a typo silently maps to a key
+  no window will ever match (reported as a misleading "0 windows").
+
+### Smaller rejected alternatives (so they're not re-proposed)
+
+- **Plain `@click.group` + positional `WORKFLOW`** — the obvious restructure. It's *broken in Click*
+  (reproduced in review: both the new verbs and the existing `pflow ui <wf> --no-open` fail). Must use
+  a custom `UiGroup` mirroring `PflowCLI`. Don't retry the plain group.
+- **WebSocket** — nothing needs a bidirectional socket; SSE (down) + plain POST (up) is enough and is
+  the transport shape the overlay was always named for.
+- **`navigator.sendBeacon`** for the interaction report — rejected: it sends a CORS-safelisted content
+  type, which would *bypass* the `application/json`-forces-preflight cross-origin defense. Use
+  `fetch(keepalive:true)` with a JSON content-type.
+- **`--output-format json`** on the verbs — there's no such convention for subcommands; the repo idiom
+  is a boolean `--json` + inline `json.dumps` (like `list.py`).
+
+### Why this is also the overlay's transport (don't let it rot)
+
+This channel is the live-run overlay's (Task 133) future transport. The single rule that keeps the two
+tracks decoupled: **the SSE envelope stays vocabulary-agnostic** (`{type, ...}`) and this task defines
+**no run-event schema**. If you find yourself baking interaction-message assumptions into the bus
+plumbing, stop — the overlay adds its own `type`s over the same pipe later.
+
+### For implementation: do Phase 0 (the ADR) before code
+
+The server going stateful + push reopens a *recorded* "read-only, stateless, no side effects" decision
+(`server.py:279`, `ui/CLAUDE.md`, ADR-0005). Write the amendment first, or a future validation-
+consistency review will (correctly) flag the stateful server as an unjustified regression.

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -146,3 +146,45 @@ plumbing, stop — the overlay adds its own `type`s over the same pipe later.
 The server going stateful + push reopens a *recorded* "read-only, stateless, no side effects" decision
 (`server.py:279`, `ui/CLAUDE.md`, ADR-0005). Write the amendment first, or a future validation-
 consistency review will (correctly) flag the stateful server as an unjustified regression.
+
+---
+
+## 2026-06-19 — Apply model: the "sent vs shown" correction (and why there is NO ack channel)
+
+A contradiction surfaced after the deep-review (the user caught it; it was *my* planning over-reach):
+the plan reported a command's outcome at the moment the message was **queued** to the SSE connections,
+yet *also* promised browser-determined outcomes back in the command response — e.g. it literally said
+"the command's window entry notes 'target hidden'". There was **no channel** for the browser to report
+that, and the word "delivered" quietly conflated **queued** with **shown**. So the CLI could report
+success while the user's screen showed nothing.
+
+We considered building command **acknowledgments** (command id → each Viewer POSTs applied/failed →
+the CLI waits a bounded time and returns per-window outcomes). **We deliberately did NOT.** The cleaner
+resolution — which the user steered — is two rules that make the report honest without a protocol:
+
+1. **The server validates before sending** → a bad target never broadcasts; it returns a *great error*
+   (not-found + fuzzy suggestions / ambiguous + qualified scopes / 0 windows). All server-knowable.
+2. **The browser always reveals a resolvable target** (total apply: focus/edge/frame expand collapsed
+   ancestors; edge focus un-hides in beautiful). So "exists in the view → shown" holds without a
+   confirmation round-trip.
+
+The report now says **`sent_to` N windows (+ per-window visible/backgrounded)** — never "shown".
+
+**The insight that makes acks unnecessary in v1: the human is the acknowledgment.** This is a
+*conversation* — the agent points, says "see it?", and the human says yes/no. Two corollaries a future
+agent must not forget:
+- The screenshot skill drives the **agent's own** headless browser, **not the user's window** — so it
+  can never confirm the point landed in the user's Viewer. Don't reach for it as proof.
+- The only residual gap is a **stale browser view** (~1.5s after an edit, before Auto-update
+  refreshes): a just-validated target may not be in that window yet → nothing shows. It **self-heals**
+  on the next poll and the human re-points. A transient, not a failure mode worth a protocol.
+
+**When acks WOULD be worth building (deferred fast-follow):** an autonomous/no-human flow that must
+programmatically confirm "shown", or the run-overlay (which would define its own confirmation). Until
+such a consumer exists, building it would violate the same "build it when a consumer exists" discipline
+that deleted the original SSE stub. The envelope is generic, so an `applied`/ack message type is purely
+additive later — no rework.
+
+**Meta-lesson for the next agent:** don't add a confirmation protocol when a human closes the loop.
+"Validate hard up front + always reveal + report honestly" beats "do it blind, then build machinery to
+check whether it worked."

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -276,3 +276,47 @@ clear/focus each reported `sent_to: 1`, a real pointer drag moved the canvas, re
 node on-screen with its focus ring/panel, and Watch returned the real `node_click` with structural ref,
 flat id, and view state. An earlier false negative mutated only the viewport DOM style (desynchronizing
 React Flow's internal camera state); replacing it with a real pointer drag made the check production-faithful.
+
+---
+
+## 2026-06-21 — Independent review pass + post-review fixes (PR #527)
+
+The staged implementation was reviewed independently (not by its author): four specialist agents in
+parallel (concurrency, agent-ux, feature-interactions, test-fidelity) plus a direct read of `server.py` +
+`targets.py`. Verdict: faithful to the plan, **0 Critical**, and — notably — the three self-reported
+deviations all held up and each closed a real PLAN gap:
+- the edge descriptor's `source_path` (without it the plan would broadcast sub-key edges indistinguishably);
+- `--open` re-posting *every* target, not just edges (load-time `?focus=` can't parse qualified addresses);
+- subscribing only after the graph loads (so `--open` can't count a not-yet-ready Viewer).
+The reviews confirmed the load-bearing claims in the actual code: async-only/no-locks holds, the SSE
+keepalive disconnect is correct, the address grammar carries full identity, and the tests are real
+(raw-ASGI disconnect — not TestClient theater; qualify round-trips; production-faithful fixtures).
+
+Three fixes applied on top (commit `378cd952`):
+1. **Edge-dedup "shown-nothing"** (the one review Warning). The frontend FlowEdge dedup key excludes
+   `output_field`/`output_path`, so two field-level data edges between the same nodes collapse to one
+   line in beautiful — and a Point at the deduped-away one focused an id that was never rendered →
+   nothing lit. Fixed at the dedup seam: the build records dropped ids on the kept edge's
+   `data.mergedIds`, and `applyFocus` matches a focused id against `e.id` OR `mergedIds`. Paint-safe;
+   GraphView needed no change. A synchronous fallback in `applyPoint` was rejected — at apply time the
+   `edges` snapshot is pre-reveal, so it can't tell "deduped, stays deduped" from "collapsed, reveal
+   will build it".
+2. **CLI second-grammar drift** (test-fidelity finding). The Watch display re-implemented the address
+   grammar in `ui.py` — the exact "two sources of truth" the plan's one-parser rule forbids. Moved it
+   into `targets.py` (`_format_ref`/`_format_target` + tolerant `address_for_*`); `ui.py` delegates.
+   Byte-identical (existing tests green) + a new round-trip drift guard.
+3. **Keepalive coverage.** Added a raw-ASGI test that an idle connection emits the `:` keepalive (what
+   surfaces dropped sockets on ASGI ≥2.4). Deliberately NOT a send-failure-finalization test — that
+   path depends on asyncio async-gen finalization subtleties and would be fragile/theater.
+
+Skipped, per the reviewers' own guidance: moving `render_react_flow` off-loop (the concurrency reviewer
+judged the current split better than the plan's wording), the stdout/stderr split (defensible), and an
+off-loop-build *behavior* test (low marginal value over the mechanism assertion).
+
+Correction to an earlier note in this log: the Phase-1 "sandbox denies localhost socket binding" claim
+was the *original implementer's* environment — **verified false here**. The full Task 169 Python set
+(78 tests, including the socket/port-probe ones) passes in this environment with 0 skipped.
+
+Verification: ruff + mypy clean; **78 Task 169 Python tests pass**; tsc clean; **524 web vitest pass**.
+Shipped as **PR #527** (`04faa88e` implementation + `378cd952` review fixes). The distilled
+invariants / patterns / gotchas now live in `task-review.md`.

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -509,3 +509,45 @@ Written up for the next agent: `scratchpads/handoffs/ui-sse-reconnect-and-discov
 real-browser-verified** (headless Chrome where `readyState`/`visibilityState`/console are observable), folded into
 the overlay design. **Meta-lesson:** a browser-behavior fix that can't be verified from the CLI must be verified in
 a real browser *before* shipping — a green unit test over a wrong assumption is worse than no test.
+
+---
+
+## 2026-06-22 — Bot-review evaluation + polish commit (PR #527, pre-merge)
+
+Evaluated the two `claude[bot]` reviews on PR #527 (`#issuecomment-4763394321` pre-polish, `…4770265223`
+post-polish). User flagged them as possibly stale — verified every finding against current code (3 parallel
+`pflow-codebase-searcher` passes + direct reads of `server.py`/`ui.py`/`types.ts`/`GraphView.tsx`). Staleness
+was real but only shifted **line numbers**; none of the pre-polish findings had been silently fixed. **8 findings:
+6 confirmed + applied, 1 deferred, 1 disputed.**
+
+### Applied (one commit, `[skip review]`)
+- **R1-W1 — dropped the inoperative `path.suffix == ".pflow.md"` clause** (`server.py` `_workflow_key`). `Path.suffix`
+  is only `.md`, so the clause was always False; behavior already rested on `path.exists()`. Took the reviewer's
+  fix **(a)** (drop it), *not* (b) (`value.endswith`) — (b) would have *changed* behavior to accept non-existent
+  paths as phantom keys, worse than the current "non-existent → not found." Behavior-identical; added the missing
+  branch test (`_workflow_key("/no/such/x.pflow.md") is None`).
+- **R2-S2 — `clear-focus` at 0 windows no longer prints the circular "→ open the workflow first"** (open a window
+  only to clear focus on it?). Threaded a `clearing` flag through `_render_dispatch`/`_render_delivery`; clear now
+  says "→ no Viewer open — nothing to clear." `frame`'s "open first" is left (not circular). +CLI test.
+- **R1-S2 — whitelisted the recorded interaction fields** (`server.py` `interaction()`) to `(type, target,
+  view_state)` instead of passing through every client key. Verified safe: `InteractionReport` is exactly those
+  three (`types.ts:175`) and the GraphView callsite sends only them, so it's a no-op for the real client and only
+  filters unexpected extras → predictable Watch shape for the consuming agent. +endpoint test (junk key dropped).
+- **R1-S3 / R1-Nit / R2-S3 — three clarity comments only** (no behavior change): the deliberate `workflow_key=None`
+  fire-and-forget choice in `interaction()` (vs `command`/`activity` 404), the `err=output_json` stdout-cleanliness
+  idiom in `focus --open` timeout, and that `not opened` intentionally suppresses the background-tab nudge.
+
+### Deferred → GH #529
+- **R1-S4 — `focus --open` re-POSTs the full (graph-rebuilding) command ~60× while waiting for the new window.**
+  Confirmed, but benign on the localhost `--open`-only path; the reviewer's fix (poll a cheap connection-count,
+  send once) needs exactly the lightweight count/health endpoint #529's discovery/probe work introduces. Folded
+  there rather than adding surface now.
+
+### Disputed → kept as-is (user decision)
+- **R2-S1 — docs no longer mention `--output-format json` for the `ui` commands.** Technically true, but the omission
+  was a **deliberate** earlier decision (text is the agent's read surface; JSON is an assumable universal escape
+  hatch — *don't push agents toward JSON*). The bot lacked that intent. Not staleness; the reviewer disagreeing with
+  a settled call. Left removed.
+
+Verification: `make check` clean (ruff, ruff-format, mypy 237, deptry 240); **`make test` 8066 passed** (8063 +3
+new regression tests); the four Task 169 Python suites 90 → 93. No frontend change (no `make ui-build` needed).

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -188,3 +188,91 @@ additive later — no rework.
 **Meta-lesson for the next agent:** don't add a confirmation protocol when a human closes the loop.
 "Validate hard up front + always reveal + report honestly" beats "do it blind, then build machinery to
 check whether it worked."
+
+---
+
+## 2026-06-20 — Phase 1 implementation started
+
+Scope is intentionally server-only: the in-memory hub, target resolver, five interaction endpoints,
+security note, and Python tests. Baseline before code: `tests/test_cli/test_ui.py` plus the React Flow
+renderer suite produced **73 passed, 3 failed**; all three failures require binding a localhost socket,
+which this sandbox denies (`PermissionError`) before project code runs. Phase 0's ADR-0007 was the only
+pre-existing worktree change and is being preserved.
+
+Phase 1 complete. The hub is per-`create_app()` and loop-owned; SSE uses a 15-second keepalive send so
+disconnect cleanup is ASGI-version-independent. Name/path subscriptions converge on one resolved key,
+and Point validation resolves only to structural refs. One necessary plan correction: edge descriptors
+now include `source_path`. Existing `RFEdge.output_path` is part of edge identity, so omitting it made
+distinct sub-key edges resolve to different addresses but become indistinguishable after broadcast.
+No frontend or CLI code was changed; their wiring and user-facing docs remain in their planned later
+phases rather than documenting a partial surface.
+
+Verification: **21 focused tests passed** (including real nested/batch renders and raw-ASGI SSE
+broadcast+disconnect), **94 relevant regressions passed**, pre-commit/Ruff, full mypy (237 files), and
+deptry passed. Near-full sandbox run: **8030 passed, 18 skipped** after excluding ten environment-only
+cases (Homebrew `uv` panics before Python or localhost socket binds denied); an unfiltered run confirmed
+the four additional exclusions fail inside Homebrew `uv`, not project code.
+
+---
+
+## 2026-06-20 — Phase 2 implementation started
+
+Scope is frontend-only: the SSE/reporting API seam, structural target mapping, total reveal before
+focus/frame, and deliberate-interaction reporting. Lockfile dependencies restored with `npm ci`;
+baseline before edits is **40 test files / 509 tests passed** plus a clean TypeScript typecheck. Real
+browser verification is required after the bundle build because jsdom does not render edge geometry or
+prove camera behavior.
+
+Phase 2 complete. `events.ts` validates the vocabulary-agnostic SSE envelope, tracks reconnect-issued
+connection ids/visibility, and makes interaction POST failures inert. Graph mapping uses full `RFRef`
+identity; Point expands collapsed ancestor chains before focus/frame, edge focus reveals both endpoints,
+and frame is camera-only and paint-deferred when reveal changes layout. User clicks, row/chip focus,
+clear, view toggles, and workflow open report structural + local flat identity; agent commands do not
+echo into Watch.
+
+Two implementation refinements from seam verification: (1) subscription starts only after the graph is
+loaded, so `--open` cannot count a Viewer that is not yet able to apply its first command; (2) edge
+resolution first finds the browser's contract `RFEdge` by original endpoint refs + fields + full
+`source_path`, then focuses that local edge id after reveal. This is simpler than searching the current
+FlowEdge by render anchors and preserves the plan's load-bearing rule: re-anchored `edge.source/target`
+are never used as identity.
+
+Verification: **41 frontend files / 521 tests passed** (baseline +12), TypeScript typecheck and two
+production `make ui-build` runs passed, plus **94 Python UI/renderer regressions**. A real headless Chrome
+run successfully subscribed, accepted focus/frame commands (`HTTP 200`), dispatched a real node click,
+and produced `/private/tmp/pflow-shots/task169-phase2-live-200.png`; the final image shows the clicked
+`process-small` selection/panel after the command sequence. Its final result-aggregation node had a local
+MCP-result type mismatch; the corrected rerun was blocked by the environment execution quota, so the
+intermediate focus-vs-frame DOM JSON could not be recovered. Unit/jsdom tests directly pin that state
+transition; the remaining live-verification limitation is explicit rather than inferred away.
+
+---
+
+## 2026-06-21 — Phases 3–4 complete
+
+The CLI now preserves bare `pflow ui [workflow]` through a custom `UiGroup` while adding `focus`,
+`frame`, `clear-focus`, and `user-activity`; all verbs support structured JSON failures and actionable
+no-server/zero-window output. Unresolved, ambiguous, zero-window, and open-timeout Point outcomes exit
+nonzero so shell/agent callers cannot mistake a no-op for success. `--no-watch` is renamed
+`--no-auto-update` without changing the private
+`?watch=0` contract. Server/frontend/CLI docs now describe the stateful hub, target grammar, security,
+and deferred boundaries; Task 169 is marked done.
+
+One plan deviation was necessary after seam verification: `focus --open` re-posts every target after
+the Viewer subscribes, not only edges. Load-time `focus=` accepts bare node/flat ids but not qualified
+nested or `in:`/`out:` addresses; retrying the already-validated structural command keeps one parser and
+makes all target types reliable. Review also found and fixed reconnect-stale visibility, stale deferred
+camera frames, non-round-trippable nested IO output, blocking graph builds on the hub loop, unbounded
+connection queues, unknown-workflow Watch ambiguity, and production-inaccurate fixtures. Control-edge
+identity remains deferred by plan; data-edge `frame` remains camera-only, while `focus` reveals the line.
+
+Verification: **76 focused Python UI tests passed** (including localhost lifecycle tests), **523 frontend
+tests passed**, production build/typecheck passed, and the full non-LLM suite passed **8077 tests** after
+excluding one confirmed Homebrew-`uv` environment failure (`test_dry_run_json_mode_emits_no_stderr`;
+`uv` cannot spawn `pflow` from its temporary cwd). Pre-commit, full mypy (237 files), deptry (240 files),
+and docs tests passed. Phase 2's real Chrome Point/Watch run remains the live-browser evidence; the final
+same-page rerun also passed using `scratchpads/task169-live-rerun/point-watch-rerun.pflow.md`: CLI
+clear/focus each reported `sent_to: 1`, a real pointer drag moved the canvas, repeated focus restored the
+node on-screen with its focus ring/panel, and Watch returned the real `node_click` with structural ref,
+flat id, and view state. An earlier false negative mutated only the viewport DOM style (desynchronizing
+React Flow's internal camera state); replacing it with a real pointer drag made the check production-faithful.

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -551,3 +551,15 @@ was real but only shifted **line numbers**; none of the pre-polish findings had 
 
 Verification: `make check` clean (ruff, ruff-format, mypy 237, deptry 240); **`make test` 8066 passed** (8063 +3
 new regression tests); the four Task 169 Python suites 90 → 93. No frontend change (no `make ui-build` needed).
+
+### Merge attempt surfaced a latent Python 3.10 incompatibility (fixed)
+Squash-merging (the repo's only allowed method; main is rules-gated on CI, auto-merge disabled) ran the full check
+matrix and the **`tests-and-type-check (3.10)`** job went red while 3.11–3.14 were green. Root cause: `ui.py` did
+`from datetime import UTC` — `datetime.UTC` is **3.11+**, so on 3.10 `pflow`'s import chain broke and cascaded
+across the suite. It's Task 169's own code (the `user-activity` timestamp formatter), latent since the original
+implementation; nothing local caught it because **mypy has no pinned `python_version`** (defaults to the local
+3.11+ interpreter) and local pytest runs on 3.11+ — only the CI 3.10 job exercises it, and an unmerged PR's red
+3.10 check sat unnoticed until an actual merge forced the matrix. Fixed with the 3.10-safe `timezone.utc`
+(`ui.py:15`/`:595`); ruff (target `py39`) does not rewrite it back to `UTC` (UP017 is 3.11+ only). 99 Task 169 +
+error-boundary tests pass. *Follow-up worth considering (out of scope here): pin mypy `python_version = "3.10"` so
+this class of regression is caught locally, not only in CI.*

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -320,3 +320,83 @@ was the *original implementer's* environment — **verified false here**. The fu
 Verification: ruff + mypy clean; **78 Task 169 Python tests pass**; tsc clean; **524 web vitest pass**.
 Shipped as **PR #527** (`04faa88e` implementation + `378cd952` review fixes). The distilled
 invariants / patterns / gotchas now live in `task-review.md`.
+
+---
+
+## 2026-06-22 — Post-merge dogfooding: Point address grammar aligned to the file's vocabulary
+
+Rebased the branch onto `main` (linear; only `CLAUDE.md` roadmap conflict — `main` had reorganized the
+overlay track into 172→169→173) and force-pushed. Then **used the feature as a fresh agent** against
+`examples/advanced/content-pipeline.pflow.md` and immediately tripped on the address grammar — the
+exact failure the spec exists to prevent, hit by its own author.
+
+### The root cause (the one thing the next agent must internalize)
+
+The Point grammar had invented a **parallel naming notation** that diverged from the `.pflow.md` the agent
+already reads:
+- the file says `source_file` under `## Inputs`; the grammar demanded `in:source_file`.
+- the file shows `read_source` consuming `${source_file}`; the grammar's `source.field -> target.input`
+  shape gave no hint the input end keeps its `in:` prefix.
+
+So the mistakes were **translation errors between the file's vocabulary and a made-up second notation**,
+not missing information. This is the *same* "two sources of truth" drift this codebase hunts elsewhere —
+here, "what is this element called" had two answers.
+
+### First instinct was a bandaid; the real fix is subtractive
+
+I initially added a `pflow ui targets <wf>` command to *list* the addresses (so an agent could read them
+instead of guess). The task owner correctly called it a bandaid: **the `.pflow.md` IS the target list** —
+a command that re-prints it fails the deletion test. The honest fix is to *delete the divergence*, not add
+a surface that bridges it. So `targets` was **added then removed** (don't re-add it without reading this).
+
+### What changed (all in `src/pflow/ui/targets.py` + `cli/commands/ui.py`)
+
+- **Bare IO names resolve** (`_node_addresses` now returns the full alias set incl. the unprefixed name;
+  the canonical prefixed/scoped form stays as the `qualified`/report value). `in:`/`out:` only surfaces in
+  the **qualify list** when an input and output genuinely share a name — same self-correcting loop as a
+  bare node name duplicated across two sub-workflows. Edges compose from the unprefixed endpoints, so
+  `source_file -> read_source.file_path` (my original miss) now resolves.
+- **Shape-aware not-found suggestions** (`resolve_target` 0-match arm): an edge attempt (`a -> b`) is
+  fuzzy-matched against real **connections**; a name attempt against **all** node/IO names (the old pool
+  excluded ports → an input typo used to suggest a random step).
+- **Orientation hint on the dead-end** (`_render_dispatch`): when there is **no** near-miss, append
+  "Targets are names from the workflow file: a step, input, or output, or a connection `source -> target`"
+  — rescues the fundamental-mismatch case that used to print a bare "not found." (a real typo still gets the
+  terse `Did you mean: …`).
+- **`--json` → project-standard `--output-format [text|json]`** (default `text`) via a tiny `_wants_json`
+  callback that maps onto the existing internal `output_json: bool` — zero signature/body churn. The CLI was
+  split (6 commands on `--output-format` incl. flagship `run`; 3 on `--json`); the plan's rationale for
+  `--json` ("no `--output-format` subcommand convention") was **inaccurate** (`probe`/`settings` use it).
+  `list`/`mcp` remain on `--json` → tracked in **GH issue #528** (option B: ui now, sweep the rest later).
+- **`workflow key:` → `workflow:`** in agent-facing output (internal-vocabulary leak), + the empty
+  `user-activity` message.
+- **Docs** now say it outright — guide `visualization.md`, `ui/CLAUDE.md`, CLI reference: *"a target is the
+  name you already read in the `.pflow.md` — there is no separate notation to learn."* Per-command `--json`
+  mentions stripped (it's an assumable universal escape hatch; text is the agent's read surface, JSON is for
+  scripting — don't push agents toward JSON).
+
+### Verification
+
+- `make check` clean (ruff, ruff-format, mypy 237 files, deptry); **`make test` 8055 passed**.
+- **Fresh-agent cold-use test** (a context-free general-purpose agent, docs+help only, barred from source):
+  focused a step, an input, AND an edge **all first-try, zero misses** — "it was easy." Its one honest flag:
+  the guide's input-edge example happens to be drawn from the same workflow it was tested on, so the example
+  doubles as the answer; it verified the rule held independently. (Left as-is; the guide also carries the
+  generic `gen.response -> summarize.prompt`.)
+- Real browser Point/Watch confirmed live (step/input/edge focus, per-window visible-vs-backgrounded
+  reporting). A **background-tab apply glitch** was reported once ("not highlighted correctly") but did **not
+  reproduce** under a controlled edge→node-while-hidden repro — concluded transient (rAF throttled in hidden
+  tabs frames the camera late), not a deterministic bug. Not formally closed; re-test if it recurs.
+
+### Sub-workflow addressing (answered for the record)
+
+Reference a nested element by the **container step's name**: `create.echo`, ports `in:create.data` /
+`out:create.data`, batched `create[0].name`; or just try the bare name and let the ambiguous→qualify list
+hand you the scoped forms. The scope segment is the `### create` `type: workflow` step — read from the file.
+
+**Standalone fields are NOT addressable alone** (deferred body-rows): `read_source.file_path` typed bare →
+"not found, did you mean: read_source" (redirects to the step). The field is only addressable as a connection
+endpoint (`X -> read_source.file_path`). Left as-is — the redirect is the sensible recovery.
+
+Status: **committed on `feat/agent-browser-interaction` (single follow-up commit), not yet pushed.** These
+changes sit on top of the rebased PR #527.

--- a/.taskmaster/tasks/task_169/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_169/implementation/progress-log.md
@@ -400,3 +400,112 @@ endpoint (`X -> read_source.file_path`). Left as-is — the redirect is the sens
 
 Status: **committed on `feat/agent-browser-interaction` (single follow-up commit), not yet pushed.** These
 changes sit on top of the rebased PR #527.
+
+---
+
+## 2026-06-22 — Dogfooding polish round 2 (F1/F2/F4/F5/F6) + two agent-UX reviews → pushed
+
+> Same day as the grammar entry above, separate session. That entry's "not yet pushed" is now resolved: the
+> grammar commit (`3bb89fd5`) shipped together with this polish as `ab891ad2 [skip review]` — **PR #527 now
+> has 7 commits.** Trust boundary: the implementation and the A2 debunk are **[authored/verified]** here; the
+> two reviews are `review-agent-ux` subagent passes (read end-to-end, conclusions re-checked against code).
+
+### The method, because it paid off: a before/after review sandwich
+Drove the feature cold as a fresh agent, then ran **two `review-agent-ux` passes** — one on the **committed
+baseline** (read `HEAD` via `git show`, NOT the working tree, so it's a true pre-change picture) and one on
+the **changes**. Baseline scored **3.5/5**, the changes **4.5/5**. The split is the point: the baseline review
+caught a leak my own (contaminated) read missed (F6 below). Reviewing only your own diff is grading your own
+homework — the baseline pass is what makes the delta honest.
+
+### What landed and the why that isn't in the spec
+- **F2 — the success *report* must speak the file's vocabulary, not just resolution.** Typing the file's bare
+  `source_file` resolved fine, but the echo said `resolved 1 (in:source_file)` — re-teaching the exact
+  `in:`/`out:` notation the grammar fix worked to delete, and `in:output_file` (an input literally named
+  `output_file`) read as a contradiction. Fix: on a unique match, drop the side-prefix **iff the bare form
+  still resolves to exactly one element** (`targets.py` `_drop_side_prefixes` + a uniqueness guard in
+  `resolve_target`). The guard is load-bearing — naively stripping breaks the collision case (a typed
+  `in:data` in an in/out collision must stay `in:data` or it stops round-tripping). The qualify list keeps the
+  prefix where it disambiguates.
+- **F1 + F6 — two complementary `None`-repr leaks in `_render_activity`, found by different eyes.** I caught
+  `workflow: None` (no-arg `user-activity`); the **baseline review** caught `· focus None` (any unfocused
+  Watch event — the most common one). Same class, same function, neither of us saw both alone. Fix:
+  `_echo_workflow_key` suppresses the null line; view-state fields fall back to `none`/`unknown`.
+- **F4 — `pflow guide ui` was a dead topic; the command name and its docs disagreed.** Same "two names for
+  one thing" smell as F2. Renamed the topic `visualization → ui` (canonical, matches the command), kept
+  `visualization` as an alias (the existing `_TOPIC_ALIASES` idiom; it's still the accurate concept word),
+  aligned the H1 + `entry.md` menu. `ui` was *already* a reserved workflow name (it's a CLI command) — the
+  linter deleted my redundant add to the reserved set, which is the correct signal, not a problem.
+- **F5 — the visible/backgrounded line was a *stat*, not an *instruction*.** The user's "can we explain this
+  better?" wasn't about the vacuous `(0 visible, 0 backgrounded)` at 0 windows (dropped that too) — it was
+  that the report never said what to *do* about "all backgrounded." Added the actionable hint ("the Viewer is
+  a background tab — tell the user to switch to it"). Delivery report extracted to `_render_delivery` (the new
+  branch tripped C901; the split also reads better — dispatch decides not-found/ambiguous/delivered, delivery
+  owns the who-got-it report).
+
+### The most important judgment call: A2 was a non-bug — verify the reviewer
+The baseline review's one "critical" finding: `focus --open` timeout "exits 0 while nothing was delivered."
+The user approved fixing it. **It's false.** `_dispatch_failed` returns True on `sent_to==0` (ui.py:209) and
+runs on *every* path including the timeout (ui.py:483) → it exits **1**. The reviewer misread the control
+flow. Verified by direct read before touching code; did **not** implement the approved "fix." Lesson
+(reinforcing the manifesto): a same-model reviewer cites well but you own the conclusions — and "the user
+approved it" does not override "the code says otherwise." A2's other sub-points are defensible (text output
+goes to stdout like the rest of the report; `target!r` correctly quotes edge targets that contain spaces).
+
+### Left deliberately (so they're not re-litigated)
+- **Focus-echo vs activity-display prefix asymmetry**: `focus` now echoes `source_file`, but `user-activity`
+  still shows `in:source_file` for a clicked port. Both round-trip into `focus` (verified); the activity line
+  has no graph to run the uniqueness check against, so the prefixed form is the safe default. Review B: leave.
+- **F3 exit-code granularity** (bad-target vs resolved-but-0-windows both exit 1): left. The *message*
+  distinguishes them crystal-clearly in text AND JSON; the exit code is a coarse "did it land" backstop. The
+  user settled it: an agent reads the message, not just `$?`.
+- Review-A minors untouched: generic JSON/server-error fallbacks (A4/A5, only `ConnectError` is gold-standard),
+  mid-edit-held guide note (A7), clear-focus-to-0-windows exit code (A8/F3-adjacent).
+
+### Verification
+`make check` clean (ruff, mypy 237, deptry); **`make test` 8063 passed** (+4 regression tests: F2 prefix-
+retention guard, F1 no-None, F5 ×2, F6, F4 alias). F1/F2/F4/F5 confirmed live on a fresh server; F6 pinned by
+a unit test (a real focus-null event isn't reproducible from the CLI). Shipped `ab891ad2 [skip review]`,
+pushed; PR #527 → 7 commits.
+
+### Still standing (unchanged by this detour)
+The real next increment remains the live-overlay track: **172 (emit-time streamable trace producer — the
+keystone every downstream task, incl. 173/164/125, consumes) → 173 (overlay UI on 169's SSE bus).** This whole
+session was polish on a done feature.
+
+---
+
+## 2026-06-22 — SSE reconnect robustness: investigated, the "simple fix" was the wrong lever, reverted + handed off
+
+While dogfooding Point/Watch live, the server was hot-swapped (restarted) to load the polish build. The user's
+**backgrounded** browser tab then **silently stopped receiving Point** (`focus` reported `0 windows`) while
+**Watch kept working** — clicks still showed up. Root cause: `web/src/api/events.ts` `subscribe()` relies
+**entirely on native EventSource auto-reconnect** (no `onerror`), and a tab whose stream drops while hidden/frozen
+does not reliably re-register its SSE subscription. Watch survives because its reports are **connectionless POSTs**;
+Point needs the **live SSE registration**. Recovery today needs a manual page reload.
+
+**Tried (and reverted):** a `visibilitychange → if visible && readyState===CLOSED, re-subscribe` patch in
+`events.ts` (+ a jsdom regression test). It unit-tested green, but **live verification killed it** — and that's the
+lesson: the CLI cannot see the browser's EventSource state, so this is unverifiable from here, and the live run was
+**confounded**. Two findings:
+1. **`visibilitychange` is the wrong lever.** Switching to the terminal usually keeps the tab **`"visible"`** (the
+   Page Visibility API tracks the browser's foreground tab + non-minimized window, *not* which OS app has focus;
+   Chrome-macOS occlusion only flips it on a *full* cover) — so the event may never fire in a browser-plus-terminal
+   workflow, and the patch never runs.
+2. **`CLOSED` is likely the wrong state.** A server restart leaves the EventSource in **`CONNECTING`** (native
+   retrying), not `CLOSED`, so even if the event fired the check would skip.
+
+**The reframe (user's, and it's right):** this is **not** a rare edge case for where the UI is heading — a
+**persistent viewer that agents discover and reuse**. Two foundational capabilities fall out, both belonging to the
+**live-overlay track (172/173, ADR-0008)**, where the SSE stream becomes *load-bearing* (a dropped connection =
+missed **run events**, not just a missed point):
+- **(A) Robust live connection** — driven by **`onerror`, not visibility**: reconnect to a live server when the
+  stream drops *for any reason* (sleep/wake, network blip, tab freeze, restart). Trigger-agnostic.
+- **(B) Server discovery / reuse** — an agent should **probe the port and reuse** a running viewer rather than
+  spawn a new one (or fail on port-in-use). No discovery exists today.
+
+**Decision:** reverted the patch (working tree clean again; the committed polish `ab891ad2` never included it),
+bundle rebuilt clean. **Not fixed in this context window** (Task 172 is already in progress in another worktree).
+Written up for the next agent: `scratchpads/handoffs/ui-sse-reconnect-and-discovery.md` — to be solved **properly,
+real-browser-verified** (headless Chrome where `readyState`/`visibilityState`/console are observable), folded into
+the overlay design. **Meta-lesson:** a browser-behavior fix that can't be verified from the CLI must be verified in
+a real browser *before* shipping — a green unit test over a wrong assumption is worse than no test.

--- a/.taskmaster/tasks/task_169/task-169.md
+++ b/.taskmaster/tasks/task_169/task-169.md
@@ -10,7 +10,7 @@ the canvas a shared surface for human↔agent conversation about a workflow.
 
 ## Status
 
-in progress
+done
 
 ## Priority
 

--- a/.taskmaster/tasks/task_169/task-169.md
+++ b/.taskmaster/tasks/task_169/task-169.md
@@ -10,7 +10,7 @@ the canvas a shared surface for human↔agent conversation about a workflow.
 
 ## Status
 
-not started
+in progress
 
 ## Priority
 
@@ -70,9 +70,13 @@ incoming/outgoing edge highlighting the feature wants IS what focus already does
 - **Agent-pointing = focus, reused verbatim.** No separate "agent highlight" visual state in v1.
   If "the agent is pointing here" should later look different from "I clicked here" (e.g. a
   pulsing ring), that's an additive style on top — not a parallel mechanism.
-- **Single-node commands, extensible shape.** Explaining often involves a path ("data flows
-  A → B → C"); v1 is one node per command, but the command payload shape should not preclude a
-  multi-node form later.
+- **Single-target commands, extensible shape.** One target per command. **v1 target types expanded
+  during planning** to: a node, a container (sub-workflow/batch box), a workflow/sub-workflow IO
+  port, AND a data edge (named by a `from -> to` pair, e.g. `gen.response -> summarize.prompt`).
+  Deferred to a fast-follow: standalone body-rows (an output/input field alone), control/branch
+  edges, and any multi-target form — the structural target-descriptor payload does not preclude
+  them. See `implementation/implementation-plan.md` for the addressing grammar (scope prefixes,
+  `in:`/`out:`, `[batch_index]`).
 - **Watch = deliberate interactions only.** Hover/pan/zoom are noise that would drown the
   buffer and the agent. Clicks, row clicks, focus changes, workflow switches.
 - **Delivered-count in every command response, with per-window visibility.** A broadcast into
@@ -147,10 +151,15 @@ incoming/outgoing edge highlighting the feature wants IS what focus already does
 - The channel carries no run/trace data and defines no run-event schema (Task 133 boundary).
 
 ### CLI
-- `pflow ui` (serve, with optional workflow + `--port`/`--no-open`) keeps its exact current
-  behavior; the new verbs are additive.
-- New verbs are thin HTTP clients; when no server is running they fail fast with an
-  agent-actionable hint (how to start one), not a hang or traceback.
+- `pflow ui` keeps serving with optional workflow + `--port`/`--no-open`; the new verbs are
+  additive. Mechanism: a custom `click.Group` modeled on `PflowCLI` (a plain group with a
+  positional arg cannot coexist with subcommands — see the implementation plan). The pre-existing
+  `--no-watch` serve flag is renamed `--no-auto-update` (Watch now means the agent watching the
+  user; that flag controls the source-file auto-update).
+- New verbs (thin HTTP clients, all taking `--json`): `pflow ui focus <wf> <target> [--open]`,
+  `pflow ui frame <wf> <target>`, `pflow ui clear-focus <wf>`, `pflow ui user-activity [wf]` (the
+  Watch read — named to avoid colliding with the renamed auto-update flag). When no server is
+  running they fail fast with an agent-actionable hint, not a hang or traceback.
 
 ### Packaging
 - No new runtime dependency beyond what `[ui]` already declares (SSE is within Starlette's
@@ -214,3 +223,9 @@ incoming/outgoing edge highlighting the feature wants IS what focus already does
   (`focus=`/`node=` resolution rules), `web/CLAUDE.md` (the `api/` seam).
 - **Task 133** (`.taskmaster/tasks/task_133/`) — the overlay whose schema this task must NOT
   pin; shares only the transport shape.
+- **`implementation/implementation-plan.md`** — the authoritative, deep-reviewed execution plan
+  (server hub + SSE, target resolver, frontend wiring, CLI group, phases, tests, edge cases).
+  Where any detail above conflicts with it (e.g. the ring buffer is one global tagged buffer, not
+  literally per-workflow), the plan wins.
+- **`context/CONTEXT.md`** — glossary terms added this task: Viewer, Point, Watch, Auto-update
+  (plus the Watch-vs-Auto-update ambiguity).

--- a/.taskmaster/tasks/task_169/task-review.md
+++ b/.taskmaster/tasks/task_169/task-review.md
@@ -1,0 +1,78 @@
+# Task 169 Review: Agent↔Browser Interaction Channel — Point & Watch
+
+## Metadata
+- **Implemented:** 2026-06-20/21. **PR #527** (open, not merged). Commits: `04faa88e` (implementation) + `378cd952` (post-review fixes).
+- **Trust boundary:** the bulk of the implementation was authored by another agent (its phase-by-phase journey is in `implementation/progress-log.md` — **read it for the "why it happened that way"**). This review's author owns, first-hand and **[verified]**: the design + plan, two 4-agent deep-reviews (plan + code), the three post-review fixes in `378cd952`, and the full test/lint/type run. Implementation internals not personally written are **[reviewed]** (read end-to-end + test-exercised), not **[authored]**.
+- **Project stakes:** pre-1.0, no external users (per root `CLAUDE.md`) — breaking changes are cheap. So this review weights **silent-correctness invariants** (concurrency, identity-over-the-wire) over migration/back-compat, because those are the failure modes that *don't* announce themselves.
+
+## Read First — the load-bearing block
+
+**What exists now:** the previously read-only `pflow ui` Starlette server gained a stateful, push-capable layer (an in-memory `_Hub` + SSE) plus a server-side target resolver; the CLI gained `focus`/`frame`/`clear-focus`/`user-activity`; the frontend gained an SSE client and reveal-before-focus. The agent Points at canvas elements in the user's *own* open browser windows and Watches their recent clicks.
+
+**Read these first (path · symbol):**
+- `src/pflow/ui/server.py` · `_Hub`, `events()`, `command()`, `_workflow_key()` — the hub + the five endpoints.
+- `src/pflow/ui/targets.py` · `resolve_target()`, `_format_ref()`/`_format_target()`, `address_for_target()` — the **single** address grammar + parser.
+- `web/src/api/events.ts` · `subscribe()`, `reportInteraction()` — the browser SSE seam.
+- `web/src/views/GraphView.tsx` · `applyPoint()` — maps a server descriptor to focus/frame.
+- `web/src/graph/flow.ts` (the edge dedup loop) + `web/src/graph/focus.ts` · `applyFocus()` — the `mergedIds` coupling.
+
+**Invariants that must NOT break:**
+1. **Every hub-touching handler is `async def`.** A sync handler runs in Starlette's threadpool and races the loop-affine `asyncio.Queue`/`deque` with **no lock** → state corruption. (Comment pins this at `_Hub` and the route list. Don't add a sync "stats" endpoint that reads `app.state.hub`.)
+2. **Flat ids (`n*`/`g*`/`e*`) never cross the SSE wire.** Only structural `RFRef` identity does. The server's fresh render ≠ the browser's live render; a flat id silently targets the wrong element or nothing.
+3. **The address grammar lives ONCE in `targets.py`.** The CLI Watch display delegates (`address_for_target`). Re-implementing it elsewhere drifts → the "ambiguous → qualify → re-point" self-correcting loop dead-ends. Guarded by the drift-guard test.
+4. **The SSE keepalive `yield` is required.** Removing it leaks connections on ASGI spec ≥2.4 (no disconnect listener there; a dead socket only surfaces on the next `send`). Do **not** swap it for `request.is_disconnected()` — that double-consumes `receive()` on spec <2.4.
+5. **No run-event schema here.** The envelope stays vocabulary-agnostic `{type, ...}`; Task 133's overlay adds its own message types over the same pipe. Baking interaction assumptions into the bus breaks that decoupling.
+6. **Edge identity = (source `RFRef`, target `RFRef`, `output_field`, `output_path`, `input_name`)** — never the re-anchored `edge.source/target`. And the `flow.ts` dedup must record dropped ids on `mergedIds` (invariant #6b below) or edge-focus silently shows nothing.
+
+## What Was Built (actual vs. planned)
+
+The transport/resolver/CLI shape matches the plan. The **deviations that matter** (each a real plan gap the implementer or the code-review caught — do not "revert to the plan"):
+
+- **Edge descriptor carries `source_path`** (plan omitted it). `RFEdge.output_path` is part of edge identity, so `gen.result.ok → x` and `gen.result.err → x` had identical descriptors → indistinguishable after broadcast. Fixed in both the address and the descriptor.
+- **`--open` re-posts *every* target** after the Viewer subscribes, not just edges. The load-time `?focus=` deep-link can't parse qualified / `in:`/`out:` / nested addresses, so re-posting the validated structural command is what makes all target types reliable.
+- **Subscription starts only after the graph loads.** Otherwise `--open`'s zero-window count could include a Viewer that can't yet apply a command.
+- **Edge resolution keys on the contract `RFEdge`** (matched by endpoint refs + fields + `source_path`), not a search of the painted `FlowEdge` by `data.from`/`data.to`. The plan's `data.from/to` guidance was premised on a rejected approach; the contract endpoints *are* the pre-re-anchor identity, so this is simpler and equivalent. (`web/src/graph/remap.ts` · `edgeIdForTarget`.)
+- **`render_react_flow` is left on the event loop** (only `resolve_validate_build` is `to_thread`'d). The plan said move both off-loop; the render is pure in-memory and cheap, so the split is deliberate, not an oversight.
+- **Watch buffer is one global `deque` tagged by workflow** (spec said "per workflow") — observably equivalent, simpler.
+
+**Post-review fixes (`378cd952`, [verified] mine):** (a) edge-dedup `mergedIds` (invariant #6b); (b) the single address grammar (#3); (c) the idle-keepalive test.
+
+## Patterns & Anti-Patterns
+
+**Reuse these:**
+- **Server resolves text → structural identity; browser maps via the existing `sameRef`.** One parser (Python, unit-testable), browser stays a dumb display. This is the template for *any* future "address a canvas element from outside the browser" feature.
+- **Tolerant public + strict private formatter** (`targets.py`): `address_for_ref` validates an untrusted wire dict and returns `None`; `_format_ref` assumes a well-formed payload. Internal callers use the strict one; the CLI uses the tolerant one. Same grammar, no drift.
+- **All-async, loop-owned, lock-free shared state** behind a one-line invariant comment naming the *specific* failure. Cheaper and clearer than locks for a single-process server.
+- **Bounded queue + evict a non-consuming client** (`_CONNECTION_QUEUE_MAX`): a socket that can't drain 64 human-paced commands is evicted, so memory and the `sent_to` count stay truthful.
+
+**Rejected / anti-patterns (don't reintroduce):**
+- A plain `@click.group` with a positional `WORKFLOW` + subcommands — **broken in Click** (reproduced). Must mirror `PflowCLI` (custom `resolve_command` routing to a hidden `serve`).
+- A bare `try/finally` for SSE disconnect cleanup (silently breaks on ASGI ≥2.4 — use the keepalive).
+- `TestClient` for SSE disconnect cleanup — it can't deliver `http.disconnect` to an infinite generator, so the test passes green **without testing cleanup** (false confidence). Use a raw-ASGI scope.
+- A browser→server apply-ack — deliberately *not* built; the human in the loop is the acknowledgment, and the report says `sent_to`, never "shown".
+
+## Gotchas & Non-Obvious Coupling
+
+- **6b — the `flow.ts` FlowEdge dedup key excludes `output_field`/`output_path`.** Two distinct contract data edges between the same nodes (different fields) that fall back to node-level handles in beautiful density **collapse to one rendered edge**. The dropped contract ids are recorded on the kept edge's `data.mergedIds`, and `applyFocus` matches a focused id against `e.id` **or** `e.data.mergedIds`. If you change the dedup to drop without recording, or change `applyFocus` to match only `e.id`, the "resolvable but shown nothing" edge-focus bug returns. This coupling spans `flow.ts` (producer) ↔ `focus.ts` (consumer) and is invisible from either file alone.
+- **`_workflow_key` does sync filesystem I/O on the event loop** (a `stat`/resolve per command/interaction/events/activity). Negligible for a localhost single-user server; would matter if this ever went multi-client.
+- **`get_path()` never raises** — it returns a phantom path for any string. The `exists()` gate in `_workflow_key` is load-bearing; without it a typo'd workflow name silently maps to a key no window matches (a misleading "0 windows").
+- **Density vocabulary splits:** code says `detailed`/`compact`; the agent-facing words are `advanced`/`beautiful` (via `DENSITY_TO_PARAM`). Watch events report the agent-facing words.
+- **The spec≥2.4 silent-drop path has no red test** (only the keepalive *emission* is tested + spec-2.3 disconnect). It rests on the keepalive comment + Starlette's send-failure behavior. Acceptable; know it if you touch the SSE generator.
+
+## Integration Points
+
+- **Depends on:** `execution/graph_service.resolve_validate_build` + `render_react_flow` (per-command graph build, same as `/api/graph`); `WorkflowManager.{exists,get_path,list_names}`; `suggestion_utils.find_similar_items(method="fuzzy")`; the `RFRef`/`RFEdge` contract (`react_flow.py`) and `sameRef` (`remap.ts`).
+- **Now depended on by (blast radius):** the **SSE envelope** is the seam Task 133's run overlay will ride (coordinate only there). The **`_Hub`** is the first stateful piece of the UI server — ADR-0007 records why; a future "simplify the server back to stateless" would re-break this.
+- **Contracts:** new endpoints `/api/events|command|interaction|visibility|activity`; the security comment in `server.py` was extended (JSON-content-type preflight defense — any future mutating endpoint must revisit it). No DB/cache/queue/schema changes. CLI: `--no-watch` → `--no-auto-update` (the `?watch=0` URL param is unchanged, internal).
+
+## Tests That Matter
+
+Run these when you touch the named area:
+- `tests/test_cli/test_ui_targets.py` — the resolver. Guards: every `qualify` address round-trips to exactly 1 element; `in:`/`out:`/`[batch_index]` disambiguation; **the display-grammar drift guard** (a `user-activity`-rendered address re-points). Touch `targets.py` → run this.
+- `tests/test_cli/test_ui_interaction_server.py` — the hub. Guards: register/broadcast/visibility/**eviction**; the **raw-ASGI `http.disconnect`** cleanup (not TestClient theater); off-loop build; **idle-keepalive emission**. Touch `server.py` → run this.
+- `web/src/graph/flow.test.ts` — the **`mergedIds`** regression: a deduped-away data edge focuses the kept line. Touch the `flow.ts` dedup or `focus.ts` edge matching → run this (it's the only guard for invariant #6b).
+- `tests/test_cli/test_ui_commands.py` — `UiGroup` routing + preserved bare-serve + exit codes + `httpx` error rendering. Touch `ui.py` → run this; also keep `test_ui.py`'s lazy-import boundary test green (don't move server imports to module top).
+- **The visual layer is NOT unit-testable** (jsdom renders no edges/camera). A data line actually lighting was verified in real headless Chrome (progress log Phase 2 + rerun); re-verify there after any focus/reveal change, via `.claude/skills/screenshot-pflow-web-ui`.
+
+---
+*Distilled from the implementation + review context of Task 169. The chronological journey (phase-by-phase deviations, dead ends, the live-browser runs) lives in `implementation/progress-log.md` — this review is the durable forward-reference, not a re-narration of it.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,12 +229,12 @@ MVP feature-complete. Published to PyPI (initial release v0.8.0; current version
 - ✅ Task 155: Workflow Graph Model for Multi-Renderer Support
 - ✅ Task 168: Workflow Visualization Web UI
 - ✅ Task 133: Trace/Cache Storage Architecture
+- ✅ Task 169: Agent↔Browser Interaction Channel
 
 ### Planned Features (in order of priority)
 
 **Next?** (in build order)
 - Task 172: Streamable trace
-- Task 169: Live UI transport (SSE)
 - Task 173: Live execution overlay
 - Task 125: Human-in-the-Loop Approval Gates
 - Task 164: Resume Workflow From a Failed Node

--- a/context/CONTEXT.md
+++ b/context/CONTEXT.md
@@ -94,6 +94,26 @@ an input/output wrapper, or (future) a detected cycle. One record type for every
 carrying its members, nesting depth, and parent. A Loop is metadata on its node, not a
 Container. _Avoid_: subgraph, cluster, box, group.
 
+### Viewer & agent interaction
+
+**Viewer** — an open `pflow ui` browser window showing one workflow. Several Viewers can show
+the same workflow at once; an agent's Point reaches all of them. _Avoid_: window, tab, canvas
+(the canvas is the diagram drawn *inside* a Viewer).
+
+**Point** — the agent action of focusing, framing, or clearing a target (a node, port, container,
+or edge) in every Viewer showing a workflow, reusing the exact selection a user's click produces.
+The agent-side counterpart to a user click — the "hands" half of the shared canvas.
+_Avoid_: highlight, navigate; select (select is the user's click).
+
+**Watch** — reading the recent, bounded history of the user's *deliberate* interactions in the
+Viewers (clicks, focus changes, workflow switches — never hover/pan/zoom), most-recent-first.
+The agent's read-only "eyes" onto what the user is doing; the CLI surface is `user-activity`.
+_Avoid_: monitor, track, observe; auto-update (a different "watch", below).
+
+**Auto-update** — the Viewer rebuilding its canvas in place when the workflow's `.pflow.md`
+changes on disk, preserving view state. On by default; frozen with `pflow ui --no-auto-update`.
+_Avoid_: watch, live-reload, hot-reload.
+
 ## Ambiguity
 
 **Batch vs Loop** — both repeat a step. Discriminator: can you write the list of runs
@@ -124,3 +144,8 @@ after (the prior Iteration's output). One input key carries both roles.
 engine *executes* (run-oriented, the source of truth for behavior); the Graph model is what a
 renderer *draws* (structure-oriented, derived from the IR, never executed). They also identify
 nodes differently — see ADR-0003.
+
+**Watch vs Auto-update** — both involve "watching". Discriminator: Auto-update is the *Viewer*
+watching the *source file* to live-rebuild the canvas (the `--no-auto-update` flag freezes it);
+Watch is the *agent* watching the *user's* interactions (the `user-activity` command reads them).
+Different watcher, different watched.

--- a/context/adr/0007-169-ui-stateful-sse-channel.md
+++ b/context/adr/0007-169-ui-stateful-sse-channel.md
@@ -1,0 +1,22 @@
+# The UI server adds a stateful SSE push channel for agent↔browser interaction (and the run-overlay's transport)
+
+**Status:** accepted — builds on ADR-0005 (the "someday" it anticipated); coordinates with the deferred run-overlay (Task 133) only at the message-envelope seam.
+
+The `pflow ui` server (Task 168) was stateless and read-only: every request a fresh re-parse, no side effects, no CORS, bound to `127.0.0.1` (the `server.py` security note + `ui/CLAUDE.md`). Task 169 adds its first **stateful, push-capable** layer — an **ephemeral, in-memory, per-process** connection registry plus a bounded interaction ring, served over **Server-Sent Events** (server→browser) alongside a few plain JSON POST/GET endpoints (browser/CLI→server). This lets an agent **Point** at a target in the user's open Viewers and **Watch** the user's recent interactions, and it is the same transport the deferred live-run overlay (Task 133) will ride — realizing the "SSE for runtime events" that ADR-0005 named as the reason a server (not a static export) was chosen.
+
+The SSE **message envelope is deliberately vocabulary-agnostic** (`{type, …payload}`): Task 169 defines interaction message types; the overlay adds run-event types later over the same pipe. This ADR **does not define a run-event schema** — that stays pinned against the overlay's own consumers (Task 133, D1), so the two tracks share only the envelope seam. State is added **for live connections + the interaction ring only**; graph data stays stateless-per-request. The state is ephemeral (a restart drops connections and the ring) — the only sane behavior for a local, single-user server — so **no persistence layer** is introduced.
+
+## Considered options
+
+- **WebSocket instead of SSE** — rejected. Nothing needs a bidirectional socket: commands flow down over SSE, events/visibility up over plain POST. SSE is the shape ADR-0005 named; a later genuinely-bidirectional need (Task 125 approval gates) can add WS without disturbing this.
+- **Stay stateless; poll for commands** — rejected. A poll cannot *push* a focus into an already-open page, and command-polling is laggy and wasteful; the overlay genuinely needs push.
+- **Define the run-event schema now** — rejected. Task 133's consumers don't exist yet, and pinning it early over-constrains. The generic envelope keeps run events purely additive.
+- **Persist the connection/interaction state** — rejected. Unnecessary for a local single-user server; restart-drops-all is correct, and persistence would be the kind of layer this codebase deletes.
+- **Browser→server apply-acknowledgments** (the browser confirming a Point was *shown*) — rejected for v1. The human is in the loop (it's a conversation), and "the server validates the target up front + the browser always reveals a resolvable one" makes the command's report honest without an ack round-trip. Additive later, only for autonomous/no-human flows or the overlay.
+
+## Consequences
+
+- The `server.py` security note must be **extended, not merely preserved**: it still binds `127.0.0.1` with no CORS, but now also records that mutating POSTs require `Content-Type: application/json` (so a cross-origin page is forced into a failing CORS preflight) and that the worst-case cross-origin write is benign (focusing a node in the user's own Viewer — no file/system effect). **Any future mutating or live-run endpoint must revisit this exposure.**
+- Concurrency rests on a single uvicorn process/event loop plus an **async-only invariant** for every handler that touches the hub → no locks. A sync handler touching the hub would silently break it (the invariant is documented at the hub).
+- The overlay can ride this transport without re-litigating the channel; the envelope is the only coordination point between the two tracks.
+- Recorded so the server is not later "simplified" back into a stateless read-only emitter — which would re-break the interaction channel and the overlay seam this shape exists to provide. The mirror of ADR-0005's own "don't simplify this into a JSON/static-HTML emitter" caution.

--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -480,6 +480,8 @@ Serve an interactive browser canvas for a workflow — the visual counterpart to
 pflow ui workflow.pflow.md          # open straight to a workflow
 pflow ui my-saved-workflow          # a saved workflow by name
 pflow ui                            # the catalog of saved workflows
+pflow ui focus my-saved-workflow fetch-data
+pflow ui user-activity my-saved-workflow
 ```
 
 The canvas updates in place — no page reload — as the workflow's `.pflow.md` is edited on disk, so you can watch it take shape (while keeping the current zoom and selection) as you, or an AI agent, build it. An edit that doesn't validate is held: the last valid version stays on screen with an error banner until the source parses again. The server blocks until `Ctrl+C`, so run it in the background while you edit.
@@ -490,9 +492,20 @@ Runs on a standard install. If `pflow ui` reports a missing dependency, add the 
 |--------|-------------|
 | `--port N` | Port to serve on (default: 8765) |
 | `--no-open` | Don't open a browser window |
-| `--no-watch` | Freeze the view — don't live-update when the source changes |
+| `--no-auto-update` | Freeze the view — don't live-update when the source changes |
 
 The full view is described by the URL, so you can share or screenshot an exact state — for example `?workflow=<name-or-path>&focus=<node-id>&direction=TD`. `focus=` highlights a node and reveals its connections; `node=` centers the camera on it.
+
+An agent can interact with every open Viewer showing a workflow:
+
+```bash
+pflow ui focus <workflow> <target> [--open]  # focus and reveal a node, container, IO port, or data edge
+pflow ui frame <workflow> <target>           # move the camera without changing focus
+pflow ui clear-focus <workflow>
+pflow ui user-activity [workflow]             # recent deliberate clicks and view changes
+```
+
+These commands target the server on port 8765 by default; pass `--port N` for another instance or `--json` for structured output. Point commands exit nonzero when the target is unresolved/ambiguous or no Viewer received the command. `focus --open` opens a Viewer only when no window for that workflow is connected. Data edges use `source.field -> target.input`; IO ports use `in:name` / `out:name` (for example `in:child.data`); qualify duplicate nested node ids with their container path.
 
 ## Mermaid command
 

--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -499,13 +499,15 @@ The full view is described by the URL, so you can share or screenshot an exact s
 An agent can interact with every open Viewer showing a workflow:
 
 ```bash
-pflow ui focus <workflow> <target> [--open]  # focus and reveal a node, container, IO port, or data edge
+pflow ui focus <workflow> <target> [--open]  # focus and reveal a step, input/output, or connection
 pflow ui frame <workflow> <target>           # move the camera without changing focus
 pflow ui clear-focus <workflow>
 pflow ui user-activity [workflow]             # recent deliberate clicks and view changes
 ```
 
-These commands target the server on port 8765 by default; pass `--port N` for another instance or `--json` for structured output. Point commands exit nonzero when the target is unresolved/ambiguous or no Viewer received the command. `focus --open` opens a Viewer only when no window for that workflow is connected. Data edges use `source.field -> target.input`; IO ports use `in:name` / `out:name` (for example `in:child.data`); qualify duplicate nested node ids with their container path.
+Name a target the way it reads in the `.pflow.md`: a step, input, or output by its name (`process_content`, `source_file`), or a connection as `source -> target` (`gen.response -> summarize.prompt`) — there's no separate notation to learn. If a name matches more than one thing — the same step inside two sub-workflows, or an input and output that share a name — the command lists qualified addresses to pick from instead of guessing, and an unknown name returns the closest real matches. So you point, read the reply, and re-point.
+
+These commands target port 8765 by default (pass `--port N` for another instance). Point commands exit nonzero when the target is unresolved/ambiguous or no Viewer received the command. `focus --open` opens a Viewer only when no window for that workflow is connected.
 
 ## Mermaid command
 

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -236,6 +236,7 @@ def _render_delivery(
     workflow: str,
     opened: bool,
     open_supported: bool,
+    clearing: bool = False,
 ) -> None:
     """The matched/sent report: how many windows received the command, their
     visibility, and what to do when nobody — or nobody looking — got it."""
@@ -259,14 +260,19 @@ def _render_delivery(
         click.echo(f"{subject}: {delivery}")
     _echo_workflow_key(payload)
 
-    if sent_to == 0 and not opened and open_supported:
+    if sent_to == 0 and clearing:
+        # Nothing to clear when no Viewer is open; the "open the workflow first"
+        # hint below would be circular here (open a window only to clear it).
+        click.echo("  → no Viewer open — nothing to clear")
+    elif sent_to == 0 and not opened and open_supported:
         click.echo(f"  → re-run with --open, or run `pflow ui {workflow}`")
     elif sent_to == 0 and not opened:
         click.echo(f"  → open the workflow first: `pflow ui {workflow}`")
     elif resolution and visible == 0 and not opened:
         # Reached >=1 window, but every one is a background tab — the target was
         # revealed where the user is not looking. The fix is to get them to the
-        # tab, not to re-point; say so rather than leave a silent count.
+        # tab, not to re-point; say so rather than leave a silent count. `not opened`
+        # suppresses this for a window this invocation just opened (it lands in front).
         click.echo("  → the Viewer is a background tab — tell the user to switch to it to see it")
 
 
@@ -278,6 +284,7 @@ def _render_dispatch(
     *,
     open_supported: bool = False,
     opened: bool = False,
+    clearing: bool = False,
 ) -> None:
     resolution = _resolution(payload)
     matched = _int_field(resolution, "matched")
@@ -304,7 +311,9 @@ def _render_dispatch(
                 click.echo(f"  {address}")
         return
 
-    _render_delivery(subject, resolution, payload, workflow=workflow, opened=opened, open_supported=open_supported)
+    _render_delivery(
+        subject, resolution, payload, workflow=workflow, opened=opened, open_supported=open_supported, clearing=clearing
+    )
 
 
 def _emit_payload(payload: dict[str, object], output_json: bool) -> None:
@@ -475,6 +484,8 @@ def focus_cmd(
             opened=opened,
         )
     if timed_out:
+        # err=output_json routes this human note to stderr in JSON mode so the
+        # parseable payload already emitted on stdout stays clean for consumers.
         click.echo(
             "Opened a window but it didn't connect within 15s.\n"
             f"→ re-run `pflow ui focus {workflow} {target!r}` now that it may be up.",
@@ -535,7 +546,7 @@ def clear_focus_cmd(ctx: click.Context, workflow: str, output_json: bool, port: 
     )
     _emit_payload(payload, output_json)
     if not output_json:
-        _render_dispatch("clear focus", workflow, None, payload)
+        _render_dispatch("clear focus", workflow, None, payload, clearing=True)
     if _dispatch_failed(payload):
         ctx.exit(1)
 

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -209,6 +209,67 @@ def _dispatch_failed(payload: dict[str, object]) -> bool:
     return _int_field(payload, "sent_to") == 0
 
 
+def _echo_workflow_key(payload: dict[str, object]) -> None:
+    """Echo the resolved workflow key, but never the bare ``None`` an unfiltered
+    ``user-activity`` returns — the ``all workflows`` label already conveys it."""
+    key = payload.get("workflow_key")
+    if key is not None:
+        click.echo(f"  workflow: {key}")
+
+
+def _visibilities(payload: dict[str, object]) -> list[str]:
+    windows = payload.get("windows")
+    if not isinstance(windows, list):
+        return []
+    return [
+        visibility
+        for window in windows
+        if isinstance(window, dict) and isinstance(visibility := window.get("visibility"), str)
+    ]
+
+
+def _render_delivery(
+    subject: str,
+    resolution: dict[str, object] | None,
+    payload: dict[str, object],
+    *,
+    workflow: str,
+    opened: bool,
+    open_supported: bool,
+) -> None:
+    """The matched/sent report: how many windows received the command, their
+    visibility, and what to do when nobody — or nobody looking — got it."""
+    sent_to = _int_field(payload, "sent_to")
+    visibilities = _visibilities(payload)
+    visible = visibilities.count("visible")
+    backgrounded = visibilities.count("hidden")
+    window_word = "window" if sent_to == 1 else "windows"
+
+    # The visible/backgrounded split only carries information once something was
+    # sent — at 0 it is just 0 = 0 + 0. The `resolved 1` line already confirms the
+    # target was valid; the hint below says what to do about the empty audience.
+    if sent_to == 0:
+        delivery = f"sent to 0 {window_word}"
+    else:
+        delivery = f"sent to {sent_to} {window_word} ({visible} visible, {backgrounded} backgrounded)"
+
+    if resolution:
+        click.echo(f"{subject}: resolved 1 ({resolution.get('address')}) · {delivery}")
+    else:
+        click.echo(f"{subject}: {delivery}")
+    _echo_workflow_key(payload)
+
+    if sent_to == 0 and not opened and open_supported:
+        click.echo(f"  → re-run with --open, or run `pflow ui {workflow}`")
+    elif sent_to == 0 and not opened:
+        click.echo(f"  → open the workflow first: `pflow ui {workflow}`")
+    elif resolution and visible == 0 and not opened:
+        # Reached >=1 window, but every one is a background tab — the target was
+        # revealed where the user is not looking. The fix is to get them to the
+        # tab, not to re-point; say so rather than leave a silent count.
+        click.echo("  → the Viewer is a background tab — tell the user to switch to it to see it")
+
+
 def _render_dispatch(
     action: str,
     workflow: str,
@@ -243,32 +304,7 @@ def _render_dispatch(
                 click.echo(f"  {address}")
         return
 
-    sent_to = _int_field(payload, "sent_to")
-    windows = payload.get("windows")
-    visibilities = (
-        [
-            window.get("visibility")
-            for window in windows
-            if isinstance(window, dict) and isinstance(window.get("visibility"), str)
-        ]
-        if isinstance(windows, list)
-        else []
-    )
-    visible = visibilities.count("visible")
-    backgrounded = visibilities.count("hidden")
-    window_word = "window" if sent_to == 1 else "windows"
-    visibility = f"{visible} visible, {backgrounded} backgrounded"
-
-    if resolution:
-        address = resolution.get("address")
-        click.echo(f"{subject}: resolved 1 ({address}) · sent to {sent_to} {window_word} ({visibility})")
-    else:
-        click.echo(f"{subject}: sent to {sent_to} {window_word} ({visibility})")
-    click.echo(f"  workflow: {payload.get('workflow_key')}")
-    if sent_to == 0 and not opened and open_supported:
-        click.echo(f"  → re-run with --open, or run `pflow ui {workflow}`")
-    elif sent_to == 0 and not opened:
-        click.echo(f"  → open the workflow first: `pflow ui {workflow}`")
+    _render_delivery(subject, resolution, payload, workflow=workflow, opened=opened, open_supported=open_supported)
 
 
 def _emit_payload(payload: dict[str, object], output_json: bool) -> None:
@@ -537,7 +573,7 @@ def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
             click.echo("  server up, no interactions recorded for this workflow (is a window open on it?).")
         else:
             click.echo("  server up, no interactions recorded yet.")
-        click.echo(f"  workflow: {payload.get('workflow_key')}")
+        _echo_workflow_key(payload)
         return
 
     for raw_event in event_list:
@@ -555,7 +591,10 @@ def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
             target_text += f" [{flat_id}]"
         view = raw_event.get("view_state")
         if isinstance(view, dict):
-            state = f"{view.get('density')}/{view.get('direction')} · focus {view.get('focus')}"
+            density = view.get("density") or "unknown"
+            direction = view.get("direction") or "unknown"
+            focus = view.get("focus") or "none"
+            state = f"{density}/{direction} · focus {focus}"
         else:
             state = "view state unknown"
         workflow_key = raw_event.get("workflow_key")
@@ -564,7 +603,7 @@ def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
             f"  {when} ({_format_age(raw_event.get('age_seconds'))}) "
             f"{raw_event.get('type')} · {target_text} · {state}{workflow_text}"
         )
-    click.echo(f"  workflow: {payload.get('workflow_key')}")
+    _echo_workflow_key(payload)
 
 
 @ui_cmd.command(name="user-activity")

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -74,6 +74,15 @@ def _viewer_url(port: int, workflow: str, *, focus: str | None = None) -> str:
     return f"http://{_HOST}:{port}/?{urlencode(query)}"
 
 
+def _wants_json(ctx: click.Context, param: click.Parameter, value: str) -> bool:
+    """Map the project-standard ``--output-format`` flag onto the internal bool.
+
+    Keeps every command/helper signature on ``output_json: bool`` while the
+    user-facing flag matches the rest of the CLI (``run``, ``probe``, ``settings``).
+    """
+    return value == "json"
+
+
 def _request(
     ctx: click.Context,
     port: int,
@@ -215,10 +224,16 @@ def _render_dispatch(
 
     if resolution and matched == 0:
         suggestions = resolution.get("suggestions")
-        suffix = ""
         if isinstance(suggestions, list) and suggestions:
-            suffix = f" Did you mean: {', '.join(str(item) for item in suggestions)}?"
-        click.echo(f"{subject}: not found.{suffix}")
+            click.echo(f"{subject}: not found. Did you mean: {', '.join(str(item) for item in suggestions)}?")
+        else:
+            # No near-miss to offer — orient the agent to the file's vocabulary so
+            # a fundamental mismatch (wrong workflow, wrong idea of the grammar)
+            # recovers instead of dead-ending on a bare "not found".
+            click.echo(f"{subject}: not found.")
+            click.echo(
+                "  Targets are names from the workflow file: a step, input, or output, or a connection `source -> target`."
+            )
         return
     if matched > 1:
         click.echo(f"{subject}: ambiguous — {matched} matches, not sent. Qualify with one of:")
@@ -249,7 +264,7 @@ def _render_dispatch(
         click.echo(f"{subject}: resolved 1 ({address}) · sent to {sent_to} {window_word} ({visibility})")
     else:
         click.echo(f"{subject}: sent to {sent_to} {window_word} ({visibility})")
-    click.echo(f"  workflow key: {payload.get('workflow_key')}")
+    click.echo(f"  workflow: {payload.get('workflow_key')}")
     if sent_to == 0 and not opened and open_supported:
         click.echo(f"  → re-run with --open, or run `pflow ui {workflow}`")
     elif sent_to == 0 and not opened:
@@ -368,7 +383,14 @@ def serve_cmd(
 @click.argument("workflow")
 @click.argument("target")
 @click.option("--open", "open_if_absent", is_flag=True, help="Open a Viewer when no window is connected.")
-@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option(
+    "--output-format",
+    "output_json",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    callback=_wants_json,
+    help="Output format: text (default) or json.",
+)
 @click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
 @click.pass_context
 def focus_cmd(
@@ -379,7 +401,14 @@ def focus_cmd(
     output_json: bool,
     port: int,
 ) -> None:
-    """Focus TARGET in every Viewer showing WORKFLOW."""
+    """Focus TARGET in every Viewer showing WORKFLOW.
+
+    TARGET is a name from the workflow file: a step (``process_content``), an
+    input or output (``source_file``), or a connection
+    (``gen.response -> summarize.prompt``). If a name matches more than one
+    element the command replies with qualified addresses to pick from — you never
+    have to guess the syntax.
+    """
     payload = _point_request(ctx, port, workflow, "focus", target, output_json=output_json)
     opened = False
     timed_out = False
@@ -422,11 +451,21 @@ def focus_cmd(
 @ui_cmd.command(name="frame")
 @click.argument("workflow")
 @click.argument("target")
-@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option(
+    "--output-format",
+    "output_json",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    callback=_wants_json,
+    help="Output format: text (default) or json.",
+)
 @click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
 @click.pass_context
 def frame_cmd(ctx: click.Context, workflow: str, target: str, output_json: bool, port: int) -> None:
-    """Frame TARGET without changing focus state."""
+    """Frame TARGET without changing focus state.
+
+    TARGET uses the same names as ``pflow ui focus``.
+    """
     payload = _point_request(ctx, port, workflow, "frame", target, output_json=output_json)
     _emit_payload(payload, output_json)
     if not output_json:
@@ -437,7 +476,14 @@ def frame_cmd(ctx: click.Context, workflow: str, target: str, output_json: bool,
 
 @ui_cmd.command(name="clear-focus")
 @click.argument("workflow")
-@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option(
+    "--output-format",
+    "output_json",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    callback=_wants_json,
+    help="Output format: text (default) or json.",
+)
 @click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
 @click.pass_context
 def clear_focus_cmd(ctx: click.Context, workflow: str, output_json: bool, port: int) -> None:
@@ -488,10 +534,10 @@ def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
     click.echo(f"user-activity {label} ({count} {event_word})")
     if not event_list:
         if workflow:
-            click.echo("  server up, no interactions recorded for this workflow key (is a window open on it?).")
+            click.echo("  server up, no interactions recorded for this workflow (is a window open on it?).")
         else:
             click.echo("  server up, no interactions recorded yet.")
-        click.echo(f"  workflow key: {payload.get('workflow_key')}")
+        click.echo(f"  workflow: {payload.get('workflow_key')}")
         return
 
     for raw_event in event_list:
@@ -518,12 +564,19 @@ def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
             f"  {when} ({_format_age(raw_event.get('age_seconds'))}) "
             f"{raw_event.get('type')} · {target_text} · {state}{workflow_text}"
         )
-    click.echo(f"  workflow key: {payload.get('workflow_key')}")
+    click.echo(f"  workflow: {payload.get('workflow_key')}")
 
 
 @ui_cmd.command(name="user-activity")
 @click.argument("workflow", required=False)
-@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option(
+    "--output-format",
+    "output_json",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    callback=_wants_json,
+    help="Output format: text (default) or json.",
+)
 @click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
 @click.pass_context
 def user_activity_cmd(ctx: click.Context, workflow: str | None, output_json: bool, port: int) -> None:

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -458,51 +458,19 @@ def clear_focus_cmd(ctx: click.Context, workflow: str, output_json: bool, port: 
         ctx.exit(1)
 
 
-def _ref_address(ref: object) -> str | None:
-    if not isinstance(ref, dict):
-        return None
-    node_id = ref.get("node_id")
-    if not isinstance(node_id, str):
-        return None
-    segments: list[str] = []
-    ancestors = ref.get("ancestor_path")
-    if isinstance(ancestors, list):
-        for ancestor in ancestors:
-            if not isinstance(ancestor, dict) or not isinstance(ancestor.get("node_id"), str):
-                continue
-            segment = str(ancestor["node_id"])
-            batch_index = ancestor.get("batch_index")
-            if isinstance(batch_index, int):
-                segment += f"[{batch_index}]"
-            segments.append(segment)
-    address = ".".join([*segments, node_id])
-    port = ref.get("port")
-    return f"{port}:{address}" if port in {"in", "out"} else address
-
-
 def _target_address(target: object) -> tuple[str | None, str | None]:
-    if not isinstance(target, dict):
-        return None, None
-    flat_id = target.get("flat_id") if isinstance(target.get("flat_id"), str) else None
-    if target.get("kind") == "node":
-        return _ref_address(target.get("ref")), flat_id
-    if target.get("kind") != "edge":
-        return None, flat_id
+    """Render a Watch event's structural target in the Point address grammar.
 
-    source = _ref_address(target.get("source"))
-    destination = _ref_address(target.get("target"))
-    if source is None or destination is None:
-        return None, flat_id
-    source_field = target.get("source_field")
-    if isinstance(source_field, str):
-        source += f".{source_field}"
-    source_path = target.get("source_path")
-    if isinstance(source_path, list):
-        source += "".join(f".{part}" for part in source_path if isinstance(part, str))
-    input_name = target.get("input_name")
-    if isinstance(input_name, str):
-        destination += f".{input_name}"
-    return f"{source} -> {destination}", flat_id
+    Delegates to ``targets.address_for_target`` so the address shown by
+    ``user-activity`` is the SAME grammar ``resolve_target`` accepts — an agent
+    copies the line straight back into ``pflow ui focus``. One parser, no drift.
+    Lazy import keeps ``pflow.ui.targets`` out of module load (the lazy-import
+    boundary test asserts the server stack isn't pulled in by importing the CLI).
+    """
+    from pflow.ui.targets import address_for_target
+
+    flat_id = target.get("flat_id") if isinstance(target, dict) and isinstance(target.get("flat_id"), str) else None
+    return address_for_target(target), flat_id
 
 
 def _format_age(value: object) -> str:

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -12,7 +12,7 @@ import json
 import socket
 import time
 import webbrowser
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import NoReturn
 from urllib.parse import urlencode
 
@@ -592,7 +592,7 @@ def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
             continue
         timestamp = raw_event.get("ts")
         when = (
-            datetime.fromtimestamp(timestamp, tz=UTC).isoformat(timespec="seconds")
+            datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat(timespec="seconds")
             if isinstance(timestamp, (int, float))
             else "timestamp unknown"
         )

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -1,17 +1,47 @@
-"""``pflow ui`` — serve the interactive workflow visualization web UI.
+"""``pflow ui`` — serve and interact with the workflow Viewer.
 
 The web stack (Starlette + uvicorn + the built frontend bundle) ships behind the
-``pflow-cli[ui]`` extra. This command imports it **lazily** inside the body so a base
-install without the extra still loads the CLI; a missing import prints the
-install hint instead of crashing. Keep the module top free of starlette/uvicorn/
-server imports (it is imported eagerly at ``main.py`` load).
+``pflow-cli[ui]`` extra. Serving imports it lazily so a base install still loads
+the CLI. Point and Watch commands are thin HTTP clients for an already-running
+server and use only the core ``httpx`` dependency.
 """
 
 from __future__ import annotations
 
+import json
 import socket
+import time
+import webbrowser
+from datetime import UTC, datetime
+from typing import NoReturn
+from urllib.parse import urlencode
 
 import click
+import httpx
+
+from pflow.core.diagnostic import Diagnostic
+from pflow.core.diagnostic_render import format_diagnostic
+
+_HOST = "127.0.0.1"
+_DEFAULT_PORT = 8765
+_REQUEST_TIMEOUT_S = 5.0
+_OPEN_TIMEOUT_S = 15.0
+_OPEN_INTERVAL_S = 0.25
+
+
+class UiGroup(click.Group):
+    """Route a non-subcommand first argument to the hidden Viewer server."""
+
+    ignore_unknown_options = True
+
+    def resolve_command(
+        self,
+        ctx: click.Context,
+        args: list[str],
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        if args and args[0] != "serve" and self.get_command(ctx, args[0]) is not None:
+            return super().resolve_command(ctx, args)
+        return "serve", self.get_command(ctx, "serve"), args
 
 
 def _port_available(host: str, port: int) -> bool:
@@ -26,19 +56,7 @@ def _port_available(host: str, port: int) -> bool:
 
 
 def _open_browser_when_ready(host: str, port: int, url: str, *, timeout: float = 15.0) -> None:
-    """Open the browser once the server is actually accepting connections.
-
-    ``uvicorn.run()`` blocks, so the browser must be opened from a side thread —
-    but rather than guess a fixed delay (which races a cold-registry startup and
-    can pop a "connection refused" page), poll the port until it accepts a
-    connection. uvicorn binds the listening socket only AFTER lifespan startup
-    (the registry warm) completes, so a successful connect means the server is
-    fully ready to serve. Falls back to opening after ``timeout`` so a stuck
-    probe never silently skips the browser.
-    """
-    import time
-    import webbrowser
-
+    """Open the browser once the server is actually accepting connections."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
@@ -49,43 +67,257 @@ def _open_browser_when_ready(host: str, port: int, url: str, *, timeout: float =
     webbrowser.open(url)
 
 
-@click.command(name="ui")
+def _viewer_url(port: int, workflow: str, *, focus: str | None = None) -> str:
+    query = {"workflow": workflow}
+    if focus is not None:
+        query["focus"] = focus
+    return f"http://{_HOST}:{port}/?{urlencode(query)}"
+
+
+def _request(
+    ctx: click.Context,
+    port: int,
+    method: str,
+    path: str,
+    *,
+    workflow: str | None,
+    output_json: bool,
+    json_body: dict[str, str] | None = None,
+    params: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Call one local Viewer endpoint and own every expected failure mode."""
+    try:
+        response = httpx.request(
+            method,
+            f"http://{_HOST}:{port}{path}",
+            timeout=_REQUEST_TIMEOUT_S,
+            json=json_body,
+            params=params,
+        )
+        response.raise_for_status()
+    except httpx.ConnectError:
+        command = f"pflow ui {workflow}" if workflow else "pflow ui"
+        _fail(
+            ctx,
+            f"No pflow ui server on port {port}.\n→ start one: {command}",
+            output_json=output_json,
+            payload={"error": "server_unavailable", "port": port, "hint": f"start one: {command}"},
+        )
+    except httpx.RequestError as exc:
+        _fail(
+            ctx,
+            f"Could not reach the pflow ui server on port {port}: {exc}\n"
+            f"→ check that it is running and retry with the matching --port",
+            output_json=output_json,
+            payload={"error": "server_unreachable", "port": port, "detail": str(exc)},
+        )
+    except httpx.HTTPStatusError as exc:
+        _render_http_error(ctx, exc.response, output_json=output_json)
+
+    try:
+        payload: object = response.json()
+    except ValueError:
+        _fail(ctx, "The pflow ui server returned invalid JSON.", output_json=output_json)
+    if not isinstance(payload, dict):
+        _fail(ctx, "The pflow ui server returned an unexpected JSON value.", output_json=output_json)
+    return payload
+
+
+def _fail(
+    ctx: click.Context,
+    message: str,
+    *,
+    output_json: bool,
+    payload: dict[str, object] | None = None,
+) -> NoReturn:
+    if output_json:
+        click.echo(json.dumps(payload or {"error": message}, indent=2))
+    else:
+        click.echo(message, err=True)
+    ctx.exit(1)
+
+
+def _response_object(response: httpx.Response) -> dict[str, object]:
+    content_type = response.headers.get("content-type", "")
+    try:
+        raw_body: object = response.json() if "json" in content_type else {}
+    except ValueError:
+        raw_body = {}
+    return raw_body if isinstance(raw_body, dict) else {}
+
+
+def _render_validation_errors(body: dict[str, object]) -> bool:
+    errors = body.get("errors")
+    if not isinstance(errors, list):
+        return False
+    rendered = False
+    for item in errors:
+        if isinstance(item, dict):
+            click.echo(format_diagnostic(Diagnostic.from_dict(item)), err=True)
+            rendered = True
+    return rendered
+
+
+def _render_http_error(ctx: click.Context, response: httpx.Response, *, output_json: bool) -> NoReturn:
+    body = _response_object(response)
+
+    if output_json:
+        payload = body or {"error": response.text or "server_error", "status_code": response.status_code}
+        click.echo(json.dumps(payload, indent=2))
+        ctx.exit(1)
+
+    if response.status_code == 422:
+        if not _render_validation_errors(body):
+            click.echo(f"Workflow validation failed: {body or response.text}", err=True)
+    elif response.status_code == 415:
+        click.echo("Server requires Content-Type: application/json (client bug).", err=True)
+    elif response.status_code == 404:
+        message = body.get("error", "Workflow not found.")
+        click.echo(str(message), err=True)
+        suggestions = body.get("suggestions")
+        if isinstance(suggestions, list) and suggestions:
+            click.echo(f"Did you mean: {', '.join(str(item) for item in suggestions)}?", err=True)
+    else:
+        detail = body or response.text
+        click.echo(f"Server error {response.status_code}: {detail}", err=True)
+    ctx.exit(1)
+
+
+def _int_field(payload: dict[str, object], name: str) -> int:
+    value = payload.get(name)
+    return value if isinstance(value, int) else 0
+
+
+def _resolution(payload: dict[str, object]) -> dict[str, object]:
+    value = payload.get("resolved")
+    return value if isinstance(value, dict) else {}
+
+
+def _dispatch_failed(payload: dict[str, object]) -> bool:
+    resolution = _resolution(payload)
+    if resolution and _int_field(resolution, "matched") != 1:
+        return True
+    return _int_field(payload, "sent_to") == 0
+
+
+def _render_dispatch(
+    action: str,
+    workflow: str,
+    target: str | None,
+    payload: dict[str, object],
+    *,
+    open_supported: bool = False,
+    opened: bool = False,
+) -> None:
+    resolution = _resolution(payload)
+    matched = _int_field(resolution, "matched")
+    subject = f"{action} {target!r} in {workflow!r}" if target is not None else f"{action} in {workflow!r}"
+
+    if resolution and matched == 0:
+        suggestions = resolution.get("suggestions")
+        suffix = ""
+        if isinstance(suggestions, list) and suggestions:
+            suffix = f" Did you mean: {', '.join(str(item) for item in suggestions)}?"
+        click.echo(f"{subject}: not found.{suffix}")
+        return
+    if matched > 1:
+        click.echo(f"{subject}: ambiguous — {matched} matches, not sent. Qualify with one of:")
+        qualify = resolution.get("qualify")
+        if isinstance(qualify, list):
+            for address in qualify:
+                click.echo(f"  {address}")
+        return
+
+    sent_to = _int_field(payload, "sent_to")
+    windows = payload.get("windows")
+    visibilities = (
+        [
+            window.get("visibility")
+            for window in windows
+            if isinstance(window, dict) and isinstance(window.get("visibility"), str)
+        ]
+        if isinstance(windows, list)
+        else []
+    )
+    visible = visibilities.count("visible")
+    backgrounded = visibilities.count("hidden")
+    window_word = "window" if sent_to == 1 else "windows"
+    visibility = f"{visible} visible, {backgrounded} backgrounded"
+
+    if resolution:
+        address = resolution.get("address")
+        click.echo(f"{subject}: resolved 1 ({address}) · sent to {sent_to} {window_word} ({visibility})")
+    else:
+        click.echo(f"{subject}: sent to {sent_to} {window_word} ({visibility})")
+    click.echo(f"  workflow key: {payload.get('workflow_key')}")
+    if sent_to == 0 and not opened and open_supported:
+        click.echo(f"  → re-run with --open, or run `pflow ui {workflow}`")
+    elif sent_to == 0 and not opened:
+        click.echo(f"  → open the workflow first: `pflow ui {workflow}`")
+
+
+def _emit_payload(payload: dict[str, object], output_json: bool) -> None:
+    if output_json:
+        click.echo(json.dumps(payload, indent=2))
+
+
+def _point_request(
+    ctx: click.Context,
+    port: int,
+    workflow: str,
+    command_type: str,
+    target: str,
+    *,
+    output_json: bool,
+) -> dict[str, object]:
+    return _request(
+        ctx,
+        port,
+        "POST",
+        "/api/command",
+        workflow=workflow,
+        output_json=output_json,
+        json_body={"workflow": workflow, "type": command_type, "target": target},
+    )
+
+
+@click.group(cls=UiGroup, name="ui", invoke_without_command=True)
+@click.pass_context
+def ui_cmd(ctx: click.Context) -> None:
+    """Serve the Viewer, Point at targets, or Watch deliberate user activity.
+
+    Serve with ``pflow ui [WORKFLOW] [--port N] [--no-open]
+    [--no-auto-update]``. A first argument other than a command is treated as
+    the workflow to serve.
+
+    Saved workflows named like a command remain reachable by path, for example
+    ``pflow ui ./focus.pflow.md``.
+    """
+    # Click does not call resolve_command for an empty invoke_without_command
+    # group. Preserve bare `pflow ui` by explicitly invoking the default here.
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(serve_cmd)
+
+
+@ui_cmd.command(name="serve", hidden=True, context_settings={"ignore_unknown_options": True})
 @click.argument("workflow", required=False)
-@click.option("--port", default=8765, type=int, help="Port to serve on (default: 8765).")
+@click.option("--port", default=_DEFAULT_PORT, type=int, help="Port to serve on (default: 8765).")
 @click.option("--no-open", is_flag=True, default=False, help="Do not open a browser window.")
 @click.option(
-    "--no-watch",
+    "--no-auto-update",
     is_flag=True,
     default=False,
-    help="Freeze the view: don't live-update the canvas when the .pflow.md source changes.",
+    help="Freeze the view: don't live-update when the .pflow.md source changes.",
 )
 @click.pass_context
-def ui_cmd(ctx: click.Context, workflow: str | None, port: int, no_open: bool, no_watch: bool) -> None:
-    """Open a browser canvas of a workflow FOR THE USER (an agent can't read a browser).
-
-    Use it when the user wants to SEE a workflow, or to let them watch it take shape as
-    you build it. With WORKFLOW (a saved name or a .pflow.md path), opens straight to it.
-    Without it, opens the catalog of saved workflows.
-
-    The canvas LIVE-UPDATES in place (no page reload) as you edit the workflow's
-    .pflow.md on disk — so an agent can build a workflow while the user watches it
-    take shape. Pass --no-watch to freeze it. Leave the server running in the
-    background while you edit (the command blocks until Ctrl+C).
-
-    Examples:
-
-        pflow ui workflow.pflow.md
-
-        pflow ui my-saved-workflow --port 9000
-
-        pflow ui --no-open
-
-        pflow ui workflow.pflow.md --no-watch
-    """
-    # Only the extra's OWN packages go under the install-hint guard. Importing
-    # the server module separately means a genuine ImportError inside it (a real
-    # bug — a bad import in graph_service, a renderer typo, a circular import)
-    # surfaces as a loud traceback, not a misleading "install [ui]" hint.
+def serve_cmd(
+    ctx: click.Context,
+    workflow: str | None,
+    port: int,
+    no_open: bool,
+    no_auto_update: bool,
+) -> None:
+    """Open a browser canvas and serve it until Ctrl+C."""
     try:
         import starlette  # noqa: F401
         import uvicorn
@@ -99,15 +331,7 @@ def ui_cmd(ctx: click.Context, workflow: str | None, port: int, no_open: bool, n
 
     from pflow.ui.server import create_app
 
-    host = "127.0.0.1"
-
-    # Pre-flight the bind so the error is ours. uvicorn catches a bind failure
-    # internally and sys.exit(1)s with only its own log line — an `except
-    # OSError` around uvicorn.run() never fires, so the actionable hint would be
-    # lost and "Serving …" would print before a doomed bind. (Tiny TOCTOU window
-    # between probe and uvicorn's bind — acceptable for a local single-user
-    # server; uvicorn still errors loudly if it loses the race.)
-    if not _port_available(host, port):
+    if not _port_available(_HOST, port):
         click.echo(
             f"Port {port} is already in use.\n→ try a different --port (e.g. --port {port + 1})",
             err=True,
@@ -116,30 +340,239 @@ def ui_cmd(ctx: click.Context, workflow: str | None, port: int, no_open: bool, n
         return
 
     app = create_app()
-    url = f"http://{host}:{port}/"
+    url = f"http://{_HOST}:{port}/"
     query: dict[str, str] = {}
     if workflow:
         query["workflow"] = workflow
-    if no_watch:
+    if no_auto_update:
+        # `watch` is the stable private CLI↔frontend URL contract. Only the
+        # user-facing flag changed to avoid colliding with Watch terminology.
         query["watch"] = "0"
     if query:
-        from urllib.parse import urlencode
-
         url += f"?{urlencode(query)}"
 
     if not no_open:
         import threading
 
-        # uvicorn.run() blocks, so open the browser from a side thread that waits
-        # until the server is actually listening — not after a guessed delay.
         threading.Thread(
             target=_open_browser_when_ready,
-            args=(host, port, url),
+            args=(_HOST, port, url),
             daemon=True,
         ).start()
 
     click.echo(f"Serving pflow UI at {url} (Ctrl+C to stop)", err=True)
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    uvicorn.run(app, host=_HOST, port=port, log_level="warning")
+
+
+@ui_cmd.command(name="focus")
+@click.argument("workflow")
+@click.argument("target")
+@click.option("--open", "open_if_absent", is_flag=True, help="Open a Viewer when no window is connected.")
+@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
+@click.pass_context
+def focus_cmd(
+    ctx: click.Context,
+    workflow: str,
+    target: str,
+    open_if_absent: bool,
+    output_json: bool,
+    port: int,
+) -> None:
+    """Focus TARGET in every Viewer showing WORKFLOW."""
+    payload = _point_request(ctx, port, workflow, "focus", target, output_json=output_json)
+    opened = False
+    timed_out = False
+    if open_if_absent and _int_field(payload, "sent_to") == 0 and _int_field(_resolution(payload), "matched") == 1:
+        opened = True
+        is_edge = "->" in target
+        webbrowser.open(_viewer_url(port, workflow, focus=None if is_edge else target))
+        # The URL focus parser accepts a bare node_id/flat id, but Point also
+        # accepts qualified nested and in:/out: addresses. Re-send for every
+        # target once the graph-ready Viewer subscribes; applying bare focus a
+        # second time is harmless and keeps one reliable open path.
+        deadline = time.monotonic() + _OPEN_TIMEOUT_S
+        while time.monotonic() < deadline:
+            time.sleep(_OPEN_INTERVAL_S)
+            payload = _point_request(ctx, port, workflow, "focus", target, output_json=output_json)
+            if _int_field(payload, "sent_to") > 0:
+                break
+        timed_out = _int_field(payload, "sent_to") == 0
+
+    _emit_payload(payload, output_json)
+    if not output_json and not timed_out:
+        _render_dispatch(
+            "focus",
+            workflow,
+            target,
+            payload,
+            open_supported=True,
+            opened=opened,
+        )
+    if timed_out:
+        click.echo(
+            "Opened a window but it didn't connect within 15s.\n"
+            f"→ re-run `pflow ui focus {workflow} {target!r}` now that it may be up.",
+            err=output_json,
+        )
+    if _dispatch_failed(payload):
+        ctx.exit(1)
+
+
+@ui_cmd.command(name="frame")
+@click.argument("workflow")
+@click.argument("target")
+@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
+@click.pass_context
+def frame_cmd(ctx: click.Context, workflow: str, target: str, output_json: bool, port: int) -> None:
+    """Frame TARGET without changing focus state."""
+    payload = _point_request(ctx, port, workflow, "frame", target, output_json=output_json)
+    _emit_payload(payload, output_json)
+    if not output_json:
+        _render_dispatch("frame", workflow, target, payload)
+    if _dispatch_failed(payload):
+        ctx.exit(1)
+
+
+@ui_cmd.command(name="clear-focus")
+@click.argument("workflow")
+@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
+@click.pass_context
+def clear_focus_cmd(ctx: click.Context, workflow: str, output_json: bool, port: int) -> None:
+    """Clear focus in every Viewer showing WORKFLOW."""
+    payload = _request(
+        ctx,
+        port,
+        "POST",
+        "/api/command",
+        workflow=workflow,
+        output_json=output_json,
+        json_body={"workflow": workflow, "type": "clear"},
+    )
+    _emit_payload(payload, output_json)
+    if not output_json:
+        _render_dispatch("clear focus", workflow, None, payload)
+    if _dispatch_failed(payload):
+        ctx.exit(1)
+
+
+def _ref_address(ref: object) -> str | None:
+    if not isinstance(ref, dict):
+        return None
+    node_id = ref.get("node_id")
+    if not isinstance(node_id, str):
+        return None
+    segments: list[str] = []
+    ancestors = ref.get("ancestor_path")
+    if isinstance(ancestors, list):
+        for ancestor in ancestors:
+            if not isinstance(ancestor, dict) or not isinstance(ancestor.get("node_id"), str):
+                continue
+            segment = str(ancestor["node_id"])
+            batch_index = ancestor.get("batch_index")
+            if isinstance(batch_index, int):
+                segment += f"[{batch_index}]"
+            segments.append(segment)
+    address = ".".join([*segments, node_id])
+    port = ref.get("port")
+    return f"{port}:{address}" if port in {"in", "out"} else address
+
+
+def _target_address(target: object) -> tuple[str | None, str | None]:
+    if not isinstance(target, dict):
+        return None, None
+    flat_id = target.get("flat_id") if isinstance(target.get("flat_id"), str) else None
+    if target.get("kind") == "node":
+        return _ref_address(target.get("ref")), flat_id
+    if target.get("kind") != "edge":
+        return None, flat_id
+
+    source = _ref_address(target.get("source"))
+    destination = _ref_address(target.get("target"))
+    if source is None or destination is None:
+        return None, flat_id
+    source_field = target.get("source_field")
+    if isinstance(source_field, str):
+        source += f".{source_field}"
+    source_path = target.get("source_path")
+    if isinstance(source_path, list):
+        source += "".join(f".{part}" for part in source_path if isinstance(part, str))
+    input_name = target.get("input_name")
+    if isinstance(input_name, str):
+        destination += f".{input_name}"
+    return f"{source} -> {destination}", flat_id
+
+
+def _format_age(value: object) -> str:
+    if not isinstance(value, (int, float)):
+        return "age unknown"
+    return f"{value:.1f}s ago" if value < 60 else f"{value / 60:.1f}m ago"
+
+
+def _render_activity(workflow: str | None, payload: dict[str, object]) -> None:
+    events = payload.get("events")
+    event_list = events if isinstance(events, list) else []
+    label = repr(workflow) if workflow else "all workflows"
+    count = len(event_list)
+    event_word = "event" if count == 1 else "events"
+    click.echo(f"user-activity {label} ({count} {event_word})")
+    if not event_list:
+        if workflow:
+            click.echo("  server up, no interactions recorded for this workflow key (is a window open on it?).")
+        else:
+            click.echo("  server up, no interactions recorded yet.")
+        click.echo(f"  workflow key: {payload.get('workflow_key')}")
+        return
+
+    for raw_event in event_list:
+        if not isinstance(raw_event, dict):
+            continue
+        timestamp = raw_event.get("ts")
+        when = (
+            datetime.fromtimestamp(timestamp, tz=UTC).isoformat(timespec="seconds")
+            if isinstance(timestamp, (int, float))
+            else "timestamp unknown"
+        )
+        address, flat_id = _target_address(raw_event.get("target"))
+        target_text = address or "no target"
+        if flat_id:
+            target_text += f" [{flat_id}]"
+        view = raw_event.get("view_state")
+        if isinstance(view, dict):
+            state = f"{view.get('density')}/{view.get('direction')} · focus {view.get('focus')}"
+        else:
+            state = "view state unknown"
+        workflow_key = raw_event.get("workflow_key")
+        workflow_text = f" · {workflow_key}" if workflow is None else ""
+        click.echo(
+            f"  {when} ({_format_age(raw_event.get('age_seconds'))}) "
+            f"{raw_event.get('type')} · {target_text} · {state}{workflow_text}"
+        )
+    click.echo(f"  workflow key: {payload.get('workflow_key')}")
+
+
+@ui_cmd.command(name="user-activity")
+@click.argument("workflow", required=False)
+@click.option("--json", "output_json", is_flag=True, help="Output the server response as JSON.")
+@click.option("--port", default=_DEFAULT_PORT, type=int, help="Viewer server port (default: 8765).")
+@click.pass_context
+def user_activity_cmd(ctx: click.Context, workflow: str | None, output_json: bool, port: int) -> None:
+    """Read recent deliberate Viewer interactions, newest first."""
+    params = {"workflow": workflow} if workflow else None
+    payload = _request(
+        ctx,
+        port,
+        "GET",
+        "/api/activity",
+        workflow=workflow,
+        output_json=output_json,
+        params=params,
+    )
+    _emit_payload(payload, output_json)
+    if not output_json:
+        _render_activity(workflow, payload)
 
 
 __all__ = ["ui_cmd"]

--- a/src/pflow/guide/__init__.py
+++ b/src/pflow/guide/__init__.py
@@ -20,6 +20,9 @@ _FRAME_THRESHOLD_BYTES = 20_000
 # menu text so generated guide pointers use the clearest public topic name.
 _TOPIC_ALIASES: dict[str, str] = {
     "caching": PROMPT_CACHING_TOPIC,
+    # The feature lives under `pflow ui`, so `ui` is the canonical topic; the
+    # accurate concept word stays reachable for an agent who reaches for it.
+    "visualization": "ui",
 }
 
 # Node types that don't map 1:1 to guide topic names.

--- a/src/pflow/guide/entry.md
+++ b/src/pflow/guide/entry.md
@@ -61,7 +61,7 @@ Features — when the user says X, load topic Y:
                    → "cache prompts", "reduce LLM cost", "speed up repeated calls"
   patterns         Multi-step LLM/agent recipes — fan-out, verify, generate-filter, tournament
                    → "fan out and combine", "verify from multiple angles", "rank/tournament", "generate and pick the best", "orchestrate steps"
-  visualization    Show the user a workflow as a LIVE visual canvas while you build it (Mermaid diagram on request)
+  ui               Show the user a workflow as a LIVE visual canvas while you build it (Mermaid diagram on request)
                    → "show me the workflow", "let me see/watch it build", "open the UI", "make a mermaid diagram"
 
 Start here:

--- a/src/pflow/guide/features/ui.md
+++ b/src/pflow/guide/features/ui.md
@@ -1,4 +1,4 @@
-# Visualization
+# Showing the workflow
 
 **Use when**: the USER wants to *see* a workflow — open it for them in the browser, most
 often while you build or edit one so they watch it take shape. Two tools, two audiences.

--- a/src/pflow/guide/features/visualization.md
+++ b/src/pflow/guide/features/visualization.md
@@ -25,8 +25,23 @@ shape as you work.
   user sees each change land while keeping their zoom and focus. An edit that doesn't
   validate is held (the last valid version stays up, with an error banner) until you fix it.
 - With no workflow argument, it opens the catalog of saved workflows.
-- Flags: `--port N` (default 8765), `--no-open` (don't open a browser), `--no-watch`
+- Flags: `--port N` (default 8765), `--no-open` (don't open a browser), `--no-auto-update`
   (freeze — stop live-updating).
+
+Once a Viewer server is running, an agent can Point in the user's open windows and
+Watch deliberate interactions:
+
+- `pflow ui focus <workflow> <target> [--open]` — focus/reveal a node, container,
+  IO port (`in:name` / `out:name`, scoped like `in:child.data`), or
+  `source.field -> target.input` data edge in every matching Viewer.
+- `pflow ui frame <workflow> <target>` — move the camera without changing focus.
+- `pflow ui clear-focus <workflow>` — clear the current focus.
+- `pflow ui user-activity [workflow]` — read recent clicks and view changes.
+
+All four accept `--port N` and `--json`. Use the command's sent-window and
+visible/backgrounded counts honestly: it reports where the command was sent, not
+a browser apply acknowledgment. Point exits nonzero when resolution fails or no
+Viewer received the command; empty `user-activity` remains a successful read.
 
 Deep-link a specific view (to point the user at a node, or for a screenshot): append
 `?workflow=<name-or-path>&focus=<node-id>` — `focus=` highlights the node and reveals its

--- a/src/pflow/guide/features/visualization.md
+++ b/src/pflow/guide/features/visualization.md
@@ -28,20 +28,34 @@ shape as you work.
 - Flags: `--port N` (default 8765), `--no-open` (don't open a browser), `--no-auto-update`
   (freeze — stop live-updating).
 
-Once a Viewer server is running, an agent can Point in the user's open windows and
-Watch deliberate interactions:
+Once a Viewer server is running, an agent can Point at things in the user's open
+windows and Watch what they deliberately click:
 
-- `pflow ui focus <workflow> <target> [--open]` — focus/reveal a node, container,
-  IO port (`in:name` / `out:name`, scoped like `in:child.data`), or
-  `source.field -> target.input` data edge in every matching Viewer.
+- `pflow ui focus <workflow> <target> [--open]` — focus/reveal a target in every
+  matching Viewer.
 - `pflow ui frame <workflow> <target>` — move the camera without changing focus.
 - `pflow ui clear-focus <workflow>` — clear the current focus.
 - `pflow ui user-activity [workflow]` — read recent clicks and view changes.
 
-All four accept `--port N` and `--json`. Use the command's sent-window and
-visible/backgrounded counts honestly: it reports where the command was sent, not
-a browser apply acknowledgment. Point exits nonzero when resolution fails or no
-Viewer received the command; empty `user-activity` remains a successful read.
+**A target is just the name you already read in the `.pflow.md` — there is no
+separate notation to learn:**
+
+- a **step** by its name — `process_content`
+- an **input** or **output** by its name — `source_file`
+- a **connection** as `source -> target`, each end named the same way —
+  `gen.response -> summarize.prompt`, or from an input `source_file -> read_source.file_path`
+
+You don't have to get it right first try. If a name matches more than one thing
+(the same step inside two sub-workflows, or an input and output that share a
+name), the command doesn't guess — it lists the qualified addresses to pick from.
+If a name isn't found, it suggests the closest real ones. So point, read the
+reply, re-point.
+
+All four take `--port N`. The command reports where it was sent (how
+many windows, visible vs backgrounded), not that the browser finished drawing it —
+the human looking at the screen is the confirmation. Point exits nonzero when
+resolution fails or no Viewer received it; an empty `user-activity` is still a
+successful read.
 
 Deep-link a specific view (to point the user at a node, or for a screenshot): append
 `?workflow=<name-or-path>&focus=<node-id>` — `focus=` highlights the node and reveals its

--- a/src/pflow/ui/CLAUDE.md
+++ b/src/pflow/ui/CLAUDE.md
@@ -173,8 +173,12 @@ heuristically-cached stale entry; the content-hashed assets stay cacheable.
   appears in the qualify list when an input and output genuinely share a name
   (mirrors how a bare node name that occurs in two sub-workflows qualifies by
   scope). A miss suggests in the shape of what was typed (a connection attempt
-  gets real connections back). `_node_addresses` returns the full alias set; the
-  canonical (prefixed, scoped) form is what reports and qualify entries echo.
+  gets real connections back). `_node_addresses` returns the full alias set. A
+  **unique-match report echoes the file's vocabulary** — the `in:`/`out:`
+  side-prefix is dropped when the bare name still resolves to one element (a
+  collision never reaches that path), but scope (`create.echo`) is kept and the
+  prefix is *retained* if dropping it would re-introduce ambiguity. The **qualify
+  list** keeps the canonical prefixed/scoped form, where it disambiguates.
 - **Local dev loop:** run `pflow ui` (backend) and Vite's dev server
   concurrently; set `server.proxy` in `vite.config.ts` to forward `/api` →
   `http://127.0.0.1:<port>` so the React app hot-reloads against the live

--- a/src/pflow/ui/CLAUDE.md
+++ b/src/pflow/ui/CLAUDE.md
@@ -2,8 +2,10 @@
 
 Local **Starlette** server behind the `pflow-cli[ui]` extra. It serves a typed JSON
 contract (the Task 155 GraphModel → `render_react_flow`) plus the built frontend
-bundle. It runs **no workflows** — every request is read-only: resolve →
-validate → `build_graph` → `render_react_flow`.
+bundle. It runs **no workflows** and never mutates workflow files. Graph requests
+remain stateless (`resolve` → `validate` → `build_graph` →
+`render_react_flow`); the interaction hub is ephemeral, in-memory state scoped to
+one `create_app()` instance.
 
 The frontend that consumes this server lives in `web/` (its own CLAUDE.md
 suite). The design *why* is `task-168.md` + `ADR-0005`.
@@ -14,6 +16,7 @@ suite). The design *why* is `task-168.md` + `ADR-0005`.
 src/pflow/ui/
 ├── __init__.py     # package marker (docstring only)
 ├── server.py       # the Starlette app: create_app(), endpoints, static mount
+├── targets.py      # pure Point address resolution to structural RFRef descriptors
 └── static/         # built frontend bundle — GITIGNORED, built by `make ui-build`,
                     #   served at "/". Absent in a source checkout.
 ```
@@ -24,7 +27,8 @@ validate→build helper is `execution/graph_service.py`.
 
 ## The HTTP contract (what the frontend codes against)
 
-`web/src/api/client.ts` is the single data-loading seam. Endpoints:
+`web/src/api/` is the server-communication seam: `client.ts` owns graph/source
+reads and `events.ts` owns the live interaction channel. Endpoints:
 
 ### `GET /api/catalog`
 → `200` `[{name, description, path}]` — saved workflows with `ir` stripped.
@@ -93,6 +97,40 @@ on the next valid save. **Known limit:** a workflow mid-edit-invalid in a *sub-w
 file tracks only the entry file's mtime until it parses again (recovery still fires on the
 fixing save).
 
+### Live interaction channel
+
+- `GET /api/events?workflow=<name|path>&visibility=<visible|hidden>` subscribes a
+  Viewer to the SSE envelope `{type, ...}`. The envelope is vocabulary-agnostic:
+  this task defines `connected`, `focus`, `frame`, and `clear`; it deliberately
+  defines no run/trace event schema.
+- `POST /api/command` validates a `focus`/`frame` target against a fresh graph (or
+  broadcasts `clear`) and reports `sent_to`, per-window visibility, and the
+  canonical `workflow_key`. It reports messages queued to live connections, not
+  browser apply acknowledgments.
+- `POST /api/interaction` records deliberate user actions; `GET /api/activity`
+  returns the bounded, newest-first snapshot. `POST /api/visibility` updates one
+  connection. All POSTs require `application/json`.
+
+Name-opened and path-opened Viewers share one resolved workflow key. Point targets
+cross the wire only as structural refs; never send positional flat ids between
+independent graph renders. The `_Hub` is per-process and non-persistent: restart
+clears connections and activity.
+
+> **Hub concurrency invariant.** Every route touching `_Hub` must be `async def`.
+> Starlette runs sync handlers in a threadpool, while the hub's `asyncio.Queue`
+> instances and deque are intentionally lock-free and event-loop-owned. Point's
+> recursive validation/build runs via `asyncio.to_thread`; only the resulting
+> graph returns to the loop before broadcast. Each connection queue is bounded;
+> a Viewer that cannot consume 64 commands is evicted so memory and `sent_to`
+> stay truthful. The SSE
+> keepalive is required to surface silently dropped sockets across ASGI versions;
+> do not replace it with a second `request.is_disconnected()` receive consumer.
+
+The server binds loopback and sends no CORS headers. JSON POSTs force a cross-origin
+preflight, and EventSource responses are unreadable cross-origin. The worst live
+command changes focus in the user's Viewer; it has no file/system side effect. Any
+future mutating or live-run endpoint must re-evaluate this boundary.
+
 ### Static bundle (`/` + assets)
 The SPA builds into `src/pflow/ui/static/` (Vite `build.outDir`, `base = "./"`
 so relative asset paths serve from `/`). The server mounts it via
@@ -113,19 +151,28 @@ heuristically-cached stale entry; the content-hashed assets stay cacheable.
 
 ## The `pflow ui` command (`cli/commands/ui.py`)
 
-- `pflow ui [workflow] [--port 8765] [--no-open] [--no-watch]`. Behind the `[ui]` extra
+- `pflow ui [workflow] [--port 8765] [--no-open] [--no-auto-update]`. Behind the `[ui]` extra
   (lazy import of `uvicorn`/`starlette` → prints `uv tool install 'pflow-cli[ui]'` if
   absent; a real bug inside the server module surfaces as a loud traceback, not
   the hint).
 - **Opens the browser to `http://127.0.0.1:{port}/?workflow=<urlencoded>`**
   once the port is actually listening (polls, not a guessed delay). `App.tsx`
   reads `?workflow=` and auto-loads it; with no param, it shows the catalog.
-  `--no-watch` appends `?watch=0` to freeze the live-source poll.
+  `--no-auto-update` appends the private `?watch=0` URL param to freeze the
+  live-source poll.
+- Point: `pflow ui focus <workflow> <target> [--open]`, `frame`, and
+  `clear-focus`. Watch: `pflow ui user-activity [workflow]`. Each accepts `--port`
+  and `--json` and talks to an already-running server. A saved workflow named
+  like a subcommand is reachable by path (for example `./focus.pflow.md`).
 - **Local dev loop:** run `pflow ui` (backend) and Vite's dev server
   concurrently; set `server.proxy` in `vite.config.ts` to forward `/api` →
   `http://127.0.0.1:<port>` so the React app hot-reloads against the live
   backend. Production serves the built bundle from the Python server directly
   (no proxy).
+
+Deferred interaction targets are standalone body rows and control/branch edges.
+Also deferred until a concrete consumer exists: activity `--follow`, replacing
+the Auto-update poll with SSE, and programmatic browser apply acknowledgments.
 
 ## The RFGraph contract + load-bearing rendering rules
 

--- a/src/pflow/ui/CLAUDE.md
+++ b/src/pflow/ui/CLAUDE.md
@@ -162,8 +162,19 @@ heuristically-cached stale entry; the content-hashed assets stay cacheable.
   live-source poll.
 - Point: `pflow ui focus <workflow> <target> [--open]`, `frame`, and
   `clear-focus`. Watch: `pflow ui user-activity [workflow]`. Each accepts `--port`
-  and `--json` and talks to an already-running server. A saved workflow named
-  like a subcommand is reachable by path (for example `./focus.pflow.md`).
+  and the project-standard `--output-format json` and talks to an already-running
+  server. A saved workflow named like a subcommand is reachable by path (for
+  example `./focus.pflow.md`).
+- **Address grammar (`targets.py`):** a target is named the way it reads in the
+  `.pflow.md` — a step/input/output by its bare name, a connection as
+  `source -> target`. The grammar deliberately mirrors the file's own vocabulary
+  rather than inventing a parallel notation: `in:`/`out:` is **not** required up
+  front; the bare name of an IO port resolves like any node, and the prefix only
+  appears in the qualify list when an input and output genuinely share a name
+  (mirrors how a bare node name that occurs in two sub-workflows qualifies by
+  scope). A miss suggests in the shape of what was typed (a connection attempt
+  gets real connections back). `_node_addresses` returns the full alias set; the
+  canonical (prefixed, scoped) form is what reports and qualify entries echo.
 - **Local dev loop:** run `pflow ui` (backend) and Vite's dev server
   concurrently; set `server.proxy` in `vite.config.ts` to forward `/api` →
   `http://127.0.0.1:<port>` so the React app hot-reloads against the live

--- a/src/pflow/ui/server.py
+++ b/src/pflow/ui/server.py
@@ -11,13 +11,18 @@ Endpoints:
 - ``GET /api/version?workflow=<name|path>`` — a cheap change-fingerprint over
   the workflow's source files, so the frontend can poll it and re-fetch the
   graph in place (no page reload) when the author edits the ``.pflow.md``.
+- ``GET /api/events?workflow=<name|path>`` — SSE commands for each open Viewer.
+- ``POST /api/command`` — validate and broadcast an agent Point command.
+- ``POST /api/interaction`` — record one deliberate Viewer interaction.
+- ``POST /api/visibility`` — update a Viewer's visible/backgrounded state.
+- ``GET /api/activity`` — read a newest-first snapshot of recent interactions.
 - ``/`` (+ assets) — the built frontend bundle, when present. Absent in a
   source checkout (the bundle is gitignored, built by ``make ui-build``); the
   server then serves a clear "not built" message instead of crashing.
 
-The server is **stateless per request**: every ``/api/graph`` call re-resolves,
-re-validates and re-builds the graph from disk. It runs no workflows and holds
-no run state.
+Graph data remains **stateless per request**: every ``/api/graph`` call
+re-resolves, re-validates and re-builds the graph from disk. The live interaction
+hub is ephemeral and per app instance; it holds no workflow run state.
 
 Failure regimes for ``/api/graph`` (kept distinct — do not collapse):
 
@@ -30,16 +35,21 @@ Failure regimes for ``/api/graph`` (kept distinct — do not collapse):
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import itertools
 import json
 import logging
-from dataclasses import asdict
+import time
+from collections import deque
+from collections.abc import AsyncIterator
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response
+from starlette.responses import PlainTextResponse, Response, StreamingResponse
 from starlette.routing import BaseRoute, Mount, Route
 from starlette.staticfiles import StaticFiles
 
@@ -51,14 +61,86 @@ from pflow.execution.graph_service import (
 )
 from pflow.execution.workflow_resolver import resolve_workflow
 from pflow.registry import Registry
+from pflow.ui.targets import resolve_target
 
 logger = logging.getLogger(__name__)
 
 # Sub-workflow expansion depth served to the client. The frontend collapses and
 # expands containers client-side, so the server always ships the full tree.
 _MAX_DEPTH = 5
+_ACTIVITY_MAX = 200
+_CONNECTION_QUEUE_MAX = 64
+_KEEPALIVE_S = 15.0
 
 _STATIC_DIR = Path(__file__).parent / "static"
+
+
+@dataclass
+class _Conn:
+    conn_id: str
+    workflow_key: str
+    queue: asyncio.Queue[dict[str, object]]
+    visibility: str
+    active: bool = True
+
+
+# INVARIANT (load-bearing): Every handler that touches the hub MUST be `async
+# def`. Starlette runs async handlers on the event loop and sync `def` handlers
+# in a threadpool thread. asyncio.Queue is loop-affine and NOT thread-safe — a
+# sync handler calling put_nowait or mutating the deque would race the loop with
+# no lock. Do NOT add a sync hub-touching handler. The existing sync GET handlers
+# never touch it.
+class _Hub:
+    """Per-app registry of live Viewers and bounded user activity."""
+
+    def __init__(self) -> None:
+        self._conns: dict[str, _Conn] = {}
+        self._activity: deque[dict[str, object]] = deque(maxlen=_ACTIVITY_MAX)
+        self._counter = itertools.count(1)
+
+    def register(self, workflow_key: str, visibility: str) -> _Conn:
+        conn = _Conn(
+            conn_id=f"viewer-{next(self._counter)}",
+            workflow_key=workflow_key,
+            queue=asyncio.Queue(maxsize=_CONNECTION_QUEUE_MAX),
+            visibility=visibility,
+        )
+        self._conns[conn.conn_id] = conn
+        return conn
+
+    def unregister(self, conn_id: str) -> None:
+        self._conns.pop(conn_id, None)
+
+    def set_visibility(self, conn_id: str, visibility: str) -> None:
+        conn = self._conns.get(conn_id)
+        if conn is not None:
+            conn.visibility = visibility
+
+    def windows_for(self, workflow_key: str) -> list[_Conn]:
+        return [conn for conn in self._conns.values() if conn.workflow_key == workflow_key]
+
+    def broadcast(self, workflow_key: str, message: dict[str, object]) -> list[_Conn]:
+        conns = self.windows_for(workflow_key)
+        sent: list[_Conn] = []
+        for conn in conns:
+            try:
+                conn.queue.put_nowait(message)
+            except asyncio.QueueFull:
+                # A socket that cannot consume 64 human-paced UI commands is
+                # no longer a truthful delivery target. Evict it rather than
+                # leak memory or report another command as sent.
+                conn.active = False
+                self.unregister(conn.conn_id)
+            else:
+                sent.append(conn)
+        return sent
+
+    def record(self, event: dict[str, object]) -> None:
+        self._activity.append(event)
+
+    def activity(self, workflow_key: str | None = None) -> list[dict[str, object]]:
+        events = reversed(self._activity)
+        return [dict(event) for event in events if workflow_key is None or event.get("workflow_key") == workflow_key]
 
 
 def _json(data: Any, *, status_code: int = 200) -> Response:
@@ -229,6 +311,203 @@ def version(request: Request) -> Response:
     return _json({"fingerprint": digest})
 
 
+def _workflow_key(value: str) -> str | None:
+    """Canonical identity shared by name-opened and path-opened Viewers."""
+    path = Path(value)
+    try:
+        if path.suffix == ".pflow.md" or path.exists():
+            return str(path.resolve())
+    except OSError:
+        return None
+
+    manager = WorkflowManager()
+    if not manager.exists(value):
+        return None
+    return str(Path(manager.get_path(value)).resolve())
+
+
+def _workflow_not_found(value: str) -> Response:
+    from pflow.core.suggestion_utils import find_similar_items
+
+    suggestions = find_similar_items(value, WorkflowManager().list_names(), method="fuzzy")
+    return _json(
+        {
+            "error": f"No workflow {value!r} was found.",
+            "suggestions": suggestions,
+        },
+        status_code=404,
+    )
+
+
+async def _json_body(request: Request) -> dict[str, object] | Response:
+    content_type = request.headers.get("content-type", "").partition(";")[0].strip().lower()
+    if content_type != "application/json":
+        return _json(
+            {"error": "Content-Type: application/json is required."},
+            status_code=415,
+        )
+    try:
+        body = await request.json()
+    except (ValueError, UnicodeDecodeError):
+        return _json({"error": "Request body must be valid JSON."}, status_code=400)
+    if not isinstance(body, dict):
+        return _json({"error": "Request JSON must be an object."}, status_code=400)
+    return body
+
+
+def _string_field(body: dict[str, object], name: str) -> str | None:
+    value = body.get(name)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _dispatch_report(workflow_key: str, conns: list[_Conn]) -> dict[str, object]:
+    return {
+        "sent_to": len(conns),
+        "windows": [{"visibility": conn.visibility} for conn in conns],
+        "workflow_key": workflow_key,
+    }
+
+
+async def events(request: Request) -> Response:
+    """Subscribe one Viewer to Point commands for a canonical workflow key."""
+    workflow = request.query_params.get("workflow")
+    if not workflow:
+        return _json({"error": "Missing required 'workflow' query parameter."}, status_code=400)
+    workflow_key = _workflow_key(workflow)
+    if workflow_key is None:
+        return _workflow_not_found(workflow)
+    visibility = request.query_params.get("visibility", "visible")
+    if visibility not in {"visible", "hidden"}:
+        return _json({"error": "Visibility must be 'visible' or 'hidden'."}, status_code=400)
+
+    hub: _Hub = request.app.state.hub
+
+    async def stream() -> AsyncIterator[str]:
+        conn = hub.register(workflow_key, visibility)
+        try:
+            yield f"data: {json.dumps({'type': 'connected', 'conn_id': conn.conn_id})}\n\n"
+            while conn.active:
+                try:
+                    message = await asyncio.wait_for(conn.queue.get(), timeout=_KEEPALIVE_S)
+                    yield f"data: {json.dumps(message)}\n\n"
+                except asyncio.TimeoutError:
+                    # Load-bearing: a periodic send surfaces silently-dead sockets
+                    # under ASGI spec >=2.4 and also defeats idle proxy timeouts.
+                    yield ": keepalive\n\n"
+        finally:
+            hub.unregister(conn.conn_id)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def command(request: Request) -> Response:
+    """Validate and broadcast one agent Point command."""
+    body = await _json_body(request)
+    if isinstance(body, Response):
+        return body
+
+    workflow = _string_field(body, "workflow")
+    command_type = _string_field(body, "type")
+    if workflow is None or command_type not in {"focus", "frame", "clear"}:
+        return _json(
+            {"error": "Fields 'workflow' and type ('focus', 'frame', or 'clear') are required."},
+            status_code=400,
+        )
+    workflow_key = _workflow_key(workflow)
+    if workflow_key is None:
+        return _workflow_not_found(workflow)
+
+    hub: _Hub = request.app.state.hub
+    if command_type == "clear":
+        return _json(_dispatch_report(workflow_key, hub.broadcast(workflow_key, {"type": "clear"})))
+
+    target = _string_field(body, "target")
+    if target is None:
+        return _json({"error": f"Command type {command_type!r} requires a non-empty target."}, status_code=400)
+    try:
+        # Validation/build can recurse through large nested workflows. Keep it
+        # off the hub's event loop so SSE sends, disconnect cleanup, and
+        # visibility/activity requests remain responsive. Hub operations stay
+        # loop-owned below.
+        model = await asyncio.to_thread(resolve_validate_build, workflow, max_depth=_MAX_DEPTH)
+    except WorkflowGraphValidationError as exc:
+        return _json({"errors": [diagnostic.to_dict() for diagnostic in exc.diagnostics]}, status_code=422)
+
+    resolution = resolve_target(render_react_flow(model), target)
+    response = {
+        "resolved": resolution.report(),
+        **_dispatch_report(workflow_key, []),
+    }
+    if resolution.matched != 1 or resolution.descriptor is None:
+        return _json(response)
+
+    conns = hub.broadcast(
+        workflow_key,
+        {"type": command_type, "target": resolution.descriptor},
+    )
+    response.update(_dispatch_report(workflow_key, conns))
+    return _json(response)
+
+
+async def interaction(request: Request) -> Response:
+    """Record one deliberate Viewer interaction; failures never affect graph state."""
+    body = await _json_body(request)
+    if isinstance(body, Response):
+        return body
+
+    workflow = _string_field(body, "workflow")
+    event_type = _string_field(body, "type")
+    view_state = body.get("view_state")
+    if workflow is None or event_type is None or not isinstance(view_state, dict):
+        return _json(
+            {"error": "Fields 'workflow', 'type', and object 'view_state' are required."},
+            status_code=400,
+        )
+
+    event = {key: value for key, value in body.items() if key != "workflow"}
+    event.update({"workflow_key": _workflow_key(workflow), "ts": time.time()})
+    hub: _Hub = request.app.state.hub
+    hub.record(event)
+    return Response(status_code=204)
+
+
+async def visibility(request: Request) -> Response:
+    """Update the visibility of a live Viewer connection."""
+    body = await _json_body(request)
+    if isinstance(body, Response):
+        return body
+
+    conn_id = _string_field(body, "conn_id")
+    state = _string_field(body, "visibility")
+    if conn_id is None or state not in {"visible", "hidden"}:
+        return _json(
+            {"error": "Fields 'conn_id' and visibility ('visible' or 'hidden') are required."},
+            status_code=400,
+        )
+    hub: _Hub = request.app.state.hub
+    hub.set_visibility(conn_id, state)
+    return Response(status_code=204)
+
+
+async def activity(request: Request) -> Response:
+    """Return a newest-first snapshot of recent deliberate interactions."""
+    workflow = request.query_params.get("workflow")
+    workflow_key = _workflow_key(workflow) if workflow else None
+    if workflow and workflow_key is None:
+        return _workflow_not_found(workflow)
+    hub: _Hub = request.app.state.hub
+    events_snapshot = hub.activity(workflow_key)
+    now = time.time()
+    for event in events_snapshot:
+        timestamp = event.get("ts")
+        event["age_seconds"] = max(0.0, now - timestamp) if isinstance(timestamp, (int, float)) else None
+    return _json({"events": events_snapshot, "workflow_key": workflow_key})
+
+
 class _BundleFiles(StaticFiles):
     """StaticFiles that makes ``index.html`` revalidate on every load.
 
@@ -266,11 +545,19 @@ def create_app() -> Starlette:
     The API routes are registered before the catch-all so ``/api/*`` is never
     shadowed by the static mount / not-built fallback.
     """
+    # INVARIANT (load-bearing): Every handler below that touches the hub MUST be
+    # `async def`. Starlette runs sync handlers in a threadpool, but the hub's
+    # asyncio queues and deque are intentionally lock-free and event-loop-owned.
     routes: list[BaseRoute] = [
         Route("/api/catalog", catalog),
         Route("/api/graph", graph),
         Route("/api/source", source),
         Route("/api/version", version),
+        Route("/api/events", events),
+        Route("/api/command", command, methods=["POST"]),
+        Route("/api/interaction", interaction, methods=["POST"]),
+        Route("/api/visibility", visibility, methods=["POST"]),
+        Route("/api/activity", activity),
     ]
     if (_STATIC_DIR / "index.html").exists():
         routes.append(Mount("/", app=_BundleFiles(directory=_STATIC_DIR, html=True)))
@@ -282,10 +569,15 @@ def create_app() -> Starlette:
     # resolution failure returns a 422 whose diagnostics may echo a source line.
     # With no `Access-Control-Allow-Origin`, a browser blocks any cross-origin
     # page from READING that response — so a malicious site can't exfiltrate
-    # workflow/file contents via the local user's browser. Every request here is
-    # a read-only GET with no side effect; adding CORS, or any mutating/live-run
-    # endpoint, must revisit this file-content exposure.
-    return Starlette(routes=routes)
+    # workflow/file contents via the local user's browser. Mutating POSTs require
+    # `Content-Type: application/json`, forcing a cross-origin preflight that
+    # fails without CORS; EventSource likewise cannot read commands cross-origin.
+    # The worst write is benign UI state (focus/frame/clear in the user's own
+    # Viewer), never a file/system mutation. Any future mutating or live-run
+    # endpoint must revisit this exposure.
+    app = Starlette(routes=routes)
+    app.state.hub = _Hub()
+    return app
 
 
 __all__ = ["create_app"]

--- a/src/pflow/ui/server.py
+++ b/src/pflow/ui/server.py
@@ -315,7 +315,7 @@ def _workflow_key(value: str) -> str | None:
     """Canonical identity shared by name-opened and path-opened Viewers."""
     path = Path(value)
     try:
-        if path.suffix == ".pflow.md" or path.exists():
+        if path.exists():
             return str(path.resolve())
     except OSError:
         return None
@@ -468,7 +468,12 @@ async def interaction(request: Request) -> Response:
             status_code=400,
         )
 
-    event = {key: value for key, value in body.items() if key != "workflow"}
+    # Whitelist the recorded fields so the Watch snapshot the agent reads from
+    # /api/activity keeps a predictable shape; arbitrary client keys are dropped.
+    event = {key: body[key] for key in ("type", "target", "view_state") if key in body}
+    # An unknown workflow records workflow_key=None and still returns 204 — unlike
+    # command()/activity() which 404 — because a Watch report is fire-and-forget and
+    # must never break the Viewer. Such events surface only in an unfiltered query.
     event.update({"workflow_key": _workflow_key(workflow), "ts": time.time()})
     hub: _Hub = request.app.state.hub
     hub.record(event)

--- a/src/pflow/ui/targets.py
+++ b/src/pflow/ui/targets.py
@@ -153,10 +153,26 @@ def address_for_target(descriptor: object) -> str | None:
     return f"{source} -> {destination}"
 
 
-def _node_addresses(ref: RFRef) -> tuple[str, str]:
+def _node_addresses(ref: RFRef) -> tuple[tuple[str, ...], str]:
+    """Every string this element answers to, plus its one canonical address.
+
+    A node answers to its bare name and its scope-qualified name. An IO port
+    answers to those *unprefixed natural* forms too (`source_file`, `child.data`
+    — the names an agent reads under ``## Inputs``/``## Outputs``), so the prefix
+    is never required up front. ``in:``/``out:`` only has to appear when a real
+    same-name collision (an input and output both called ``data``) makes the bare
+    name ambiguous — at which point it surfaces in the qualify list and teaches
+    itself. The canonical (returned second) keeps the prefix so reports and
+    qualify entries stay unambiguous.
+    """
     scoped = _format_ref(_ref_payload(ref))
-    bare = f"{ref.port}:{ref.node_id}" if ref.port in {"in", "out"} else ref.node_id
-    return bare, scoped
+    addresses: tuple[str, ...]
+    if ref.port in {"in", "out"}:
+        unprefixed_scoped = scoped[len(ref.port) + 1 :]  # strip "in:"/"out:"
+        addresses = (ref.node_id, unprefixed_scoped, f"{ref.port}:{ref.node_id}", scoped)
+    else:
+        addresses = (ref.node_id, scoped)
+    return tuple(dict.fromkeys(addresses)), scoped
 
 
 def _with_field(address: str, field: str | None, path: list[str]) -> str:
@@ -174,11 +190,11 @@ def _normalize_address(address: str) -> str:
 def _node_elements(graph: RFGraph) -> list[_Addressable]:
     elements = []
     for node in graph.nodes:
-        bare, scoped = _node_addresses(node.ref)
+        addresses, qualified = _node_addresses(node.ref)
         elements.append(
             _Addressable(
-                addresses=tuple(dict.fromkeys((bare, scoped))),
-                qualified=scoped,
+                addresses=addresses,
+                qualified=qualified,
                 descriptor={"kind": "node", "ref": _ref_payload(node.ref)},
             )
         )
@@ -195,23 +211,18 @@ def _edge_elements(graph: RFGraph, nodes_by_id: dict[str, RFNode]) -> list[_Addr
         if source is None or target is None:
             continue
 
-        source_bare, source_scoped = _node_addresses(source.ref)
-        target_bare, target_scoped = _node_addresses(target.ref)
-        source_addresses = {
-            _with_field(source_bare, edge.output_field, edge.output_path),
-            _with_field(source_scoped, edge.output_field, edge.output_path),
-        }
-        target_addresses = {
-            _with_field(target_bare, edge.input_name, []),
-            _with_field(target_scoped, edge.input_name, []),
-        }
-        addresses = tuple(
-            sorted(
-                f"{source_address} -> {target_address}"
-                for source_address in source_addresses
-                for target_address in target_addresses
-            )
+        source_addrs, _ = _node_addresses(source.ref)
+        target_addrs, _ = _node_addresses(target.ref)
+        source_endpoints = {_with_field(addr, edge.output_field, edge.output_path) for addr in source_addrs}
+        target_endpoints = {_with_field(addr, edge.input_name, []) for addr in target_addrs}
+        # The natural form (both endpoints by their bare names) leads, so it is
+        # what `resolve_target` offers as a suggestion when an edge address misses.
+        natural = (
+            f"{_with_field(source_addrs[0], edge.output_field, edge.output_path)} -> "
+            f"{_with_field(target_addrs[0], edge.input_name, [])}"
         )
+        all_addresses = {f"{src} -> {tgt}" for src in source_endpoints for tgt in target_endpoints}
+        addresses = (natural, *sorted(all_addresses - {natural}))
         descriptor: EdgeTarget = {
             "kind": "edge",
             "source": _ref_payload(source.ref),
@@ -240,12 +251,21 @@ def resolve_target(graph: RFGraph, target: str) -> TargetResolution:
     """
     normalized = _normalize_address(target)
     nodes_by_id = {node.id: node for node in graph.nodes}
-    elements = [*_node_elements(graph), *_edge_elements(graph, nodes_by_id)]
+    node_elements = _node_elements(graph)
+    edge_elements = _edge_elements(graph, nodes_by_id)
+    elements = [*node_elements, *edge_elements]
     matches = [element for element in elements if normalized in element.addresses]
 
     if not matches:
-        bare_node_ids = sorted({node.ref.node_id for node in graph.nodes if node.ref.port is None})
-        suggestions = find_similar_items(normalized, bare_node_ids, method="fuzzy")
+        # Suggest in the shape of what was typed: an edge attempt (`a -> b`) gets
+        # real connections back, anything else gets step/input/output names. The
+        # pool is each element's natural (bare) address, so a miss steers to a
+        # name an agent can actually type — never a different kind of thing.
+        if "->" in normalized:
+            pool = sorted({element.addresses[0] for element in edge_elements})
+        else:
+            pool = sorted({element.addresses[0] for element in node_elements})
+        suggestions = find_similar_items(normalized, pool, method="fuzzy")
         return TargetResolution(matched=0, suggestions=tuple(suggestions))
     if len(matches) > 1:
         return TargetResolution(

--- a/src/pflow/ui/targets.py
+++ b/src/pflow/ui/targets.py
@@ -74,20 +74,88 @@ def _ref_payload(ref: RFRef) -> RefPayload:
     }
 
 
-def _scope_prefix(ref: RFRef) -> str:
-    parts = []
-    for step in ref.ancestor_path:
+def _format_ref(payload: RefPayload) -> str:
+    """The ONE canonical scoped address for a structural ref payload.
+
+    Shared by resolution (the qualify/address strings) AND the CLI Watch display
+    (`address_for_ref` below), so an address `user-activity` prints always
+    round-trips back through `resolve_target` — one grammar, no second source of
+    truth to drift.
+    """
+    segments: list[str] = []
+    for step in payload["ancestor_path"]:
         node_id = str(step["node_id"])
-        index = step.get("batch_index")
-        parts.append(f"{node_id}[{index}]" if index is not None else node_id)
-    return ".".join(parts)
+        batch_index = step.get("batch_index")
+        segments.append(f"{node_id}[{batch_index}]" if isinstance(batch_index, int) else node_id)
+    address = ".".join([*segments, payload["node_id"]])
+    port = payload["port"]
+    return f"{port}:{address}" if port in {"in", "out"} else address
+
+
+def _format_target(descriptor: TargetDescriptor) -> str:
+    """Canonical address for a well-formed target descriptor."""
+    if descriptor["kind"] == "node":
+        return _format_ref(descriptor["ref"])
+    source = _format_ref(descriptor["source"])
+    if descriptor["source_field"]:
+        source += f".{descriptor['source_field']}"
+    source += "".join(f".{part}" for part in descriptor["source_path"])
+    destination = _format_ref(descriptor["target"])
+    if descriptor["input_name"]:
+        destination += f".{descriptor['input_name']}"
+    return f"{source} -> {destination}"
+
+
+def address_for_ref(payload: object) -> str | None:
+    """Tolerant scoped address for a raw ref payload off the wire (CLI Watch).
+
+    Same grammar as `_format_ref`, but validates an untrusted dict first so a
+    malformed browser report degrades to ``None`` instead of raising.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("node_id"), str):
+        return None
+    steps: list[dict[str, object]] = []
+    ancestors = payload.get("ancestor_path")
+    if isinstance(ancestors, list):
+        for step in ancestors:
+            if isinstance(step, dict) and isinstance(step.get("node_id"), str):
+                steps.append({"node_id": step["node_id"], "batch_index": step.get("batch_index")})
+    port = payload.get("port")
+    return _format_ref({
+        "node_id": payload["node_id"],
+        "ancestor_path": steps,
+        "port": port if isinstance(port, str) else None,
+    })
+
+
+def address_for_target(descriptor: object) -> str | None:
+    """Tolerant address for a raw target descriptor off the wire (CLI Watch)."""
+    if not isinstance(descriptor, dict):
+        return None
+    kind = descriptor.get("kind")
+    if kind == "node":
+        return address_for_ref(descriptor.get("ref"))
+    if kind != "edge":
+        return None
+    source = address_for_ref(descriptor.get("source"))
+    destination = address_for_ref(descriptor.get("target"))
+    if source is None or destination is None:
+        return None
+    field = descriptor.get("source_field")
+    if isinstance(field, str):
+        source += f".{field}"
+    path = descriptor.get("source_path")
+    if isinstance(path, list):
+        source += "".join(f".{part}" for part in path if isinstance(part, str))
+    input_name = descriptor.get("input_name")
+    if isinstance(input_name, str):
+        destination += f".{input_name}"
+    return f"{source} -> {destination}"
 
 
 def _node_addresses(ref: RFRef) -> tuple[str, str]:
-    scoped = ".".join(part for part in (_scope_prefix(ref), ref.node_id) if part)
-    bare = ref.node_id
-    if ref.port is not None:
-        return f"{ref.port}:{bare}", f"{ref.port}:{scoped}"
+    scoped = _format_ref(_ref_payload(ref))
+    bare = f"{ref.port}:{ref.node_id}" if ref.port in {"in", "out"} else ref.node_id
     return bare, scoped
 
 
@@ -144,22 +212,19 @@ def _edge_elements(graph: RFGraph, nodes_by_id: dict[str, RFNode]) -> list[_Addr
                 for target_address in target_addresses
             )
         )
-        qualified = (
-            f"{_with_field(source_scoped, edge.output_field, edge.output_path)} -> "
-            f"{_with_field(target_scoped, edge.input_name, [])}"
-        )
+        descriptor: EdgeTarget = {
+            "kind": "edge",
+            "source": _ref_payload(source.ref),
+            "source_field": edge.output_field,
+            "source_path": list(edge.output_path),
+            "target": _ref_payload(target.ref),
+            "input_name": edge.input_name,
+        }
         elements.append(
             _Addressable(
                 addresses=addresses,
-                qualified=qualified,
-                descriptor={
-                    "kind": "edge",
-                    "source": _ref_payload(source.ref),
-                    "source_field": edge.output_field,
-                    "source_path": list(edge.output_path),
-                    "target": _ref_payload(target.ref),
-                    "input_name": edge.input_name,
-                },
+                qualified=_format_target(descriptor),
+                descriptor=descriptor,
             )
         )
     return elements
@@ -196,4 +261,4 @@ def resolve_target(graph: RFGraph, target: str) -> TargetResolution:
     )
 
 
-__all__ = ["TargetDescriptor", "TargetResolution", "resolve_target"]
+__all__ = ["TargetDescriptor", "TargetResolution", "address_for_ref", "address_for_target", "resolve_target"]

--- a/src/pflow/ui/targets.py
+++ b/src/pflow/ui/targets.py
@@ -1,0 +1,199 @@
+"""Resolve agent-facing Point addresses against a rendered workflow graph.
+
+Resolution is deliberately server-side: address parsing happens once, while the
+browser receives only stable structural references. Positional React Flow ids
+never cross the live channel because independent renders may number them
+differently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+
+from pflow.core.suggestion_utils import find_similar_items
+from pflow.core.workflow.graph.renderers.react_flow import RFGraph, RFNode, RFRef
+
+
+class RefPayload(TypedDict):
+    node_id: str
+    ancestor_path: list[dict[str, object]]
+    port: str | None
+
+
+class NodeTarget(TypedDict):
+    kind: Literal["node"]
+    ref: RefPayload
+
+
+class EdgeTarget(TypedDict):
+    kind: Literal["edge"]
+    source: RefPayload
+    source_field: str | None
+    source_path: list[str]
+    target: RefPayload
+    input_name: str | None
+
+
+TargetDescriptor = NodeTarget | EdgeTarget
+
+
+@dataclass(frozen=True)
+class TargetResolution:
+    """The complete, structured outcome of resolving one Point address."""
+
+    matched: int
+    descriptor: TargetDescriptor | None = None
+    address: str | None = None
+    qualify: tuple[str, ...] = ()
+    suggestions: tuple[str, ...] = ()
+
+    def report(self) -> dict[str, object]:
+        """Return the minimal JSON response appropriate for this outcome."""
+        if self.matched == 0:
+            return {"matched": 0, "suggestions": list(self.suggestions)}
+        if self.matched > 1:
+            return {"matched": self.matched, "qualify": list(self.qualify)}
+        return {"matched": 1, "address": self.address}
+
+
+@dataclass(frozen=True)
+class _Addressable:
+    addresses: tuple[str, ...]
+    qualified: str
+    descriptor: TargetDescriptor
+
+
+def _ref_payload(ref: RFRef) -> RefPayload:
+    return {
+        "node_id": ref.node_id,
+        "ancestor_path": [
+            {"node_id": str(step["node_id"]), "batch_index": step.get("batch_index")} for step in ref.ancestor_path
+        ],
+        "port": ref.port,
+    }
+
+
+def _scope_prefix(ref: RFRef) -> str:
+    parts = []
+    for step in ref.ancestor_path:
+        node_id = str(step["node_id"])
+        index = step.get("batch_index")
+        parts.append(f"{node_id}[{index}]" if index is not None else node_id)
+    return ".".join(parts)
+
+
+def _node_addresses(ref: RFRef) -> tuple[str, str]:
+    scoped = ".".join(part for part in (_scope_prefix(ref), ref.node_id) if part)
+    bare = ref.node_id
+    if ref.port is not None:
+        return f"{ref.port}:{bare}", f"{ref.port}:{scoped}"
+    return bare, scoped
+
+
+def _with_field(address: str, field: str | None, path: list[str]) -> str:
+    suffix = [part for part in (field, *path) if part]
+    return ".".join((address, *suffix)) if suffix else address
+
+
+def _normalize_address(address: str) -> str:
+    endpoints = address.split("->")
+    if len(endpoints) == 2:
+        return f"{endpoints[0].strip()} -> {endpoints[1].strip()}"
+    return address.strip()
+
+
+def _node_elements(graph: RFGraph) -> list[_Addressable]:
+    elements = []
+    for node in graph.nodes:
+        bare, scoped = _node_addresses(node.ref)
+        elements.append(
+            _Addressable(
+                addresses=tuple(dict.fromkeys((bare, scoped))),
+                qualified=scoped,
+                descriptor={"kind": "node", "ref": _ref_payload(node.ref)},
+            )
+        )
+    return elements
+
+
+def _edge_elements(graph: RFGraph, nodes_by_id: dict[str, RFNode]) -> list[_Addressable]:
+    elements = []
+    for edge in graph.edges:
+        if edge.kind != "data_flow":
+            continue
+        source = nodes_by_id.get(edge.source)
+        target = nodes_by_id.get(edge.target)
+        if source is None or target is None:
+            continue
+
+        source_bare, source_scoped = _node_addresses(source.ref)
+        target_bare, target_scoped = _node_addresses(target.ref)
+        source_addresses = {
+            _with_field(source_bare, edge.output_field, edge.output_path),
+            _with_field(source_scoped, edge.output_field, edge.output_path),
+        }
+        target_addresses = {
+            _with_field(target_bare, edge.input_name, []),
+            _with_field(target_scoped, edge.input_name, []),
+        }
+        addresses = tuple(
+            sorted(
+                f"{source_address} -> {target_address}"
+                for source_address in source_addresses
+                for target_address in target_addresses
+            )
+        )
+        qualified = (
+            f"{_with_field(source_scoped, edge.output_field, edge.output_path)} -> "
+            f"{_with_field(target_scoped, edge.input_name, [])}"
+        )
+        elements.append(
+            _Addressable(
+                addresses=addresses,
+                qualified=qualified,
+                descriptor={
+                    "kind": "edge",
+                    "source": _ref_payload(source.ref),
+                    "source_field": edge.output_field,
+                    "source_path": list(edge.output_path),
+                    "target": _ref_payload(target.ref),
+                    "input_name": edge.input_name,
+                },
+            )
+        )
+    return elements
+
+
+def resolve_target(graph: RFGraph, target: str) -> TargetResolution:
+    """Resolve ``target`` to exactly one stable node/port/container/edge identity.
+
+    Bare node ids intentionally match every nested occurrence. Ambiguity is an
+    actionable result, never guessed: each returned qualified address carries
+    the full ancestor path, IO side, and literal-batch index and therefore
+    round-trips to one element.
+    """
+    normalized = _normalize_address(target)
+    nodes_by_id = {node.id: node for node in graph.nodes}
+    elements = [*_node_elements(graph), *_edge_elements(graph, nodes_by_id)]
+    matches = [element for element in elements if normalized in element.addresses]
+
+    if not matches:
+        bare_node_ids = sorted({node.ref.node_id for node in graph.nodes if node.ref.port is None})
+        suggestions = find_similar_items(normalized, bare_node_ids, method="fuzzy")
+        return TargetResolution(matched=0, suggestions=tuple(suggestions))
+    if len(matches) > 1:
+        return TargetResolution(
+            matched=len(matches),
+            qualify=tuple(sorted(element.qualified for element in matches)),
+        )
+
+    match = matches[0]
+    return TargetResolution(
+        matched=1,
+        descriptor=match.descriptor,
+        address=match.qualified,
+    )
+
+
+__all__ = ["TargetDescriptor", "TargetResolution", "resolve_target"]

--- a/src/pflow/ui/targets.py
+++ b/src/pflow/ui/targets.py
@@ -187,6 +187,24 @@ def _normalize_address(address: str) -> str:
     return address.strip()
 
 
+def _drop_prefix(endpoint: str) -> str:
+    for prefix in ("in:", "out:"):
+        if endpoint.startswith(prefix):
+            return endpoint[len(prefix) :]
+    return endpoint
+
+
+def _drop_side_prefixes(address: str) -> str:
+    """``address`` with each endpoint's leading ``in:``/``out:`` removed.
+
+    The bare form an agent reads in the file. ``resolve_target`` only adopts it
+    when it still resolves uniquely, so the side-prefix returns in the qualify
+    list exactly when an input and output share a name — the one case it exists
+    for.
+    """
+    return " -> ".join(_drop_prefix(endpoint) for endpoint in address.split(" -> "))
+
+
 def _node_elements(graph: RFGraph) -> list[_Addressable]:
     elements = []
     for node in graph.nodes:
@@ -274,10 +292,19 @@ def resolve_target(graph: RFGraph, target: str) -> TargetResolution:
         )
 
     match = matches[0]
+    # Report the address in the file's own vocabulary: drop the in:/out: side-prefix
+    # when the bare form still names exactly one element. The prefix exists only to
+    # disambiguate an input/output name collision — and a collision never lands here
+    # (it returns a qualify list above), so on a unique match it is notation the agent
+    # never typed. It stays in the qualify list, where it earns its place.
+    address = match.qualified
+    relaxed = _drop_side_prefixes(address)
+    if relaxed != address and sum(relaxed in element.addresses for element in elements) == 1:
+        address = relaxed
     return TargetResolution(
         matched=1,
         descriptor=match.descriptor,
-        address=match.qualified,
+        address=address,
     )
 
 

--- a/tests/test_cli/test_guide.py
+++ b/tests/test_cli/test_guide.py
@@ -111,6 +111,13 @@ def test_caching_topic_alias_resolves_to_prompt_caching() -> None:
     assert compose_guide(["caching"]) == compose_guide(["prompt-caching"])
 
 
+def test_ui_is_canonical_topic_and_visualization_is_an_alias() -> None:
+    # The feature lives under `pflow ui`, so `ui` is the canonical topic that an
+    # agent reaches for by the command name; the concept word stays reachable.
+    assert compose_guide(["visualization"]) == compose_guide(["ui"])
+    assert "pflow ui" in compose_guide(["ui"])
+
+
 def test_prompt_caching_guide_does_not_repeat_cached_values_in_quick_start() -> None:
     result = compose_guide(["prompt-caching"])
     assert 'prompt: "Pick a creative direction for the cached concept."' in result

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -92,6 +92,35 @@ class TestPointCommands:
         assert "open the workflow first" in result.output
         assert "--open" not in result.output
 
+    def test_zero_window_focus_omits_the_vacuous_visibility_breakdown(self) -> None:
+        # At 0 windows the "(0 visible, 0 backgrounded)" split is just 0 = 0 + 0.
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, _dispatch_payload(sent_to=0))):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet"])
+
+        assert result.exit_code == 1, result.output
+        assert "sent to 0 windows" in result.output
+        assert "0 visible, 0 backgrounded" not in result.output
+        assert "--open" in result.output
+
+    def test_focus_to_only_background_tabs_says_to_switch_to_it(self) -> None:
+        # Delivered to >=1 window but every one is a background tab: the highlight
+        # applied where the user isn't looking, so the report must say what to do.
+        payload = {
+            "resolved": {"matched": 1, "address": "greet"},
+            "sent_to": 1,
+            "windows": [{"visibility": "hidden"}],
+            "workflow_key": "/workflows/demo.pflow.md",
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet"])
+
+        assert result.exit_code == 0, result.output
+        assert "0 visible, 1 backgrounded" in result.output
+        assert "background tab" in result.output
+        assert "switch to it" in result.output
+
     def test_unresolved_target_exits_nonzero_with_json_payload_intact(self) -> None:
         payload = {
             "resolved": {"matched": 0, "suggestions": ["greet"]},
@@ -286,6 +315,45 @@ class TestUserActivityCommand:
         assert "user-activity 'demo' (0 events)" in result.output
         assert "server up, no interactions recorded for this workflow" in result.output
         assert "/workflows/demo.pflow.md" in result.output
+
+    def test_unfiltered_activity_does_not_leak_none_workflow_key(self) -> None:
+        # No workflow arg → the server returns workflow_key: null. The text must not
+        # echo a bare "workflow: None" (a Python repr leaking into agent output); the
+        # "all workflows" label already conveys that nothing is filtered.
+        payload = {"events": [], "workflow_key": None}
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["user-activity"])
+
+        assert result.exit_code == 0, result.output
+        assert "user-activity all workflows (0 events)" in result.output
+        assert "server up, no interactions recorded yet" in result.output
+        assert "None" not in result.output
+        assert "workflow:" not in result.output
+
+    def test_activity_renders_unfocused_view_state_without_python_none(self) -> None:
+        # A pan / zoom / density-toggle event has no focused node → focus is null
+        # over the wire. The line must read "focus none", never a raw Python "None".
+        payload = {
+            "workflow_key": "/workflows/demo.pflow.md",
+            "events": [
+                {
+                    "ts": 1_750_000_000.0,
+                    "age_seconds": 1.0,
+                    "type": "density_change",
+                    "target": None,
+                    "view_state": {"density": "advanced", "direction": "LR", "focus": None},
+                    "workflow_key": "/workflows/demo.pflow.md",
+                }
+            ],
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["user-activity", "demo"])
+
+        assert result.exit_code == 0, result.output
+        assert "focus none" in result.output
+        assert "None" not in result.output
 
     def test_activity_formats_structural_and_flat_identity_with_view_state(self) -> None:
         payload = {

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -1,0 +1,312 @@
+"""CLI contract tests for Point and Watch commands under ``pflow ui``."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+from click.testing import CliRunner
+
+from pflow.cli.commands import ui as ui_module
+
+
+def _response(status: int, payload: dict[str, object]) -> httpx.Response:
+    request = httpx.Request("POST", "http://127.0.0.1:8765/api/command")
+    return httpx.Response(status, json=payload, request=request)
+
+
+def _dispatch_payload(*, sent_to: int = 1) -> dict[str, object]:
+    windows = [{"visibility": "visible"}] if sent_to else []
+    return {
+        "resolved": {"matched": 1, "address": "greet"},
+        "sent_to": sent_to,
+        "windows": windows,
+        "workflow_key": "/workflows/demo.pflow.md",
+    }
+
+
+class TestUiRouting:
+    def test_group_help_exposes_serve_flags_and_interaction_commands(self) -> None:
+        result = CliRunner().invoke(ui_module.ui_cmd, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "--no-auto-update" in result.output
+        assert "focus" in result.output
+        assert "user-activity" in result.output
+
+    def test_focus_dispatches_as_subcommand(self) -> None:
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, _dispatch_payload())) as request:
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--port", "9123"])
+
+        assert result.exit_code == 0, result.output
+        assert "sent to 1 window" in result.output
+        assert request.call_args.args[:2] == ("POST", "http://127.0.0.1:9123/api/command")
+        assert request.call_args.kwargs["json"] == {
+            "workflow": "demo",
+            "type": "focus",
+            "target": "greet",
+        }
+
+    def test_workflow_path_named_like_subcommand_still_routes_to_serve(self) -> None:
+        runner = CliRunner()
+        with (
+            patch.object(ui_module, "_port_available", return_value=True),
+            patch("uvicorn.run") as run,
+        ):
+            result = runner.invoke(ui_module.ui_cmd, ["./focus.pflow.md", "--no-open"])
+
+        assert result.exit_code == 0, result.output
+        assert "workflow=.%2Ffocus.pflow.md" in result.output
+        run.assert_called_once()
+
+    def test_no_auto_update_preserves_private_watch_query_param(self) -> None:
+        runner = CliRunner()
+        with (
+            patch.object(ui_module, "_port_available", return_value=True),
+            patch("uvicorn.run"),
+        ):
+            result = runner.invoke(ui_module.ui_cmd, ["demo", "--no-open", "--no-auto-update"])
+
+        assert result.exit_code == 0, result.output
+        assert "workflow=demo&watch=0" in result.output
+
+
+class TestPointCommands:
+    def test_json_mode_passes_server_payload_through(self) -> None:
+        payload = _dispatch_payload()
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["frame", "demo", "greet", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == payload
+
+    def test_frame_zero_windows_does_not_suggest_unsupported_open_flag(self) -> None:
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, _dispatch_payload(sent_to=0))):
+            result = runner.invoke(ui_module.ui_cmd, ["frame", "demo", "greet"])
+
+        assert result.exit_code == 1, result.output
+        assert "open the workflow first" in result.output
+        assert "--open" not in result.output
+
+    def test_unresolved_target_exits_nonzero_with_json_payload_intact(self) -> None:
+        payload = {
+            "resolved": {"matched": 0, "suggestions": ["greet"]},
+            "sent_to": 0,
+            "windows": [],
+            "workflow_key": "/workflows/demo.pflow.md",
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "grete", "--json"])
+
+        assert result.exit_code == 1
+        assert json.loads(result.output) == payload
+
+    def test_connection_failure_has_actionable_start_hint(self) -> None:
+        error = httpx.ConnectError(
+            "connection refused",
+            request=httpx.Request("POST", "http://127.0.0.1:9000/api/command"),
+        )
+        runner = CliRunner()
+        with patch("httpx.request", side_effect=error):
+            result = runner.invoke(ui_module.ui_cmd, ["clear-focus", "demo", "--port", "9000"])
+
+        assert result.exit_code == 1
+        assert "No pflow ui server on port 9000" in result.output
+        assert "pflow ui demo" in result.output
+        assert "Traceback" not in result.output
+
+    def test_connection_failure_is_structured_in_json_mode(self) -> None:
+        error = httpx.ConnectError(
+            "connection refused",
+            request=httpx.Request("POST", "http://127.0.0.1:9000/api/command"),
+        )
+        runner = CliRunner()
+        with patch("httpx.request", side_effect=error):
+            result = runner.invoke(ui_module.ui_cmd, ["clear-focus", "demo", "--port", "9000", "--json"])
+
+        assert result.exit_code == 1
+        assert json.loads(result.output) == {
+            "error": "server_unavailable",
+            "port": 9000,
+            "hint": "start one: pflow ui demo",
+        }
+
+    def test_422_renders_structured_diagnostic_without_traceback(self) -> None:
+        payload = {
+            "errors": [
+                {
+                    "severity": "error",
+                    "message": "Unknown node type 'missing'.",
+                    "source": "/workflows/demo.pflow.md",
+                }
+            ]
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(422, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet"])
+
+        assert result.exit_code == 1
+        assert "Unknown node type 'missing'" in result.output
+        assert "Traceback" not in result.output
+
+    def test_422_json_mode_passes_server_error_body_through(self) -> None:
+        payload = {
+            "errors": [
+                {
+                    "severity": "error",
+                    "message": "Unknown node type 'missing'.",
+                    "source": "/workflows/demo.pflow.md",
+                }
+            ]
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(422, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--json"])
+
+        assert result.exit_code == 1
+        assert json.loads(result.output) == payload
+
+    def test_open_never_duplicates_an_existing_background_window(self) -> None:
+        payload = {
+            **_dispatch_payload(),
+            "windows": [{"visibility": "hidden"}],
+        }
+        runner = CliRunner()
+        with (
+            patch("httpx.request", return_value=_response(200, payload)),
+            patch("webbrowser.open") as open_browser,
+        ):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--open"])
+
+        assert result.exit_code == 0, result.output
+        assert "1 backgrounded" in result.output
+        open_browser.assert_not_called()
+
+    def test_open_loads_then_reposts_non_edge_target_when_viewer_connects(self) -> None:
+        zero = _dispatch_payload(sent_to=0)
+        connected = _dispatch_payload(sent_to=1)
+        runner = CliRunner()
+        with (
+            patch("httpx.request", side_effect=[_response(200, zero), _response(200, connected)]) as request,
+            patch("webbrowser.open") as open_browser,
+            patch("time.sleep"),
+        ):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--open"])
+
+        assert result.exit_code == 0, result.output
+        assert request.call_count == 2
+        open_browser.assert_called_once_with("http://127.0.0.1:8765/?workflow=demo&focus=greet")
+        assert "sent to 1 window" in result.output
+
+    def test_edge_open_reposts_until_viewer_connects(self) -> None:
+        zero = _dispatch_payload(sent_to=0)
+        connected = _dispatch_payload(sent_to=1)
+        runner = CliRunner()
+        with (
+            patch("httpx.request", side_effect=[_response(200, zero), _response(200, connected)]) as request,
+            patch("webbrowser.open") as open_browser,
+            patch("time.sleep"),
+        ):
+            result = runner.invoke(
+                ui_module.ui_cmd,
+                ["focus", "demo", "gen.response -> use.prompt", "--open"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert request.call_count == 2
+        open_browser.assert_called_once_with("http://127.0.0.1:8765/?workflow=demo")
+        assert "sent to 1 window" in result.output
+
+    def test_edge_open_timeout_has_distinct_rerun_message(self) -> None:
+        runner = CliRunner()
+        with (
+            patch("httpx.request", return_value=_response(200, _dispatch_payload(sent_to=0))),
+            patch("webbrowser.open"),
+            patch.object(ui_module, "_OPEN_TIMEOUT_S", 0.0),
+        ):
+            result = runner.invoke(
+                ui_module.ui_cmd,
+                ["focus", "demo", "gen.response -> use.prompt", "--open"],
+            )
+
+        assert result.exit_code == 1, result.output
+        assert "didn't connect within 15s" in result.output
+        assert "re-run `pflow ui focus demo" in result.output
+        assert "0 windows" not in result.output
+
+
+class TestUserActivityCommand:
+    def test_empty_filtered_activity_is_explicit(self) -> None:
+        payload = {"events": [], "workflow_key": "/workflows/demo.pflow.md"}
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["user-activity", "demo"])
+
+        assert result.exit_code == 0, result.output
+        assert "user-activity 'demo' (0 events)" in result.output
+        assert "server up, no interactions recorded for this workflow key" in result.output
+        assert "/workflows/demo.pflow.md" in result.output
+
+    def test_activity_formats_structural_and_flat_identity_with_view_state(self) -> None:
+        payload = {
+            "workflow_key": "/workflows/demo.pflow.md",
+            "events": [
+                {
+                    "ts": 1_750_000_000.0,
+                    "age_seconds": 0.25,
+                    "type": "node_click",
+                    "target": {
+                        "kind": "node",
+                        "flat_id": "n3",
+                        "ref": {
+                            "node_id": "greet",
+                            "ancestor_path": [{"node_id": "child", "batch_index": 2}],
+                            "port": None,
+                        },
+                    },
+                    "view_state": {"density": "beautiful", "direction": "LR", "focus": "greet"},
+                    "workflow_key": "/workflows/demo.pflow.md",
+                }
+            ],
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["user-activity", "demo"])
+
+        assert result.exit_code == 0, result.output
+        assert "child[2].greet [n3]" in result.output
+        assert "beautiful/LR · focus greet" in result.output
+        assert "0.2s ago" in result.output
+
+    def test_nested_io_activity_uses_round_trippable_point_grammar(self) -> None:
+        payload = {
+            "workflow_key": "/workflows/demo.pflow.md",
+            "events": [
+                {
+                    "ts": 1_750_000_000.0,
+                    "age_seconds": 1.0,
+                    "type": "port_click",
+                    "target": {
+                        "kind": "node",
+                        "flat_id": "p3",
+                        "ref": {
+                            "node_id": "data",
+                            "ancestor_path": [{"node_id": "child", "batch_index": None}],
+                            "port": "in",
+                        },
+                    },
+                    "view_state": {"density": "advanced", "direction": "TD", "focus": "data"},
+                }
+            ],
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["user-activity", "demo"])
+
+        assert result.exit_code == 0, result.output
+        assert "in:child.data [p3]" in result.output

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -78,7 +78,7 @@ class TestPointCommands:
         payload = _dispatch_payload()
         runner = CliRunner()
         with patch("httpx.request", return_value=_response(200, payload)):
-            result = runner.invoke(ui_module.ui_cmd, ["frame", "demo", "greet", "--json"])
+            result = runner.invoke(ui_module.ui_cmd, ["frame", "demo", "greet", "--output-format", "json"])
 
         assert result.exit_code == 0, result.output
         assert json.loads(result.output) == payload
@@ -101,10 +101,43 @@ class TestPointCommands:
         }
         runner = CliRunner()
         with patch("httpx.request", return_value=_response(200, payload)):
-            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "grete", "--json"])
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "grete", "--output-format", "json"])
 
         assert result.exit_code == 1
         assert json.loads(result.output) == payload
+
+    def test_not_found_without_suggestions_orients_to_file_vocabulary(self) -> None:
+        payload = {
+            "resolved": {"matched": 0, "suggestions": []},
+            "sent_to": 0,
+            "windows": [],
+            "workflow_key": "/workflows/demo.pflow.md",
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "xyzzy"])
+
+        assert result.exit_code == 1
+        assert "not found." in result.output
+        assert "names from the workflow file" in result.output
+        # Nothing close — don't fabricate a "did you mean".
+        assert "Did you mean" not in result.output
+
+    def test_not_found_with_suggestions_stays_terse(self) -> None:
+        payload = {
+            "resolved": {"matched": 0, "suggestions": ["process_content"]},
+            "sent_to": 0,
+            "windows": [],
+            "workflow_key": "/workflows/demo.pflow.md",
+        }
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "proces"])
+
+        assert result.exit_code == 1
+        assert "Did you mean: process_content?" in result.output
+        # The orientation line is only for the no-suggestion dead-end.
+        assert "names from the workflow file" not in result.output
 
     def test_connection_failure_has_actionable_start_hint(self) -> None:
         error = httpx.ConnectError(
@@ -127,7 +160,9 @@ class TestPointCommands:
         )
         runner = CliRunner()
         with patch("httpx.request", side_effect=error):
-            result = runner.invoke(ui_module.ui_cmd, ["clear-focus", "demo", "--port", "9000", "--json"])
+            result = runner.invoke(
+                ui_module.ui_cmd, ["clear-focus", "demo", "--port", "9000", "--output-format", "json"]
+            )
 
         assert result.exit_code == 1
         assert json.loads(result.output) == {
@@ -166,7 +201,7 @@ class TestPointCommands:
         }
         runner = CliRunner()
         with patch("httpx.request", return_value=_response(422, payload)):
-            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--json"])
+            result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--output-format", "json"])
 
         assert result.exit_code == 1
         assert json.loads(result.output) == payload
@@ -249,7 +284,7 @@ class TestUserActivityCommand:
 
         assert result.exit_code == 0, result.output
         assert "user-activity 'demo' (0 events)" in result.output
-        assert "server up, no interactions recorded for this workflow key" in result.output
+        assert "server up, no interactions recorded for this workflow" in result.output
         assert "/workflows/demo.pflow.md" in result.output
 
     def test_activity_formats_structural_and_flat_identity_with_view_state(self) -> None:

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -92,6 +92,18 @@ class TestPointCommands:
         assert "open the workflow first" in result.output
         assert "--open" not in result.output
 
+    def test_clear_focus_zero_windows_says_nothing_to_clear_not_open_first(self) -> None:
+        # Clearing with no Viewer open has nothing to clear; the "open the workflow
+        # first" hint would be circular (open a window only to clear focus on it).
+        payload = {"sent_to": 0, "windows": [], "workflow_key": "/workflows/demo.pflow.md"}
+        runner = CliRunner()
+        with patch("httpx.request", return_value=_response(200, payload)):
+            result = runner.invoke(ui_module.ui_cmd, ["clear-focus", "demo"])
+
+        assert result.exit_code == 1, result.output
+        assert "nothing to clear" in result.output
+        assert "open the workflow first" not in result.output
+
     def test_zero_window_focus_omits_the_vacuous_visibility_breakdown(self) -> None:
         # At 0 windows the "(0 visible, 0 backgrounded)" split is just 0 = 0 + 0.
         runner = CliRunner()

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -288,3 +288,58 @@ def test_sse_disconnect_unregisters_connection_via_raw_asgi(tmp_path: Path) -> N
     assert app.state.hub.windows_for(str(workflow.resolve())) == []
     assert response_frames[0]["type"] == "http.response.start"
     assert any(b'"type": "clear"' in frame.get("body", b"") for frame in response_frames)
+
+
+def test_idle_connection_emits_keepalive_frames(tmp_path: Path) -> None:
+    """An idle SSE connection periodically emits a `:` comment frame.
+
+    This keepalive is load-bearing: on ASGI spec >=2.4 ``StreamingResponse`` has
+    no disconnect listener, so a silently-dropped socket only surfaces when the
+    next ``send`` fails — and the keepalive is the only ``send`` an idle stream
+    makes. Here we drive the real generator (spec 2.3 so the listener tears it
+    down cleanly once a keepalive is seen) and assert the keepalive actually
+    fires and cleanup still runs."""
+    workflow = _workflow(tmp_path)
+    app = create_app()
+    frames: list[dict[str, object]] = []
+    request_sent = False
+    keepalive_seen = asyncio.Event()
+
+    def _is_comment(message: dict[str, object]) -> bool:
+        body = message.get("body")
+        return isinstance(body, bytes) and body.strip().startswith(b":")
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await keepalive_seen.wait()  # end the stream once the keepalive has fired
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        frames.append(message)
+        if _is_comment(message):
+            keepalive_seen.set()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/api/events",
+        "raw_path": b"/api/events",
+        "query_string": urlencode({"workflow": str(workflow), "visibility": "visible"}).encode(),
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 8765),
+        "root_path": "",
+    }
+
+    with patch("pflow.ui.server._KEEPALIVE_S", 0.01):
+        asyncio.run(app(scope, receive, send))
+
+    assert keepalive_seen.is_set()
+    assert any(_is_comment(frame) for frame in frames)
+    assert app.state.hub.windows_for(str(workflow.resolve())) == []

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -1,0 +1,290 @@
+"""Server-side Point/Watch hub and endpoint contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from urllib.parse import urlencode
+
+from starlette.testclient import TestClient
+
+from pflow.core.workflow.manager import WorkflowManager
+from pflow.ui.server import _ACTIVITY_MAX, _Hub, _workflow_key, create_app
+from tests.shared.markdown_utils import write_workflow_file
+
+_VALID_IR = {
+    "nodes": [
+        {"id": "greet", "type": "shell", "params": {"command": "echo hello"}},
+        {"id": "done", "type": "shell", "params": {"command": "echo ${greet.stdout}"}},
+    ],
+    "edges": [{"from": "greet", "to": "done"}],
+}
+
+
+def _workflow(tmp_path: Path) -> Path:
+    path = tmp_path / "interaction.pflow.md"
+    write_workflow_file(_VALID_IR, path)
+    return path
+
+
+def test_workflow_key_groups_saved_name_and_resolved_path() -> None:
+    manager = WorkflowManager()
+    workflow_dir = manager.workflows_dir / "interaction"
+    workflow_dir.mkdir(parents=True)
+    path = workflow_dir / "interaction.pflow.md"
+    write_workflow_file(_VALID_IR, path)
+
+    assert _workflow_key("interaction") == _workflow_key(str(path)) == str(path.resolve())
+
+
+class TestHub:
+    def test_register_broadcast_visibility_and_unregister(self) -> None:
+        hub = _Hub()
+        first = hub.register("/a.pflow.md", "visible")
+        second = hub.register("/a.pflow.md", "hidden")
+        hub.register("/other.pflow.md", "visible")
+
+        sent = hub.broadcast("/a.pflow.md", {"type": "clear"})
+
+        assert [conn.conn_id for conn in sent] == [first.conn_id, second.conn_id]
+        assert first.queue.get_nowait() == {"type": "clear"}
+        assert second.queue.get_nowait() == {"type": "clear"}
+        hub.set_visibility(second.conn_id, "visible")
+        assert [conn.visibility for conn in hub.windows_for("/a.pflow.md")] == ["visible", "visible"]
+
+        hub.unregister(first.conn_id)
+        assert [conn.conn_id for conn in hub.windows_for("/a.pflow.md")] == [second.conn_id]
+
+    def test_slow_connection_is_evicted_instead_of_growing_without_bound(self) -> None:
+        hub = _Hub()
+        conn = hub.register("/wf.pflow.md", "visible")
+        for sequence in range(conn.queue.maxsize):
+            conn.queue.put_nowait({"sequence": sequence})
+
+        sent = hub.broadcast("/wf.pflow.md", {"type": "focus"})
+
+        assert sent == []
+        assert conn.active is False
+        assert hub.windows_for("/wf.pflow.md") == []
+
+    def test_activity_ring_is_bounded_filtered_and_newest_first(self) -> None:
+        hub = _Hub()
+        for index in range(_ACTIVITY_MAX + 5):
+            hub.record({"workflow_key": "/a.pflow.md", "sequence": index})
+        hub.record({"workflow_key": "/b.pflow.md", "sequence": 999})
+
+        all_events = hub.activity()
+        filtered = hub.activity("/a.pflow.md")
+
+        assert len(all_events) == _ACTIVITY_MAX
+        assert all_events[0]["sequence"] == 999
+        assert filtered[0]["sequence"] == _ACTIVITY_MAX + 4
+        assert filtered[-1]["sequence"] == 6
+
+
+class TestInteractionEndpoints:
+    def test_focus_resolves_and_broadcasts_to_matching_windows(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        app = create_app()
+        key = str(workflow.resolve())
+        visible = app.state.hub.register(key, "visible")
+        app.state.hub.register(key, "hidden")
+        app.state.hub.register("/different.pflow.md", "visible")
+
+        response = TestClient(app).post(
+            "/api/command",
+            json={"workflow": str(workflow), "type": "focus", "target": "greet"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "resolved": {"matched": 1, "address": "greet"},
+            "sent_to": 2,
+            "windows": [{"visibility": "visible"}, {"visibility": "hidden"}],
+            "workflow_key": key,
+        }
+        assert visible.queue.get_nowait() == {
+            "type": "focus",
+            "target": {
+                "kind": "node",
+                "ref": {"node_id": "greet", "ancestor_path": [], "port": None},
+            },
+        }
+
+    def test_clear_does_not_require_a_target(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        app = create_app()
+        conn = app.state.hub.register(str(workflow.resolve()), "visible")
+
+        response = TestClient(app).post(
+            "/api/command",
+            json={"workflow": str(workflow), "type": "clear"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["sent_to"] == 1
+        assert conn.queue.get_nowait() == {"type": "clear"}
+
+    def test_point_build_runs_off_the_hub_event_loop(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+
+        async def run_in_thread(function: Callable[..., object], *args: object, **kwargs: object) -> object:
+            return function(*args, **kwargs)
+
+        to_thread = AsyncMock(side_effect=run_in_thread)
+        with patch("pflow.ui.server.asyncio.to_thread", to_thread):
+            response = TestClient(create_app()).post(
+                "/api/command",
+                json={"workflow": str(workflow), "type": "focus", "target": "greet"},
+            )
+
+        assert response.status_code == 200
+        to_thread.assert_awaited_once()
+
+    def test_not_found_and_ambiguous_targets_are_not_broadcast(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        app = create_app()
+        conn = app.state.hub.register(str(workflow.resolve()), "visible")
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/command",
+            json={"workflow": str(workflow), "type": "focus", "target": "grete"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["resolved"] == {"matched": 0, "suggestions": ["greet"]}
+        assert response.json()["sent_to"] == 0
+        assert conn.queue.empty()
+
+    def test_unknown_workflow_name_is_actionable_404(self) -> None:
+        response = TestClient(create_app()).post(
+            "/api/command",
+            json={"workflow": "does-not-exist", "type": "focus", "target": "greet"},
+        )
+
+        assert response.status_code == 404
+        assert "does-not-exist" in response.json()["error"]
+        assert response.json()["suggestions"] == []
+
+    def test_mutating_endpoints_require_json_content_type(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        client = TestClient(create_app())
+
+        for path in ("/api/command", "/api/interaction", "/api/visibility"):
+            response = client.post(path, content=json.dumps({"workflow": str(workflow)}))
+            assert response.status_code == 415
+            assert "application/json" in response.json()["error"]
+
+    def test_invalid_workflow_source_is_422(self, tmp_path: Path) -> None:
+        workflow = tmp_path / "invalid.pflow.md"
+        write_workflow_file(
+            {"nodes": [{"id": "bad", "type": "nonexistent_type_xyz", "params": {}}]},
+            workflow,
+        )
+
+        response = TestClient(create_app()).post(
+            "/api/command",
+            json={"workflow": str(workflow), "type": "focus", "target": "bad"},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["errors"]
+
+    def test_interactions_are_recorded_and_read_as_an_aged_snapshot(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        client = TestClient(create_app())
+        event = {
+            "workflow": str(workflow),
+            "type": "node_click",
+            "target": {
+                "kind": "node",
+                "flat_id": "n0",
+                "ref": {"node_id": "greet", "ancestor_path": [], "port": None},
+            },
+            "view_state": {"density": "beautiful", "direction": "LR", "focus": "greet"},
+        }
+
+        posted = client.post("/api/interaction", json=event)
+        response = client.get("/api/activity", params={"workflow": str(workflow)})
+
+        assert posted.status_code == 204
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["workflow_key"] == str(workflow.resolve())
+        assert len(payload["events"]) == 1
+        assert payload["events"][0]["type"] == "node_click"
+        assert payload["events"][0]["target"]["flat_id"] == "n0"
+        assert payload["events"][0]["age_seconds"] >= 0
+
+    def test_unknown_workflow_activity_is_actionable_404(self) -> None:
+        response = TestClient(create_app()).get(
+            "/api/activity",
+            params={"workflow": "does-not-exist"},
+        )
+
+        assert response.status_code == 404
+        assert "does-not-exist" in response.json()["error"]
+
+    def test_visibility_updates_only_the_named_connection(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        app = create_app()
+        conn = app.state.hub.register(str(workflow.resolve()), "visible")
+
+        response = TestClient(app).post(
+            "/api/visibility",
+            json={"conn_id": conn.conn_id, "visibility": "hidden"},
+        )
+
+        assert response.status_code == 204
+        assert conn.visibility == "hidden"
+
+
+def test_sse_disconnect_unregisters_connection_via_raw_asgi(tmp_path: Path) -> None:
+    """Exercise real ``http.disconnect`` delivery; TestClient cannot do this."""
+    workflow = _workflow(tmp_path)
+    app = create_app()
+    command_sent = asyncio.Event()
+    request_sent = False
+    response_frames: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await command_sent.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        response_frames.append(message)
+        body = message.get("body")
+        if isinstance(body, bytes) and b'"type": "connected"' in body:
+            app.state.hub.broadcast(str(workflow.resolve()), {"type": "clear"})
+        if isinstance(body, bytes) and b'"type": "clear"' in body:
+            command_sent.set()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/api/events",
+        "raw_path": b"/api/events",
+        "query_string": urlencode({"workflow": str(workflow), "visibility": "visible"}).encode(),
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 8765),
+        "root_path": "",
+    }
+
+    asyncio.run(app(scope, receive, send))
+
+    assert command_sent.is_set()
+    assert app.state.hub.windows_for(str(workflow.resolve())) == []
+    assert response_frames[0]["type"] == "http.response.start"
+    assert any(b'"type": "clear"' in frame.get("body", b"") for frame in response_frames)

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -40,6 +40,13 @@ def test_workflow_key_groups_saved_name_and_resolved_path() -> None:
     assert _workflow_key("interaction") == _workflow_key(str(path)) == str(path.resolve())
 
 
+def test_workflow_key_returns_none_for_a_nonexistent_pflow_md_path() -> None:
+    # A ".pflow.md" path that does not exist is "not found", not a phantom key:
+    # the suffix is not a special case (Path.suffix is only ".md"), so identity
+    # rests entirely on exists() — you cannot Point at a graph that cannot be built.
+    assert _workflow_key("/no/such/workflow.pflow.md") is None
+
+
 class TestHub:
     def test_register_broadcast_visibility_and_unregister(self) -> None:
         hub = _Hub()
@@ -219,6 +226,24 @@ class TestInteractionEndpoints:
         assert payload["events"][0]["type"] == "node_click"
         assert payload["events"][0]["target"]["flat_id"] == "n0"
         assert payload["events"][0]["age_seconds"] >= 0
+
+    def test_interaction_records_only_whitelisted_fields(self, tmp_path: Path) -> None:
+        # Arbitrary client-supplied keys must not leak into the Watch snapshot, so
+        # the agent reading /api/activity sees a predictable event shape.
+        workflow = _workflow(tmp_path)
+        client = TestClient(create_app())
+        event = {
+            "workflow": str(workflow),
+            "type": "node_click",
+            "view_state": {"density": "beautiful", "direction": "LR", "focus": None},
+            "injected": "should-not-be-recorded",
+        }
+
+        assert client.post("/api/interaction", json=event).status_code == 204
+        recorded = client.get("/api/activity", params={"workflow": str(workflow)}).json()["events"]
+        assert len(recorded) == 1
+        assert "injected" not in recorded[0]
+        assert recorded[0]["type"] == "node_click"
 
     def test_unknown_workflow_activity_is_actionable_404(self) -> None:
         response = TestClient(create_app()).get(

--- a/tests/test_cli/test_ui_targets.py
+++ b/tests/test_cli/test_ui_targets.py
@@ -237,6 +237,75 @@ def test_not_found_uses_fuzzy_node_suggestions() -> None:
     assert resolution.suggestions[0] == "fetch-data"
 
 
+def test_io_port_resolves_by_its_bare_name_without_a_prefix() -> None:
+    """An agent points at an input by the name it reads under ``## Inputs`` — the
+    `in:`/`out:` prefix is never required when nothing collides."""
+    graph = _graph([_node("n0", _ref("source_file", port="in"))])
+
+    resolution = resolve_target(graph, "source_file")
+
+    assert resolution.matched == 1
+    assert resolution.descriptor is not None
+    assert resolution.descriptor["ref"]["port"] == "in"
+    # The canonical address keeps the prefix so the report stays unambiguous,
+    # even though the bare name is what the agent typed.
+    assert resolution.address == "in:source_file"
+
+
+def test_same_name_input_and_output_qualify_to_the_prefixed_forms() -> None:
+    """The one case the prefix exists for: a bare name that is genuinely two
+    elements returns a qualify list that teaches `in:`/`out:` exactly when needed."""
+    graph = _graph([
+        _node("n0", _ref("data", port="in")),
+        _node("n1", _ref("data", port="out")),
+    ])
+
+    resolution = resolve_target(graph, "data")
+
+    assert resolution.matched == 2
+    assert resolution.qualify == ("in:data", "out:data")
+    assert all(resolve_target(graph, address).matched == 1 for address in resolution.qualify)
+
+
+def test_edge_resolves_when_its_source_is_an_io_port_named_bare() -> None:
+    """A connection from a workflow input composes from the input's bare name —
+    `source_file -> read_source.file_path` resolves with no prefix."""
+    source = _node("n0", _ref("source_file", port="in"))
+    target = _node("n1", _ref("read_source"))
+    graph = _graph(
+        [source, target],
+        edges=[RFEdge("e0", "n0", "n1", "data_flow", None, None, "file_path", False)],
+    )
+
+    resolution = resolve_target(graph, "source_file -> read_source.file_path")
+
+    assert resolution.matched == 1
+    assert resolution.address == "in:source_file -> read_source.file_path"
+
+
+def test_not_found_input_typo_suggests_input_names_not_unrelated_steps() -> None:
+    graph = _graph([_node("n0", _ref("source_file", port="in")), _node("n1", _ref("read_source"))])
+
+    resolution = resolve_target(graph, "source_fil")
+
+    assert resolution.matched == 0
+    assert "source_file" in resolution.suggestions
+
+
+def test_not_found_edge_attempt_suggests_real_connections() -> None:
+    source = _node("n0", _ref("gen"))
+    target = _node("n1", _ref("summarize"))
+    graph = _graph(
+        [source, target],
+        edges=[RFEdge("e0", "n0", "n1", "data_flow", None, "response", "prompt", False)],
+    )
+
+    resolution = resolve_target(graph, "gen.response -> summarize.promt")
+
+    assert resolution.matched == 0
+    assert resolution.suggestions[0] == "gen.response -> summarize.prompt"
+
+
 def test_display_grammar_matches_resolver_and_round_trips() -> None:
     """`address_for_target` (the CLI Watch display formatter) and `resolve_target`
     share ONE grammar — an address `pflow ui user-activity` prints re-points to

--- a/tests/test_cli/test_ui_targets.py
+++ b/tests/test_cli/test_ui_targets.py
@@ -14,7 +14,7 @@ from pflow.core.workflow.graph.renderers.react_flow import (
     RFRef,
 )
 from pflow.core.workflow.sub_workflow_resolver import SubWorkflowResult
-from pflow.ui.targets import resolve_target
+from pflow.ui.targets import address_for_target, resolve_target
 
 
 def _ref(
@@ -235,3 +235,28 @@ def test_not_found_uses_fuzzy_node_suggestions() -> None:
 
     assert resolution.matched == 0
     assert resolution.suggestions[0] == "fetch-data"
+
+
+def test_display_grammar_matches_resolver_and_round_trips() -> None:
+    """`address_for_target` (the CLI Watch display formatter) and `resolve_target`
+    share ONE grammar — an address `pflow ui user-activity` prints re-points to
+    exactly one element. Guards the two-source-of-truth drift the plan warned
+    about (the Watch display path used to re-implement the grammar in ui.py)."""
+    graph = _graph(
+        [
+            _node("n0", _ref("gen", ("create", 0))),
+            _node("n1", _ref("summarize", ("create", 0))),
+            _node("n2", _ref("data", port="in")),
+        ],
+        edges=[RFEdge("e0", "n0", "n1", "data_flow", None, "result", "prompt", False, output_path=["ok"])],
+    )
+
+    for probe in ("gen", "in:data", "gen.result.ok -> summarize.prompt"):
+        resolution = resolve_target(graph, probe)
+        assert resolution.matched == 1, probe
+        assert resolution.descriptor is not None
+        # The CLI renders the recorded descriptor via the SAME formatter; it must
+        # equal the resolver's canonical address and itself re-point to one element.
+        rendered = address_for_target(resolution.descriptor)
+        assert rendered == resolution.address
+        assert resolve_target(graph, rendered).matched == 1

--- a/tests/test_cli/test_ui_targets.py
+++ b/tests/test_cli/test_ui_targets.py
@@ -1,0 +1,237 @@
+"""Pure target-address resolution for ``pflow ui`` Point commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pflow.core.workflow.graph import build_graph, render_react_flow
+from pflow.core.workflow.graph.renderers.react_flow import (
+    RFEdge,
+    RFGraph,
+    RFGroup,
+    RFNode,
+    RFRef,
+)
+from pflow.core.workflow.sub_workflow_resolver import SubWorkflowResult
+from pflow.ui.targets import resolve_target
+
+
+def _ref(
+    node_id: str,
+    *ancestors: tuple[str, int | None],
+    port: str | None = None,
+) -> RFRef:
+    return RFRef(
+        node_id=node_id,
+        ancestor_path=[{"node_id": host, "batch_index": index} for host, index in ancestors],
+        port=port,
+    )
+
+
+def _node(flat_id: str, ref: RFRef, *, group_host: bool = False) -> RFNode:
+    return RFNode(
+        id=flat_id,
+        ref=ref,
+        kind="shell",
+        purpose="",
+        params=[],
+        io=None,
+        loop=None,
+        batch=None,
+        parent=None,
+        source=None,
+        is_decision=False,
+        is_terminal=False,
+        is_group_host=group_host,
+        is_transform=False,
+        output_shape=None,
+        cached_prefix=None,
+        unexpanded=None,
+        annotations={},
+    )
+
+
+def _graph(
+    nodes: list[RFNode],
+    *,
+    edges: list[RFEdge] | None = None,
+    groups: list[RFGroup] | None = None,
+) -> RFGraph:
+    return RFGraph(nodes=nodes, edges=edges or [], groups=groups or [])
+
+
+def _child_resolver(children: dict[str, dict[str, Any]]):
+    def resolver(params: dict[str, Any], base: Path | None) -> SubWorkflowResult | None:
+        reference = params.get("workflow")
+        child = children.get(reference)
+        return SubWorkflowResult(child, Path(f"/fake/{reference}.pflow.md"), ()) if child is not None else None
+
+    return resolver
+
+
+def test_resolves_flat_node_and_container_host_to_structural_ref() -> None:
+    host = _node("n0", _ref("research"), group_host=True)
+    graph = _graph(
+        [host],
+        groups=[RFGroup("g0", "workflow", None, "n0", [], 0, {})],
+    )
+
+    resolution = resolve_target(graph, "research")
+
+    assert resolution.matched == 1
+    assert resolution.address == "research"
+    assert resolution.descriptor == {
+        "kind": "node",
+        "ref": {"node_id": "research", "ancestor_path": [], "port": None},
+    }
+
+
+def test_duplicate_nested_node_reports_round_trippable_qualified_addresses() -> None:
+    graph = _graph([
+        _node("n0", _ref("gen", ("create", None))),
+        _node("n1", _ref("gen", ("remix", None))),
+    ])
+
+    resolution = resolve_target(graph, "gen")
+
+    assert resolution.matched == 2
+    assert resolution.qualify == ("create.gen", "remix.gen")
+    assert all(resolve_target(graph, address).matched == 1 for address in resolution.qualify)
+
+
+def test_literal_batch_index_is_part_of_qualified_address() -> None:
+    graph = _graph([
+        _node("n0", _ref("gen", ("fanout", 0))),
+        _node("n1", _ref("gen", ("fanout", 1))),
+    ])
+
+    resolution = resolve_target(graph, "gen")
+
+    assert resolution.qualify == ("fanout[0].gen", "fanout[1].gen")
+    assert all(resolve_target(graph, address).matched == 1 for address in resolution.qualify)
+
+
+def test_real_nested_render_preserves_scope_qualification() -> None:
+    child = {"nodes": [{"id": "gen", "type": "shell"}]}
+    model = build_graph(
+        {
+            "nodes": [
+                {"id": "create", "type": "workflow", "params": {"workflow": "child"}},
+                {"id": "remix", "type": "workflow", "params": {"workflow": "child"}},
+            ]
+        },
+        resolve_child=_child_resolver({"child": child}),
+        max_depth=2,
+    )
+
+    resolution = resolve_target(render_react_flow(model), "gen")
+
+    assert resolution.qualify == ("create.gen", "remix.gen")
+    assert all(resolve_target(render_react_flow(model), address).matched == 1 for address in resolution.qualify)
+
+
+def test_real_truncated_batch_exposes_only_rendered_representatives() -> None:
+    child = {"nodes": [{"id": "gen", "type": "shell"}]}
+    model = build_graph(
+        {
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {"workflow": "child"},
+                    "batch": {"items": [{"workflow": "child"} for _ in range(6)]},
+                }
+            ]
+        },
+        resolve_child=_child_resolver({"child": child}),
+        max_depth=2,
+    )
+
+    resolution = resolve_target(render_react_flow(model), "gen")
+
+    assert resolution.qualify == ("fanout[0].gen", "fanout[1].gen")
+
+
+def test_input_and_output_ports_with_same_name_are_distinct() -> None:
+    graph = _graph([
+        _node("n0", _ref("data", port="in")),
+        _node("n1", _ref("data", port="out")),
+    ])
+
+    incoming = resolve_target(graph, "in:data")
+    outgoing = resolve_target(graph, "out:data")
+
+    assert incoming.matched == outgoing.matched == 1
+    assert incoming.descriptor is not None
+    assert outgoing.descriptor is not None
+    assert incoming.descriptor["ref"]["port"] == "in"
+    assert outgoing.descriptor["ref"]["port"] == "out"
+
+
+def test_resolves_data_edge_by_original_structural_endpoints() -> None:
+    source = _node("n0", _ref("gen"))
+    target = _node("n1", _ref("summarize"))
+    graph = _graph(
+        [source, target],
+        edges=[
+            RFEdge(
+                id="e0",
+                source="n0",
+                target="n1",
+                kind="data_flow",
+                label=None,
+                output_field="response",
+                input_name="prompt",
+                shadowed=False,
+                output_path=["text"],
+            )
+        ],
+    )
+
+    resolution = resolve_target(graph, "gen.response.text->summarize.prompt")
+
+    assert resolution.matched == 1
+    assert resolution.address == "gen.response.text -> summarize.prompt"
+    assert resolution.descriptor == {
+        "kind": "edge",
+        "source": {"node_id": "gen", "ancestor_path": [], "port": None},
+        "source_field": "response",
+        "source_path": ["text"],
+        "target": {"node_id": "summarize", "ancestor_path": [], "port": None},
+        "input_name": "prompt",
+    }
+
+
+def test_ambiguous_edge_qualifiers_also_round_trip() -> None:
+    nodes = [
+        _node("n0", _ref("gen", ("left", None))),
+        _node("n1", _ref("sink", ("left", None))),
+        _node("n2", _ref("gen", ("right", None))),
+        _node("n3", _ref("sink", ("right", None))),
+    ]
+    graph = _graph(
+        nodes,
+        edges=[
+            RFEdge("e0", "n0", "n1", "data_flow", None, "stdout", "text", False),
+            RFEdge("e1", "n2", "n3", "data_flow", None, "stdout", "text", False),
+        ],
+    )
+
+    resolution = resolve_target(graph, "gen.stdout -> sink.text")
+
+    assert resolution.matched == 2
+    assert resolution.qualify == (
+        "left.gen.stdout -> left.sink.text",
+        "right.gen.stdout -> right.sink.text",
+    )
+    assert all(resolve_target(graph, address).matched == 1 for address in resolution.qualify)
+
+
+def test_not_found_uses_fuzzy_node_suggestions() -> None:
+    graph = _graph([_node("n0", _ref("fetch-data")), _node("n1", _ref("summarize"))])
+
+    resolution = resolve_target(graph, "fetchdata")
+
+    assert resolution.matched == 0
+    assert resolution.suggestions[0] == "fetch-data"

--- a/tests/test_cli/test_ui_targets.py
+++ b/tests/test_cli/test_ui_targets.py
@@ -247,9 +247,11 @@ def test_io_port_resolves_by_its_bare_name_without_a_prefix() -> None:
     assert resolution.matched == 1
     assert resolution.descriptor is not None
     assert resolution.descriptor["ref"]["port"] == "in"
-    # The canonical address keeps the prefix so the report stays unambiguous,
-    # even though the bare name is what the agent typed.
-    assert resolution.address == "in:source_file"
+    # On a unique match the report speaks the file's vocabulary back: the in:/out:
+    # side-prefix is dropped when the bare name still resolves to exactly one
+    # element (it only ever exists to break an input/output collision, which never
+    # reaches this path). The structural descriptor still carries port == "in".
+    assert resolution.address == "source_file"
 
 
 def test_same_name_input_and_output_qualify_to_the_prefixed_forms() -> None:
@@ -267,6 +269,24 @@ def test_same_name_input_and_output_qualify_to_the_prefixed_forms() -> None:
     assert all(resolve_target(graph, address).matched == 1 for address in resolution.qualify)
 
 
+def test_unique_match_keeps_prefix_when_bare_form_would_be_ambiguous() -> None:
+    """When an input and output share a name, the in:/out: prefix the agent typed to
+    disambiguate is KEPT in the unique-match report — dropping it to the bare name
+    would no longer resolve to one element, so the round-trip guard retains it."""
+    graph = _graph([
+        _node("n0", _ref("data", port="in")),
+        _node("n1", _ref("data", port="out")),
+    ])
+
+    resolution = resolve_target(graph, "in:data")
+
+    assert resolution.matched == 1
+    assert resolution.descriptor is not None
+    assert resolution.descriptor["ref"]["port"] == "in"
+    assert resolution.address == "in:data"
+    assert resolve_target(graph, resolution.address).matched == 1
+
+
 def test_edge_resolves_when_its_source_is_an_io_port_named_bare() -> None:
     """A connection from a workflow input composes from the input's bare name —
     `source_file -> read_source.file_path` resolves with no prefix."""
@@ -280,7 +300,9 @@ def test_edge_resolves_when_its_source_is_an_io_port_named_bare() -> None:
     resolution = resolve_target(graph, "source_file -> read_source.file_path")
 
     assert resolution.matched == 1
-    assert resolution.address == "in:source_file -> read_source.file_path"
+    # The unique-match report drops the input endpoint's in: prefix (the bare name
+    # still resolves uniquely) — the connection reads exactly as it does in the file.
+    assert resolution.address == "source_file -> read_source.file_path"
 
 
 def test_not_found_input_typo_suggests_input_names_not_unrelated_steps() -> None:
@@ -324,8 +346,13 @@ def test_display_grammar_matches_resolver_and_round_trips() -> None:
         resolution = resolve_target(graph, probe)
         assert resolution.matched == 1, probe
         assert resolution.descriptor is not None
-        # The CLI renders the recorded descriptor via the SAME formatter; it must
-        # equal the resolver's canonical address and itself re-point to one element.
+        # The CLI Watch display renders the recorded descriptor via the SAME
+        # formatter (no second grammar in ui.py); the address it prints re-points
+        # to exactly one element.
         rendered = address_for_target(resolution.descriptor)
-        assert rendered == resolution.address
-        assert resolve_target(graph, rendered).matched == 1
+        assert resolve_target(graph, rendered).matched == 1, probe
+        # The unique-match report address also re-points to exactly one element —
+        # it may be the file-vocabulary form with the in:/out: prefix dropped, so it
+        # need not equal the canonical Watch-display form, but it must still resolve.
+        assert resolution.address is not None
+        assert resolve_target(graph, resolution.address).matched == 1, probe

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -35,8 +35,8 @@ src/
   index.css          all styles (one sheet; theme vars at :root — geometry vars are
                      INJECTED from graph/metrics.ts, never hardcoded here)
   types.ts           the wire contract (mirrors react_flow.py) — imported everywhere
-  api/               server communication (client.ts: fetch + ApiError + fetchVersion,
-                     the source-watch poll; a live /events subscription would go here)
+  api/               server communication (client.ts: graph/source/version;
+                     events.ts: SSE Point subscription + fire-and-forget Watch reports)
   graph/             PURE contract → React Flow transform; NO React (tests run node-env).
                      flow.ts is the FAÇADE (re-exports the siblings); the DAG is
                      scan → io → rows → focus/flow.  >> src/graph/CLAUDE.md
@@ -99,7 +99,8 @@ Tests sit beside their subject.
   `is_transform` ship as booleans from the contract; the frontend decides treatment. Don't
   re-derive them in JS.
 - **Overlay-ready seam.** Node components keep static data separate from a future `status`
-  prop; `api/` is the single data-loading point a live stream plugs into. Every React Flow
+  prop; `api/events.ts` owns the vocabulary-agnostic SSE envelope. Point messages use it
+  today; a future run overlay adds message types without defining them here. Every React Flow
   component the registries reference must be `memo()`'d.
 - **Chrome palette is SCOPED, never `:root`.** The dark UI tokens (`--bg/--border/--text/
   --accent/--bg-field`, surface ladder `#0d0d0d` void < `#151515` panel < `#1c1c1c` field) are

--- a/web/src/api/events.test.ts
+++ b/web/src/api/events.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { reportInteraction, subscribe } from "./events";
+import type { RFRef } from "../types";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  readonly url: string;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  closed = false;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    FakeEventSource.instances.push(this);
+  }
+
+  emit(message: unknown): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(message) }));
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+const ref: RFRef = { node_id: "greet", ancestor_path: [], port: null };
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  vi.stubGlobal("EventSource", FakeEventSource);
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("subscribe", () => {
+  it("validates and dispatches connected/focus/frame/clear messages", () => {
+    const handlers = { focus: vi.fn(), frame: vi.fn(), clear: vi.fn() };
+    const unsubscribe = subscribe("folder/wf.pflow.md", handlers);
+    const source = FakeEventSource.instances[0]!;
+    expect(source.url).toContain("workflow=folder%2Fwf.pflow.md");
+
+    source.emit({ type: "focus", target: { kind: "node", ref } });
+    source.emit({ type: "frame", target: { kind: "node", ref } });
+    source.emit({ type: "clear" });
+    source.emit({
+      type: "focus",
+      target: {
+        kind: "edge",
+        source: ref,
+        source_field: "result",
+        source_path: ["ok"],
+        target: { ...ref, node_id: "use" },
+        input_name: "value",
+      },
+    });
+    source.emit({ type: "focus", target: { kind: "node", ref: { node_id: 4 } } });
+    source.emit({ type: "focus", target: { kind: "edge", source: ref, source_path: [4], target: ref } });
+
+    expect(handlers.focus).toHaveBeenCalledTimes(2);
+    expect(handlers.frame).toHaveBeenCalledOnce();
+    expect(handlers.clear).toHaveBeenCalledOnce();
+    unsubscribe();
+    expect(source.closed).toBe(true);
+  });
+
+  it("reports current visibility for every server-supplied connection id", async () => {
+    const handlers = { focus: vi.fn(), frame: vi.fn(), clear: vi.fn() };
+    const unsubscribe = subscribe("wf", handlers);
+    const source = FakeEventSource.instances[0]!;
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(fetch).not.toHaveBeenCalled();
+    source.emit({ type: "connected", conn_id: "viewer-7" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/visibility",
+      expect.objectContaining({
+        method: "POST",
+        keepalive: true,
+        body: JSON.stringify({ conn_id: "viewer-7", visibility: "visible" }),
+      }),
+    );
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    source.emit({ type: "connected", conn_id: "viewer-8" });
+    expect(fetch).toHaveBeenLastCalledWith(
+      "/api/visibility",
+      expect.objectContaining({
+        body: JSON.stringify({ conn_id: "viewer-8", visibility: "hidden" }),
+      }),
+    );
+    unsubscribe();
+  });
+});
+
+describe("reportInteraction", () => {
+  it("posts JSON with keepalive and swallows transport rejection", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError("offline"));
+
+    expect(() =>
+      reportInteraction("wf", {
+        type: "node_click",
+        target: { kind: "node", flat_id: "n3", ref: { ...ref } },
+        view_state: { density: "beautiful", direction: "LR", focus: "greet" },
+      }),
+    ).not.toThrow();
+    await Promise.resolve();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/interaction",
+      expect.objectContaining({ method: "POST", keepalive: true, headers: { "Content-Type": "application/json" } }),
+    );
+  });
+});

--- a/web/src/api/events.ts
+++ b/web/src/api/events.ts
@@ -1,0 +1,96 @@
+// Live interaction seam: SSE carries Point commands down to the Viewer while
+// deliberate user interactions travel back as fire-and-forget JSON POSTs.
+
+import type { InteractionReport, PointTarget, RFRef } from "../types";
+
+export interface PointHandlers {
+  focus: (target: PointTarget) => void;
+  frame: (target: PointTarget) => void;
+  clear: () => void;
+}
+
+const visibility = (): "visible" | "hidden" => (document.visibilityState === "visible" ? "visible" : "hidden");
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRef(value: unknown): value is RFRef {
+  if (!isRecord(value) || typeof value.node_id !== "string" || !Array.isArray(value.ancestor_path)) return false;
+  if (value.port !== null && value.port !== "in" && value.port !== "out") return false;
+  return value.ancestor_path.every(
+    (step) =>
+      isRecord(step) &&
+      typeof step.node_id === "string" &&
+      (step.batch_index === null || typeof step.batch_index === "number"),
+  );
+}
+
+function isTarget(value: unknown): value is PointTarget {
+  if (!isRecord(value)) return false;
+  if (value.kind === "node") return isRef(value.ref);
+  return (
+    value.kind === "edge" &&
+    isRef(value.source) &&
+    (value.source_field === null || typeof value.source_field === "string") &&
+    Array.isArray(value.source_path) &&
+    value.source_path.every((part) => typeof part === "string") &&
+    isRef(value.target) &&
+    (value.input_name === null || typeof value.input_name === "string")
+  );
+}
+
+/** Subscribe one Viewer. EventSource reconnects automatically after transport failures. */
+export function subscribe(workflow: string, handlers: PointHandlers): () => void {
+  const params = new URLSearchParams({ workflow, visibility: visibility() });
+  const source = new EventSource(`/api/events?${params.toString()}`);
+  let connId: string | null = null;
+
+  const reportVisibility = (): void => {
+    if (connId === null) return;
+    void fetch("/api/visibility", {
+      method: "POST",
+      keepalive: true,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conn_id: connId, visibility: visibility() }),
+    }).catch(() => undefined);
+  };
+
+  source.onmessage = (event: MessageEvent<string>): void => {
+    let message: unknown;
+    try {
+      message = JSON.parse(event.data) as unknown;
+    } catch {
+      return;
+    }
+    if (!isRecord(message) || typeof message.type !== "string") return;
+    if (message.type === "connected" && typeof message.conn_id === "string") {
+      connId = message.conn_id;
+      // EventSource reconnects with its original URL, whose visibility value
+      // may now be stale. Correct every newly registered connection
+      // immediately; do not wait for another visibility transition.
+      reportVisibility();
+    } else if (message.type === "clear") {
+      handlers.clear();
+    } else if ((message.type === "focus" || message.type === "frame") && isTarget(message.target)) {
+      handlers[message.type](message.target);
+    }
+  };
+
+  document.addEventListener("visibilitychange", reportVisibility);
+
+  return () => {
+    document.removeEventListener("visibilitychange", reportVisibility);
+    source.close();
+  };
+}
+
+/** Report user intent without ever surfacing a transport failure into the UI. */
+export function reportInteraction(workflow: string, report: InteractionReport): void {
+  void fetch("/api/interaction", {
+    method: "POST",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workflow, ...report }),
+  }).catch(() => undefined);
+}

--- a/web/src/graph/collapse.test.ts
+++ b/web/src/graph/collapse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { AUTO_COLLAPSE_NODE_BUDGET, collapsibleGroupIds, initialCollapsed } from "./collapse";
+import { AUTO_COLLAPSE_NODE_BUDGET, collapsibleGroupIds, initialCollapsed, revealNodes } from "./collapse";
 import type { RFGraph, RFGroup, RFNode } from "../types";
 
 function node(id: string, over: Partial<RFNode> = {}): RFNode {
@@ -137,5 +137,26 @@ describe("initialCollapsed — big workflows open as an overview", () => {
     expect(collapsed.has("g0")).toBe(false); // source's chain
     expect(collapsed.has("g1")).toBe(false); // target's chain
     expect(collapsed.has("g2")).toBe(true); // unrelated stays collapsed
+  });
+});
+
+describe("revealNodes", () => {
+  it("opens both endpoint chains while preserving unrelated collapse and no-op identity", () => {
+    const g = graphWith(
+      5,
+      [
+        group("outer"),
+        group("left", { parent: "outer" }),
+        group("right"),
+        group("unrelated"),
+      ],
+      [node("source", { parent: "left" }), node("target", { parent: "right" })],
+    );
+    const collapsed = new Set(["outer", "left", "right", "unrelated"]);
+
+    const revealed = revealNodes(g, collapsed, ["source", "target"]);
+
+    expect(revealed).toEqual(new Set(["unrelated"]));
+    expect(revealNodes(g, revealed, ["source", "target"])).toBe(revealed);
   });
 });

--- a/web/src/graph/collapse.ts
+++ b/web/src/graph/collapse.ts
@@ -32,6 +32,27 @@ export function collapsibleGroupIds(graph: RFGraph): string[] {
     .map((g) => g.id);
 }
 
+/** Expand every collapsed ancestor needed to render the given contract nodes. */
+export function revealNodes(
+  graph: RFGraph,
+  collapsed: ReadonlySet<string>,
+  nodeIds: readonly string[],
+): ReadonlySet<string> {
+  if (collapsed.size === 0) return collapsed;
+  const nodeById = new Map(graph.nodes.map((node) => [node.id, node]));
+  const groupById = new Map(graph.groups.map((group) => [group.id, group]));
+  const next = new Set(collapsed);
+  let changed = false;
+  for (const nodeId of nodeIds) {
+    let parent = nodeById.get(nodeId)?.parent ?? null;
+    while (parent) {
+      if (next.delete(parent)) changed = true;
+      parent = groupById.get(parent)?.parent ?? null;
+    }
+  }
+  return changed ? next : collapsed;
+}
+
 /** The collapsed set a workflow opens with. `mode` (the `collapse=` param) wins;
  *  otherwise auto: over-budget workflows open fully collapsed, others fully expanded.
  *  `protect` (deep-link targets — node_id, flat id, or a flat EDGE id) keeps each

--- a/web/src/graph/flow.test.ts
+++ b/web/src/graph/flow.test.ts
@@ -531,6 +531,34 @@ describe("buildFlow — density governs edge density (beautiful = control skelet
     expect(buildFlow(g, DETAILED).edges.find((e) => e.id === "df")?.label).toBeUndefined();
   });
 
+  it("collapsed data edges keep the dropped id in mergedIds so a Point at it lights the kept line", () => {
+    // Two distinct contract data edges between the same nodes that fall back to
+    // node-level handles in beautiful collapse to ONE rendered line. The dropped
+    // id must survive on mergedIds so an agent Point that the server resolves to
+    // it still focuses the kept line — never a "resolvable but shown nothing" no-op.
+    const g: RFGraph = {
+      nodes: [node("a"), node("b")],
+      edges: [
+        edge("df0", "a", "b", "data_flow", { output_field: "out", input_name: "x" }),
+        edge("df1", "a", "b", "data_flow", { output_field: "out", input_name: "x" }),
+      ],
+      groups: [],
+    };
+    const { nodes, edges } = buildFlow(g, COMPACT);
+    const dataEdges = edges.filter((e) => e.data?.kind === "data_flow");
+    expect(dataEdges).toHaveLength(1);
+    expect(dataEdges[0]?.id).toBe("df0");
+    expect(dataEdges[0]?.data?.mergedIds).toEqual(["df1"]);
+
+    // Focusing the deduped-away id lights (selects + reveals) the kept line.
+    const viaMerged = applyFocus(nodes, edges, "df1").edges.find((e) => e.id === "df0");
+    expect(viaMerged?.data?.selected).toBe(true);
+    expect(viaMerged?.hidden).toBe(false);
+    // The kept id still selects it; an unrelated id does not.
+    expect(applyFocus(nodes, edges, "df0").edges.find((e) => e.id === "df0")?.data?.selected).toBe(true);
+    expect(applyFocus(nodes, edges, "nope").edges.find((e) => e.id === "df0")?.data?.selected).toBeUndefined();
+  });
+
   it("a cache edge's label presents the reserved prompt_cache name as the cached prefix", () => {
     // A cache edge can never land row-to-row (no param row exists for it), so
     // the beautiful label always shows — the raw sentinel must never reach it.

--- a/web/src/graph/flow.ts
+++ b/web/src/graph/flow.ts
@@ -180,6 +180,13 @@ export type EdgeData = {
   // node OR an individual IO port (whose edges re-anchor onto a shared ports node).
   from: string;
   to: string;
+  // Contract edge ids this rendered line ABSORBED at build-time dedup — two edges
+  // sharing a render key (same anchored endpoints / kind / label / handles) collapse
+  // to one line, e.g. two field-level data edges between the same nodes that fall back
+  // to node-level handles in beautiful. applyFocus matches a focused id against these,
+  // so an agent Point at a deduped-away edge still lights the kept line instead of
+  // focusing an id that was never rendered (a "resolvable but shown nothing" no-op).
+  mergedIds?: string[];
   // Set ONCE by the build: "this edge renders hidden unless revealed by focus"
   // (beautiful mode's data-flow lines). applyFocus must read THIS, never the mutable
   // `hidden` flag it also writes — otherwise re-processing its own output would
@@ -660,7 +667,7 @@ export function buildFlow(graph: RFGraph, view: BuildOptions): { nodes: FlowNode
     return detailed || expandedSet.has(id);
   };
   const flowEdges: FlowEdge[] = [];
-  const seen = new Set<string>();
+  const keptByKey = new Map<string, FlowEdge>();
   for (const e of graph.edges) {
     const source = renderAnchor(e.source);
     const target = renderAnchor(e.target);
@@ -678,8 +685,14 @@ export function buildFlow(graph: RFGraph, view: BuildOptions): { nodes: FlowNode
     const targetHandle = targetHandleFor(e, target, rowsVisible(e.target), nodeById, ioNodeToOwner, refRowsByNode);
 
     const key = `${source}->${target}|${e.kind}|${e.label ?? ""}|${sourceHandle}|${targetHandle}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
+    const kept = keptByKey.get(key);
+    if (kept) {
+      // Same render key as an already-kept edge → it collapses onto that one line.
+      // Record the dropped contract id so a Point at it still resolves (focus.ts
+      // matches mergedIds) rather than targeting an id that was never rendered.
+      if (kept.data) (kept.data.mergedIds ??= []).push(e.id);
+      continue;
+    }
     // Control edges (sequential/branch) draw as a source-node-color → target-node-
     // color gradient (the GradientEdge custom edge). Colors come from the ORIGINAL
     // endpoints (the real producer→consumer), even when re-anchored — via nodeColor,
@@ -708,23 +721,23 @@ export function buildFlow(graph: RFGraph, view: BuildOptions): { nodes: FlowNode
     // LR target entries get their outcome name (TD-style bare text) whenever the
     // source's rows show — rows + target labels appear together.
     const lrOutcomeLabel = view.direction === "LR" && e.kind === "branch" && rowsVisible(e.source);
-    flowEdges.push(
-      toFlowEdge(
-        e,
-        source,
-        target,
-        sourceHandle,
-        targetHandle,
-        detailed,
-        view.direction,
-        sourceColor,
-        targetColor,
-        rowsVisible(e.source) && !conditionOnRow,
-        lrOutcomeLabel,
-        ioBinding,
-        decisionEnd,
-      ),
+    const flowEdge = toFlowEdge(
+      e,
+      source,
+      target,
+      sourceHandle,
+      targetHandle,
+      detailed,
+      view.direction,
+      sourceColor,
+      targetColor,
+      rowsVisible(e.source) && !conditionOnRow,
+      lrOutcomeLabel,
+      ioBinding,
+      decisionEnd,
     );
+    flowEdges.push(flowEdge);
+    keptByKey.set(key, flowEdge);
   }
 
   // The root IO cards JOIN THE CONTROL SKELETON (user-decided 2026-06-10): the

--- a/web/src/graph/focus.ts
+++ b/web/src/graph/focus.ts
@@ -170,7 +170,13 @@ export function applyFocus(
   // Selecting an EDGE: deliberately NOT the unit machinery below — seeding the
   // unit with the endpoints would light their entire neighborhoods, when the
   // subject is one connection.
-  const focusedEdge = focus != null ? (edges.find((e) => e.id === focus) ?? null) : null;
+  // Match the focus id against the rendered edge's own id OR any contract edge id
+  // it absorbed at build-time dedup (`mergedIds`). An agent Point can resolve to a
+  // contract edge that collapsed into a node-level render representative (two
+  // field-level data edges between the same nodes in beautiful); without this it
+  // would focus an id that was never rendered and reveal nothing.
+  const focusedEdge =
+    focus != null ? (edges.find((e) => e.id === focus || (e.data?.mergedIds?.includes(focus) ?? false)) ?? null) : null;
   // Selecting a CONTAINER (focus = a group node's id) selects the whole UNIT:
   // the group, ALL its descendants, and every edge touching any of them —
   // internal wiring and external bindings light up, everything else dims
@@ -201,7 +207,7 @@ export function applyFocus(
     unit.has(e.source) || unit.has(e.target) || (e.data != null && (unit.has(e.data.from) || unit.has(e.data.to)));
   // Incidence: for an edge focus, exactly the focused edge; otherwise any edge
   // touching the unit.
-  const incidentTo = (e: FlowEdge): boolean => (focusedEdge ? e.id === focus : touches(e));
+  const incidentTo = (e: FlowEdge): boolean => (focusedEdge ? e === focusedEdge : touches(e));
   const connected = new Set<string>(unit);
   if (focusedEdge) {
     // The lit nodes are the selected edge's endpoints — both the rendered anchors
@@ -271,7 +277,7 @@ export function applyFocus(
   });
   const outEdges = edges.map((e) => {
     const incident = focus != null && incidentTo(e);
-    const selected = focusedEdge != null && e.id === focus ? true : undefined;
+    const selected = e === focusedEdge ? true : undefined;
     // A default-hidden edge (beautiful mode's data-flow lines) is revealed when it
     // touches the focus — "show me this node's / port's data wiring." Edges hidden
     // by the build stay hidden otherwise; control edges are never default-hidden.

--- a/web/src/graph/remap.test.ts
+++ b/web/src/graph/remap.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { remapCollapsed, remapSelection, sameRef } from "./remap";
+import {
+  edgeIdForTarget,
+  edgeTargetForId,
+  flatIdForRef,
+  refForFlatId,
+  remapCollapsed,
+  remapSelection,
+  sameRef,
+} from "./remap";
 import type { AncestorStepRef, RFEdge, RFGraph, RFGroup, RFNode, RFRef } from "../types";
 
 // ---- fixtures --------------------------------------------------------------
@@ -54,6 +62,45 @@ describe("sameRef", () => {
     expect(sameRef(ref("a", path), ref("a", path))).toBe(true);
     expect(sameRef(ref("a", path), ref("a", [{ node_id: "wf", batch_index: 3 }]))).toBe(false);
     expect(sameRef(ref("a", path), ref("a", []))).toBe(false);
+  });
+});
+
+describe("live structural target mapping", () => {
+  const sourceRef = ref("gen", [{ node_id: "child", batch_index: 1 }]);
+  const targetRef = ref("use");
+  const g = graph({
+    nodes: [node("n7", sourceRef), node("n2", targetRef), node("n8", ref("host"), { is_group_host: true })],
+    edges: [
+      {
+        ...edge("e3", "n7", "n2"),
+        kind: "data_flow",
+        output_field: "result",
+        output_path: ["ok"],
+        input_name: "value",
+      },
+    ],
+    groups: [group("g4", { host: "n8" })],
+  });
+
+  it("maps full refs both ways without relying on node_id alone", () => {
+    expect(flatIdForRef(g, sourceRef)).toBe("n7");
+    expect(flatIdForRef(g, ref("gen", [{ node_id: "child", batch_index: 0 }]))).toBeNull();
+    expect(refForFlatId(g, "n7")).toEqual(sourceRef);
+    expect(refForFlatId(g, "g4")).toEqual(ref("host"));
+  });
+
+  it("matches data edges by original endpoints plus the complete field path", () => {
+    const target = {
+      kind: "edge" as const,
+      source: sourceRef,
+      source_field: "result",
+      source_path: ["ok"],
+      target: targetRef,
+      input_name: "value",
+    };
+    expect(edgeIdForTarget(g, target)).toBe("e3");
+    expect(edgeIdForTarget(g, { ...target, source_path: ["error"] })).toBeNull();
+    expect(edgeTargetForId(g, "e3")).toEqual(target);
   });
 });
 

--- a/web/src/graph/remap.ts
+++ b/web/src/graph/remap.ts
@@ -8,7 +8,7 @@
 // one clears. Identity is preserved when nothing renumbered (the common append
 // case), so the build memo doesn't needlessly re-run.
 
-import type { RFGraph, RFNode, RFRef } from "../types";
+import type { PointEdgeTarget, RFGraph, RFNode, RFRef } from "../types";
 
 /** Two structural refs denote the same node iff node_id, port, and the full
  *  ancestor path (node_id + batch_index per step) match — the contract's stable
@@ -20,6 +20,55 @@ export function sameRef(a: RFRef, b: RFRef): boolean {
     const other = b.ancestor_path[i];
     return other !== undefined && seg.node_id === other.node_id && seg.batch_index === other.batch_index;
   });
+}
+
+/** Resolve a stable structural ref into this render's positional flat id. */
+export function flatIdForRef(graph: RFGraph, ref: RFRef): string | null {
+  return graph.nodes.find((node) => sameRef(node.ref, ref))?.id ?? null;
+}
+
+/** Resolve a node, IO port, or represented container flat id back to its ref. */
+export function refForFlatId(graph: RFGraph, flatId: string): RFRef | null {
+  const direct = nodeByFlatId(graph, flatId);
+  if (direct) return direct.ref;
+  const host = graph.groups.find((group) => group.id === flatId)?.host;
+  return host ? (nodeByFlatId(graph, host)?.ref ?? null) : null;
+}
+
+/** Resolve an edge descriptor against original contract endpoints and fields. */
+export function edgeIdForTarget(graph: RFGraph, target: PointEdgeTarget): string | null {
+  const source = flatIdForRef(graph, target.source);
+  const destination = flatIdForRef(graph, target.target);
+  if (source === null || destination === null) return null;
+  return (
+    graph.edges.find(
+      (edge) =>
+        edge.kind === "data_flow" &&
+        edge.source === source &&
+        edge.target === destination &&
+        edge.output_field === target.source_field &&
+        edge.input_name === target.input_name &&
+        edge.output_path.length === target.source_path.length &&
+        edge.output_path.every((part, index) => part === target.source_path[index]),
+    )?.id ?? null
+  );
+}
+
+/** Rebuild a structural edge descriptor for a deliberate user edge click. */
+export function edgeTargetForId(graph: RFGraph, edgeId: string): PointEdgeTarget | null {
+  const edge = graph.edges.find((candidate) => candidate.id === edgeId && candidate.kind === "data_flow");
+  if (!edge) return null;
+  const source = nodeByFlatId(graph, edge.source);
+  const target = nodeByFlatId(graph, edge.target);
+  if (!source || !target) return null;
+  return {
+    kind: "edge",
+    source: source.ref,
+    source_field: edge.output_field,
+    source_path: edge.output_path,
+    target: target.ref,
+    input_name: edge.input_name,
+  };
 }
 
 function nodeByFlatId(graph: RFGraph, flatId: string): RFNode | undefined {

--- a/web/src/hooks/CLAUDE.md
+++ b/web/src/hooks/CLAUDE.md
@@ -74,4 +74,4 @@ is `utils/panelWidth.ts`.
 Polls `GET /api/version` (~1.5s, visibility-gated, in-flight-guarded) for a source-file
 fingerprint; fires the `useWorkflowGraph` reload on a CHANGE. Detection is deliberately separable
 from reaction: Task 169's SSE can later replace the poll with a push calling the same trigger,
-nothing downstream changing. On by default; `--no-watch` (→ `?watch=0`) freezes it.
+nothing downstream changing. On by default; `--no-auto-update` (→ `?watch=0`) freezes it.

--- a/web/src/hooks/useCameraNavigation.test.tsx
+++ b/web/src/hooks/useCameraNavigation.test.tsx
@@ -109,6 +109,64 @@ describe("useCameraNavigation", () => {
     expect(fitViewSpy).not.toHaveBeenCalled();
   });
 
+  it("frames without changing focus, deferring until a revealed target paints", () => {
+    rf.renderedIds = [];
+    const props = makeProps();
+    const { result, rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    act(() => result.current.frameTargets(["n1", "n2"]));
+    expect(props.setFocus).not.toHaveBeenCalled();
+    expect(props.setSelectedId).not.toHaveBeenCalled();
+    expect(fitViewSpy).not.toHaveBeenCalled();
+
+    rf.renderedIds = ["n1", "n2"];
+    rerender({ ...props, paintEpoch: 1 });
+    expect(fitViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nodes: [{ id: "n1" }, { id: "n2" }] }),
+    );
+  });
+
+  it("frames already-rendered targets immediately", () => {
+    rf.renderedIds = ["n1"];
+    const { result } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: makeProps() });
+    fitViewSpy.mockClear();
+
+    act(() => result.current.frameTargets(["n1"]));
+
+    expect(followCalls("n1")).toBe(1);
+  });
+
+  it("a newer immediate frame cancels an older paint-deferred frame", () => {
+    rf.renderedIds = ["n2"];
+    const props = makeProps();
+    const { result, rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    act(() => result.current.frameTargets(["n1"], true));
+    act(() => result.current.frameTargets(["n2"]));
+    expect(followCalls("n2")).toBe(1);
+
+    rf.renderedIds = ["n1", "n2"];
+    rerender({ ...props, paintEpoch: 1 });
+    expect(followCalls("n1")).toBe(0);
+  });
+
+  it("user navigation cancels an older paint-deferred agent frame", () => {
+    rf.renderedIds = ["n2"];
+    const props = makeProps({ focus: "n2" });
+    const { result, rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    act(() => result.current.frameTargets(["n1"], true));
+    act(() => result.current.onNavigate("n2"));
+    expect(followCalls("n2")).toBe(1);
+
+    rf.renderedIds = ["n1", "n2"];
+    rerender({ ...props, paintEpoch: 1 });
+    expect(followCalls("n1")).toBe(0);
+  });
+
   it("fits the whole view once per workflow|direction|node key — focus restyles never refit; a direction flip does", () => {
     rf.renderedIds = ["n1"];
     const props = makeProps();

--- a/web/src/hooks/useCameraNavigation.ts
+++ b/web/src/hooks/useCameraNavigation.ts
@@ -31,6 +31,7 @@ interface CameraNavigationArgs {
 
 export interface CameraNavigation {
   onNavigate: (focusId: string, selected?: string | null) => void;
+  frameTargets: (ids: readonly string[], deferUntilPaint?: boolean) => void;
 }
 
 export function useCameraNavigation({
@@ -117,12 +118,20 @@ export function useCameraNavigation({
   // path follows just as promptly. A SAME-focus navigate repaints nothing, so
   // it fits immediately (positions are already settled — the old behavior).
   const pendingFollowRef = useRef<string | null>(null);
+  const pendingFrameRef = useRef<readonly string[] | null>(null);
   useEffect(() => {
     const id = pendingFollowRef.current;
-    if (id == null) return;
-    pendingFollowRef.current = null;
-    if (getNodes().some((n) => n.id === id)) {
+    if (id != null) {
+      pendingFollowRef.current = null;
+    }
+    const rendered = new Set(getNodes().map((node) => node.id));
+    if (id != null && rendered.has(id)) {
       fitView({ nodes: [{ id }], padding: 0.45, maxZoom: 1.2, duration: 300 });
+    }
+    const frameIds = pendingFrameRef.current;
+    if (frameIds != null && frameIds.every((target) => rendered.has(target))) {
+      pendingFrameRef.current = null;
+      fitView({ nodes: frameIds.map((target) => ({ id: target })), padding: 0.45, maxZoom: 1.2, duration: 300 });
     }
   }, [paintEpoch, fitView, getNodes]);
   const onNavigate = useCallback(
@@ -130,6 +139,9 @@ export function useCameraNavigation({
       // The clicked chip may unmount with the panel swap — its mouseleave never
       // fires, so the hover mark would stick. Clear it here.
       clearHover();
+      // A newer user/chip navigation supersedes any agent frame that was
+      // waiting for a reveal paint.
+      pendingFrameRef.current = null;
       setFocus(focusId);
       if (selected !== undefined) setSelectedId(selected);
       // An io-PORT chip names a row, not a node — the camera follows the OWNER
@@ -148,5 +160,26 @@ export function useCameraNavigation({
     [fitView, getNodes, ioPorts, focus, setFocus, setSelectedId, clearHover],
   );
 
-  return { onNavigate };
+  // Agent frame command: reveal is owned by GraphView; this camera-only arm
+  // waits for the resulting paint when a target is currently collapsed, and
+  // never mutates focus or selection.
+  const frameTargets = useCallback(
+    (ids: readonly string[], deferUntilPaint = false) => {
+      clearHover();
+      // Latest command wins. Without this, a pending frame for A can run on
+      // the paint caused by a later immediate frame for B.
+      pendingFrameRef.current = null;
+      const targets = [...new Set(ids.map((id) => ioPorts?.get(id) ?? id))];
+      if (targets.length === 0) return;
+      const rendered = new Set(getNodes().map((node) => node.id));
+      if (!deferUntilPaint && targets.every((id) => rendered.has(id))) {
+        fitView({ nodes: targets.map((id) => ({ id })), padding: 0.45, maxZoom: 1.2, duration: 300 });
+      } else {
+        pendingFrameRef.current = targets;
+      }
+    },
+    [clearHover, fitView, getNodes, ioPorts],
+  );
+
+  return { onNavigate, frameTargets };
 }

--- a/web/src/hooks/useSourceWatch.test.tsx
+++ b/web/src/hooks/useSourceWatch.test.tsx
@@ -52,7 +52,7 @@ describe("useSourceWatch", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it("does not poll at all when disabled (pflow ui --no-watch)", async () => {
+  it("does not poll at all when disabled (pflow ui --no-auto-update)", async () => {
     mockedFetchVersion.mockResolvedValue("v1");
     const onChange = vi.fn();
     renderHook(() => useSourceWatch("wf", false, onChange));

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -143,6 +143,41 @@ export interface RFGraph {
   kind_output_types?: Record<string, Record<string, string>>;
 }
 
+// Live Point command descriptors. These mirror src/pflow/ui/targets.py and
+// deliberately contain structural refs only — positional flat ids are local to
+// one render and must never cross the SSE channel.
+export interface PointNodeTarget {
+  kind: "node";
+  ref: RFRef;
+}
+
+export interface PointEdgeTarget {
+  kind: "edge";
+  source: RFRef;
+  source_field: string | null;
+  source_path: string[];
+  target: RFRef;
+  input_name: string | null;
+}
+
+export type PointTarget = PointNodeTarget | PointEdgeTarget;
+
+export interface InteractionViewState {
+  density: "advanced" | "beautiful";
+  direction: "LR" | "TD";
+  focus: string | null;
+}
+
+export type InteractionTarget =
+  | (PointNodeTarget & { flat_id: string })
+  | (PointEdgeTarget & { flat_id: string });
+
+export interface InteractionReport {
+  type: string;
+  target?: InteractionTarget;
+  view_state: InteractionViewState;
+}
+
 export interface SourceFiles {
   root: string | null;
   files: Record<string, string>;

--- a/web/src/utils/viewParams.test.ts
+++ b/web/src/utils/viewParams.test.ts
@@ -20,7 +20,7 @@ describe("readViewParams", () => {
     });
   });
 
-  it("watch is on by default and only watch=0 disables it (pflow ui --no-watch)", () => {
+  it("watch is on by default and only watch=0 disables it (pflow ui --no-auto-update)", () => {
     expect(readViewParams("").watch).toBe(true);
     expect(readViewParams("?watch=1").watch).toBe(true);
     expect(readViewParams("?watch=0").watch).toBe(false);

--- a/web/src/utils/viewParams.ts
+++ b/web/src/utils/viewParams.ts
@@ -31,7 +31,7 @@ export interface ViewParams {
   // state rides the URL so screenshots/deep links can reproduce it.
   source: boolean;
   // Live source watch: poll for `.pflow.md` edits and re-fetch the graph in
-  // place. On by default; `pflow ui --no-watch` opens with `watch=0` to freeze
+  // place. On by default; `pflow ui --no-auto-update` opens with `watch=0` to freeze
   // the view. Read-only (a session preference), like the other view params.
   watch: boolean;
 }
@@ -40,7 +40,10 @@ export const DEFAULT_VIEW: ViewParams = { direction: null, density: "compact", n
 
 // The URL uses the USER-FACING density words (advanced/beautiful); the code uses the
 // internal density (detailed/compact). Keep the mapping in one place so they can't drift.
-const DENSITY_TO_PARAM: Record<Density, string> = { detailed: "advanced", compact: "beautiful" };
+export const DENSITY_TO_PARAM: Record<Density, "advanced" | "beautiful"> = {
+  detailed: "advanced",
+  compact: "beautiful",
+};
 const PARAM_TO_DENSITY: Record<string, Density> = { advanced: "detailed", beautiful: "compact" };
 
 /** Parse the three view params from a query string. Invalid/missing values fall back
@@ -60,7 +63,7 @@ export function readViewParams(search: string): ViewParams {
     focus: focus !== null && focus.trim() !== "" ? focus : null,
     collapse: collapse === "all" || collapse === "none" ? collapse : null,
     source: source === "1",
-    watch: p.get("watch") !== "0", // on unless explicitly disabled (pflow ui --no-watch)
+    watch: p.get("watch") !== "0", // on unless explicitly disabled (pflow ui --no-auto-update)
   };
 }
 

--- a/web/src/views/GraphView.test.tsx
+++ b/web/src/views/GraphView.test.tsx
@@ -7,7 +7,7 @@
 // determinism; real ELK layout is covered in graph/flow.test.ts.
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { installReactFlowJsdomMocks } from "../test/rf-jsdom";
 import type { FlowNode } from "../graph/flow";
@@ -19,6 +19,17 @@ vi.mock("../api/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api/client")>();
   return { ...actual, fetchGraph: vi.fn(), fetchCatalog: vi.fn(), fetchSource: vi.fn() };
 });
+const live = vi.hoisted(() => ({
+  handlers: null as import("../api/events").PointHandlers | null,
+  report: vi.fn(),
+}));
+vi.mock("../api/events", () => ({
+  subscribe: vi.fn((_workflow: string, handlers: import("../api/events").PointHandlers) => {
+    live.handlers = handlers;
+    return vi.fn();
+  }),
+  reportInteraction: live.report,
+}));
 // Stub ELK so the component test is deterministic; overridable per-test.
 vi.mock("../graph/layout", () => ({ layoutGraph: vi.fn() }));
 // Keep the read panel's ParamBlocks synchronous: the real shiki load under
@@ -133,6 +144,8 @@ beforeEach(() => {
   vi.mocked(layoutGraph).mockReset();
   vi.mocked(layoutGraph).mockImplementation(layoutStub);
   fitViewSpy.mockClear();
+  live.handlers = null;
+  live.report.mockReset();
 });
 
 describe("GraphView mount", () => {
@@ -596,6 +609,132 @@ describe("GraphView mount", () => {
       (c) => (c[0] as { nodes?: { id: string }[] } | undefined)?.nodes?.[0]?.id === "g_wf",
     );
     expect(followed).toBe(true);
+  });
+
+  it("applies live node focus/clear and camera-only frame without reporting agent actions", async () => {
+    vi.mocked(fetchGraph).mockResolvedValue(GRAPH);
+    const { container } = render(<GraphView workflow="demo" onBack={() => {}} />);
+    await waitFor(() => expect(live.handlers).not.toBeNull());
+    await waitFor(() => expect(screen.getByText("say hi")).toBeTruthy());
+    const reportsAfterOpen = live.report.mock.calls.length;
+
+    act(() => live.handlers!.focus({ kind: "node", ref: GRAPH.nodes[0]!.ref }));
+    await waitFor(() => expect(container.querySelector(".read-panel")).toBeTruthy());
+    expect(live.report).toHaveBeenCalledTimes(reportsAfterOpen);
+
+    act(() => live.handlers!.clear());
+    await waitFor(() => expect(container.querySelector(".read-panel")).toBeNull());
+
+    fitViewSpy.mockClear();
+    act(() => live.handlers!.frame({ kind: "node", ref: GRAPH.nodes[1]!.ref }));
+    await waitFor(() =>
+      expect(
+        fitViewSpy.mock.calls.some(
+          (call) => (call[0] as { nodes?: { id: string }[] } | undefined)?.nodes?.[0]?.id === "n1",
+        ),
+      ).toBe(true),
+    );
+    expect(container.querySelector(".read-panel")).toBeNull();
+    expect(live.report).toHaveBeenCalledTimes(reportsAfterOpen);
+  });
+
+  it("reports deliberate user clicks with structural and flat identity", async () => {
+    vi.mocked(fetchGraph).mockResolvedValue(GRAPH);
+    render(<GraphView workflow="demo" onBack={() => {}} />);
+    await waitFor(() => expect(screen.getByText("say hi")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("say hi"));
+
+    await waitFor(() =>
+      expect(live.report).toHaveBeenCalledWith(
+        "demo",
+        expect.objectContaining({
+          type: "node_click",
+          target: { kind: "node", flat_id: "n0", ref: GRAPH.nodes[0]!.ref },
+          view_state: expect.objectContaining({ focus: "greet" }),
+        }),
+      ),
+    );
+  });
+
+  it("resolves and selects a live data-edge descriptor by structural endpoints", async () => {
+    vi.mocked(fetchGraph).mockResolvedValue(GRAPH);
+    const { container } = render(<GraphView workflow="demo" onBack={() => {}} />);
+    await waitFor(() => expect(live.handlers).not.toBeNull());
+
+    const target = {
+      kind: "edge" as const,
+      source: GRAPH.nodes[0]!.ref,
+      source_field: "stdout",
+      source_path: [],
+      target: GRAPH.nodes[1]!.ref,
+      input_name: "command",
+    };
+    act(() => live.handlers!.focus(target));
+
+    await waitFor(() => expect(container.querySelector(".read-panel")).toBeTruthy());
+    expect(screen.getByText("greet")).toBeTruthy();
+
+    // Re-pointing after the user pans must frame immediately: same focus
+    // produces no paint epoch for a deferred camera request to wait on.
+    fitViewSpy.mockClear();
+    act(() => live.handlers!.focus(target));
+    await waitFor(() => expect(fitViewSpy).toHaveBeenCalled());
+  });
+
+  it("reveals both collapsed endpoint chains before applying a live edge focus", async () => {
+    const sourceRef = { node_id: "produce", ancestor_path: [{ node_id: "left", batch_index: null }], port: null } as const;
+    const targetRef = { node_id: "consume", ancestor_path: [{ node_id: "right", batch_index: null }], port: null } as const;
+    const nested: RFGraph = {
+      nodes: [
+        { ...GRAPH.nodes[0]!, id: "h0", ref: { node_id: "left", ancestor_path: [], port: null }, kind: "workflow", is_group_host: true, params: [] },
+        { ...GRAPH.nodes[0]!, id: "a", ref: { ...sourceRef, ancestor_path: [...sourceRef.ancestor_path] }, purpose: "hidden producer", parent: "ga", params: [] },
+        { ...GRAPH.nodes[0]!, id: "h1", ref: { node_id: "right", ancestor_path: [], port: null }, kind: "workflow", is_group_host: true, params: [] },
+        { ...GRAPH.nodes[1]!, id: "b", ref: { ...targetRef, ancestor_path: [...targetRef.ancestor_path] }, purpose: "hidden consumer", parent: "gb", params: [] },
+      ],
+      edges: [
+        {
+          id: "e_nested",
+          source: "a",
+          target: "b",
+          kind: "data_flow",
+          label: null,
+          output_field: "stdout",
+          input_name: "command",
+          shadowed: false,
+          condition: null,
+          output_path: [],
+        },
+      ],
+      groups: [
+        { id: "ga", kind: "workflow", parent: null, host: "h0", members: ["a"], nesting_depth: 0, annotations: {} },
+        { id: "gb", kind: "workflow", parent: null, host: "h1", members: ["b"], nesting_depth: 0, annotations: {} },
+      ],
+    };
+    vi.mocked(fetchGraph).mockResolvedValue(nested);
+    window.history.replaceState({}, "", "/?collapse=all&density=beautiful");
+    try {
+      const { container } = render(<GraphView workflow="demo" onBack={() => {}} />);
+      await waitFor(() => expect(live.handlers).not.toBeNull());
+      await waitFor(() => expect(screen.queryByText("hidden producer")).toBeNull());
+
+      act(() =>
+        live.handlers!.focus({
+          kind: "edge",
+          source: { ...sourceRef, ancestor_path: [...sourceRef.ancestor_path] },
+          source_field: "stdout",
+          source_path: [],
+          target: { ...targetRef, ancestor_path: [...targetRef.ancestor_path] },
+          input_name: "command",
+        }),
+      );
+
+      await waitFor(() => expect(screen.getByText("hidden producer")).toBeTruthy());
+      expect(screen.getByText("hidden consumer")).toBeTruthy();
+      expect(container.querySelector(".read-panel")).toBeTruthy();
+    } finally {
+      window.history.replaceState({}, "", "/");
+    }
   });
 
   it("surfaces a layout failure as an error banner, not a permanent 'Laying out…' (C1)", async () => {

--- a/web/src/views/GraphView.tsx
+++ b/web/src/views/GraphView.tsx
@@ -15,17 +15,31 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
-import { collapsibleGroupIds, initialCollapsed } from "../graph/collapse";
+import { reportInteraction, subscribe, type PointHandlers } from "../api/events";
+import { collapsibleGroupIds, initialCollapsed, revealNodes } from "../graph/collapse";
 import { autoDirection } from "../graph/direction";
 import { consumedReadPaths, ioOwners, rowTouches, type Density, type Direction, type FlowEdge, type FlowNode } from "../graph/flow";
-import { remapCollapsed, remapSelection } from "../graph/remap";
+import {
+  edgeIdForTarget,
+  edgeTargetForId,
+  flatIdForRef,
+  refForFlatId,
+  remapCollapsed,
+  remapSelection,
+} from "../graph/remap";
 import { useCameraNavigation } from "../hooks/useCameraNavigation";
 import { usePanelPair } from "../hooks/usePanelPair";
 import { useSourceWatch } from "../hooks/useSourceWatch";
 import { useWorkflowGraph } from "../hooks/useWorkflowGraph";
 import { ApiError, fetchSource } from "../api/client";
-import { edgeClickAction, nodeRepresentativeId, readViewParams, writeViewParams } from "../utils/viewParams";
-import type { RFEdge, RFGraph, RFNode, SourceFiles } from "../types";
+import {
+  DENSITY_TO_PARAM,
+  edgeClickAction,
+  nodeRepresentativeId,
+  readViewParams,
+  writeViewParams,
+} from "../utils/viewParams";
+import type { InteractionTarget, PointTarget, RFEdge, RFGraph, RFNode, SourceFiles } from "../types";
 import { EdgePanel } from "../components/EdgePanel";
 import { edgeTypes } from "../components/edges";
 import { HoverMarksProvider, InteractionProvider, NO_HOVER } from "../components/interaction";
@@ -82,7 +96,7 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
 
   // Live source watch: poll /api/version and bump `reload` when the .pflow.md
   // changes on disk, so the graph re-fetches and rebuilds IN PLACE (no page
-  // reload — view state is preserved). On unless `pflow ui --no-watch` opened
+  // reload — view state is preserved). On unless `pflow ui --no-auto-update` opened
   // with watch=0. Detection only; the in-place reaction lives in the hook.
   const [reload, setReload] = useState(0);
   const onSourceChanged = useCallback(() => setReload((n) => n + 1), []);
@@ -176,8 +190,6 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
     url.search = writeViewParams(window.location.search, patch);
     window.history.replaceState({}, "", url);
   }, []);
-  const changeDensity = useCallback((d: Density) => { setDensity(d); syncUrl({ density: d }); }, [syncUrl]);
-  const changeDirection = useCallback((d: Direction) => { setDirection(d); syncUrl({ direction: d }); }, [syncUrl]);
   const changeSourceOpen = useCallback((open: boolean) => { setSourceOpen(open); syncUrl({ source: open }); }, [syncUrl]);
   // The read panel's source-link click: open the pane (if closed) and bump a
   // counter so SourcePane re-scrolls to the selected node's line even when it's
@@ -191,6 +203,69 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
   graphRef.current = graph;
   const edgesRef = useRef(edges);
   edgesRef.current = edges;
+  const ioOwnership = useMemo(() => (graph ? ioOwners(graph) : null), [graph]);
+
+  const interactionTargetForNode = useCallback(
+    (flatId: string): InteractionTarget | undefined => {
+      if (!graph) return undefined;
+      const ref = refForFlatId(graph, flatId);
+      return ref ? { kind: "node", flat_id: flatId, ref } : undefined;
+    },
+    [graph],
+  );
+  const interactionTargetForEdge = useCallback(
+    (flatId: string): InteractionTarget | undefined => {
+      if (!graph) return undefined;
+      const target = edgeTargetForId(graph, flatId);
+      return target ? { ...target, flat_id: flatId } : undefined;
+    },
+    [graph],
+  );
+  const reportUser = useCallback(
+    (
+      type: string,
+      target?: InteractionTarget,
+      nextFocus: string | null = focus,
+      nextDensity: Density = density,
+      nextDirection: Direction = direction,
+    ): void => {
+      const focusRef = graph && nextFocus ? refForFlatId(graph, nextFocus) : null;
+      reportInteraction(workflow, {
+        type,
+        ...(target ? { target } : {}),
+        view_state: {
+          density: DENSITY_TO_PARAM[nextDensity],
+          direction: nextDirection,
+          focus: focusRef?.node_id ?? null,
+        },
+      });
+    },
+    [density, direction, focus, graph, workflow],
+  );
+
+  const changeDensity = useCallback(
+    (next: Density) => {
+      setDensity(next);
+      syncUrl({ density: next });
+      reportUser("density_change", undefined, focus, next, direction);
+    },
+    [direction, focus, reportUser, syncUrl],
+  );
+  const changeDirection = useCallback(
+    (next: Direction) => {
+      setDirection(next);
+      syncUrl({ direction: next });
+      reportUser("direction_change", undefined, focus, density, next);
+    },
+    [density, focus, reportUser, syncUrl],
+  );
+
+  const reportedOpen = useRef(false);
+  useEffect(() => {
+    if (!graph || reportedOpen.current) return;
+    reportedOpen.current = true;
+    reportUser("workflow_open");
+  }, [graph, reportUser]);
 
   // Initial collapse state, applied ONCE per workflow when its contract arrives: big
   // workflows open as an overview (everything collapsed), small ones fully expanded;
@@ -221,7 +296,8 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
     // beautiful-mode rows still open via focus (expansion IS its focus state).
     setFocus(node.id);
     setSelectedId(node.id);
-  }, []);
+    reportUser("node_click", interactionTargetForNode(node.id), node.id);
+  }, [interactionTargetForNode, reportUser]);
 
   const onNodeDoubleClick = useCallback(
     (_: unknown, node: Node) => {
@@ -238,7 +314,8 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
     const action = edgeClickAction(edge);
     setFocus(action.focus);
     setSelectedId(action.selectedId);
-  }, []);
+    reportUser("edge_click", interactionTargetForEdge(edge.id), action.focus);
+  }, [interactionTargetForEdge, reportUser]);
 
   // A selected EDGE id has no `from`/`to` escape hatch through rebuilds: a
   // single-group collapse can re-anchor + dedupe the focused edge's id out of the
@@ -261,37 +338,48 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
   const onPaneClick = useCallback(() => {
     setFocus(null);
     setSelectedId(null);
-  }, []);
+    reportUser("focus_clear", undefined, null);
+  }, [reportUser]);
+  const onClearFocus = useCallback(() => {
+    setFocus(null);
+    reportUser("focus_clear", undefined, null);
+  }, [reportUser]);
 
   // Clicking a single IO ROW focuses just that port — its connections reveal, the
   // row highlights. On a ROOT IO card the row ALSO opens the interface panel with
   // its entry marked (card = the whole interface, row = one port, same panel both
   // ways). Nested rows (on group cards) stay focus-only: their owner's panel is
   // the host ReadPanel, and auto-opening it on a row click is a different gesture.
-  const ioOwnership = useMemo(() => (graph ? ioOwners(graph) : null), [graph]);
+  const selectPort = useCallback(
+    (portId: string, force: boolean, report: boolean): void => {
+      const owner = ioOwnership?.ports.get(portId);
+      const ownerGroup = owner != null ? graphRef.current?.groups.find((g) => g.id === owner) : undefined;
+      const isRootWrapper =
+        ownerGroup != null &&
+        ownerGroup.parent == null &&
+        (ownerGroup.kind === "input_wrapper" || ownerGroup.kind === "output_wrapper");
+      // A user-clicked nested port with no line would reveal nothing. Agent Point
+      // is total-apply, so it bypasses this guard and still reveals the named row.
+      if (!force && !isRootWrapper) {
+        const touched = edgesRef.current.some(
+          (edge) =>
+            edge.source === portId ||
+            edge.target === portId ||
+            edge.data?.from === portId ||
+            edge.data?.to === portId,
+        );
+        if (!touched) return;
+      }
+      setFocus(portId);
+      if (isRootWrapper) setSelectedId(owner!);
+      if (report) reportUser("port_click", interactionTargetForNode(portId), portId);
+    },
+    [interactionTargetForNode, ioOwnership, reportUser],
+  );
+
   const interaction = useMemo(
     () => ({
-      focusPort: (portId: string) => {
-        const owner = ioOwnership?.ports.get(portId);
-        const ownerGroup = owner != null ? graphRef.current?.groups.find((g) => g.id === owner) : undefined;
-        const isRootWrapper =
-          ownerGroup != null &&
-          ownerGroup.parent == null &&
-          (ownerGroup.kind === "input_wrapper" || ownerGroup.kind === "output_wrapper");
-        // A NESTED port with no line in the current view: focusing would dim the
-        // whole canvas and reveal nothing — the into-nowhere click (user-caught
-        // 2026-06-12; e.g. an output no caller reads, its inner producer edge
-        // self-loop-dropped on the collapsed card). Root rows always click — the
-        // interface panel is the payoff regardless of lines.
-        if (!isRootWrapper) {
-          const touched = edgesRef.current.some(
-            (e) => e.source === portId || e.target === portId || e.data?.from === portId || e.data?.to === portId,
-          );
-          if (!touched) return;
-        }
-        setFocus(portId);
-        if (isRootWrapper) setSelectedId(owner!);
-      },
+      focusPort: (portId: string) => selectPort(portId, false, true),
       toggleGroup,
       hoverNode: (flatId: string | null) => setHovered(flatId != null ? new Set([flatId]) : NO_HOVER),
       // A hovered row marks its touch set — derived from the FLOW edges (the
@@ -299,7 +387,7 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
       hoverRow: (row: { nodeId: string; handles: readonly string[] } | null) =>
         setHovered(row != null ? rowTouches(edgesRef.current, row.nodeId, row.handles) : NO_HOVER),
     }),
-    [ioOwnership, toggleGroup],
+    [selectPort, toggleGroup],
   );
 
   // A selected CONTAINER reads as its HOST node — purpose, params (bindings),
@@ -349,7 +437,7 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
   // Camera ownership (fit-on-view-change, the node=/focus= deep links, chip
   // navigation + the paint-deferred follow) lives in useCameraNavigation.
   const clearHover = useCallback(() => setHovered(NO_HOVER), []);
-  const { onNavigate } = useCameraNavigation({
+  const { onNavigate: navigate, frameTargets } = useCameraNavigation({
     status,
     paintEpoch,
     graph,
@@ -362,6 +450,13 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
     setSelectedId,
     clearHover,
   });
+  const onNavigate = useCallback(
+    (focusId: string, selected?: string | null): void => {
+      navigate(focusId, selected);
+      reportUser("focus_change", interactionTargetForNode(focusId), focusId);
+    },
+    [interactionTargetForNode, navigate, reportUser],
+  );
 
   // Collapse-all folds every collapsible container and clears focus (the focused
   // node is about to disappear into a box — a ring on a hidden node is meaningless).
@@ -371,7 +466,8 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
     setCollapsed(new Set(collapsibleIds));
     setFocus(null);
     setSelectedId(null);
-  }, [collapsibleIds]);
+    reportUser("focus_clear", undefined, null);
+  }, [collapsibleIds, reportUser]);
   const onExpandAll = useCallback(() => setCollapsed(new Set()), []);
 
   // The rail's search: the searchable subjects are the workflow's STEPS + container
@@ -380,6 +476,20 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
     () => (graph ? graph.nodes.filter((n) => n.kind !== "input" && n.kind !== "output" && n.kind !== "end") : []),
     [graph],
   );
+  const reveal = useCallback(
+    (nodeIds: readonly string[]): void => {
+      if (!graph) return;
+      setCollapsed((current) => revealNodes(graph, current, nodeIds));
+    },
+    [graph],
+  );
+  const representativeFor = useCallback(
+    (node: RFNode): string => {
+      if (node.ref.port !== null) return ioOwnership?.ports.get(node.id) ?? node.id;
+      return graph ? nodeRepresentativeId(graph, node) : node.id;
+    },
+    [graph, ioOwnership],
+  );
   // Search-select behaves like CLICKING the node: REVEAL it (expand the collapsed
   // ancestor chain so a buried target becomes visible), then focus + SELECT +
   // camera its representative (a host → its group; a leaf → itself). Passing the
@@ -387,26 +497,87 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
   // syncs the source pane (selectedNode → activeLine → scroll, SourcePane) — a bare
   // focus would do neither. The follow is paint-deferred, landing after the reveal
   // re-layout — the same ordering the node=/focus= deep link relies on.
-  const onSelectNode = useCallback(
-    (node: RFNode) => {
+  const selectNode = useCallback(
+    (node: RFNode, report: boolean) => {
       if (!graph) return;
-      setCollapsed((prev) => {
-        if (prev.size === 0) return prev;
-        const groupById = new Map(graph.groups.map((g) => [g.id, g]));
-        const next = new Set(prev);
-        let parent: string | null = node.parent ?? null;
-        let changed = false;
-        while (parent) {
-          if (next.delete(parent)) changed = true;
-          parent = groupById.get(parent)?.parent ?? null;
-        }
-        return changed ? next : prev;
-      });
-      const repId = nodeRepresentativeId(graph, node);
-      onNavigate(repId, repId);
+      reveal([node.id]);
+      const repId = representativeFor(node);
+      navigate(repId, repId);
+      if (report) reportUser("node_click", interactionTargetForNode(repId), repId);
     },
-    [graph, onNavigate],
+    [graph, interactionTargetForNode, navigate, reportUser, representativeFor, reveal],
   );
+  const onSelectNode = useCallback((node: RFNode) => selectNode(node, true), [selectNode]);
+
+  const applyPoint = useCallback(
+    (command: "focus" | "frame", target: PointTarget): void => {
+      if (!graph) return;
+      if (target.kind === "node") {
+        const flatId = flatIdForRef(graph, target.ref);
+        const node = flatId ? graph.nodes.find((candidate) => candidate.id === flatId) : undefined;
+        if (!node) return; // stale Viewer; Auto-update + a human re-point self-heals
+        reveal([node.id]);
+        const representative = representativeFor(node);
+        if (command === "frame") {
+          frameTargets([representative], !nodes.some((rendered) => rendered.id === representative));
+        } else if (node.ref.port !== null) {
+          selectPort(node.id, true, false);
+          frameTargets(
+            [representative],
+            focus !== node.id || !nodes.some((rendered) => rendered.id === representative),
+          );
+        } else {
+          selectNode(node, false);
+          // onNavigate cannot see a currently-collapsed representative until
+          // the reveal paints; arm the camera explicitly in that one case.
+          if (!nodes.some((rendered) => rendered.id === representative)) frameTargets([representative], true);
+        }
+        return;
+      }
+
+      const edgeId = edgeIdForTarget(graph, target);
+      const sourceId = flatIdForRef(graph, target.source);
+      const targetId = flatIdForRef(graph, target.target);
+      if (!edgeId || !sourceId || !targetId) return;
+      reveal([sourceId, targetId]);
+      const endpointRepresentatives = [sourceId, targetId]
+        .map((id) => graph.nodes.find((node) => node.id === id))
+        .filter((node): node is RFNode => node !== undefined)
+        .map(representativeFor);
+      const endpointsNeedPaint = endpointRepresentatives.some(
+        (representative) => !nodes.some((rendered) => rendered.id === representative),
+      );
+      if (command === "frame") {
+        frameTargets(endpointRepresentatives, endpointsNeedPaint);
+      } else {
+        setFocus(edgeId);
+        setSelectedId(edgeId);
+        frameTargets(endpointRepresentatives, focus !== edgeId || endpointsNeedPaint);
+      }
+    },
+    [focus, frameTargets, graph, nodes, representativeFor, reveal, selectNode, selectPort],
+  );
+
+  // Subscribe only after the graph is present. This prevents the open-if-absent
+  // retry from observing a live Viewer before it can resolve/apply a command.
+  const pointHandlers = useRef<PointHandlers | null>(null);
+  pointHandlers.current = {
+    focus: (target) => applyPoint("focus", target),
+    frame: (target) => applyPoint("frame", target),
+    clear: () => {
+      setFocus(null);
+      setSelectedId(null);
+    },
+  };
+  const graphReady = graph !== null;
+  useEffect(() => {
+    if (!graphReady) return;
+    return subscribe(workflow, {
+      focus: (target) => pointHandlers.current?.focus(target),
+      frame: (target) => pointHandlers.current?.frame(target),
+      clear: () => pointHandlers.current?.clear(),
+    });
+  }, [graphReady, workflow]);
 
   const toolbar = (): JSX.Element => (
     <Toolbar
@@ -435,7 +606,7 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
       onSourceOpen={changeSourceOpen}
       onCollapseAll={onCollapseAll}
       onExpandAll={onExpandAll}
-      onClearFocus={() => setFocus(null)}
+      onClearFocus={onClearFocus}
       onSelectNode={onSelectNode}
     />
   );


### PR DESCRIPTION
## Summary

A bidirectional CLI↔server↔browser channel for the `pflow ui` viewer so an AI agent can **Point** (focus / frame / clear a node, container, IO port, or data edge in *every* open browser Viewer of a workflow) and **Watch** (read a snapshot of the user's recent deliberate interactions). Together with the existing screenshot tooling this makes the canvas a shared surface for human↔agent conversation. It also builds the **SSE push transport** the deferred live-run overlay (Task 133) will ride — carrying a vocabulary-agnostic envelope, deliberately defining **no** run-event schema.

## Task

169

## Changes

- **Server (`src/pflow/ui/server.py`):** first stateful layer on the previously read-only Starlette server — an in-memory `_Hub` (connection registry + bounded activity ring) and five `async` endpoints: SSE `GET /api/events`, `POST /api/command|interaction|visibility`, `GET /api/activity`. Hub access is event-loop-owned and lock-free; the recursive graph build runs off-loop via `asyncio.to_thread`; an SSE keepalive surfaces silently-dropped sockets across ASGI versions; mutating POSTs require `application/json` (cross-origin preflight defense). Security comment extended.
- **Resolver (`src/pflow/ui/targets.py`, new):** parses an agent target to a stable structural `RFRef` (flat ids never cross the wire). Ambiguity is actionable — each qualified address round-trips to exactly one element (scope prefix, `in:`/`out:`, `[batch_index]`).
- **CLI (`src/pflow/cli/commands/ui.py`):** `pflow ui` becomes a custom `UiGroup` preserving bare `pflow ui [workflow]` (mirrors `PflowCLI`), adding `focus` / `frame` / `clear-focus` / `user-activity` — thin `httpx` clients with `--output-format json`, actionable nonzero exit codes, and rendered (never traceback) 422/415 errors. `--no-watch` renamed `--no-auto-update`.
- **Frontend (`web/`):** `web/src/api/events.ts` SSE client (vocabulary-agnostic envelope, reconnect-safe visibility, fire-and-forget Watch); total-apply reveal-before-focus; deliberate-interaction reporting; structural `RFRef` mapping via the existing `sameRef`.
- **Docs:** ADR-0007 (the server's stateful/push turn), `ui/CLAUDE.md`, `web/CLAUDE.md`, the CLI reference, and the visualization guide.

## Explanation

The viewer (Task 168) was one-way: the agent could only *see* its own headless browser, never act in the user's window — the originating trigger was a user saying "I can't find it." The hard parts already existed (the frontend focus/expand mechanism, the `?focus=` deep-link semantics), so this is mostly a transport + a server-side resolver + a CLI surface. The feature was **designed and deep-reviewed before any code** (a 4-agent plan review), then the staged implementation got a second 4-agent code review whose findings are folded in (see the second commit). Net: 38 files, +4663/-182.

Two load-bearing decisions worth calling out for reviewers: (1) **resolution is server-side, identity is structural** — the server resolves the agent's text to an `RFRef` and the browser maps it locally via `sameRef`, because positional flat ids differ between two independent renders; (2) **the command reports `sent_to`, not "shown"** — there is no browser apply-ack (the human in the loop is the acknowledgment), and the browser *always reveals* a resolvable target so "sent" is a faithful proxy.

## Created Docs

- `context/adr/0007-169-ui-stateful-sse-channel.md` — why the UI server became stateful + push-capable
- `.taskmaster/tasks/task_169/task-169.md` — the spec (updated to match shipped scope)
- `.taskmaster/tasks/task_169/implementation/implementation-plan.md` — the deep-reviewed execution plan
- `.taskmaster/tasks/task_169/implementation/progress-log.md` — design + implementation journey
- `.taskmaster/tasks/task_169/task-review.md` — post-implementation review (invariants, gotchas, tests-that-matter).
- User-facing: `docs/reference/cli/index.mdx`, `src/pflow/guide/features/ui.md`, `src/pflow/ui/CLAUDE.md`, `web/CLAUDE.md`.

## Testing

- `tests/test_cli/test_ui_targets.py` — resolver matrix: duplicate-nested + literal-batch + IO-port-collision disambiguation, every emitted `qualify` address round-trips to one element, fuzzy not-found suggestions, and a **display-grammar drift guard** (an address `user-activity` prints re-points through `resolve_target`).
- `tests/test_cli/test_ui_interaction_server.py` — hub register/broadcast/visibility/eviction, a **raw-ASGI `http.disconnect`** cleanup test (TestClient can't reach it), the off-loop build, and an **idle-keepalive** test (the mechanism that surfaces dropped sockets on ASGI ≥2.4).
- `tests/test_cli/test_ui_commands.py` — the four verbs, `UiGroup` routing + preserved bare-serve, exit codes, `httpx` error rendering, `--json`.
- `web/src/graph/flow.test.ts` — a deduped-away data edge keeps its id in `mergedIds` so a Point at it lights the kept line (no "resolvable but shown nothing").
- **Suite:** 93 Task 169 Python tests pass; `ruff` + `mypy` clean; `tsc --noEmit` clean; 524 web vitest pass; full `make test` green. The visual layer (a data line actually lighting) was verified in real headless Chrome (implementation Phase 2 + a same-page rerun).

## Follow-ups

Deferred work spawned by this PR, tracked as issues:

- **#529** — UI SSE robustness (`onerror`-driven reconnect + viewer discovery/reuse): the live-overlay (Task 173) foundation, where the SSE stream becomes load-bearing. The `focus --open` rebuild-loop optimization raised in code review is folded in here.
- **#528** — finish the CLI JSON-output flag standardization: the `ui` verbs moved to `--output-format json` in this PR; `list`/`mcp` remain on `--json`.
