### PR TITLE
feat: UI SSE robustness — onerror reconnect + viewer discovery/reuse (#529)

### DIFF
--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -13,6 +13,7 @@ import socket
 import time
 import webbrowser
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import NoReturn
 from urllib.parse import urlencode
 
@@ -428,10 +429,17 @@ def serve_cmd(
         # Port taken. If it's our own viewer, reuse it (open a tab) rather than fail —
         # `pflow ui <wf>` becomes idempotent. A foreign process keeps the hard error.
         if _probe_health(port) is not None:
-            url = _serve_url(port, workflow, no_auto_update)
+            # The already-running server may have a DIFFERENT cwd, so a relative path
+            # would resolve against ITS cwd, not the caller's — opening the wrong/
+            # missing workflow. Send an absolute path for a path-like arg; a saved
+            # NAME resolves via the registry regardless of cwd, so leave it untouched.
+            reuse_workflow = str(Path(workflow).resolve()) if workflow and Path(workflow).exists() else workflow
+            url = _serve_url(port, reuse_workflow, no_auto_update)
             if not no_open:
                 webbrowser.open(url)
-            click.echo(f"pflow UI already running on port {port} — opened a view at {url}", err=True)
+                click.echo(f"pflow UI already running on port {port} — opened a view at {url}", err=True)
+            else:
+                click.echo(f"pflow UI already running on port {port} — view available at {url}", err=True)
             ctx.exit(0)
             return
         click.echo(

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -25,6 +25,7 @@ from pflow.core.diagnostic_render import format_diagnostic
 _HOST = "127.0.0.1"
 _DEFAULT_PORT = 8765
 _REQUEST_TIMEOUT_S = 5.0
+_PROBE_TIMEOUT_S = 1.0
 _OPEN_TIMEOUT_S = 15.0
 _OPEN_INTERVAL_S = 0.25
 
@@ -72,6 +73,38 @@ def _viewer_url(port: int, workflow: str, *, focus: str | None = None) -> str:
     if focus is not None:
         query["focus"] = focus
     return f"http://{_HOST}:{port}/?{urlencode(query)}"
+
+
+def _serve_url(port: int, workflow: str | None, no_auto_update: bool) -> str:
+    """The browser URL ``serve`` opens — for both a fresh start and a reuse-existing.
+
+    ``no_auto_update`` appends the private ``watch=0`` param that freezes the live
+    source poll, so a reused tab honors ``--no-auto-update`` just like a fresh start.
+    """
+    query: dict[str, str] = {}
+    if workflow:
+        query["workflow"] = workflow
+    if no_auto_update:
+        query["watch"] = "0"
+    return f"http://{_HOST}:{port}/" + (f"?{urlencode(query)}" if query else "")
+
+
+def _probe_health(port: int, workflow: str | None = None) -> dict[str, object] | None:
+    """Return the ``/api/health`` body if a pflow viewer is on the port, else ``None``.
+
+    Never raises or exits — unlike ``_request`` (which ``ctx.exit``s on any failure),
+    this is safe to call in a poll loop and to probe a port that may hold a foreign
+    process. Uses a short ``_PROBE_TIMEOUT_S`` so a non-pflow socket on the port does
+    not stall the caller for the full ``_REQUEST_TIMEOUT_S`` before falling through.
+    """
+    params = {"workflow": workflow} if workflow else None
+    try:
+        response = httpx.get(f"http://{_HOST}:{port}/api/health", params=params, timeout=_PROBE_TIMEOUT_S)
+        response.raise_for_status()
+        body = response.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    return body if isinstance(body, dict) and body.get("service") == "pflow-ui" else None
 
 
 def _wants_json(ctx: click.Context, param: click.Parameter, value: str) -> bool:
@@ -392,6 +425,15 @@ def serve_cmd(
     from pflow.ui.server import create_app
 
     if not _port_available(_HOST, port):
+        # Port taken. If it's our own viewer, reuse it (open a tab) rather than fail —
+        # `pflow ui <wf>` becomes idempotent. A foreign process keeps the hard error.
+        if _probe_health(port) is not None:
+            url = _serve_url(port, workflow, no_auto_update)
+            if not no_open:
+                webbrowser.open(url)
+            click.echo(f"pflow UI already running on port {port} — opened a view at {url}", err=True)
+            ctx.exit(0)
+            return
         click.echo(
             f"Port {port} is already in use.\n→ try a different --port (e.g. --port {port + 1})",
             err=True,
@@ -400,16 +442,9 @@ def serve_cmd(
         return
 
     app = create_app()
-    url = f"http://{_HOST}:{port}/"
-    query: dict[str, str] = {}
-    if workflow:
-        query["workflow"] = workflow
-    if no_auto_update:
-        # `watch` is the stable private CLI↔frontend URL contract. Only the
-        # user-facing flag changed to avoid colliding with Watch terminology.
-        query["watch"] = "0"
-    if query:
-        url += f"?{urlencode(query)}"
+    # `watch=0` (in _serve_url) is the stable private CLI↔frontend URL contract; only
+    # the user-facing flag is named --no-auto-update to avoid colliding with Watch.
+    url = _serve_url(port, workflow, no_auto_update)
 
     if not no_open:
         import threading
@@ -461,16 +496,22 @@ def focus_cmd(
         opened = True
         is_edge = "->" in target
         webbrowser.open(_viewer_url(port, workflow, focus=None if is_edge else target))
-        # The URL focus parser accepts a bare node_id/flat id, but Point also
-        # accepts qualified nested and in:/out: addresses. Re-send for every
-        # target once the graph-ready Viewer subscribes; applying bare focus a
-        # second time is harmless and keeps one reliable open path.
+        # Poll a CHEAP readiness signal (the live window count) instead of re-POSTing
+        # the build-triggering `focus` on a timer (that re-ran the full graph build
+        # ~60x). `windows > 0` means the Viewer has registered its SSE connection,
+        # which only happens after its graph is built, so it is the same readiness
+        # proxy the old `sent_to > 0` loop used.
         deadline = time.monotonic() + _OPEN_TIMEOUT_S
         while time.monotonic() < deadline:
             time.sleep(_OPEN_INTERVAL_S)
-            payload = _point_request(ctx, port, workflow, "focus", target, output_json=output_json)
-            if _int_field(payload, "sent_to") > 0:
+            health = _probe_health(port, workflow)
+            if health is not None and _int_field(health, "windows") > 0:
                 break
+        # Deliver once after the loop, unconditionally: this makes `timed_out` reflect
+        # a real send (a window that connects in the final poll interval must not be
+        # reported "didn't connect"), and an edge focus can ONLY arrive over SSE — the
+        # opened URL carries no edge focus. Applying a bare focus once is harmless.
+        payload = _point_request(ctx, port, workflow, "focus", target, output_json=output_json)
         timed_out = _int_field(payload, "sent_to") == 0
 
     _emit_payload(payload, output_json)

--- a/src/pflow/ui/CLAUDE.md
+++ b/src/pflow/ui/CLAUDE.md
@@ -110,6 +110,16 @@ fixing save).
 - `POST /api/interaction` records deliberate user actions; `GET /api/activity`
   returns the bounded, newest-first snapshot. `POST /api/visibility` updates one
   connection. All POSTs require `application/json`.
+- `GET /api/health` is the cheap liveness + identity probe for discovery/reuse:
+  `{"service": "pflow-ui"}` always, plus `{"workflow_key", "windows"}` when a
+  resolvable `workflow` is supplied (`windows = len(windows_for(key))`, **no graph
+  build**). An unresolvable workflow reports identity only (no 404 — a liveness probe
+  must answer regardless, unlike `events()`/`command()`). It reads the hub, so it is
+  `async def` per the invariant below. **`windows` can transiently over-count by 1**
+  for up to one `_KEEPALIVE_S` cycle after a Viewer's `onerror` reconnect to *this*
+  server (the dropped connection lingers until its next keepalive write fails); a
+  server *restart* frees the whole hub, so that path is clean. Benign for a local
+  single-user viewer; the count self-corrects.
 
 Name-opened and path-opened Viewers share one resolved workflow key. Point targets
 cross the wire only as structural refs; never send positional flat ids between
@@ -160,6 +170,21 @@ heuristically-cached stale entry; the content-hashed assets stay cacheable.
   reads `?workflow=` and auto-loads it; with no param, it shows the catalog.
   `--no-auto-update` appends the private `?watch=0` URL param to freeze the
   live-source poll.
+- **Discovery / reuse (probe-then-reuse-or-start).** On a port-in-use, `serve` probes
+  `GET /api/health`; if a pflow viewer answers it **reuses** it — opens a tab against
+  the running server (honoring `--no-open` / `--no-auto-update` via `_serve_url`) and
+  exits 0, so `pflow ui <wf>` is idempotent. A *foreign* process on the port keeps the
+  "port in use, try `--port`" error. `focus --open` polls the same cheap
+  `/api/health?workflow=X` for `windows > 0` (then sends `focus` once) instead of
+  re-POSTing the build-triggering command on a timer (which re-ran the full graph build
+  ~60×). `windows > 0` means "SSE registered" (which only happens after the graph
+  builds), not "render-acked" — the same readiness proxy the old `sent_to > 0` loop used.
+  A server *restart* needs no cross-process cleanup (the killed process frees its whole
+  `_Hub`); `SO_REUSEADDR` lets a fast double-invoke briefly "reuse" a dying server
+  (benign — the frontend's reconnect + the `--open` poll recover). The probe
+  (`_probe_health`) is non-failing (returns `None`, never `ctx.exit`) with a short
+  `_PROBE_TIMEOUT_S` so a foreign socket can't stall it. Reuse composes only within one
+  port (per-process `_Hub`, no cross-port broadcast).
 - Point: `pflow ui focus <workflow> <target> [--open]`, `frame`, and
   `clear-focus`. Watch: `pflow ui user-activity [workflow]`. Each accepts `--port`
   and the project-standard `--output-format json` and talks to an already-running

--- a/src/pflow/ui/server.py
+++ b/src/pflow/ui/server.py
@@ -12,6 +12,8 @@ Endpoints:
   the workflow's source files, so the frontend can poll it and re-fetch the
   graph in place (no page reload) when the author edits the ``.pflow.md``.
 - ``GET /api/events?workflow=<name|path>`` — SSE commands for each open Viewer.
+- ``GET /api/health`` — liveness + identity probe for discovery/reuse; reports the
+  live window count when a resolvable ``workflow`` is supplied.
 - ``POST /api/command`` — validate and broadcast an agent Point command.
 - ``POST /api/interaction`` — record one deliberate Viewer interaction.
 - ``POST /api/visibility`` — update a Viewer's visible/backgrounded state.
@@ -404,6 +406,38 @@ async def events(request: Request) -> Response:
     )
 
 
+async def health(request: Request) -> Response:
+    """Liveness + identity probe for discovery/reuse. Cheap: no graph build.
+
+    Always reports the service identity (``{"service": "pflow-ui"}``) so a probe can
+    tell a pflow viewer from any other process on the port. When a resolvable
+    ``workflow`` is supplied, also reports the live window count for that key — the
+    cheap readiness signal ``pflow ui focus --open`` polls instead of re-running the
+    build-triggering ``/api/command`` on a timer.
+
+    Unknown/unresolvable ``workflow`` reports identity only (no ``windows``): a
+    liveness probe must answer regardless, unlike ``events()``/``command()`` which 404.
+
+    ``async def`` is load-bearing: it reads the hub (``windows_for``), so it MUST run
+    on the event loop, never the threadpool (see the hub concurrency invariant).
+
+    Note: ``windows`` can transiently over-count by 1 for up to one ``_KEEPALIVE_S``
+    cycle after a viewer's ``onerror`` reconnect to *this* server (the dropped
+    connection lingers in the hub until its next keepalive write fails). Benign for a
+    local single-user viewer; a server restart frees the whole hub, so that path is
+    clean.
+    """
+    hub: _Hub = request.app.state.hub
+    body: dict[str, object] = {"service": "pflow-ui"}
+    workflow = request.query_params.get("workflow")
+    if workflow:
+        workflow_key = _workflow_key(workflow)
+        if workflow_key is not None:
+            body["workflow_key"] = workflow_key
+            body["windows"] = len(hub.windows_for(workflow_key))
+    return _json(body)
+
+
 async def command(request: Request) -> Response:
     """Validate and broadcast one agent Point command."""
     body = await _json_body(request)
@@ -559,6 +593,7 @@ def create_app() -> Starlette:
         Route("/api/source", source),
         Route("/api/version", version),
         Route("/api/events", events),
+        Route("/api/health", health),
         Route("/api/command", command, methods=["POST"]),
         Route("/api/interaction", interaction, methods=["POST"]),
         Route("/api/visibility", visibility, methods=["POST"]),

--- a/tests/test_cli/test_ui.py
+++ b/tests/test_cli/test_ui.py
@@ -635,13 +635,14 @@ class TestUiCommand:
         assert (host, port) == ("127.0.0.1", 9124)
         assert url.startswith("http://127.0.0.1:9124/?workflow=")
 
-    def test_port_in_use_prints_actionable_hint(self) -> None:
-        """An occupied port → exit 1 with an actionable hint; uvicorn is never reached.
+    def test_port_in_use_by_foreign_process_prints_actionable_hint(self) -> None:
+        """An occupied port held by a NON-pflow process → exit 1 with an actionable hint.
 
         Regression guard: uvicorn swallows the bind OSError and sys.exit(1)s with
         only its own log line, so the command pre-flights the bind to own the
-        message. ``uvicorn.run`` is stubbed as a safety net against a hang if the
-        pre-flight check ever wrongly passes.
+        message. ``_probe_health`` is patched to ``None`` (not a pflow viewer) so
+        the reuse branch is skipped — and so the real probe doesn't stall on the
+        bound-but-non-HTTP socket. ``uvicorn.run`` is stubbed as a hang safety net.
         """
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(("127.0.0.1", 0))
@@ -649,7 +650,10 @@ class TestUiCommand:
         port = sock.getsockname()[1]
         try:
             runner = CliRunner()
-            with patch("uvicorn.run") as mock_run:
+            with (
+                patch("pflow.cli.commands.ui._probe_health", return_value=None),
+                patch("uvicorn.run") as mock_run,
+            ):
                 result = runner.invoke(ui_cmd, ["--no-open", "--port", str(port)])
         finally:
             sock.close()
@@ -658,6 +662,161 @@ class TestUiCommand:
         assert "already in use" in result.output
         assert "--port" in result.output
         mock_run.assert_not_called()
+
+    def test_port_in_use_by_pflow_viewer_reuses_it(self, tmp_path: Path) -> None:
+        """An occupied port held by a pflow viewer → reuse: open a tab, exit 0, no new server.
+
+        ``pflow ui <wf>`` becomes idempotent. ``_port_available`` is False (occupied)
+        and ``_probe_health`` confirms a pflow viewer, so the command opens a browser
+        tab against the running server and exits 0 without starting uvicorn.
+        """
+        workflow_path = tmp_path / "wf.pflow.md"
+        write_workflow_file(_VALID_IR, workflow_path)
+
+        runner = CliRunner()
+        with (
+            patch("pflow.cli.commands.ui._port_available", return_value=False),
+            patch("pflow.cli.commands.ui._probe_health", return_value={"service": "pflow-ui"}),
+            patch("uvicorn.run") as mock_run,
+            patch("webbrowser.open") as mock_open,
+        ):
+            result = runner.invoke(ui_cmd, [str(workflow_path), "--port", "9131"])
+
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
+        mock_run.assert_not_called()
+        mock_open.assert_called_once()
+        assert "9131" in mock_open.call_args.args[0]
+
+    def test_port_in_use_by_pflow_viewer_honors_no_open(self, tmp_path: Path) -> None:
+        """Reuse path respects ``--no-open``: report it, open nothing, exit 0."""
+        workflow_path = tmp_path / "wf.pflow.md"
+        write_workflow_file(_VALID_IR, workflow_path)
+
+        runner = CliRunner()
+        with (
+            patch("pflow.cli.commands.ui._port_available", return_value=False),
+            patch("pflow.cli.commands.ui._probe_health", return_value={"service": "pflow-ui"}),
+            patch("uvicorn.run") as mock_run,
+            patch("webbrowser.open") as mock_open,
+        ):
+            result = runner.invoke(ui_cmd, [str(workflow_path), "--no-open", "--port", "9132"])
+
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
+        mock_run.assert_not_called()
+        mock_open.assert_not_called()
+
+
+class TestServeUrl:
+    """``_serve_url`` — the shared browser-URL builder for fresh-start AND reuse paths."""
+
+    def test_includes_workflow_and_freezes_watch_when_no_auto_update(self) -> None:
+        from pflow.cli.commands.ui import _serve_url
+
+        url = _serve_url(8765, "wf", True)
+        assert "workflow=wf" in url
+        assert "watch=0" in url  # --no-auto-update must survive the reuse path (parity guard)
+
+    def test_includes_workflow_without_watch_when_auto_update_on(self) -> None:
+        from pflow.cli.commands.ui import _serve_url
+
+        url = _serve_url(8765, "wf", False)
+        assert "workflow=wf" in url
+        assert "watch" not in url
+
+    def test_bare_url_when_no_workflow(self) -> None:
+        from pflow.cli.commands.ui import _serve_url
+
+        assert _serve_url(8765, None, False) == "http://127.0.0.1:8765/"
+
+
+class TestProbeHealth:
+    """``_probe_health`` — the non-failing GET probe (returns body or None, never exits)."""
+
+    def test_returns_body_for_a_pflow_viewer(self) -> None:
+        import httpx
+
+        from pflow.cli.commands.ui import _probe_health
+
+        # A real httpx.get() always sets .request (raise_for_status needs it).
+        request = httpx.Request("GET", "http://127.0.0.1:8765/api/health")
+        response = httpx.Response(200, json={"service": "pflow-ui", "windows": 2}, request=request)
+        with patch("pflow.cli.commands.ui.httpx.get", return_value=response):
+            assert _probe_health(8765) == {"service": "pflow-ui", "windows": 2}
+
+    def test_returns_none_for_a_non_pflow_json_body(self) -> None:
+        import httpx
+
+        from pflow.cli.commands.ui import _probe_health
+
+        request = httpx.Request("GET", "http://127.0.0.1:8765/api/health")
+        response = httpx.Response(200, json={"some": "other-server"}, request=request)
+        with patch("pflow.cli.commands.ui.httpx.get", return_value=response):
+            assert _probe_health(8765) is None
+
+    def test_returns_none_on_transport_error(self) -> None:
+        import httpx
+
+        from pflow.cli.commands.ui import _probe_health
+
+        with patch("pflow.cli.commands.ui.httpx.get", side_effect=httpx.ConnectError("refused")):
+            assert _probe_health(8765) is None
+
+
+class TestFocusOpen:
+    def test_polls_health_then_delivers_once(self) -> None:
+        """``focus --open`` polls the cheap /api/health for windows>0, then sends focus ONCE.
+
+        Replaces the old loop that re-POSTed the build-triggering ``focus`` each tick
+        (~60 graph builds). Now: one initial probe-POST + cheap health polls until a
+        window registers + one final delivery = 2 ``_point_request`` calls total.
+        """
+        initial = {"resolved": {"matched": 1, "address": "greet"}, "sent_to": 0, "windows": [], "workflow_key": "k"}
+        delivered = {
+            "resolved": {"matched": 1, "address": "greet"},
+            "sent_to": 1,
+            "windows": [{"visibility": "visible"}],
+            "workflow_key": "k",
+        }
+        runner = CliRunner()
+        with (
+            patch("pflow.cli.commands.ui._point_request", side_effect=[initial, delivered]) as mock_point,
+            patch(
+                "pflow.cli.commands.ui._probe_health",
+                side_effect=[{"service": "pflow-ui", "windows": 0}, {"service": "pflow-ui", "windows": 1}],
+            ) as mock_probe,
+            patch("webbrowser.open") as mock_open,
+            patch("time.sleep"),
+        ):
+            result = runner.invoke(ui_cmd, ["focus", "wf", "greet", "--open", "--port", "9133"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_point.call_count == 2  # initial POST + ONE delivery (not ~60 re-POSTs)
+        assert mock_probe.call_count == 2  # cheap polls until windows>0
+        mock_open.assert_called_once()
+
+    def test_open_timeout_still_delivers_once_for_accurate_status(self) -> None:
+        """If no window ever connects, the final delivery still runs so ``timed_out``
+        reflects a real send (not a stale pre-open payload) — and an edge re-send stays
+        unconditional. The window-never-connects case ⇒ exit 1 + the 'didn't connect' note."""
+        initial = {"resolved": {"matched": 1, "address": "greet"}, "sent_to": 0, "windows": [], "workflow_key": "k"}
+        still_empty = {"resolved": {"matched": 1, "address": "greet"}, "sent_to": 0, "windows": [], "workflow_key": "k"}
+        runner = CliRunner()
+
+        # monotonic: start, then a value past the deadline so the poll loop exits immediately.
+        with (
+            patch("pflow.cli.commands.ui._point_request", side_effect=[initial, still_empty]) as mock_point,
+            patch("pflow.cli.commands.ui._probe_health", return_value={"service": "pflow-ui", "windows": 0}),
+            patch("webbrowser.open"),
+            patch("time.sleep"),
+            patch("time.monotonic", side_effect=[0.0, 100.0, 100.0]),
+        ):
+            result = runner.invoke(ui_cmd, ["focus", "wf", "greet", "--open", "--port", "9134"])
+
+        assert result.exit_code == 1
+        assert "didn't connect" in result.output
+        assert mock_point.call_count == 2  # initial + one final delivery even on timeout
 
 
 class TestLazyImportBoundary:

--- a/tests/test_cli/test_ui.py
+++ b/tests/test_cli/test_ui.py
@@ -683,13 +683,13 @@ class TestUiCommand:
             result = runner.invoke(ui_cmd, [str(workflow_path), "--port", "9131"])
 
         assert result.exit_code == 0, result.output
-        assert "already running" in result.output
+        assert "opened a view" in result.output  # a tab WAS opened (no --no-open)
         mock_run.assert_not_called()
         mock_open.assert_called_once()
         assert "9131" in mock_open.call_args.args[0]
 
     def test_port_in_use_by_pflow_viewer_honors_no_open(self, tmp_path: Path) -> None:
-        """Reuse path respects ``--no-open``: report it, open nothing, exit 0."""
+        """Reuse path respects ``--no-open``: open nothing, and the message says so."""
         workflow_path = tmp_path / "wf.pflow.md"
         write_workflow_file(_VALID_IR, workflow_path)
 
@@ -703,9 +703,33 @@ class TestUiCommand:
             result = runner.invoke(ui_cmd, [str(workflow_path), "--no-open", "--port", "9132"])
 
         assert result.exit_code == 0, result.output
-        assert "already running" in result.output
+        # The message must NOT falsely claim a view was opened under --no-open.
+        assert "view available" in result.output
+        assert "opened a view" not in result.output
         mock_run.assert_not_called()
         mock_open.assert_not_called()
+
+    def test_reuse_resolves_a_relative_workflow_path_to_absolute(self) -> None:
+        """The already-running server may have a different cwd, so the reuse URL must
+        carry an ABSOLUTE path — a relative one would resolve against the server's cwd
+        and open the wrong/missing workflow."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("wf.pflow.md").write_text(
+                "# x\n\n## Steps\n\n### a\n\nDo a thing now.\n\n- type: shell\n- command: echo hi\n"
+            )
+            with (
+                patch("pflow.cli.commands.ui._port_available", return_value=False),
+                patch("pflow.cli.commands.ui._probe_health", return_value={"service": "pflow-ui"}),
+                patch("uvicorn.run"),
+                patch("webbrowser.open") as mock_open,
+            ):
+                result = runner.invoke(ui_cmd, ["wf.pflow.md", "--port", "9135"])
+
+        assert result.exit_code == 0, result.output
+        encoded_workflow = mock_open.call_args.args[0].split("workflow=")[1]
+        # An absolute path url-encodes its slashes (%2F); the relative "wf.pflow.md" has none.
+        assert "%2F" in encoded_workflow
 
 
 class TestServeUrl:

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -92,6 +92,46 @@ class TestHub:
         assert filtered[-1]["sequence"] == 6
 
 
+class TestHealthEndpoint:
+    """``/api/health`` — the discovery/reuse probe. It TOUCHES THE HUB, so the
+    load-bearing invariant is that it counts live connections under the SAME
+    ``_workflow_key`` a Viewer registers under. If health derived a different key
+    than ``events()``, a connected Viewer would read as ``windows: 0`` forever —
+    discovery would re-spawn duplicates and ``focus --open`` would silently time
+    out instead of sending. This is the same register-then-assert-count pattern as
+    ``test_focus_resolves_and_broadcasts_to_matching_windows``."""
+
+    def test_counts_live_windows_under_the_resolved_key_for_a_saved_name(self) -> None:
+        # The realistic case: `pflow ui <name>` opens the Viewer (registers under the
+        # resolved PATH); `pflow ui focus <name> --open` polls health by NAME. Health
+        # must resolve name→path to see the connection — a raw-string lookup would read
+        # 0 (name != path) on EVERY platform, so this pins the resolution unambiguously.
+        manager = WorkflowManager()
+        wf_dir = manager.workflows_dir / "discoverable"
+        wf_dir.mkdir(parents=True)
+        path = wf_dir / "discoverable.pflow.md"
+        write_workflow_file(_VALID_IR, path)
+        key = str(path.resolve())
+
+        app = create_app()
+        app.state.hub.register(key, "visible")
+        app.state.hub.register(key, "hidden")
+        app.state.hub.register("/different.pflow.md", "visible")  # other workflow — must NOT count
+
+        body = TestClient(app).get("/api/health", params={"workflow": "discoverable"}).json()
+
+        assert body == {"service": "pflow-ui", "workflow_key": key, "windows": 2}
+
+    def test_identity_only_without_a_workflow(self) -> None:
+        assert TestClient(create_app()).get("/api/health").json() == {"service": "pflow-ui"}
+
+    def test_unknown_workflow_is_identity_only_not_404(self) -> None:
+        # A liveness probe must answer regardless — unlike command()/activity(), which 404.
+        response = TestClient(create_app()).get("/api/health", params={"workflow": "no-such-workflow-xyz"})
+        assert response.status_code == 200
+        assert response.json() == {"service": "pflow-ui"}
+
+
 class TestInteractionEndpoints:
     def test_focus_resolves_and_broadcasts_to_matching_windows(self, tmp_path: Path) -> None:
         workflow = _workflow(tmp_path)

--- a/web/src/api/events.test.ts
+++ b/web/src/api/events.test.ts
@@ -10,6 +10,7 @@ class FakeEventSource {
 
   readonly url: string;
   onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
   closed = false;
 
   constructor(url: string | URL) {
@@ -19,6 +20,10 @@ class FakeEventSource {
 
   emit(message: unknown): void {
     this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(message) }));
+  }
+
+  fail(): void {
+    this.onerror?.(new Event("error"));
   }
 
   close(): void {
@@ -32,6 +37,9 @@ beforeEach(() => {
   FakeEventSource.instances = [];
   vi.stubGlobal("EventSource", FakeEventSource);
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
+  // Reset visibility every test: a later test flips it to "hidden" and does not
+  // restore it, which would otherwise leak into whatever test runs next.
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
 });
 
 afterEach(() => vi.unstubAllGlobals());
@@ -94,6 +102,71 @@ describe("subscribe", () => {
       }),
     );
     unsubscribe();
+  });
+});
+
+describe("subscribe reconnect", () => {
+  // The logic test (necessary, NOT sufficient — a jsdom FakeEventSource can't prove a
+  // real backgrounded/slept tab recovers; that's the real-browser harness's job).
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const handlers = () => ({ focus: vi.fn(), frame: vi.fn(), clear: vi.fn() });
+
+  it("closes the dead source and reopens a fresh one after the retry delay", () => {
+    const unsubscribe = subscribe("wf", handlers());
+    const first = FakeEventSource.instances[0]!;
+
+    first.fail();
+    expect(first.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(1); // not yet — reconnect is scheduled, not immediate
+
+    vi.advanceTimersByTime(1000);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1]!.url).toContain("workflow=wf");
+    unsubscribe();
+  });
+
+  it("schedules at most one reconnect for repeated errors before the timer fires (churn guard)", () => {
+    const unsubscribe = subscribe("wf", handlers());
+    const first = FakeEventSource.instances[0]!;
+
+    first.fail();
+    first.fail();
+    first.fail();
+    vi.advanceTimersByTime(1000);
+
+    expect(FakeEventSource.instances).toHaveLength(2); // exactly one new source, not three
+    unsubscribe();
+  });
+
+  it("re-seeds the connection id and reports visibility after a reconnect", () => {
+    const unsubscribe = subscribe("wf", handlers());
+    FakeEventSource.instances[0]!.fail();
+    vi.advanceTimersByTime(1000);
+
+    FakeEventSource.instances[1]!.emit({ type: "connected", conn_id: "viewer-9" });
+    // The reconnected source's `connected` re-seeds connId, so the visibility POST
+    // targets the NEW id (not the dead pre-reconnect connection).
+    expect(fetch).toHaveBeenLastCalledWith(
+      "/api/visibility",
+      expect.objectContaining({ body: JSON.stringify({ conn_id: "viewer-9", visibility: "visible" }) }),
+    );
+    unsubscribe();
+  });
+
+  it("cancels a pending reconnect on unsubscribe and never reconnects after teardown", () => {
+    const unsubscribe = subscribe("wf", handlers());
+    const first = FakeEventSource.instances[0]!;
+
+    first.fail(); // schedules a retry
+    unsubscribe(); // must clear it
+    vi.advanceTimersByTime(5000);
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    first.fail(); // an error after teardown must not resurrect a connection
+    vi.advanceTimersByTime(5000);
+    expect(FakeEventSource.instances).toHaveLength(1);
   });
 });
 

--- a/web/src/api/events.ts
+++ b/web/src/api/events.ts
@@ -40,11 +40,21 @@ function isTarget(value: unknown): value is PointTarget {
   );
 }
 
-/** Subscribe one Viewer. EventSource reconnects automatically after transport failures. */
+const RETRY_MS = 1000; // localhost single-user: a fixed beat beats exponential backoff's moving parts
+
+/**
+ * Subscribe one Viewer to Point commands. Drives its OWN reconnect on drop —
+ * native EventSource auto-reconnect is unreliable for backgrounded/slept/frozen
+ * tabs (it may stay in CONNECTING and never re-register). On any `onerror` we
+ * explicitly close the dead source and reopen a fresh one after a fixed delay,
+ * trigger-agnostic: recovers from server restart, sleep/wake, network blip, and
+ * tab freeze uniformly, without ever reading `readyState` or `visibilityState`.
+ */
 export function subscribe(workflow: string, handlers: PointHandlers): () => void {
-  const params = new URLSearchParams({ workflow, visibility: visibility() });
-  const source = new EventSource(`/api/events?${params.toString()}`);
+  let source: EventSource | null = null;
   let connId: string | null = null;
+  let retry: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
 
   const reportVisibility = (): void => {
     if (connId === null) return;
@@ -56,32 +66,58 @@ export function subscribe(workflow: string, handlers: PointHandlers): () => void
     }).catch(() => undefined);
   };
 
-  source.onmessage = (event: MessageEvent<string>): void => {
-    let message: unknown;
-    try {
-      message = JSON.parse(event.data) as unknown;
-    } catch {
-      return;
-    }
-    if (!isRecord(message) || typeof message.type !== "string") return;
-    if (message.type === "connected" && typeof message.conn_id === "string") {
-      connId = message.conn_id;
-      // EventSource reconnects with its original URL, whose visibility value
-      // may now be stale. Correct every newly registered connection
-      // immediately; do not wait for another visibility transition.
-      reportVisibility();
-    } else if (message.type === "clear") {
-      handlers.clear();
-    } else if ((message.type === "focus" || message.type === "frame") && isTarget(message.target)) {
-      handlers[message.type](message.target);
-    }
+  const connect = (): void => {
+    if (stopped) return; // defensive: a fired-but-not-yet-cleared timer must not resurrect a connection
+    const params = new URLSearchParams({ workflow, visibility: visibility() });
+    source = new EventSource(`/api/events?${params.toString()}`);
+
+    source.onmessage = (event: MessageEvent<string>): void => {
+      let message: unknown;
+      try {
+        message = JSON.parse(event.data) as unknown;
+      } catch {
+        return;
+      }
+      if (!isRecord(message) || typeof message.type !== "string") return;
+      if (message.type === "connected" && typeof message.conn_id === "string") {
+        connId = message.conn_id;
+        // A reconnect reopens with the original URL, whose visibility value may
+        // now be stale. Correct every newly registered connection immediately;
+        // do not wait for another visibility transition.
+        reportVisibility();
+      } else if (message.type === "clear") {
+        handlers.clear();
+      } else if ((message.type === "focus" || message.type === "frame") && isTarget(message.target)) {
+        handlers[message.type](message.target);
+      }
+    };
+
+    source.onerror = (): void => {
+      // Any drop (restart/sleep/blip/freeze). Tear down the dead source and reopen
+      // against the live server — do NOT trust native retry, do NOT read readyState.
+      // The single-flight guard (retry === null) + close-before-schedule mean at most
+      // one reconnect is ever pending and at most one EventSource is ever live.
+      source?.close();
+      connId = null;
+      if (!stopped && retry === null) {
+        retry = setTimeout(() => {
+          retry = null;
+          connect();
+        }, RETRY_MS);
+      }
+    };
   };
 
+  connect();
+  // visibilitychange reports visible/hidden ONLY; it never drives reconnection.
   document.addEventListener("visibilitychange", reportVisibility);
 
   return () => {
+    stopped = true;
+    if (retry !== null) clearTimeout(retry);
     document.removeEventListener("visibilitychange", reportVisibility);
-    source.close();
+    source?.close();
+    connId = null;
   };
 }
 

--- a/web/src/hooks/CLAUDE.md
+++ b/web/src/hooks/CLAUDE.md
@@ -61,6 +61,13 @@ produces — a fit started at click time aims at the target's PRE-re-layout posi
 landed wrong, second right). A same-focus navigate repaints nothing and fits immediately. An
 io-port chip resolves to its OWNER card via `ioOwners` (graph/) for both the follow and the
 expansion anchor (a port id is never a rendered node — unresolved, the follow silently skipped).
+**Hidden-tab re-frame:** a focus that CHANGES while the tab is `hidden` applies its state but
+its camera fit (rAF-driven) never runs and is not re-issued on return, leaving the node
+off-screen (agent Point at a backgrounded Viewer, user-confirmed 2026-06-23). The hook captures
+a change-while-hidden and re-fits on `visibilitychange → visible` — change-while-hidden ONLY, so
+an ordinary tab return where focus didn't move leaves the viewport alone. This is the ONE place a
+camera concern legitimately keys on `visibilitychange`; SSE *connection* recovery (`api/events.ts`)
+deliberately must NOT (it's `onerror`-driven).
 
 ## `usePanelPair` — the two side panes
 

--- a/web/src/hooks/useCameraNavigation.test.tsx
+++ b/web/src/hooks/useCameraNavigation.test.tsx
@@ -217,6 +217,38 @@ describe("useCameraNavigation", () => {
     expect(followCalls("n2")).toBe(0);
   });
 
+  it("re-frames an EDGE focus that changed while hidden to its rendered endpoints", () => {
+    rf.renderedIds = ["n1", "n2"];
+    const graph = { nodes: [], edges: [{ id: "e0", source: "n1", target: "n2" }], groups: [] } as unknown as Args["graph"];
+    const props = makeProps({ focus: null, graph });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    setVisibility("hidden");
+    rerender({ ...props, focus: "e0" }); // an agent edge Point while hidden
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    expect(fitViewSpy).toHaveBeenCalledWith(expect.objectContaining({ nodes: [{ id: "n1" }, { id: "n2" }] }));
+  });
+
+  it("defers the hidden re-frame until the focused node paints (not-yet-rendered on return)", () => {
+    rf.renderedIds = ["other"]; // n2 was revealed while hidden but hasn't painted yet
+    const props = makeProps({ focus: "other" });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    setVisibility("hidden");
+    rerender({ ...props, focus: "n2" }); // pending = n2
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(followCalls("n2")).toBe(0); // not rendered yet → not fit, pending kept (NOT cleared)
+
+    rf.renderedIds = ["other", "n2"]; // the reveal paints
+    rerender({ ...props, focus: "n2", paintEpoch: 1 }); // paintEpoch bump re-runs the re-frame
+    expect(followCalls("n2")).toBe(1); // now it lands, exactly once
+  });
+
   it("fits the whole view once per workflow|direction|node key — focus restyles never refit; a direction flip does", () => {
     rf.renderedIds = ["n1"];
     const props = makeProps();

--- a/web/src/hooks/useCameraNavigation.test.tsx
+++ b/web/src/hooks/useCameraNavigation.test.tsx
@@ -54,7 +54,13 @@ const followCalls = (id: string): number =>
 beforeEach(() => {
   fitViewSpy.mockClear();
   rf.renderedIds = [];
+  // Default visible; the hidden-tab re-frame tests flip it and must not leak it.
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
 });
+
+const setVisibility = (value: "visible" | "hidden"): void => {
+  Object.defineProperty(document, "visibilityState", { configurable: true, value });
+};
 
 describe("useCameraNavigation", () => {
   it("a NEW-focus navigate defers the follow to the paint the click produces (paintEpoch), never click time", () => {
@@ -165,6 +171,50 @@ describe("useCameraNavigation", () => {
     rf.renderedIds = ["n1", "n2"];
     rerender({ ...props, paintEpoch: 1 });
     expect(followCalls("n1")).toBe(0);
+  });
+
+  it("re-frames a focus that CHANGED while the tab was hidden, once it returns to visible", () => {
+    rf.renderedIds = ["n1", "n2"];
+    const props = makeProps({ focus: "n1" });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    // Tab hidden, then an agent Point moves focus to n2 — fitView is rAF-throttled,
+    // so nothing frames while hidden.
+    setVisibility("hidden");
+    rerender({ ...props, focus: "n2" });
+    expect(followCalls("n2")).toBe(0);
+
+    // Back to visible → the missed focus is framed exactly once.
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(followCalls("n2")).toBe(1);
+  });
+
+  it("an io-PORT focus that changed while hidden re-frames its OWNER card on return", () => {
+    rf.renderedIds = ["g1"];
+    const props = makeProps({ focus: null, ioPorts: new Map([["p1", "g1"]]) });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    setVisibility("hidden");
+    rerender({ ...props, focus: "p1" });
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(followCalls("g1")).toBe(1);
+  });
+
+  it("does NOT re-frame when focus changed while VISIBLE — an ordinary tab return leaves the viewport alone", () => {
+    rf.renderedIds = ["n1", "n2"];
+    const props = makeProps({ focus: "n1" });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    rerender({ ...props, focus: "n2" }); // focus moved while visible → the normal follow owns it
+    setVisibility("hidden");
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(followCalls("n2")).toBe(0);
   });
 
   it("fits the whole view once per workflow|direction|node key — focus restyles never refit; a direction flip does", () => {

--- a/web/src/hooks/useCameraNavigation.test.tsx
+++ b/web/src/hooks/useCameraNavigation.test.tsx
@@ -249,6 +249,46 @@ describe("useCameraNavigation", () => {
     expect(followCalls("n2")).toBe(1); // now it lands, exactly once
   });
 
+  it("re-frames an edge endpoint to its rendered REPRESENTATIVE, not the raw (suppressed) flat id", () => {
+    // The endpoint `member1` isn't rendered (its leaf box is suppressed); its io-wrapper
+    // group `wrap1` is. The re-frame must resolve to the representative like the live path,
+    // else an edge touching a sub-workflow/batch host fits the wrong subset (or nothing).
+    rf.renderedIds = ["wrap1", "n2"];
+    const graph = {
+      nodes: [],
+      edges: [{ id: "e0", source: "member1", target: "n2" }],
+      groups: [{ id: "wrap1", kind: "input_wrapper", host: null, members: ["member1"], parent: null }],
+    } as unknown as Args["graph"];
+    const props = makeProps({ focus: null, graph });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    setVisibility("hidden");
+    rerender({ ...props, focus: "e0" });
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    expect(fitViewSpy).toHaveBeenCalledWith(expect.objectContaining({ nodes: [{ id: "wrap1" }, { id: "n2" }] }));
+  });
+
+  it("drops a pending re-frame when focus is cleared while visible (no jump to a dismissed node)", () => {
+    rf.renderedIds = ["other"]; // the focused node hasn't painted yet, so the re-frame stays pending
+    const props = makeProps({ focus: "other" });
+    const { rerender } = renderHook((p: Args) => useCameraNavigation(p), { initialProps: props });
+    fitViewSpy.mockClear();
+
+    setVisibility("hidden");
+    rerender({ ...props, focus: "n2" }); // agent Point while hidden → pending = n2
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(followCalls("n2")).toBe(0); // n2 not painted → pending kept
+
+    rerender({ ...props, focus: null }); // user Clear Focus while visible → pending must clear
+    rf.renderedIds = ["other", "n2"]; // n2 finally paints
+    rerender({ ...props, focus: null, paintEpoch: 1 });
+    expect(followCalls("n2")).toBe(0); // the dismissed node is NOT jumped to
+  });
+
   it("fits the whole view once per workflow|direction|node key — focus restyles never refit; a direction flip does", () => {
     rf.renderedIds = ["n1"];
     const props = makeProps();

--- a/web/src/hooks/useCameraNavigation.ts
+++ b/web/src/hooks/useCameraNavigation.ts
@@ -8,7 +8,7 @@ import { useNodesInitialized, useReactFlow } from "@xyflow/react";
 
 import type { Direction } from "../graph/flow";
 import type { GraphStatus } from "./useWorkflowGraph";
-import { resolveNodeFlatId, type ViewParams } from "../utils/viewParams";
+import { resolveEndpointFlatId, resolveNodeFlatId, type ViewParams } from "../utils/viewParams";
 import type { RFGraph } from "../types";
 
 interface CameraNavigationArgs {
@@ -149,28 +149,34 @@ export function useCameraNavigation({
   useEffect(() => {
     if (focus === prevFocusRef.current) return;
     prevFocusRef.current = focus;
-    if (document.visibilityState === "hidden") pendingReframeRef.current = focus;
+    // Arm a re-frame only for a focus that moves WHILE HIDDEN; a focus change while
+    // visible (including Clear Focus → null) clears any pending one, so a stale
+    // pending can't jerk the camera to a since-dismissed target on the next paint.
+    pendingReframeRef.current = document.visibilityState === "hidden" ? focus : null;
   }, [focus]);
   useEffect(() => {
     const reframeOnShow = (): void => {
       if (document.visibilityState !== "visible") return;
       const id = pendingReframeRef.current;
       if (id == null) return;
+      const graph = graphRef.current;
       const rendered = new Set(getNodes().map((node) => node.id));
-      // A node focus fits the node (or its io-port OWNER card); an EDGE focus fits
-      // its rendered endpoints (focus can be an edge id — GraphView sets it, and the
-      // CLI re-sends edge focus over SSE). Endpoints/owner may not be painted yet
-      // (an agent Point that revealed a collapsed target while hidden) — in that case
-      // DON'T clear: the paintEpoch dep re-runs this once the reveal paints.
-      let fitIds: string[];
-      const owner = ioPorts?.get(id);
-      if (rendered.has(id)) fitIds = [id];
-      else if (owner != null && rendered.has(owner)) fitIds = [owner];
-      else {
-        const edge = graphRef.current?.edges.find((e) => e.id === id);
-        fitIds = edge ? [edge.source, edge.target].filter((endpoint) => rendered.has(endpoint)) : [];
-      }
-      if (fitIds.length === 0) return; // not rendered yet — keep pending, retry on the next paint
+      // Resolve to the SAME on-canvas representative the live Point path uses: a node
+      // (or group HOST → its rendered group / io-wrapper) via resolveEndpointFlatId; an
+      // io-PORT → its owner card; an EDGE focus → its rendered endpoints. A target not
+      // painted yet (an agent Point that revealed a collapsed node while hidden) resolves
+      // to null — DON'T clear; the paintEpoch dep re-runs this once the reveal paints.
+      const resolve = (flatId: string): string | null => {
+        const port = ioPorts?.get(flatId);
+        if (port != null) return rendered.has(port) ? port : null;
+        if (graph) return resolveEndpointFlatId(graph, rendered, flatId);
+        return rendered.has(flatId) ? flatId : null;
+      };
+      const edge = graph?.edges.find((e) => e.id === id);
+      const fitIds = (edge ? [edge.source, edge.target] : [id])
+        .map(resolve)
+        .filter((fitId): fitId is string => fitId !== null);
+      if (fitIds.length === 0) return; // nothing rendered yet — keep pending, retry on the next paint
       pendingReframeRef.current = null;
       fitView({ nodes: fitIds.map((fitId) => ({ id: fitId })), padding: 0.45, maxZoom: 1.2, duration: 300 });
     };

--- a/web/src/hooks/useCameraNavigation.ts
+++ b/web/src/hooks/useCameraNavigation.ts
@@ -155,16 +155,31 @@ export function useCameraNavigation({
     const reframeOnShow = (): void => {
       if (document.visibilityState !== "visible") return;
       const id = pendingReframeRef.current;
-      pendingReframeRef.current = null;
       if (id == null) return;
       const rendered = new Set(getNodes().map((node) => node.id));
+      // A node focus fits the node (or its io-port OWNER card); an EDGE focus fits
+      // its rendered endpoints (focus can be an edge id — GraphView sets it, and the
+      // CLI re-sends edge focus over SSE). Endpoints/owner may not be painted yet
+      // (an agent Point that revealed a collapsed target while hidden) — in that case
+      // DON'T clear: the paintEpoch dep re-runs this once the reveal paints.
+      let fitIds: string[];
       const owner = ioPorts?.get(id);
-      const fitId = rendered.has(id) ? id : owner != null && rendered.has(owner) ? owner : null;
-      if (fitId != null) fitView({ nodes: [{ id: fitId }], padding: 0.45, maxZoom: 1.2, duration: 300 });
+      if (rendered.has(id)) fitIds = [id];
+      else if (owner != null && rendered.has(owner)) fitIds = [owner];
+      else {
+        const edge = graphRef.current?.edges.find((e) => e.id === id);
+        fitIds = edge ? [edge.source, edge.target].filter((endpoint) => rendered.has(endpoint)) : [];
+      }
+      if (fitIds.length === 0) return; // not rendered yet — keep pending, retry on the next paint
+      pendingReframeRef.current = null;
+      fitView({ nodes: fitIds.map((fitId) => ({ id: fitId })), padding: 0.45, maxZoom: 1.2, duration: 300 });
     };
+    // Re-fit when the tab returns to visible, AND on each paint while a re-frame is
+    // pending (so a focus whose node hadn't painted when the tab was shown still lands).
+    reframeOnShow();
     document.addEventListener("visibilitychange", reframeOnShow);
     return () => document.removeEventListener("visibilitychange", reframeOnShow);
-  }, [fitView, getNodes, ioPorts]);
+  }, [paintEpoch, fitView, getNodes, ioPorts]);
   const onNavigate = useCallback(
     (focusId: string, selected?: string | null) => {
       // The clicked chip may unmount with the panel swap — its mouseleave never

--- a/web/src/hooks/useCameraNavigation.ts
+++ b/web/src/hooks/useCameraNavigation.ts
@@ -134,6 +134,37 @@ export function useCameraNavigation({
       fitView({ nodes: frameIds.map((target) => ({ id: target })), padding: 0.45, maxZoom: 1.2, duration: 300 });
     }
   }, [paintEpoch, fitView, getNodes]);
+
+  // Hidden-tab camera re-frame. A focus that lands while the tab is hidden applies
+  // its STATE (panel, dim/reveal) but never moves the camera: fitView is rAF-driven
+  // and rAF is throttled/paused in a hidden tab, so the transition never runs and is
+  // not re-issued on return — the focused node ends up off-screen (user-confirmed
+  // 2026-06-23). Capture a focus that CHANGES while hidden and re-fit when the tab
+  // is shown again, so an agent Point made while the user was away is actually framed.
+  // Only a change-while-hidden re-frames — an ordinary tab return where focus didn't
+  // move leaves the user's viewport alone. (Connection recovery must NOT key on
+  // visibilitychange — see api/events.ts — but CAMERA re-framing legitimately does.)
+  const pendingReframeRef = useRef<string | null>(null);
+  const prevFocusRef = useRef(focus);
+  useEffect(() => {
+    if (focus === prevFocusRef.current) return;
+    prevFocusRef.current = focus;
+    if (document.visibilityState === "hidden") pendingReframeRef.current = focus;
+  }, [focus]);
+  useEffect(() => {
+    const reframeOnShow = (): void => {
+      if (document.visibilityState !== "visible") return;
+      const id = pendingReframeRef.current;
+      pendingReframeRef.current = null;
+      if (id == null) return;
+      const rendered = new Set(getNodes().map((node) => node.id));
+      const owner = ioPorts?.get(id);
+      const fitId = rendered.has(id) ? id : owner != null && rendered.has(owner) ? owner : null;
+      if (fitId != null) fitView({ nodes: [{ id: fitId }], padding: 0.45, maxZoom: 1.2, duration: 300 });
+    };
+    document.addEventListener("visibilitychange", reframeOnShow);
+    return () => document.removeEventListener("visibilitychange", reframeOnShow);
+  }, [fitView, getNodes, ioPorts]);
   const onNavigate = useCallback(
     (focusId: string, selected?: string | null) => {
       // The clicked chip may unmount with the panel swap — its mouseleave never

--- a/web/src/views/GraphView.test.tsx
+++ b/web/src/views/GraphView.test.tsx
@@ -135,6 +135,24 @@ const GRAPH: RFGraph = {
 beforeAll(() => installReactFlowJsdomMocks());
 beforeEach(() => {
   cleanup();
+  // Pin the SNAP path (force prefers-reduced-motion ON) so the paint-deferred camera
+  // follow is DETERMINISTIC. The animated path bumps paintEpoch only when its rAF
+  // glide lands; that's fine at ~100ms locally but races the `waitFor` under CI load,
+  // so the follow intermittently never fires. Animation is not the subject of these
+  // mount/integration tests — same lever useWorkflowGraph.test.tsx's setReducedMotion uses.
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
   vi.mocked(fetchGraph).mockReset();
   vi.mocked(fetchSource).mockReset();
   vi.mocked(fetchSource).mockResolvedValue({


### PR DESCRIPTION
## Summary

Makes the `pflow ui` SSE channel survive connection drops and lets an agent discover/reuse a running Viewer — the connection-robustness foundation the live-execution overlay (Task 173 / ADR-0008) needs, and a de-risker for Task 174's "Point & Say" demo. Also fixes a related, now-reproduced hidden-tab camera glitch surfaced during verification.

Under Task 169's human-in-the-loop model a dropped connection is an honest `sent_to: 0` that a human reloads away. Task 173 is autonomous — a non-recovering drop = silently missing run events. This PR is that robustness half, landed as its own real-browser-verified change.

Fixes #529

## Changes

**(A) `onerror`-driven SSE reconnect** — `web/src/api/events.ts`
- `subscribe()` now drives its own reconnect: on any `onerror`, close the dead `EventSource` and reopen after a fixed delay, with a single-flight churn guard and a teardown guard. Trigger-agnostic (server restart, sleep/wake, network blip, tab freeze).
- Deliberately **never** keys on `visibilitychange` or `readyState === CLOSED` — the two levers a prior attempt used that unit-tested green but failed live and were reverted. `visibilitychange` stays wired to visibility reporting only.

**(B) Viewer discovery / reuse**
- `src/pflow/ui/server.py`: new `async def health` (`GET /api/health`) — liveness/identity (`{"service":"pflow-ui"}`) plus the live window count for a resolvable `workflow` (no graph build). Async to honor the load-bearing async-only `_Hub` invariant.
- `src/pflow/cli/commands/ui.py`: `serve` reuses an existing pflow server on port-in-use (opens a tab, exits 0) instead of failing; a foreign process still errors. `focus --open` polls the cheap `/api/health` for `windows > 0` then sends once — replacing the ~60 graph rebuilds it did while waiting. New non-failing `_probe_health` helper (short timeout, returns `None` not `ctx.exit`).

**Camera re-frame (related glitch, fixed here by request)** — `web/src/hooks/useCameraNavigation.ts`
- A focus that lands while the tab is `hidden` applied its state but never moved the camera (`fitView` is rAF-driven; rAF is throttled when hidden). Now re-frames a focus that **changed while hidden** on return to `visible` — change-while-hidden only, so an ordinary tab return leaves the viewport alone. This is the one place a camera concern legitimately keys on `visibilitychange` (the connection recovery must not).

## Explanation

`Watch` (browser→agent) is connectionless POSTs and survives anything; `Point`/run-events (agent→browser) need the browser's live SSE registration in the in-memory `_Hub`. A drop that doesn't re-register silently kills delivery while Watch lives on — benign under 169, a correctness failure under 173. (A) closes that asymmetry; (B) makes the channel agent-discoverable and removes the `--open` rebuild storm using the same probe.

Scope held tight: catch-up/replay of events missed during a gap is deferred to Task 173 (ADR-0008's trace-file tail is its replay substrate — no second mechanism here); `web/src/api/client.ts` untouched (discovery is CLI→server, the served frontend doesn't probe itself); the SSE envelope dispatch is preserved so Task 174's `say` type appends cleanly.

Stats: 10 files, +541/-44. Docs updated: `src/pflow/ui/CLAUDE.md` (`/api/health` + discovery/reuse + restart lifecycle), `web/src/hooks/CLAUDE.md` (the hidden-tab re-frame).

**Discovered nuance (separable follow-up):** a *graceful* server shutdown can briefly hold the SSE socket open (it waits on the never-ending stream), so `onerror` lags; abrupt drops — the load-bearing cases — fire it promptly. Prompt SSE-cancel-on-shutdown would be a small server-side improvement, out of scope here.

## Testing

Frontend (jsdom, `web/`):
- `events.test.ts` — reconnect logic: drop→reopen after the delay; **churn guard** (repeated `onerror` → exactly one new `EventSource`, guarding against two live sources); `conn_id` re-seed on reconnect; teardown cancels a pending reconnect and never reconnects after unmount. Also fixed a pre-existing `visibilityState` test-isolation leak.
- `useCameraNavigation.test.tsx` — re-frames a focus changed while hidden (and its io-port owner) on return to visible; **does NOT** re-frame when focus changed while visible (the don't-disturb-the-viewport guarantee).

Server/CLI (pytest):
- `test_ui_interaction_server.py::TestHealthEndpoint::test_counts_live_windows_under_the_resolved_key_for_a_saved_name` — registers live hub connections under the resolved path, queries `/api/health` by saved **name**, asserts `windows: 2` (filters a different workflow). **Mutation-verified**: making `health` skip the key resolution drops it to `windows: 0` and the test fails. This pins the invariant that makes discovery/`--open` work.
- `test_ui.py::TestFocusOpen` — `focus --open` calls `_point_request` exactly twice (initial + one delivery), not per-poll (the ~60x→2 fix); the timeout path still delivers once so `timed_out` reflects a real send.
- `test_ui.py::TestProbeHealth` / `TestServeUrl` / serve-reuse — probe discriminates a pflow viewer from a foreign process and never raises; `_serve_url` threads `--no-auto-update` (`watch=0`); serve reuses a pflow server (exit 0, no duplicate) and still errors on a foreign one.

Real-browser verification (chrome-devtools MCP + manual, the gate that reverted the prior attempt):
- Genuinely hidden tab + server hot-swap → SSE re-registered in ~0.5s, no reload; `focus` delivered to the reconnected tab. Confirmed via instrumented build (`onerror` fired, reconnect loop ran) and the server-side window count.
- Focus a node while hidden → switch back → camera re-centers on it (with animation). Headless can't reproduce real frozen-tab throttling, so this was confirmed manually.

Full suite green: Python `make test` 8118 passed; `make check` (ruff/mypy/deptry) clean; web vitest 531 passed; strict `tsc` clean.