### PR TITLE
fix: restore Task-159 cache-analysis baseline oracle — key-aware harness + JSONL trace I/O (#532)

### DIFF
--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/02-greenfield-json/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/02-greenfield-json/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/04-steady-state-json/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/04-steady-state-json/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/05-trace-from-trace/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/05-trace-from-trace/expected-stdout.txt
@@ -4,6 +4,7 @@
   Workflow: 2 LLM nodes using anthropic/claude-sonnet-4-5
   Evidence: complete trace (2 LLM nodes executed)
   Trace: sample-2.1.0-trace.json (success, recorded 2026-05-01 14:46)
+  IR/settings declares: gemini/gemini-2.5-flash (overridden by trace evidence)
 
 ## Summary
 

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/06-no-trace-autoload/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/06-no-trace-autoload/command.sh
@@ -3,13 +3,18 @@ set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
 # Seed a matching trace so auto-load WOULD fire if the flag didn't suppress it.
 mkdir -p "$BASELINE_HOME/.pflow/debug"
-python3 - <<'PY'
-import json, os
+uv run python - <<'PY'
+import os
+from pathlib import Path
+
+from pflow.core.trace_io import load_trace_file
+from tests.shared.trace_jsonl import write_trace_jsonl
+
 src = os.environ["BASELINE_DIR"] + "/_shared/fixtures/sample-2.1.0-trace.json"
 dst = os.environ["BASELINE_HOME"] + "/.pflow/debug/workflow-trace-deadbeef-smoke-with-cache-20260101-000000.json"
-d = json.load(open(src))
+d = load_trace_file(Path(src))
 d["workflow_path"] = os.environ["BASELINE_DIR"] + "/_shared/workflows/smoke-with-cache.pflow.md"
-json.dump(d, open(dst, "w"))
+write_trace_jsonl(Path(dst), d)
 PY
 uv run pflow analyze-cache \
   "$BASELINE_DIR/_shared/workflows/smoke-with-cache.pflow.md" \

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/07-autoload-prefers-success/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/07-autoload-prefers-success/command.sh
@@ -5,8 +5,13 @@ cd "$BASELINE_REPO_ROOT"
 # the same workflow. Auto-load must prefer the older success over the newer
 # failed; a Notes line names both files.
 mkdir -p "$BASELINE_HOME/.pflow/debug"
-python3 - <<'PY'
-import hashlib, json, os
+uv run python - <<'PY'
+import hashlib, os
+from pathlib import Path
+
+from pflow.core.trace_io import load_trace_file
+from tests.shared.trace_jsonl import write_trace_jsonl
+
 src = os.environ["BASELINE_DIR"] + "/_shared/fixtures/sample-2.1.0-trace.json"
 wf_path = os.environ["BASELINE_DIR"] + "/_shared/workflows/smoke-with-cache.pflow.md"
 debug = os.environ["BASELINE_HOME"] + "/.pflow/debug"
@@ -14,13 +19,13 @@ debug = os.environ["BASELINE_HOME"] + "/.pflow/debug"
 # must encode it or the trace is invisible to ``_autoload_trace``.
 wf_hash = hashlib.md5(wf_path.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
 
-src_data = json.load(open(src))
+src_data = load_trace_file(Path(src))
 # Older success — earlier timestamp wins sort tiebreaks; final_status=success.
 older = dict(src_data)
 older["workflow_path"] = wf_path
 older["final_status"] = "success"
 older["start_time"] = "2026-05-08T15:32:00"
-json.dump(older, open(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-153200.json", "w"))
+write_trace_jsonl(Path(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-153200.json"), older)
 
 # Newer failed — later timestamp; final_status=failed.
 newer = dict(src_data)
@@ -28,7 +33,7 @@ newer["workflow_path"] = wf_path
 newer["final_status"] = "failed"
 newer["start_time"] = "2026-05-08T16:30:00"
 newer["failed_node_ids"] = ["echo"]
-json.dump(newer, open(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-163000.json", "w"))
+write_trace_jsonl(Path(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-163000.json"), newer)
 PY
 uv run pflow analyze-cache \
   "$BASELINE_DIR/_shared/workflows/smoke-with-cache.pflow.md" \

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/07-autoload-prefers-success/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/07-autoload-prefers-success/expected-stdout.txt
@@ -3,7 +3,7 @@
 
   Workflow: 2 LLM nodes using anthropic/claude-sonnet-4-5
   Evidence: complete trace (2 LLM nodes executed)
-  Trace: workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json (success, recorded 2026-05-08 15:32)
+  Trace: workflow-trace-<HASH>-smoke-with-cache-<TIMESTAMP>.json (success, recorded 2026-05-08 15:32)
   IR/settings declares: gemini/gemini-2.5-flash (overridden by trace evidence)
 
 ## Summary
@@ -23,5 +23,5 @@
 
 ## Notes
 
-  · Skipped newer trace `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (failed run) in favor of `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (success). Pass `--from-trace <path>` to override.
+  · Skipped newer trace `workflow-trace-<HASH>-smoke-with-cache-<TIMESTAMP>.json` (failed run) in favor of `workflow-trace-<HASH>-smoke-with-cache-<TIMESTAMP>.json` (success). Pass `--from-trace <path>` to override.
   · Cache fidelity check skipped: this is a first run (no prior runs to compare cached vs uncached against). On later runs, specific cache misfires (TTL expired, chunks skipped) will appear here.

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/07-autoload-prefers-success/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/07-autoload-prefers-success/expected-stdout.txt
@@ -3,7 +3,8 @@
 
   Workflow: 2 LLM nodes using anthropic/claude-sonnet-4-5
   Evidence: complete trace (2 LLM nodes executed)
-  Trace: workflow-trace-b3b96a76-smoke-with-cache-<TIMESTAMP>.json (success, recorded 2026-05-08 15:32)
+  Trace: workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json (success, recorded 2026-05-08 15:32)
+  IR/settings declares: gemini/gemini-2.5-flash (overridden by trace evidence)
 
 ## Summary
 
@@ -22,5 +23,5 @@
 
 ## Notes
 
-  · Skipped newer trace `workflow-trace-b3b96a76-smoke-with-cache-<TIMESTAMP>.json` (failed run) in favor of `workflow-trace-b3b96a76-smoke-with-cache-<TIMESTAMP>.json` (success). Pass `--from-trace <path>` to override.
+  · Skipped newer trace `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (failed run) in favor of `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (success). Pass `--from-trace <path>` to override.
   · Cache fidelity check skipped: this is a first run (no prior runs to compare cached vs uncached against). On later runs, specific cache misfires (TTL expired, chunks skipped) will appear here.

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/08-autoload-failed-only/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/08-autoload-failed-only/command.sh
@@ -5,20 +5,25 @@ cd "$BASELINE_REPO_ROOT"
 # the newest failed trace and discloses the lack of successful evidence so
 # the agent knows to re-run or pass --from-trace.
 mkdir -p "$BASELINE_HOME/.pflow/debug"
-python3 - <<'PY'
-import hashlib, json, os
+uv run python - <<'PY'
+import hashlib, os
+from pathlib import Path
+
+from pflow.core.trace_io import load_trace_file
+from tests.shared.trace_jsonl import write_trace_jsonl
+
 src = os.environ["BASELINE_DIR"] + "/_shared/fixtures/sample-2.1.0-trace.json"
 wf_path = os.environ["BASELINE_DIR"] + "/_shared/workflows/smoke-with-cache.pflow.md"
 debug = os.environ["BASELINE_HOME"] + "/.pflow/debug"
 # Autoload globs by the md5 hash prefix of the workflow_path; the filename
 # must encode it or the trace is invisible to ``_autoload_trace``.
 wf_hash = hashlib.md5(wf_path.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
-data = dict(json.load(open(src)))
+data = dict(load_trace_file(Path(src)))
 data["workflow_path"] = wf_path
 data["final_status"] = "failed"
 data["start_time"] = "2026-05-08T16:30:00"
 data["failed_node_ids"] = ["echo"]
-json.dump(data, open(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-163000.json", "w"))
+write_trace_jsonl(Path(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-163000.json"), data)
 PY
 uv run pflow analyze-cache \
   "$BASELINE_DIR/_shared/workflows/smoke-with-cache.pflow.md" \

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/08-autoload-failed-only/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/08-autoload-failed-only/expected-stdout.txt
@@ -3,7 +3,8 @@
 
   Workflow: 2 LLM nodes using anthropic/claude-sonnet-4-5
   Evidence: complete trace (2 LLM nodes executed)
-  Trace: workflow-trace-b3b96a76-smoke-with-cache-<TIMESTAMP>.json (failed, recorded 2026-05-08 16:30)
+  Trace: workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json (failed, recorded 2026-05-08 16:30)
+  IR/settings declares: gemini/gemini-2.5-flash (overridden by trace evidence)
 
 ## Summary
 
@@ -22,5 +23,5 @@
 
 ## Notes
 
-  · Auto-loaded `workflow-trace-b3b96a76-smoke-with-cache-<TIMESTAMP>.json` (failed run); no successful trace exists for this workflow. Trace-dependent recommendations may be suppressed. Re-run the workflow to record a successful trace, or pass `--from-trace <path>` to use a specific trace.
+  · Auto-loaded `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (failed run); no successful trace exists for this workflow. Trace-dependent recommendations may be suppressed. Re-run the workflow to record a successful trace, or pass `--from-trace <path>` to use a specific trace.
   · Cache fidelity check skipped: this is a first run (no prior runs to compare cached vs uncached against). On later runs, specific cache misfires (TTL expired, chunks skipped) will appear here.

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/08-autoload-failed-only/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/08-autoload-failed-only/expected-stdout.txt
@@ -3,7 +3,7 @@
 
   Workflow: 2 LLM nodes using anthropic/claude-sonnet-4-5
   Evidence: complete trace (2 LLM nodes executed)
-  Trace: workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json (failed, recorded 2026-05-08 16:30)
+  Trace: workflow-trace-<HASH>-smoke-with-cache-<TIMESTAMP>.json (failed, recorded 2026-05-08 16:30)
   IR/settings declares: gemini/gemini-2.5-flash (overridden by trace evidence)
 
 ## Summary
@@ -23,5 +23,5 @@
 
 ## Notes
 
-  · Auto-loaded `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (failed run); no successful trace exists for this workflow. Trace-dependent recommendations may be suppressed. Re-run the workflow to record a successful trace, or pass `--from-trace <path>` to use a specific trace.
+  · Auto-loaded `workflow-trace-<HASH>-smoke-with-cache-<TIMESTAMP>.json` (failed run); no successful trace exists for this workflow. Trace-dependent recommendations may be suppressed. Re-run the workflow to record a successful trace, or pass `--from-trace <path>` to use a specific trace.
   · Cache fidelity check skipped: this is a first run (no prior runs to compare cached vs uncached against). On later runs, specific cache misfires (TTL expired, chunks skipped) will appear here.

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/09-autoload-rejected-names-file/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/09-autoload-rejected-names-file/command.sh
@@ -7,15 +7,20 @@ cd "$BASELINE_REPO_ROOT"
 # name the rejected file + its final_status so the agent knows which trace
 # was attempted.
 mkdir -p "$BASELINE_HOME/.pflow/debug"
-python3 - <<'PY'
-import hashlib, json, os
+uv run python - <<'PY'
+import hashlib, os
+from pathlib import Path
+
+from pflow.core.trace_io import load_trace_file
+from tests.shared.trace_jsonl import write_trace_jsonl
+
 src = os.environ["BASELINE_DIR"] + "/_shared/fixtures/sample-2.1.0-trace.json"
 wf_path = os.environ["BASELINE_DIR"] + "/_shared/workflows/smoke-with-cache.pflow.md"
 debug = os.environ["BASELINE_HOME"] + "/.pflow/debug"
 # Autoload globs by the md5 hash prefix of the workflow_path; the filename
 # must encode it or the trace is invisible to ``_autoload_trace``.
 wf_hash = hashlib.md5(wf_path.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
-data = json.load(open(src))
+data = load_trace_file(Path(src))
 data["workflow_path"] = wf_path
 data["final_status"] = "success"
 data["start_time"] = "2026-05-08T15:32:00"
@@ -26,7 +31,7 @@ for node in data["nodes"]:
         node["node_id"] = "outdated-answer-a"
     elif node.get("node_id") == "answer-b":
         node["node_id"] = "outdated-answer-b"
-json.dump(data, open(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-153200.json", "w"))
+write_trace_jsonl(Path(f"{debug}/workflow-trace-{wf_hash}-smoke-with-cache-20260508-153200.json"), data)
 PY
 uv run pflow analyze-cache \
   "$BASELINE_DIR/_shared/workflows/smoke-with-cache.pflow.md" \

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/09-autoload-rejected-names-file/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/09-autoload-rejected-names-file/expected-stdout.txt
@@ -40,4 +40,4 @@
 
 ## Notes
 
-  · Auto-loaded trace `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (success) did not cover all root LLM nodes (some root LLM nodes have no matching events — workflow may have been edited since the trace was recorded). Ignored for workflow-wide cache analysis. Pass `--from-trace <path>` to inspect a specific trace anyway.
+  · Auto-loaded trace `workflow-trace-<HASH>-smoke-with-cache-<TIMESTAMP>.json` (success) did not cover all root LLM nodes (some root LLM nodes have no matching events — workflow may have been edited since the trace was recorded). Ignored for workflow-wide cache analysis. Pass `--from-trace <path>` to inspect a specific trace anyway.

--- a/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/09-autoload-rejected-names-file/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/03-analyze-cache-modes/09-autoload-rejected-names-file/expected-stdout.txt
@@ -40,4 +40,4 @@
 
 ## Notes
 
-  · Auto-loaded trace `workflow-trace-b3b96a76-smoke-with-cache-<TIMESTAMP>.json` (success) did not cover all root LLM nodes (some root LLM nodes have no matching events — workflow may have been edited since the trace was recorded). Ignored for workflow-wide cache analysis. Pass `--from-trace <path>` to inspect a specific trace anyway.
+  · Auto-loaded trace `workflow-trace-3333c34d-smoke-with-cache-<TIMESTAMP>.json` (success) did not cover all root LLM nodes (some root LLM nodes have no matching events — workflow may have been edited since the trace was recorded). Ignored for workflow-wide cache analysis. Pass `--from-trace <path>` to inspect a specific trace anyway.

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/01-cache.order-mismatch/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/01-cache.order-mismatch/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/02-cache.unused-chunk/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/02-cache.unused-chunk/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/03-cache.invalid-on-non-llm/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/03-cache.invalid-on-non-llm/expected-stdout.txt
@@ -73,7 +73,7 @@
     "lower_bound_cache_ready_row_count": 0,
     "lower_bound_cache_opportunity_row_count": 0,
     "models_in_use": [],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/04-cache.shared-context-undeclared/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/04-cache.shared-context-undeclared/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/05-cache.sub-workflow-cache-undeclared/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/05-cache.sub-workflow-cache-undeclared/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/06-cache.batch-prewarm-recommended/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/06-cache.batch-prewarm-recommended/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/07-cache.dynamic-before-static/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/07-cache.dynamic-before-static/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09a-cache.below-min-predicted/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09a-cache.below-min-predicted/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09b-cache.below-min-observed/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09b-cache.below-min-observed/command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
-python3 "$BASELINE_DIR/_shared/write_cache_warning_trace.py" observed "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
+uv run python "$BASELINE_DIR/_shared/write_cache_warning_trace.py" observed "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
 uv run pflow analyze-cache "$BASELINE_CASE_DIR/workflow.pflow.md" --from-trace "$BASELINE_CASE_DIR/trace.json" --format=json

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09b-cache.below-min-observed/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09b-cache.below-min-observed/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [
       "anthropic/claude-sonnet-4-5"
     ],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09c-cache.below-min-rendered/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09c-cache.below-min-rendered/command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
-python3 "$BASELINE_DIR/_shared/write_cache_warning_trace.py" rendered "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
+uv run python "$BASELINE_DIR/_shared/write_cache_warning_trace.py" rendered "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
 uv run pflow analyze-cache "$BASELINE_CASE_DIR/workflow.pflow.md" --from-trace "$BASELINE_CASE_DIR/trace.json" --format=json

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09c-cache.below-min-rendered/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09c-cache.below-min-rendered/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [
       "anthropic/claude-sonnet-4-5"
     ],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09d-cache.prewarm-disabled-below-min/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09d-cache.prewarm-disabled-below-min/command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
-python3 "$BASELINE_DIR/_shared/write_cache_warning_trace.py" prewarm-disabled "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
+uv run python "$BASELINE_DIR/_shared/write_cache_warning_trace.py" prewarm-disabled "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
 uv run pflow analyze-cache "$BASELINE_CASE_DIR/workflow.pflow.md" --from-trace "$BASELINE_CASE_DIR/trace.json" --format=json 'items=[{"text":"alpha"},{"text":"beta"}]'

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09d-cache.prewarm-disabled-below-min/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09d-cache.prewarm-disabled-below-min/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [
       "anthropic/claude-sonnet-4-5"
     ],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09e-cache.conditional-warmup-recommended/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09e-cache.conditional-warmup-recommended/command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
-python3 "$BASELINE_DIR/_shared/write_cache_warning_trace.py" conditional "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
+uv run python "$BASELINE_DIR/_shared/write_cache_warning_trace.py" conditional "$BASELINE_CASE_DIR/workflow.pflow.md" "$BASELINE_CASE_DIR/trace.json"
 uv run pflow analyze-cache "$BASELINE_CASE_DIR/workflow.pflow.md" --from-trace "$BASELINE_CASE_DIR/trace.json" --format=json 'items=[{"text":"alpha"},{"text":"beta"},{"text":"gamma"},{"text":"delta"}]'

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09e-cache.conditional-warmup-recommended/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/09e-cache.conditional-warmup-recommended/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [
       "anthropic/claude-sonnet-4-5"
     ],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/10-cache.cross-workflow-prose-mismatch/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/10-cache.cross-workflow-prose-mismatch/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/11-cache.cross-workflow-rename-detected/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/11-cache.cross-workflow-rename-detected/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/12-cache.discrepancy/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/12-cache.discrepancy/command.sh
@@ -4,11 +4,11 @@ cd "$BASELINE_REPO_ROOT"
 TRACE="$BASELINE_HOME/discrepancy-trace.json"
 
 uv run python - <<'PY'
-import json
 import os
 from pathlib import Path
 
 from pflow.runtime.cache import MemoizationCache
+from tests.shared.trace_jsonl import write_trace_jsonl
 
 # The analyzer only predicts memo keys when a memo database exists. The
 # database does not need entries; plan_node still computes the miss key.
@@ -64,7 +64,7 @@ trace = {
         }
     ],
 }
-Path(os.environ["BASELINE_HOME"], "discrepancy-trace.json").write_text(json.dumps(trace, indent=2))
+write_trace_jsonl(Path(os.environ["BASELINE_HOME"], "discrepancy-trace.json"), trace)
 PY
 
 uv run pflow analyze-cache "$BASELINE_CASE_DIR/workflow.pflow.md" --from-trace "$TRACE"

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/12-cache.discrepancy/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/12-cache.discrepancy/expected-stdout.txt
@@ -4,6 +4,7 @@
   Workflow: 1 LLM node using anthropic/claude-sonnet-4-5
   Evidence: complete trace (1 LLM nodes executed)
   Trace: discrepancy-trace.json (success, recorded 2026-05-11 10:00)
+  IR/settings declares: gemini/gemini-2.5-flash (overridden by trace evidence)
 
 ## Summary
 

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/13-cache.prewarm-no-prefix/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/13-cache.prewarm-no-prefix/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/15-cache.heterogeneous-models-fragment-cache/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/15-cache.heterogeneous-models-fragment-cache/expected-stdout.txt
@@ -76,7 +76,7 @@
       "anthropic/claude-haiku-4-5",
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/16-cache.first-call-write-penalty/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/16-cache.first-call-write-penalty/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/17-cache.opaque-prompt/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/17-cache.opaque-prompt/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/18-cache.prompt-body-duplicates-cache/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/18-cache.prompt-body-duplicates-cache/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/19-cache.prompt-body-shadows-cache/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/19-cache.prompt-body-shadows-cache/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/20-llm.thinking-temperature-mismatch/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/20-llm.thinking-temperature-mismatch/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-opus-4-7"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/20b-llm.thinking-temperature-mismatch-subworkflow/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/20b-llm.thinking-temperature-mismatch-subworkflow/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-opus-4-7"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/21-cache.prompt-cache-incomplete/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/21-cache.prompt-cache-incomplete/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/22-cache.batch-prewarm-below-min/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/22-cache.batch-prewarm-below-min/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/23-cache.batch-prewarm-lower-bound-recommended/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/23-cache.batch-prewarm-lower-bound-recommended/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/04-warning-catalog/24-cache.shared-context-undeclared-conditional/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/04-warning-catalog/24-cache.shared-context-undeclared-conditional/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-haiku-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/05-advisory-cases/01-prewarm-savings-below-5pct-silent/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/05-advisory-cases/01-prewarm-savings-below-5pct-silent/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/05-advisory-cases/02-prewarm-explicit-false-suppresses-warning/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/05-advisory-cases/02-prewarm-explicit-false-suppresses-warning/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/05-advisory-cases/03-prewarm-explicit-true-no-warning/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/05-advisory-cases/03-prewarm-explicit-true-no-warning/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/05-advisory-cases/04-model-fragmentation-with-write-penalty/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/05-advisory-cases/04-model-fragmentation-with-write-penalty/expected-stdout.txt
@@ -76,7 +76,7 @@
       "anthropic/claude-haiku-4-5",
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/05-advisory-cases/05-cost-projection-excludes-heterogeneous-cohort/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/05-advisory-cases/05-cost-projection-excludes-heterogeneous-cohort/expected-stdout.txt
@@ -76,7 +76,7 @@
       "anthropic/claude-sonnet-4-5",
       "ollama/llama3.2:8b"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [

--- a/.taskmaster/tasks/task_159/baseline/06-dry-run-nudge/01-actionable-shared-context-nudge/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/06-dry-run-nudge/01-actionable-shared-context-nudge/expected-stdout.txt
@@ -1,11 +1,11 @@
 Dry-run for workflow.pflow.md: 3 nodes
 
   ─── nothing cached — full run ───
-  ▸ summarize  [LLM]   ≈ $? (no history)
-  ▸ translate  [LLM]   ≈ $? (no history)
-  ▸ tag  [LLM]   ≈ $? (no history)
+  ▸ summarize  [llm]   ≈ $? (no history)
+  ▸ translate  [llm]   ≈ $? (no history)
+  ▸ tag  [llm]   ≈ $? (no history)
 
-Summary: 0 cached · 3 would execute (3 LLM)
+Summary: 0 cached · 3 would execute (3 llm)
   (3 LLM nodes without cost history)
   (3 nodes without duration history)
 

--- a/.taskmaster/tasks/task_159/baseline/06-dry-run-nudge/02-optimal-workflow-silent/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/06-dry-run-nudge/02-optimal-workflow-silent/expected-stdout.txt
@@ -1,8 +1,8 @@
 Dry-run for workflow.pflow.md: 1 nodes
 
   ─── nothing cached — full run ───
-  ▸ scoring  [LLM]   ≈ $? (no history)
+  ▸ scoring  [llm]   ≈ $? (no history)
 
-Summary: 0 cached · 1 would execute (1 LLM)
+Summary: 0 cached · 1 would execute (1 llm)
   (1 LLM node without cost history)
   (1 node without duration history)

--- a/.taskmaster/tasks/task_159/baseline/10-live-recordings/05-gemini-lyrics-generator/minimize-trace-fixture.py
+++ b/.taskmaster/tasks/task_159/baseline/10-live-recordings/05-gemini-lyrics-generator/minimize-trace-fixture.py
@@ -31,7 +31,7 @@ from typing import Any
 # One-shot authoring tool: it imports repo-internal helpers (pflow + tests.shared). Run via
 # `uv run python` so pflow resolves; bootstrap the repo root onto sys.path so `tests.shared`
 # resolves too (a `python <path>` run puts the SCRIPT dir on sys.path[0], not the repo root).
-_REPO_ROOT = Path(__file__).resolve()
+_REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / "pyproject.toml").exists():
     if _REPO_ROOT.parent == _REPO_ROOT:
         raise SystemExit("minimize-trace-fixture.py: could not locate repo root (pyproject.toml)")

--- a/.taskmaster/tasks/task_159/baseline/10-live-recordings/05-gemini-lyrics-generator/minimize-trace-fixture.py
+++ b/.taskmaster/tasks/task_159/baseline/10-live-recordings/05-gemini-lyrics-generator/minimize-trace-fixture.py
@@ -12,19 +12,34 @@ preserving the analyzer facts this baseline is meant to exercise:
 - one prompt source per LLM event (``llm_prompt``)
 - producer values needed for cross-workflow cache projections
 
-Run from the repository root, for example:
+The committed fixture is Task-172 JSONL — the only on-disk format ``load_trace_file``
+reads since #531 — so this tool reads the raw trace and writes the minimized fixture via
+the shared JSONL helpers (``load_trace_file`` / ``tests.shared.trace_jsonl.write_trace_jsonl``).
+Run from the repository root with ``uv run python`` (so pflow is importable), for example:
 
-    python .taskmaster/tasks/task_159/baseline/10-live-recordings/05-gemini-lyrics-generator/minimize-trace-fixture.py \
-      /Users/andfal/.pflow/debug/workflow-trace-c2f89d56-lyrics-generator-20260508-221119.json \
+    uv run python .taskmaster/tasks/task_159/baseline/10-live-recordings/05-gemini-lyrics-generator/minimize-trace-fixture.py \
+      ~/.pflow/debug/workflow-trace-<hash>-lyrics-generator-<timestamp>.json \
       .taskmaster/tasks/task_159/baseline/_shared/fixtures/live-gemini-lyrics-generator.trace.json
 """
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 from typing import Any
+
+# One-shot authoring tool: it imports repo-internal helpers (pflow + tests.shared). Run via
+# `uv run python` so pflow resolves; bootstrap the repo root onto sys.path so `tests.shared`
+# resolves too (a `python <path>` run puts the SCRIPT dir on sys.path[0], not the repo root).
+_REPO_ROOT = Path(__file__).resolve()
+while not (_REPO_ROOT / "pyproject.toml").exists():
+    if _REPO_ROOT.parent == _REPO_ROOT:
+        raise SystemExit("minimize-trace-fixture.py: could not locate repo root (pyproject.toml)")
+    _REPO_ROOT = _REPO_ROOT.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from pflow.core.trace_io import load_trace_file  # noqa: E402 — needs the sys.path bootstrap above
+from tests.shared.trace_jsonl import write_trace_jsonl  # noqa: E402 — needs the sys.path bootstrap above
 
 DROP_STRING_KEYS = {
     # Direct LLM/request echoes duplicated elsewhere.
@@ -123,10 +138,10 @@ def main(argv: list[str]) -> int:
 
     source = Path(argv[1])
     output = Path(argv[2])
-    data = json.loads(source.read_text(encoding="utf-8"))
+    data = load_trace_file(source)
     minimize_trace(data)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(data, separators=(",", ":"), ensure_ascii=False), encoding="utf-8")
+    write_trace_jsonl(output, data)
     print(f"wrote {output} ({output.stat().st_size:,} bytes)")
     return 0
 

--- a/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/01-analyze-cache-text/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/01-analyze-cache-text/expected-stdout.txt
@@ -1,8 +1,7 @@
 # Cache Analysis: lyrics-generator.pflow.md
   File: .taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md
 
-  Workflow: 25 LLM nodes, invocation count unavailable (3 dynamic batch nodes)
-  Models: not resolved (set settings.default_model)
+  Workflow: 25 LLM nodes, invocation count unavailable (3 dynamic batch nodes) using gemini/gemini-2.5-flash
   Heterogeneous: generate-chorus-options (model varies per batch item)
   (2 in lyrics-generator.pflow.md, 23 in 14 sub-workflows)
 
@@ -10,16 +9,17 @@
 
   Cost per run:                unavailable
 
-  6 recommended actions
+  5 recommended actions
 
-  Cost data unavailable: no model resolved for LLM nodes (set settings.default_model or add per-node `- model:`).
+  Cost data unavailable: run the workflow once for cost figures.
+  Suggested:  pflow run .taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md sources=<value> output_base=<value>
 
 ## Blocking errors
 
   1. In step 'fetch-sources' sub-workflow: Unknown node type: 'mcp-klavis-youtube-get_youtube_video_transcript'
      fetch-youtube-mcp in fetch-source.pflow.md
 
-## Recommended actions (6)
+## Recommended actions (5, ordered by impact)
 
   Each item below is a cache-optimization opportunity for this workflow.
   Declared values are sent once and reused at 0.1× input cost.
@@ -29,33 +29,27 @@
     (2) Add the listed values as named entries under the child workflow's ## Cache section.
     (3) Reference that named entry in `prompt_cache:` on each consumer node.
 
-  1. Dynamic ref blocks caching on write-lyrics — move `${choose-chorus.chorus_guide}` after stable content  savings unavailable
-     write-lyrics in song-creator.pflow.md
-     write-lyrics: dynamic `${choose-chorus.chorus_guide}` reference at line 68 appears before ~1002 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
-     → Move the cacheable content (everything stable across calls) to BEFORE `${choose-chorus.chorus_guide}` in the prompt template.
-     → Projected cache ratio after fix: ?%.
-
-  2. Dynamic ref blocks caching on rewrite-emotional — move `${write-lyrics.response}` after stable content  savings unavailable
-     rewrite-emotional in song-creator.pflow.md
-     rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~2028 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
-     → Move the cacheable content (everything stable across calls) to BEFORE `${write-lyrics.response}` in the prompt template.
-     → Projected cache ratio after fix: ?%.
-
-  3. Dynamic ref blocks caching on rewrite-craft — move `${extract-emotional-lyrics.result.lyrics}` after stable content  savings unavailable
+  1. Dynamic ref blocks caching on rewrite-craft — move `${extract-emotional-lyrics.result.lyrics}` after stable content  saves ~$0.0005/run
      rewrite-craft in song-creator.pflow.md
-     rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~2170 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
+     rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~1904 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
      → Move the cacheable content (everything stable across calls) to BEFORE `${extract-emotional-lyrics.result.lyrics}` in the prompt template.
      → Projected cache ratio after fix: ?%.
 
-  4. Dynamic ref blocks caching on generate-suno-prompt — move `${extract-lyrics.result.lyrics}` after stable content  savings unavailable
+  2. Dynamic ref blocks caching on rewrite-emotional — move `${write-lyrics.response}` after stable content  saves ~$0.0005/run
+     rewrite-emotional in song-creator.pflow.md
+     rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~1784 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
+     → Move the cacheable content (everything stable across calls) to BEFORE `${write-lyrics.response}` in the prompt template.
+     → Projected cache ratio after fix: ?%.
+
+  3. Dynamic ref blocks caching on generate-suno-prompt — move `${extract-lyrics.result.lyrics}` after stable content  saves ~$0.0003/run
      generate-suno-prompt in song-creator.pflow.md
-     generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1223 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
+     generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1044 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
      → Move the cacheable content (everything stable across calls) to BEFORE `${extract-lyrics.result.lyrics}` in the prompt template.
      → Projected cache ratio after fix: 92%.
 
-  5. Sub-workflow cache undeclared in chorus-chooser.pflow.md — add 4 entries in ## Cache  unmeasurable
+  4. Sub-workflow cache undeclared in chorus-chooser.pflow.md — add 4 entries in ## Cache  not yet cacheable
      chorus-chooser.pflow.md
-     Four values flow in but no consumer node has a resolved model — cannot compute the cache threshold.
+     Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 — Anthropic Sonnet 4.5).
      Only these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.
      Edit child workflow:
        Add or extend ## Cache:
@@ -82,35 +76,41 @@
        • `concept.title` unmeasurable — node(s) `select-chorus` use `${concept.title}`
        • `creative_brief` unmeasurable — node(s) `select-chorus` use `${creative_brief}`
            flows in from parent as `${concept_brief}`
-     → Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.
+     → Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.
+     → Verify: confirm ~0 tokens is the realistic per-call size.
      → Edit: .taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md
 
-  6. Prompt opaque to static analysis on generate-chorus-options — refactor inline for cache detection  savings unavailable
+  5. Prompt opaque to static analysis on generate-chorus-options — refactor inline for cache detection  savings unavailable
      generate-chorus-options in chorus-chooser.pflow.md
      generate-chorus-options: prompt is `${item.prompt}`, assembled by `build-grouped-items` (type: code). Static analysis cannot inspect the assembled prompt's structure, so cache opportunities (shared prefixes, prewarm) are not detected. If the assembled prompt has a stable prefix and per-call dynamic content, refactoring to an inline declarative prompt unlocks detection.
      → Inline the prompt template on `generate-chorus-options`: replace `${item.prompt}` with the literal prompt content, with stable bytes BEFORE per-call dynamic references.
      → See `pflow guide prompt-caching` (Python-assembled prompts section) for the refactor pattern.
 
 ## Per-call cache report
+  How to read each row:
+    · ready: tokens already active or unlockable by a direct cache edit in the current prompt shape.
+    · upside: unrealized cache opportunity after the notes column's required edit.
+    · — means the column does not apply to this row.
+    · ? means the column applies but the token count can't be measured yet (run the workflow once to populate).
   Showing 8 of 25 LLM nodes; low-signal rows hidden (--all-rows shows everything).
 
-  node                     model         input  notes
-  ----------------------------------------------
+  node                     model                    input  ready  notes
+  ----------------------------------------------------------------
 
 ### song-creator.pflow.md (called by create-songs)
-  write-lyrics             <unresolved>  3,684  dynamic-before-static
-  song-architecture        <unresolved>  2,886
-  rewrite-emotional        <unresolved>  2,575  dynamic-before-static
-  rewrite-craft            <unresolved>  2,454  dynamic-before-static
-  generate-suno-prompt     <unresolved>  1,340  dynamic-before-static
-  creative-direction       <unresolved>  1,248
-  easter-eggs              <unresolved>  1,066
+  write-lyrics             gemini/gemini-2.5-flash  3,247      ?
+  song-architecture        gemini/gemini-2.5-flash  2,568      ?
+  rewrite-emotional        gemini/gemini-2.5-flash  2,239      ?  dynamic-before-static
+  rewrite-craft            gemini/gemini-2.5-flash  2,141      ?  dynamic-before-static
+  generate-suno-prompt     gemini/gemini-2.5-flash  1,137      ?  dynamic-before-static
+  creative-direction       gemini/gemini-2.5-flash  1,084      ?
+  easter-eggs              gemini/gemini-2.5-flash    898      ?
 
 ### chorus-chooser.pflow.md (called by choose-chorus)
-  generate-chorus-options  <varies>          ?  opaque-prompt
+  generate-chorus-options  <varies>                     ?      —  opaque-prompt
 
   Token estimate confidence:
-    · Projected input tokens for: write-lyrics, song-architecture, rewrite-emotional, rewrite-craft, generate-suno-prompt, creative-direction, easter-eggs, generate-chorus-options.
+    · Projected input tokens for: song-architecture, creative-direction, easter-eggs, generate-chorus-options.
 
 ## Per-child analyze-cache commands
 

--- a/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/02-analyze-cache-json/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/02-analyze-cache-json/expected-stdout.txt
@@ -6,8 +6,8 @@
   "estimate_confidence_coverage": {
     "trace": 0,
     "memo": 0,
-    "estimator": 0,
-    "heuristic": 25,
+    "estimator": 3,
+    "heuristic": 1,
     "total": 25
   },
   "trace_path": null,
@@ -56,13 +56,13 @@
     "trace_llm_nodes_executed": 0,
     "trace_unexecuted_llm_rows": [],
     "blocking_errors": 0,
-    "actionable_opportunities": 23,
-    "warnings_count": 4,
+    "actionable_opportunities": 22,
+    "warnings_count": 3,
     "info_count": 19,
     "total_llm_nodes_estimated": 25,
     "total_llm_invocations_estimated": null,
     "dynamic_batch_node_count": 3,
-    "total_input_tokens_estimated": 38442,
+    "total_input_tokens_estimated": 33326,
     "total_cache_active_tokens_estimated": 0,
     "total_cache_ready_tokens_estimated": 0,
     "total_cache_opportunity_tokens_estimated": 0,
@@ -72,91 +72,15 @@
     "unknown_cache_opportunity_row_count": 0,
     "lower_bound_cache_ready_row_count": 0,
     "lower_bound_cache_opportunity_row_count": 0,
-    "models_in_use": [],
-    "ir_default_model": null,
+    "models_in_use": [
+      "gemini/gemini-2.5-flash"
+    ],
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],
     "unavailable_models_by_workflow": {},
     "projection_exclusions": [
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md",
-        "node_path": "curate-briefs",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md",
-        "node_path": "evaluate-songs",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/analyze-source/analyze-source.pflow.md",
-        "node_path": "analyze",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/concept-chooser/concept-chooser.pflow.md",
-        "node_path": "generate-concepts",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/concept-chooser/concept-chooser.pflow.md",
-        "node_path": "select-concepts",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/enforce-diversity/enforce-diversity.pflow.md",
-        "node_path": "assign-diversity",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "creative-direction",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "song-architecture",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "easter-eggs",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "write-lyrics",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "rewrite-emotional",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "rewrite-craft",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
-      {
-        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "node_path": "generate-suno-prompt",
-        "reason": "unresolved_model",
-        "actual_cost_usd": null
-      },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md",
         "node_path": "generate-chorus-options",
@@ -164,69 +88,147 @@
         "actual_cost_usd": null
       },
       {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md",
+        "node_path": "curate-briefs",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md",
+        "node_path": "evaluate-songs",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/analyze-source/analyze-source.pflow.md",
+        "node_path": "analyze",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/concept-chooser/concept-chooser.pflow.md",
+        "node_path": "generate-concepts",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/concept-chooser/concept-chooser.pflow.md",
+        "node_path": "select-concepts",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/enforce-diversity/enforce-diversity.pflow.md",
+        "node_path": "assign-diversity",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "creative-direction",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "song-architecture",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "easter-eggs",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "write-lyrics",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "rewrite-emotional",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "rewrite-craft",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
+        "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
+        "node_path": "generate-suno-prompt",
+        "reason": "missing_output_tokens",
+        "actual_cost_usd": null
+      },
+      {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md",
         "node_path": "score-choruses",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md",
         "node_path": "select-chorus",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-emotional-architecture.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-narrative.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-imagery.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-stranger-summary.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-ai-tells.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-cliche.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-genre.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-accuracy.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       },
       {
         "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-rhyme.pflow.md",
         "node_path": "review",
-        "reason": "unresolved_model",
+        "reason": "missing_output_tokens",
         "actual_cost_usd": null
       }
     ],
@@ -412,12 +414,12 @@
     {
       "rank": 1,
       "warning_id": "cache.dynamic-before-static",
-      "node_id": "write-lyrics",
-      "estimated_savings_usd": null,
+      "node_id": "rewrite-craft",
+      "estimated_savings_usd": 0.00051408,
       "scope_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "message": "write-lyrics: dynamic `${choose-chorus.chorus_guide}` reference at line 68 appears before ~1002 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
+      "message": "rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~1904 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
       "suggestions": [
-        "Move the cacheable content (everything stable across calls) to BEFORE `${choose-chorus.chorus_guide}` in the prompt template.",
+        "Move the cacheable content (everything stable across calls) to BEFORE `${extract-emotional-lyrics.result.lyrics}` in the prompt template.",
         "Projected cache ratio after fix: ?%."
       ]
     },
@@ -425,9 +427,9 @@
       "rank": 2,
       "warning_id": "cache.dynamic-before-static",
       "node_id": "rewrite-emotional",
-      "estimated_savings_usd": null,
+      "estimated_savings_usd": 0.00048168,
       "scope_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "message": "rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~2028 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
+      "message": "rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~1784 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
       "suggestions": [
         "Move the cacheable content (everything stable across calls) to BEFORE `${write-lyrics.response}` in the prompt template.",
         "Projected cache ratio after fix: ?%."
@@ -436,40 +438,28 @@
     {
       "rank": 3,
       "warning_id": "cache.dynamic-before-static",
-      "node_id": "rewrite-craft",
-      "estimated_savings_usd": null,
-      "scope_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "message": "rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~2170 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
-      "suggestions": [
-        "Move the cacheable content (everything stable across calls) to BEFORE `${extract-emotional-lyrics.result.lyrics}` in the prompt template.",
-        "Projected cache ratio after fix: ?%."
-      ]
-    },
-    {
-      "rank": 4,
-      "warning_id": "cache.dynamic-before-static",
       "node_id": "generate-suno-prompt",
-      "estimated_savings_usd": null,
+      "estimated_savings_usd": 0.00028188,
       "scope_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "message": "generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1223 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
+      "message": "generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1044 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
       "suggestions": [
         "Move the cacheable content (everything stable across calls) to BEFORE `${extract-lyrics.result.lyrics}` in the prompt template.",
         "Projected cache ratio after fix: 92%."
       ]
     },
     {
-      "rank": 5,
+      "rank": 4,
       "warning_id": "cache.sub-workflow-cache-undeclared",
       "node_id": null,
       "estimated_savings_usd": null,
       "scope_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md",
-      "message": "Four values flow in but no consumer node has a resolved model \u2014 cannot compute the cache threshold.\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.",
+      "message": "Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 \u2014 Anthropic Sonnet 4.5).\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.\n\u2192 Verify: confirm ~0 tokens is the realistic per-call size.",
       "suggestions": [
         "Edit: <REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md"
       ]
     },
     {
-      "rank": 6,
+      "rank": 5,
       "warning_id": "cache.opaque-prompt",
       "node_id": "generate-chorus-options",
       "estimated_savings_usd": null,
@@ -486,12 +476,12 @@
     {
       "node_path": "curate-briefs",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": true,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 3869,
+      "input_tokens_estimated": 3235,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 3869,
+      "body_tokens_estimated": 3235,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -553,7 +543,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -566,12 +556,12 @@
     {
       "node_path": "evaluate-songs",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/lyrics-generator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 782,
+      "input_tokens_estimated": 713,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 782,
+      "body_tokens_estimated": 713,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -633,7 +623,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -646,12 +636,12 @@
     {
       "node_path": "analyze",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/analyze-source/analyze-source.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": true,
       "batch_size_estimated": 6,
-      "input_tokens_estimated": 3,
+      "input_tokens_estimated": 4,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 3,
+      "body_tokens_estimated": 4,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -713,7 +703,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -726,12 +716,12 @@
     {
       "node_path": "generate-concepts",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/concept-chooser/concept-chooser.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": true,
       "batch_size_estimated": 4,
-      "input_tokens_estimated": 3,
+      "input_tokens_estimated": 4,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 3,
+      "body_tokens_estimated": 4,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -793,7 +783,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -806,12 +796,12 @@
     {
       "node_path": "select-concepts",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/concept-chooser/concept-chooser.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 826,
+      "input_tokens_estimated": 812,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 826,
+      "body_tokens_estimated": 812,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -873,7 +863,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -886,12 +876,12 @@
     {
       "node_path": "assign-diversity",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/enforce-diversity/enforce-diversity.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1348,
+      "input_tokens_estimated": 1130,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1348,
+      "body_tokens_estimated": 1130,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -953,7 +943,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -966,12 +956,12 @@
     {
       "node_path": "creative-direction",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1248,
+      "input_tokens_estimated": 1084,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1248,
+      "body_tokens_estimated": 1084,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -985,7 +975,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -998,7 +988,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1027,7 +1017,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1040,7 +1030,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1061,7 +1051,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "concept",
@@ -1077,12 +1067,12 @@
     {
       "node_path": "song-architecture",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 2886,
+      "input_tokens_estimated": 2568,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 2886,
+      "body_tokens_estimated": 2568,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1096,7 +1086,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1109,7 +1099,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1138,7 +1128,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1151,7 +1141,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1172,7 +1162,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "concept",
@@ -1189,12 +1179,12 @@
     {
       "node_path": "easter-eggs",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1066,
+      "input_tokens_estimated": 898,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1066,
+      "body_tokens_estimated": 898,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1208,7 +1198,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1221,7 +1211,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1250,7 +1240,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1263,7 +1253,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1284,7 +1274,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "concept",
@@ -1302,12 +1292,12 @@
     {
       "node_path": "write-lyrics",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 3684,
+      "input_tokens_estimated": 3247,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 3684,
+      "body_tokens_estimated": 3247,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1321,7 +1311,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1334,7 +1324,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1363,7 +1353,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1376,7 +1366,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1397,7 +1387,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "concept",
@@ -1416,12 +1406,12 @@
     {
       "node_path": "rewrite-emotional",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 2575,
+      "input_tokens_estimated": 2239,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 2575,
+      "body_tokens_estimated": 2239,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1435,7 +1425,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1448,7 +1438,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1477,7 +1467,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1490,7 +1480,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1511,7 +1501,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "concept",
@@ -1530,12 +1520,12 @@
     {
       "node_path": "rewrite-craft",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 2454,
+      "input_tokens_estimated": 2141,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 2454,
+      "body_tokens_estimated": 2141,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1549,7 +1539,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1562,7 +1552,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1591,7 +1581,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1604,7 +1594,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1625,7 +1615,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "concept",
@@ -1643,12 +1633,12 @@
     {
       "node_path": "generate-suno-prompt",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1340,
+      "input_tokens_estimated": 1137,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1340,
+      "body_tokens_estimated": 1137,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1662,7 +1652,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1675,7 +1665,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1704,7 +1694,7 @@
         "actionability": "configured_blocked",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [],
@@ -1717,7 +1707,7 @@
             "actionability": "configured_blocked",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": []
@@ -1738,7 +1728,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": [
         "creative-direction.response"
@@ -1833,12 +1823,12 @@
     {
       "node_path": "score-choruses",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": true,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1076,
+      "input_tokens_estimated": 1032,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1076,
+      "body_tokens_estimated": 1032,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1880,7 +1870,7 @@
         "actionability": "direct_edit",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [
@@ -1895,7 +1885,7 @@
             "actionability": "direct_edit",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": [
@@ -1912,7 +1902,7 @@
         "actionability": "direct_edit",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [
@@ -1927,7 +1917,7 @@
             "actionability": "direct_edit",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": [
@@ -1936,7 +1926,7 @@
           }
         ]
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -1949,12 +1939,12 @@
     {
       "node_path": "select-chorus",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1209,
+      "input_tokens_estimated": 1043,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1209,
+      "body_tokens_estimated": 1043,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -1996,7 +1986,7 @@
         "actionability": "direct_edit",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [
@@ -2011,7 +2001,7 @@
             "actionability": "direct_edit",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": [
@@ -2028,7 +2018,7 @@
         "actionability": "direct_edit",
         "confidence": "unknown",
         "meets_provider_min": null,
-        "provider_min_tokens": null,
+        "provider_min_tokens": 1024,
         "blocked_reason": "",
         "affects_cost_projection": false,
         "diagnostic_ids": [
@@ -2043,7 +2033,7 @@
             "actionability": "direct_edit",
             "confidence": "unknown",
             "meets_provider_min": null,
-            "provider_min_tokens": null,
+            "provider_min_tokens": 1024,
             "blocked_reason": "",
             "affects_cost_projection": false,
             "diagnostic_ids": [
@@ -2052,7 +2042,7 @@
           }
         ]
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2065,12 +2055,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-emotional-architecture.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 2020,
+      "input_tokens_estimated": 1652,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 2020,
+      "body_tokens_estimated": 1652,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2132,7 +2122,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2145,12 +2135,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-narrative.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 838,
+      "input_tokens_estimated": 693,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 838,
+      "body_tokens_estimated": 693,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2212,7 +2202,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2225,12 +2215,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-imagery.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 2129,
+      "input_tokens_estimated": 1796,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 2129,
+      "body_tokens_estimated": 1796,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2292,7 +2282,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2305,12 +2295,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-stranger-summary.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1376,
+      "input_tokens_estimated": 1228,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1376,
+      "body_tokens_estimated": 1228,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2372,7 +2362,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2385,12 +2375,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-ai-tells.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1389,
+      "input_tokens_estimated": 1283,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1389,
+      "body_tokens_estimated": 1283,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2452,7 +2442,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2465,12 +2455,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-cliche.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1312,
+      "input_tokens_estimated": 1158,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1312,
+      "body_tokens_estimated": 1158,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2532,7 +2522,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2545,12 +2535,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-genre.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1240,
+      "input_tokens_estimated": 1035,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1240,
+      "body_tokens_estimated": 1035,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2612,7 +2602,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2625,12 +2615,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-accuracy.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 2606,
+      "input_tokens_estimated": 2098,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 2606,
+      "body_tokens_estimated": 2098,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2692,7 +2682,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -2705,12 +2695,12 @@
     {
       "node_path": "review",
       "workflow_path": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/reviews/review-rhyme.pflow.md",
-      "model": "",
+      "model": "gemini/gemini-2.5-flash",
       "is_batch": false,
       "batch_size_estimated": null,
-      "input_tokens_estimated": 1136,
+      "input_tokens_estimated": 1061,
       "chunk_tokens_estimated": 0,
-      "body_tokens_estimated": 1136,
+      "body_tokens_estimated": 1061,
       "output_tokens_estimated": null,
       "output_data_source": "unavailable",
       "cache_creation_input_tokens": null,
@@ -2772,7 +2762,7 @@
         "diagnostic_ids": [],
         "components": []
       },
-      "data_source": "heuristic",
+      "data_source": "estimator-partial",
       "cross_workflow_inputs": [],
       "declared_prompt_cache": null,
       "model_is_heterogeneous": false,
@@ -3182,7 +3172,7 @@
     "value_flow_opportunities": [
       {
         "severity": "info",
-        "message": "Four values flow in but no consumer node has a resolved model \u2014 cannot compute the cache threshold.\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.",
+        "message": "Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 \u2014 Anthropic Sonnet 4.5).\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.\n\u2192 Verify: confirm ~0 tokens is the realistic per-call size.",
         "source": "cache_analyzer",
         "id": "cache.sub-workflow-cache-undeclared",
         "title": "Cache Advisory",
@@ -3292,8 +3282,8 @@
               }
             }
           ],
-          "body_block": "Four values flow in but no consumer node has a resolved model \u2014 cannot compute the cache threshold.\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.",
-          "case": "unmeasurable",
+          "body_block": "Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 \u2014 Anthropic Sonnet 4.5).\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.\n\u2192 Verify: confirm ~0 tokens is the realistic per-call size.",
+          "case": "refactor",
           "savings_usd": null,
           "category": "cache_advisory",
           "path": "workflows[path=<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md]"
@@ -3307,39 +3297,7 @@
   "warnings": [
     {
       "severity": "warning",
-      "message": "write-lyrics: dynamic `${choose-chorus.chorus_guide}` reference at line 68 appears before ~1002 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
-      "source": "cache_analyzer",
-      "id": "cache.dynamic-before-static",
-      "title": "Cache Warning",
-      "suggestions": [
-        "Move the cacheable content (everything stable across calls) to BEFORE `${choose-chorus.chorus_guide}` in the prompt template.",
-        "Projected cache ratio after fix: ?%."
-      ],
-      "node_id": "write-lyrics",
-      "context": {
-        "affected_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
-        "dynamic_ref": "choose-chorus.chorus_guide",
-        "dynamic_line": 68,
-        "cacheable_tokens": 1002,
-        "affected_calls": 1,
-        "savings_usd": null,
-        "projected_ratio_pct": null,
-        "detection_mode": "declared_cache",
-        "min_cache_tokens": 4096,
-        "model": "",
-        "tokens_before_dynamic": null,
-        "template_refs_after_dynamic": 0,
-        "static_tail_excerpt": "## How to Use the Material Palette's Key Sections When you draw from the material palette: - **Kill Moments** \u2014 The son...",
-        "category": "cache_warning",
-        "path": "nodes[id=write-lyrics].prompt"
-      },
-      "see_also": [
-        "prompt-caching"
-      ]
-    },
-    {
-      "severity": "warning",
-      "message": "rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~2028 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
+      "message": "rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~1784 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
       "source": "cache_analyzer",
       "id": "cache.dynamic-before-static",
       "title": "Cache Warning",
@@ -3352,13 +3310,13 @@
         "affected_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
         "dynamic_ref": "write-lyrics.response",
         "dynamic_line": 18,
-        "cacheable_tokens": 2028,
+        "cacheable_tokens": 1784,
         "affected_calls": 1,
-        "savings_usd": null,
+        "savings_usd": 0.00048168,
         "projected_ratio_pct": null,
         "detection_mode": "declared_cache",
-        "min_cache_tokens": 4096,
-        "model": "",
+        "min_cache_tokens": 1024,
+        "model": "gemini/gemini-2.5-flash",
         "tokens_before_dynamic": null,
         "template_refs_after_dynamic": 0,
         "static_tail_excerpt": "## What You Can Change You have permission to make structural moves that a line-level rewriter cannot: - **Rewrite enti...",
@@ -3371,7 +3329,7 @@
     },
     {
       "severity": "warning",
-      "message": "rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~2170 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
+      "message": "rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~1904 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
       "source": "cache_analyzer",
       "id": "cache.dynamic-before-static",
       "title": "Cache Warning",
@@ -3384,13 +3342,13 @@
         "affected_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
         "dynamic_ref": "extract-emotional-lyrics.result.lyrics",
         "dynamic_line": 15,
-        "cacheable_tokens": 2170,
+        "cacheable_tokens": 1904,
         "affected_calls": 1,
-        "savings_usd": null,
+        "savings_usd": 0.00051408,
         "projected_ratio_pct": null,
         "detection_mode": "declared_cache",
-        "min_cache_tokens": 4096,
-        "model": "",
+        "min_cache_tokens": 1024,
+        "model": "gemini/gemini-2.5-flash",
         "tokens_before_dynamic": null,
         "template_refs_after_dynamic": 0,
         "static_tail_excerpt": "## Rules - **Do NOT restructure sections or move emotional peaks.** The emotional architecture is locked. If a verse bu...",
@@ -3403,7 +3361,7 @@
     },
     {
       "severity": "warning",
-      "message": "generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1223 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
+      "message": "generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1044 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run",
       "source": "cache_analyzer",
       "id": "cache.dynamic-before-static",
       "title": "Cache Warning",
@@ -3416,14 +3374,14 @@
         "affected_workflow": "<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md",
         "dynamic_ref": "extract-lyrics.result.lyrics",
         "dynamic_line": 5,
-        "cacheable_tokens": 1223,
+        "cacheable_tokens": 1044,
         "affected_calls": 1,
-        "savings_usd": null,
+        "savings_usd": 0.00028188,
         "projected_ratio_pct": 92,
         "detection_mode": "declared_cache",
-        "min_cache_tokens": 4096,
-        "model": "",
-        "tokens_before_dynamic": 109,
+        "min_cache_tokens": 1024,
+        "model": "gemini/gemini-2.5-flash",
+        "tokens_before_dynamic": 85,
         "template_refs_after_dynamic": 0,
         "static_tail_excerpt": "## Output Format \u2014 Three Layers Write THREE things in this exact format, each separated by a single blank line. Order i...",
         "category": "cache_warning",
@@ -3864,7 +3822,7 @@
     },
     {
       "severity": "info",
-      "message": "Four values flow in but no consumer node has a resolved model \u2014 cannot compute the cache threshold.\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.",
+      "message": "Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 \u2014 Anthropic Sonnet 4.5).\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.\n\u2192 Verify: confirm ~0 tokens is the realistic per-call size.",
       "source": "cache_analyzer",
       "id": "cache.sub-workflow-cache-undeclared",
       "title": "Cache Advisory",
@@ -3974,8 +3932,8 @@
             }
           }
         ],
-        "body_block": "Four values flow in but no consumer node has a resolved model \u2014 cannot compute the cache threshold.\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.",
-        "case": "unmeasurable",
+        "body_block": "Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 \u2014 Anthropic Sonnet 4.5).\nOnly these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.\nEdit child workflow:\n  Add or extend ## Cache:\n    ```cache\n    The song architecture \u2014 section layout,...\n    \n    ${architecture}\n    \n    ${concept.core_idea}\n    \n    ${concept.title}\n    \n    The concept brief \u2014 material palette ta...\n    \n    ${creative_brief}\n    ```\n  Add prompt_cache entries:\n    score-choruses: prompt_cache: [concept.core_idea]\n    select-chorus: prompt_cache: [architecture, concept.core_idea, concept.title, creative_brief]\nPrompt-body templates to remove:\n  \u2022 `architecture` unmeasurable \u2014 node(s) `select-chorus` use `${architecture}`\n      flows in from parent as `${song-architecture.response}`\n  \u2022 `concept.core_idea` unmeasurable \u2014 node(s) `score-choruses`, `select-chorus` use `${concept.core_idea}`\n  \u2022 `concept.title` unmeasurable \u2014 node(s) `select-chorus` use `${concept.title}`\n  \u2022 `creative_brief` unmeasurable \u2014 node(s) `select-chorus` use `${creative_brief}`\n      flows in from parent as `${concept_brief}`\n\u2192 Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.\n\u2192 Verify: confirm ~0 tokens is the realistic per-call size.",
+        "case": "refactor",
         "savings_usd": null,
         "category": "cache_advisory",
         "path": "workflows[path=<REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md]"

--- a/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/03-analyze-cache-song-creator-text/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/03-analyze-cache-song-creator-text/expected-stdout.txt
@@ -1,8 +1,7 @@
 # Cache Analysis: song-creator.pflow.md
   File: .taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md
 
-  Workflow: 19 LLM nodes, invocation count unavailable (2 dynamic batch nodes)
-  Models: not resolved (set settings.default_model)
+  Workflow: 19 LLM nodes, invocation count unavailable (2 dynamic batch nodes) using gemini/gemini-2.5-flash
   Heterogeneous: generate-chorus-options (model varies per batch item)
   (7 in song-creator.pflow.md, 12 in 10 sub-workflows)
 
@@ -10,11 +9,12 @@
 
   Cost per run:                unavailable
 
-  6 recommended actions
+  5 recommended actions
 
-  Cost data unavailable: no model resolved for LLM nodes (set settings.default_model or add per-node `- model:`).
+  Cost data unavailable: run the workflow once for cost figures.
+  Suggested:  pflow run .taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md concept=<value> concept_brief=<value>
 
-## Recommended actions (6)
+## Recommended actions (5, ordered by impact)
 
   Each item below is a cache-optimization opportunity for this workflow.
   Declared values are sent once and reused at 0.1× input cost.
@@ -24,33 +24,27 @@
     (2) Add the listed values as named entries under the child workflow's ## Cache section.
     (3) Reference that named entry in `prompt_cache:` on each consumer node.
 
-  1. Dynamic ref blocks caching on write-lyrics — move `${choose-chorus.chorus_guide}` after stable content  savings unavailable
-     write-lyrics
-     write-lyrics: dynamic `${choose-chorus.chorus_guide}` reference at line 68 appears before ~1002 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
-     → Move the cacheable content (everything stable across calls) to BEFORE `${choose-chorus.chorus_guide}` in the prompt template.
-     → Projected cache ratio after fix: ?%.
-
-  2. Dynamic ref blocks caching on rewrite-emotional — move `${write-lyrics.response}` after stable content  savings unavailable
-     rewrite-emotional
-     rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~2028 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
-     → Move the cacheable content (everything stable across calls) to BEFORE `${write-lyrics.response}` in the prompt template.
-     → Projected cache ratio after fix: ?%.
-
-  3. Dynamic ref blocks caching on rewrite-craft — move `${extract-emotional-lyrics.result.lyrics}` after stable content  savings unavailable
+  1. Dynamic ref blocks caching on rewrite-craft — move `${extract-emotional-lyrics.result.lyrics}` after stable content  saves ~$0.0005/run
      rewrite-craft
-     rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~2170 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
+     rewrite-craft: dynamic `${extract-emotional-lyrics.result.lyrics}` reference at line 15 appears before ~1904 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
      → Move the cacheable content (everything stable across calls) to BEFORE `${extract-emotional-lyrics.result.lyrics}` in the prompt template.
      → Projected cache ratio after fix: ?%.
 
-  4. Dynamic ref blocks caching on generate-suno-prompt — move `${extract-lyrics.result.lyrics}` after stable content  savings unavailable
+  2. Dynamic ref blocks caching on rewrite-emotional — move `${write-lyrics.response}` after stable content  saves ~$0.0005/run
+     rewrite-emotional
+     rewrite-emotional: dynamic `${write-lyrics.response}` reference at line 18 appears before ~1784 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
+     → Move the cacheable content (everything stable across calls) to BEFORE `${write-lyrics.response}` in the prompt template.
+     → Projected cache ratio after fix: ?%.
+
+  3. Dynamic ref blocks caching on generate-suno-prompt — move `${extract-lyrics.result.lyrics}` after stable content  saves ~$0.0003/run
      generate-suno-prompt
-     generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1223 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
+     generate-suno-prompt: dynamic `${extract-lyrics.result.lyrics}` reference at line 5 appears before ~1044 stable tokens; move stable instructions before dynamic content so prefix caching can fire for 1 calls per run
      → Move the cacheable content (everything stable across calls) to BEFORE `${extract-lyrics.result.lyrics}` in the prompt template.
      → Projected cache ratio after fix: 92%.
 
-  5. Sub-workflow cache undeclared in chorus-chooser.pflow.md — add 4 entries in ## Cache  unmeasurable
+  4. Sub-workflow cache undeclared in chorus-chooser.pflow.md — add 4 entries in ## Cache  not yet cacheable
      chorus-chooser.pflow.md
-     Four values flow in but no consumer node has a resolved model — cannot compute the cache threshold.
+     Four values ~0 tokens per call, below the smallest provider cache minimum (1,024 — Anthropic Sonnet 4.5).
      Only these listed values are used by prompts. Do not cache full objects like `architecture`, `concept`, `creative_brief` unless you intentionally want every field in that object sent to the model.
      Edit child workflow:
        Add or extend ## Cache:
@@ -77,35 +71,41 @@
        • `concept.title` unmeasurable — node(s) `select-chorus` use `${concept.title}`
        • `creative_brief` unmeasurable — node(s) `select-chorus` use `${creative_brief}`
            flows in from parent as `${concept_brief}`
-     → Set `settings.default_model` or add `- model:` to each consumer node in chorus-chooser.pflow.md, then re-run analyze-cache.
+     → Monitor: re-run analyze-cache when per-call content grows past 1,024 tokens.
+     → Verify: confirm ~0 tokens is the realistic per-call size.
      → Edit: .taskmaster/tasks/task_159/baseline/_shared/workflows/lyrics-generator/song-creator/chorus-chooser/chorus-chooser.pflow.md
 
-  6. Prompt opaque to static analysis on generate-chorus-options — refactor inline for cache detection  savings unavailable
+  5. Prompt opaque to static analysis on generate-chorus-options — refactor inline for cache detection  savings unavailable
      generate-chorus-options in chorus-chooser.pflow.md
      generate-chorus-options: prompt is `${item.prompt}`, assembled by `build-grouped-items` (type: code). Static analysis cannot inspect the assembled prompt's structure, so cache opportunities (shared prefixes, prewarm) are not detected. If the assembled prompt has a stable prefix and per-call dynamic content, refactoring to an inline declarative prompt unlocks detection.
      → Inline the prompt template on `generate-chorus-options`: replace `${item.prompt}` with the literal prompt content, with stable bytes BEFORE per-call dynamic references.
      → See `pflow guide prompt-caching` (Python-assembled prompts section) for the refactor pattern.
 
 ## Per-call cache report
+  How to read each row:
+    · ready: tokens already active or unlockable by a direct cache edit in the current prompt shape.
+    · upside: unrealized cache opportunity after the notes column's required edit.
+    · — means the column does not apply to this row.
+    · ? means the column applies but the token count can't be measured yet (run the workflow once to populate).
   Showing 8 of 19 LLM nodes; low-signal rows hidden (--all-rows shows everything).
 
-  node                     model         input  notes
-  ----------------------------------------------
+  node                     model                    input  ready  notes
+  ----------------------------------------------------------------
 
 ### song-creator.pflow.md
-  write-lyrics             <unresolved>  3,684  dynamic-before-static
-  song-architecture        <unresolved>  2,886
-  rewrite-emotional        <unresolved>  2,575  dynamic-before-static
-  rewrite-craft            <unresolved>  2,454  dynamic-before-static
-  generate-suno-prompt     <unresolved>  1,340  dynamic-before-static
-  creative-direction       <unresolved>  1,248
-  easter-eggs              <unresolved>  1,066
+  write-lyrics             gemini/gemini-2.5-flash  3,247      ?
+  song-architecture        gemini/gemini-2.5-flash  2,568      ?
+  rewrite-emotional        gemini/gemini-2.5-flash  2,239      ?  dynamic-before-static
+  rewrite-craft            gemini/gemini-2.5-flash  2,141      ?  dynamic-before-static
+  generate-suno-prompt     gemini/gemini-2.5-flash  1,137      ?  dynamic-before-static
+  creative-direction       gemini/gemini-2.5-flash  1,084      ?
+  easter-eggs              gemini/gemini-2.5-flash    898      ?
 
 ### chorus-chooser.pflow.md (called by choose-chorus)
-  generate-chorus-options  <varies>          ?  opaque-prompt
+  generate-chorus-options  <varies>                     ?      —  opaque-prompt
 
   Token estimate confidence:
-    · Projected input tokens for: write-lyrics, song-architecture, rewrite-emotional, rewrite-craft, generate-suno-prompt, creative-direction, easter-eggs, generate-chorus-options.
+    · Projected input tokens for: song-architecture, creative-direction, easter-eggs, generate-chorus-options.
 
 ## Per-child analyze-cache commands
 

--- a/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/04-guide-auto-detect/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/04-guide-auto-detect/expected-stdout.txt
@@ -1,3 +1,7 @@
+> **10 guide sections below, split by `---`. Read each to the END before building** — they're condensed, so skimming means wrong format rules.
+> Output is long: if you see only a **preview**, the full text is preserved elsewhere (a file your tool names, or pagination) — open and read it there. Don't build from the preview, and don't re-run this command.
+> Done only when you reach the last line `⟨END OF GUIDE — 10 sections⟩` — if you're not there, you haven't read it all.
+
 # Batch Processing
 
 **Use when**: Same operation on multiple items — "each", "for every", "in parallel", "N at a time". Add `batch` to any node:
@@ -37,6 +41,25 @@ Current item: `${item}` (or custom `as`). Index: `${__index__}` (0-based). Resul
 | `parallel` | `false` | Concurrent execution |
 | `max_concurrent` | `10` | 1-100; use 30-50 for LLM APIs (rate limits) |
 | `error_handling` | `"fail_fast"` | `"continue"` = process all despite errors |
+| `max_retries` | `1` | Batch item total attempts after an exception escapes the node (`1` = no batch retry) |
+| `retry_wait` | `0` | Seconds between batch item attempts |
+
+**`parallel: false` is the default** — items run sequentially, in order. Use sequential when items must run in a specific order, when each item depends on side effects from the previous one (e.g. reading filesystem state a prior item wrote), or when you're using batch for bounded iteration. Sequential iteration over a sub-workflow is the cleanest loop-with-disk-state pattern — see `pflow guide sub-workflows` → Bounded iteration.
+
+````markdown
+### iterate
+
+Run the child once per index, in order — each iteration sees the previous one's
+filesystem changes.
+
+- type: workflow
+- workflow: ./process-one.pflow.md
+- inputs:
+    iteration: ${item}
+- batch:
+    items: [1, 2, 3, 4, 5]
+    parallel: false
+````
 
 **Text lines → JSON array:**
 ```shell
@@ -44,7 +67,9 @@ your-command | jq -R -s 'split("\n") | map(select(. != ""))'
 ```
 
 **All outputs**: `${node.results}`, `.count`, `.success_count`, `.error_count`, `.errors`
-Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`.
+Results contains only **successful** items. Each result contains `item` (original input) + inner node outputs, making results self-contained for downstream processing (e.g., `${node.results}` passed to LLM includes both inputs and outputs). With `error_handling: continue`, failed items are excluded from `results` — error details are in `errors`. `count` = total items attempted, `success_count` = `len(results)`, `error_count` = `len(errors)`. `.errors` is always an array — `[]` when there are no failures, never `null` — so a downstream node can safely annotate it as a `list`/`array`.
+
+**Batching over results nests one layer per stage.** When a later node batches over `${first.results}`, each `${item}` IS one of those entries — so `${item.response}` is the first node's output for that row and `${item.item}` is its original input. A third stage batched over the second's results adds another layer: `${item.item.response}` reaches two stages back. To avoid deep `item.item.item` chains, correlate earlier stages directly — see **Correlating parallel arrays** below.
 
 **Batch replaces the normal output structure.** `${node.response}`, `${node.llm_usage}`, `${node.stdout}`, etc. do NOT exist at the top level. Access them inside results: `${node.results[0].response}`, `${node.results[0].llm_usage}`. Note: index-based access (`results[N]`) requires `fail_fast` mode (the default). With `error_handling: continue`, use iteration (`items: ${node.results}`) instead.
 
@@ -116,11 +141,40 @@ parallel: true
 ````
 Any `${item.field}` template works in any param — not just prompt/command.
 
-**Dynamic indexing**: `${__index__}` gives current position (0-based). Use nested templates to correlate (requires `fail_fast` — not supported with `error_handling: continue`):
+**Correlating parallel arrays (zip)**: when two batches ran over aligned inputs and you need each row of one alongside the matching row of the other, there are two ways — pick by how much you trust the alignment:
+
+- **Explicit zip node** — *preferred for anything non-trivial or likely to change.* A `code` node that pairs the arrays into clean records, ideally matching on a shared key (an id both rows carry) rather than on position. It is robust to reordering and `continue` mode, inspectable on its own (`--only`, `pflow report`), and survives later edits to the pipeline.
+- **Inline `${__index__}`** — *concise, for simple, fixed, fail-fast cases.* Skip the node and reach the same-position element of the other array directly: fewer nodes, but it leans on a positional alignment invariant (see caveat below).
+
+Inline form — iterate one array, reach the other by position:
+
+````markdown
+### combine
+
+Revise each draft using its own review — iterate the reviews, reach the
+same-position draft by index.
+
+- type: llm
+- batch:
+    items: ${reviews.results}
+    parallel: true
+
+```prompt
+Original draft:
+${drafts.results[${__index__}].response}
+
+Review:
+${item.response}
+
+Revise the draft, applying the review.
 ```
-${previous.results[${__index__}]}     # Access by position (fail_fast only)
-${previous.results[${item.idx}]}      # Access by item field (fail_fast only)
-```
+````
+
+`${__index__}` also indexes by an item field: `${drafts.results[${item.idx}]}`.
+
+**Alignment caveat**: zipping by position assumes both arrays are in the same order with no gaps — true only under `fail_fast` (the default). `error_handling: continue` drops failed items, which misaligns the arrays, and index access is not supported there anyway. When alignment isn't guaranteed, use the explicit zip node and match on a key.
+
+**Indexing works on a node's `.results`, not on declared inputs.** `${my_input[${__index__}]}` does not resolve — pull the per-row value from an upstream node's `.results` instead.
 
 **Using results**:
 ```markdown
@@ -136,13 +190,36 @@ the normal output shape.
 
 **Common mistake: missing explicit prompt wiring on batch LLM.** Batch items may have `prompt:` fields in the data, but the LLM node ignores them unless you wire it explicitly: `- prompt: ${item.prompt}`. Batch provides data; the node still needs explicit parameter references.
 
+**Retry interaction:** `batch.max_retries` and node-level `retry:` are separate loops. Node-level retry handles transient failures inside the node attempt:
+
+````markdown
+### fetch-each
+
+Fetch each URL with node-level exponential backoff.
+
+- type: http
+- url: ${url}
+- retry:
+    max: 3
+    wait: 0.5
+    backoff: exponential
+- batch:
+    items: ${urls}
+    as: url
+    parallel: true
+````
+
+For `llm`, `shell`, `mcp`, `code`, and file nodes, an exhausted node `retry:` budget ends the item as a handled failure, and `batch.max_retries` does not start another attempt for it. For `http` and `claude-code` nodes, an exhausted `retry:` budget surfaces as a failure that `batch.max_retries` re-attempts, so the upper bound is `batch.max_retries * retry.max` attempts per item.
+
+Parallel batch workers inherit the configured node retry budget. A `fail_fast` batch cannot interrupt a worker that is already sleeping in backoff; exponential node backoff is clamped to 60 seconds per wait.
+
 ---
 
 # Conditional Branching
 
-**Use when**: Different paths based on data or errors — "if X then Y", "handle failures", "retry on error". Default flow is top-to-bottom; branching overrides it.
+**Use when**: Choose between paths based on data — "if X then Y", classify and route, pick a path based on a value. Default flow is top-to-bottom; branching overrides it. (For failures and retry, see `pflow guide error-handling`. For repeat-until, see `pflow guide loop`.)
 
-**Error routing** — any node can route failures to a handler:
+**Error routing** — any node can route failures to a handler (resilience patterns: `pflow guide error-handling`):
 ````markdown
 ### call-api
 
@@ -270,6 +347,7 @@ echo "B: ${route.result}"
 - `next: str = "end"` — terminate from code (code nodes only, e.g., skip optional steps)
 - `"end"` is a reserved keyword — do not use it as a node ID
 - No `next` set in code → continues to next node in document order
+- `- next:` (or dynamic `next`) to an **earlier** node forms a **backward edge** — that node re-runs, creating a loop. This is the low-level loop mechanism; for condition-terminated iteration with carried state, prefer `loop:` (see `pflow guide loop`)
 
 **Required: Branch targets MUST have explicit `- next:`**
 - Every node reached via `- on-error:` or named routing action MUST declare `- next: end` or `- next: <node-id>`
@@ -277,9 +355,11 @@ echo "B: ${route.result}"
 - If code uses dynamic routing (`next = variable`), the code node MUST declare `- next: target-a, target-b` listing all possible targets
 - Literal routing (`next: str = "target"`) does NOT need `- next:` on the code node — pflow detects targets automatically
 
-**When to use**: Error handling, classification/routing, skip-ahead, retry loops. NOT for parallel execution (use batch for that).
+**When to use**: Error handling, classification/routing, skip-ahead, and **backward-edge loops** (route to an earlier node — the low-level loop form; prefer `loop:` for condition-terminated iteration, see `pflow guide loop`). NOT for parallel execution — use batch for that.
 
-**Branch convergence** — use `??` to reference "whichever branch ran": `${branch-high.stdout ?? branch-low.stdout}`. Tries left-to-right, first operand whose node executed wins. Works in any node type — no merge node needed.
+**Branch convergence** — use `??` to reference "whichever branch ran": `${branch-high.stdout ?? branch-low.stdout}`. Tries left-to-right, first operand that resolves wins. Works in any node type — no merge node needed. Operands can also be JSON literals as a final default: `${optional_step.value ?? 0}`, `${a ?? "none"}`.
+
+`??` falls through whenever the left side **isn't there** — whether the **node didn't run** (branch not taken, or node failed) OR the **field is absent** on a node that did run. So `${ran_node.optional_field ?? "default"}` yields `"default"` when `optional_field` isn't present. A **bare** `${node.field}` with no `??` fallback still errors on a missing field, so genuine typos are caught loudly — add a fallback only where absence is expected.
 
 ---
 
@@ -292,6 +372,7 @@ echo "B: ${route.result}"
 - Receives native objects from upstream nodes (no serialization needed)
 - Supports multiple inputs from different nodes
 - Type-annotated Python code for clarity and validation
+- **Caching**: code nodes don't cache by default — safe inside iteration loops where they read state mutated between runs. Add `cache: true` only for a pure, expensive transform fully determined by its declared inputs.
 
 ### Node Creation Patterns
 
@@ -344,6 +425,7 @@ result: dict = {
 **Code node rules:**
 - Templates go in `- inputs:` param, NEVER in the `python code` block (code is literal Python, not a template)
 - All inputs and `result` MUST have type annotations: `data: list`, `result: dict = ...`
+- Bare vs valued annotations: a top-level **bare** `name: type` (no value) is read as an input declaration and needs a matching `inputs:` entry. An annotated assignment `name: type = value` is a local — so type your intermediates freely (`total: int = sum(...)`). `result`/`next` are the declared output/routing.
 - Upstream JSON is auto-parsed before your code runs — if source is JSON, declare `dict`/`list` not `str`
 - Use `Any` as the type when you don't want type validation (see syntax table below — auto-injected, no import needed)
 - Single output via `result` variable — use dict for structured output
@@ -351,17 +433,27 @@ result: dict = {
 
 ## Validate-Time Type Checking
 
-Three code-node input errors are now caught at validate time (`pflow
+Three code-node input errors are caught at validate time (`pflow
 --validate-only`) instead of runtime:
 
 1. **Input bound, annotation missing** — `inputs: {x: ${ref}}` with no `x:
    <type>` in code. The suggestion uses the upstream's declared type when
    known (`Add an annotation (in params.code): x: str  (inferred from ...)`).
-2. **Annotation declared, no input bound** — opinionated one-fix-per-case:
-   `Remove the annotation 'y: list' — it is never read in the code` for dead
-   annotations, `Add 'y' to the inputs dict` when the name is read in the
-   body, `Rename the annotation to 'items'` when a fuzzy-matched input key
-   exists (typo case).
+2. **Bare annotation declared, no input bound** — a top-level `name: type` with
+   no value and no matching `inputs:` entry. (An annotated assignment `name: type
+   = value` is a local and is never flagged — issue #331.) The fix depends on
+   whether the name is also bound in the body:
+   - **bound elsewhere** (a later `helper = ...` or `def helper(): ...`) → the
+     bare annotation is redundant, so removing it is safe. Offers both, local
+     first: `Remove the annotation 'helper: Any' — 'helper' is assigned in the
+     code, so it's a local variable` *or* `add 'helper' to the inputs dict` (if
+     it was meant as an input). To keep a type on a local, use the value form
+     (`helper: Any = ...`).
+   - **read but not bound** (`y: list` + `len(y)`) → removing would leave
+     `y` unbound, so the only fix is `Add 'y' to the inputs dict` (or `Rename
+     the annotation to 'items'` for a fuzzy-matched typo).
+   - **neither read nor bound** → dead annotation: `Remove the annotation
+     'y: list' — it is never read in the code`.
 3. **Type mismatch** — `x: dict` bound to `${upstream.result}` that declares
    `list`:
 
@@ -422,9 +514,139 @@ Only the outer type is enforced at prep time (e.g. `list[dict]` checks `isinstan
 
 ---
 
+# Error Handling
+
+**Use when**: A step can fail and you want to recover rather than abort — "retry on failure", "fall back if X fails", "handle the error", "undo on failure".
+
+Choose the tool by the kind of failure you expect:
+
+| Failure | Tool |
+|---|---|
+| Transient — the call didn't complete (dropped connection, timeout, model provider rate-limited/overloaded) | `retry:` — automatic re-attempts |
+| Expected, with an alternative path | `on-error:` — route to a handler |
+| A precondition that must hold | no handler — let it fail and stop the run |
+
+## `retry:` — automatic re-attempts for transient failures
+
+Add `retry:` to a node that does work directly (http, shell, llm, code, file). `max` is the total number of attempts (`max: 1` = no retry); when an attempt fails, pflow waits, then tries again until the attempts run out.
+
+```markdown
+### fetch
+- type: http
+- url: ${api}/data
+- retry:
+    max: 5
+    wait: 1                # base seconds between attempts
+    backoff: exponential   # 1s, 2s, 4s, ... (capped at 60s); or `fixed`
+```
+
+A node that **succeeds on a retry is a clean success** — recovering from a flaky call does not mark the run as degraded. Reach for `retry:` when a re-attempt can fix the failure: a dropped connection, a timeout, or an `llm` provider that's rate-limited or overloaded. A call that *completes* with a failure response is different — an HTTP error status (e.g. 429, 503) or a shell command that exits non-zero comes back as a result, not a retry-able error — so route those with `on-error:` (or a `loop:` that reads the status). A failure a re-run can't fix — a 404, an invalid input — should fail fast or go to `on-error:`.
+
+For a sub-workflow, put `retry:` on the failing step *inside* the child, not on the `workflow` node that calls it.
+
+## `on-error:` — fall back to a handler
+
+Any node can route its failure to a handler instead of stopping the run:
+
+```markdown
+### primary
+- type: http
+- url: ${primary_api}/data
+- on-error: use-backup
+
+### use-backup
+Fetch from the backup source when the primary fails.
+- type: http
+- url: ${backup_api}/data
+- next: combine
+```
+
+A node reached via `on-error:` must declare an explicit `- next:` (see `pflow guide branching`). The handler runs and the workflow finishes — reported as **completed with a warning** that names the fallback, so the failure stays visible rather than hidden. (Unlike `retry:`, where the same node succeeding on a re-attempt is a clean success, `on-error:` routes *around* a node that stayed failed.)
+
+**Reading the recovery path:** a failed node's own outputs aren't readable downstream — `${primary.…}` won't resolve once `primary` has failed; the failure surfaces in the run's reported result instead. A handler reads from nodes that *succeeded*, and `??` lets a later node take whichever path produced a value, skipping the failed one: `${primary.response ?? use-backup.response}`.
+
+A self-contained version you can run — `fetch` fails, `recover` supplies a backup, and the run finishes (reported with a warning that the fallback fired):
+
+````markdown
+# Fall Back On Failure
+
+Try the primary source; if it fails, recover with a backup so the run finishes.
+
+## Steps
+
+### fetch
+
+Try the primary source. On failure, hand off to the recovery handler.
+
+- type: shell
+- on-error: recover
+
+```shell command
+echo "primary unavailable" >&2
+exit 1
+```
+
+### recover
+
+Serve a backup value so the workflow finishes.
+
+- type: shell
+- next: end
+
+```shell command
+echo "served from backup"
+```
+````
+
+## Pattern: retry, then fall back
+
+Combine them — retry the transient case automatically, and fall back only if the retries are exhausted:
+
+```markdown
+### fetch
+- type: http
+- url: ${api}/data
+- retry: { max: 3, backoff: exponential }
+- on-error: use-cache        # reached only after all retries fail
+```
+
+## Pattern: compensating rollback (saga)
+
+When a sequence must undo earlier work if a later step fails, point each step's failure at a handler that reverses what was already done:
+
+```markdown
+### reserve-stock
+- type: http
+- url: ${api}/reserve
+# no handler — if reserving fails, nothing was done; the run stops here
+
+### charge-card
+- type: http
+- url: ${api}/charge
+- on-error: release-stock        # charge failed → undo the reservation
+
+### release-stock
+Undo the reservation because the charge failed.
+- type: http
+- url: ${api}/release
+- inputs:
+    id: ${reserve-stock.response.id}
+- next: end
+```
+
+Each step names the compensator for the work that came before it; the handler reverses it and the run finishes — reported as completed with a warning that the rollback fired.
+
+## Let hard failures stop the run
+
+When a failure means the workflow can't sensibly continue — a missing required input, a precondition that isn't met — leave the node without a handler. A node that fails with no `on-error:` stops the run with a non-zero exit, which is the right outcome for a precondition that must hold.
+
+---
+
 # File Node
 
 **Use for**: Reading and writing files. Known interface — no probing needed.
+
+**Caching**: file nodes don't cache by default — a `read-file` sees the current file each run (safe when a prior step or iteration rewrote it) and a `write-file` always performs its side effect. Add `cache: true` only for an expensive read of a file you know won't change during the run.
 
 ### Node Creation Patterns
 
@@ -445,6 +667,15 @@ Write the final report to disk.
 - type: write-file
 - file_path: ${output_path}
 - content: ${format-for-delivery.response}
+```
+
+**`delete-file` safety flag:** it won't act on `file_path` alone — it requires a `confirm_delete: true` flag that deliberately **cannot** be a node param (so a deletion can't be triggered by node config alone). Provide it as a workflow input and wire it in with `- inputs:` (that reference is also what lets the workflow validate):
+
+```markdown
+- type: delete-file
+- file_path: ${target}
+- inputs:
+    confirm_delete: ${confirm_delete}
 ```
 
 ---
@@ -476,21 +707,58 @@ Write content to a file with automatic directory creation.
 - `written: bool` - True if write succeeded
 - `error: str` - Error message if operation failed
 
+### copy-file
+Copy a file to a new location with automatic directory creation.
+
+**Parameters**:
+- `source_path: str` - Source file path
+- `dest_path: str` - Destination file path
+- `overwrite: bool` - Whether to overwrite existing files (optional)
+
+**Outputs**:
+- `copied: bool` - True if copy succeeded
+- `error: str` - Error message if operation failed
+
+### move-file
+Move a file to a new location with automatic directory creation.
+
+**Parameters**:
+- `source_path: str` - Source file path
+- `dest_path: str` - Destination file path
+- `overwrite: bool` - Whether to overwrite existing files (optional)
+
+**Outputs**:
+- `moved: bool` - True if move succeeded
+- `error: str` - Error message if operation failed
+- `warning: str` - Warning message on partial success (copy ok but delete failed)
+
+### delete-file
+Delete a file from the filesystem with safety confirmation.
+
+**Parameters**:
+- `file_path: str` - Path to delete
+
+**Outputs**:
+- `deleted: bool` - True if delete succeeded
+- `error: str` - Error message if operation failed
+
 ---
 
 # LLM Node
 
 **Use for**: Tasks requiring judgment — summarizing, interpreting, deciding what matters. Costs tokens per workflow execution.
 
-**Don't use LLM for**: Extracting fields from structured data (`${node.result.data.field}` does this for free), transforming/filtering data (use `code` node), or formatting with a fixed structure (use `code` node).
+**Reach for `code` or templates instead when the task is deterministic**: extracting fields (`${node.result.data.field}` does this for free), transforming or filtering data, or formatting with a fixed structure.
 
 **The test**: Can you write a deterministic algorithm for it? YES → `code` node. NO → LLM.
 
 Use `output_schema` for structured responses (guarantees valid JSON via constrained decoding).
 
+**Prompt format**: Put multi-line prompts in a ` ```prompt ` block — real line breaks, no `\n` escapes and no quote/colon escaping hazards. Reserve inline `- prompt: "..."` for genuinely single-line prompts.
+
 **Debugging prompts**: Run with `--report` to see every LLM node's rendered prompt (templates resolved) alongside the actual response, token count, and cost. Ask the user if they want reports in the project (`--report-dir ./report/`) — useful for reviewing LLM responses together or tracking them in git.
 
-**Iterating cheaply**: Use `--only <node>` to re-run a single LLM node (upstream cached, downstream skipped). Saves time and tokens when tuning prompts in multi-node workflows.
+**Iterating cheaply**: Use `--only <node>` to re-run a single LLM node against a frozen **snapshot** of the most recent full run — every other node's output is restored, not re-executed, so side-effecting upstream (shell/http/mcp) never re-fires and you only pay for the one node you're tuning. Requires a prior full run (errors otherwise).
 
 **Prompt caching**: When several LLM nodes or batch items reuse the same long
 context, rubric, instructions, source text, or parent value, run
@@ -557,12 +825,12 @@ Optional cache fields for LLM nodes:
 - `system: str` - System prompt (optional)
 - `images: list[str]` - Image URLs or file paths (optional)
 - `output_schema: dict` - JSON Schema for structured output (optional)
-- `reasoning_effort: str` - Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params)
-- `reasoning_max_tokens: int` - Direct reasoning token budget, mutually exclusive with reasoning_effort (optional)
+- `reasoning_effort: str` - Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params). Sets reasoning depth; max_tokens only caps the budget, never raises it.
+- `reasoning_max_tokens: int` - Direct reasoning token budget, mutually exclusive with reasoning_effort (optional). Still capped to stay under max_tokens when both are set.
 - `model_options: dict` - Additional provider-specific model options passed as kwargs (optional; reasoning keys must use reasoning_effort/reasoning_max_tokens)
 - `model: str` - Model to use (optional - always use smart default unless user requests specific model)
 - `temperature: float` - Sampling temperature (default: 1.0)
-- `max_tokens: int` - Max response tokens (optional)
+- `max_tokens: int` - Response-length ceiling (optional). On reasoning models this is the combined thinking+answer budget and only caps thinking depth — it never increases it. Set it explicitly when you need a long visible answer from a reasoning model (otherwise the provider may cap visible output low).
 - `timeout: int` - Execution timeout in seconds for LLM API call (default: 120)
 
 ### Outputs
@@ -580,6 +848,8 @@ Optional cache fields for LLM nodes:
 
 Node naming: `mcp-{server}-{TOOL}` (e.g., `mcp-slack-SEND_MESSAGE`, `mcp-postgres-QUERY`).
 
+**Caching**: MCP nodes don't cache by default — calls hit the live service each run, so reads see current state and writes always perform their side effect. Add `cache: true` only for an expensive, side-effect-free call whose result is stable for the run.
+
 ### Supported Service Categories
 
 MCP servers span these categories (each has unique output structure):
@@ -587,11 +857,16 @@ MCP servers span these categories (each has unique output structure):
 
 Examples: Databases (PostgreSQL, MySQL), Chat (Slack, Discord), Cloud (S3, GCS), Version Control (GitHub, GitLab), Docs (Notion, Sheets), REST/GraphQL
 
-**Always test - never assume similarity.**
-
 See `pflow mcp describe <tool> --help` for how to interpret tool details.
 
 ## ⚠️ MCP Output Has NO Standard Structure
+
+MCP nodes expose one canonical output namespace: `result`.
+
+Use `${node.result}` for the full tool payload and `${node.result.field}` for
+nested fields. Do not use `${node.field}` for MCP tool fields; validation only
+knows the declared `result` output because MCP servers do not publish stable
+output schemas.
 
 **Every MCP server is completely different. Even the SAME operation:**
 
@@ -609,6 +884,36 @@ Server C:  result.Items[]                   # DynamoDB style
 
 **There are NO patterns. Test every MCP tool:**
 `pflow probe mcp-service-TOOL param=value`
+
+### MCP Tools Can Report Failure Inside `result`
+
+Some MCP tools return a successful MCP response while the service payload says
+the operation failed. Example: a tool can return:
+
+```json
+{
+  "status": "error",
+  "reason": "expired",
+  "error": "Cannot create audio: NotebookLM auth is not valid",
+  "hint": "nlm login"
+}
+```
+
+That payload is available as `${create-audio.result.status}`,
+`${create-audio.result.error}`, and so on in traces/reports. pflow promotes
+common explicit failure flags (`status: "error"`, `ok: false`, `success:
+false`, etc.) to API-warning failures, so use `on-error:` when a workflow
+should recover from those. For tool-specific failure shapes pflow does not
+classify, guard follow-up polling/download/mutation steps by checking the
+tool's own success field before continuing.
+
+MCP failure paths:
+
+| Outcome | What it is | pflow behavior |
+|---|---|---|
+| Protocol/transport failure | MCP client/server call failed before a tool result | Writes `${node.error}` and `${node.error_details}` |
+| `isError: true` | Tool set the MCP tool-error flag | Returns `error`, so `on-error` can route it |
+| `result.status: "error"`, `result.ok: false`, etc. | Service failure inside a successful MCP payload | Stored under `${node.result}`; pflow surfaces explicit failure flags as API warnings |
 
 ### Node Creation Pattern
 
@@ -680,8 +985,6 @@ Email the analysis report to the recipient.
 **Note**: `analyze-and-format` combines analysis and formatting in one LLM call - don't use separate LLM nodes when one can do both. If you just need to concatenate data with a fixed structure, use code node or templates instead.
 
 ### MCP/HTTP Reality vs Documentation
-
-**Documentation lies. Testing reveals truth.**
 
 | What Docs Say | What You Get | How to Handle |
 |---------------|--------------|---------------|
@@ -1194,6 +1497,7 @@ paste-ready recommendations over manually guessing chunk names or order.
 - Use `$VAR` not `${VAR}` for shell variables (braces conflict with pflow template syntax)
 - **Warning sign**: Long chains of `sed`, `awk`, `jq`, `tr`, `grep` piped together → use `code` node instead (more readable, portable, debuggable)
 - **Don't use shell for data pass-through**: `jq '.'` before an LLM is unnecessary — pass `${node.response}` directly. Templates handle JSON natively.
+- **Caching**: shell nodes don't cache by default (their output depends on external state) — safe to use inside iteration loops. Add `cache: true` only for a pure, expensive command whose output is fully determined by its declared inputs.
 
 ### Node Creation Pattern
 
@@ -1318,7 +1622,7 @@ Uppercase via `tr`.
 ````markdown
 ## Steps
 
-### process_title
+### process-title
 
 Convert the title to uppercase using the shared sub-workflow.
 
@@ -1327,7 +1631,7 @@ Convert the title to uppercase using the shared sub-workflow.
 - inputs:
     text: ${title}
 
-### process_body
+### process-body
 
 Convert the body to uppercase using the shared sub-workflow.
 
@@ -1341,7 +1645,7 @@ Convert the body to uppercase using the shared sub-workflow.
 Combine the processed title and body into a single output.
 
 - type: shell
-- command: printf "Title: %s\nBody: %s" "${process_title.result}" "${process_body.result}"
+- command: printf "Title: %s\nBody: %s" "${process-title.result}" "${process-body.result}"
 ````
 
 ### Dynamic Child Selection (Template References)
@@ -1414,3 +1718,90 @@ Each child declares only the inputs it uses; nothing is "extra" from any
 child's perspective. Reading one item tells you exactly what that child
 receives. Typos in any item's `inputs:` fail at parse time with a fuzzy
 suggestion — there's no silent drop.
+
+### Pattern: Bounded iteration via batch
+
+To run the same sub-workflow N times *in order*, batch it with a static index
+list and `parallel: false`. Each iteration runs to completion before the next
+starts — so an iteration can read filesystem (or other external) state that the
+previous one mutated. This is the cleanest way to run a **known number** of
+iterations in order. It always runs all N — it cannot stop early when the work
+runs out.
+
+**Child workflow** (`process-one.pflow.md`) — reads a queue file, takes the first
+item, writes the rest back:
+````markdown
+# Process One
+
+## Inputs
+
+### iteration
+
+The current iteration index.
+
+- type: integer
+
+## Steps
+
+### read-queue
+
+Read the current queue from disk.
+
+- type: shell
+
+```shell command
+cat queue.txt
+```
+
+### take-and-write
+
+Take the first item, log it, write the remainder back.
+
+- type: shell
+- inputs:
+    raw: ${read-queue.stdout}
+    iteration: ${iteration}
+
+```shell command
+printf '%s\n' "${raw}" | head -n 1 >> log.txt
+printf '%s\n' "${raw}" | tail -n +2 > queue.txt
+```
+````
+
+**Parent** — drive it five times, sequentially:
+````markdown
+### iterate
+
+- type: workflow
+- workflow: ./process-one.pflow.md
+- inputs:
+    iteration: ${item}
+- batch:
+    items: [1, 2, 3, 4, 5]
+    parallel: false
+````
+
+Notes:
+- `${item}` supplies the per-item value to any param of the sub-workflow invocation (here, the iteration index).
+- The sub-workflow's working directory is shared with the parent by default. There is no per-item filesystem isolation — do NOT pass `cwd: ${item.workdir}`; `cwd` is not an accepted `workflow`-node param and will be rejected as an unknown field.
+- **Cache correctness:** this works without any `cache: false` annotations because non-`llm` nodes don't cache by default — `read-queue` re-runs each iteration and sees the current file. See `pflow guide core` → cache for what gets cached and why this works without annotations.
+
+This pattern is for a fixed iteration count. To loop a sub-workflow **until a condition is met** (stopping as soon as the work drains), add a `loop:` block to the `workflow`-type node instead — the child re-runs while one of its declared `## Outputs` stays truthy, capped by `max_iterations`:
+
+````markdown
+### iterate
+
+- type: workflow
+- workflow: ./process-one.pflow.md
+- inputs:
+    iteration: ${__iteration__}
+- loop:
+    while: ${iterate.remaining}   # a declared `## Output` of the child (typed list/number/bool)
+    max_iterations: 20
+````
+
+The child must declare the `while:` source as a typed `## Output` (e.g. `- type: integer`) so it isn't treated as a raw string. See `pflow guide loop` — the canonical guide to choosing between `batch:` (fixed count), `loop:` (stop-on-condition, with `carry:`/`while:`/`until:`), and the manual backward-edge form.
+
+---
+
+⟨END OF GUIDE — 10 sections⟩

--- a/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/05-visualize-mermaid/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/05-visualize-mermaid/command.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
-uv run pflow visualize "$BASELINE_DIR/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md"
+uv run pflow mermaid "$BASELINE_DIR/_shared/workflows/lyrics-generator/song-creator/song-creator.pflow.md"

--- a/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/05-visualize-mermaid/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/12-real-world-lyrics-generator/05-visualize-mermaid/expected-stdout.txt
@@ -142,6 +142,18 @@ graph LR
     generate-suno-prompt(["generate-suno-prompt (llm)"]):::llm
     input_concept --> choose-chorus__in_concept
     input_concept_brief --> choose-chorus__in_creative_brief
+    input_concept --> creative-direction
+    input_concept_brief --> creative-direction
+    input_concept --> song-architecture
+    input_concept_brief --> song-architecture
+    input_concept --> easter-eggs
+    input_concept_brief --> easter-eggs
+    input_concept --> write-lyrics
+    input_concept_brief --> write-lyrics
+    input_concept --> rewrite-emotional
+    input_concept_brief --> rewrite-emotional
+    input_concept --> rewrite-craft
+    input_concept_brief --> rewrite-craft
     subgraph workflow-outputs ["workflow outputs"]
         out_finished_song(["finished_song"]):::output
         out_emotional_rewrite_deliberation(["emotional_rewrite_deliberation"]):::output
@@ -173,16 +185,13 @@ graph LR
     generate-suno-prompt --> out_suno_style_prompt
     creative-direction --> song-architecture
     song-architecture --> easter-eggs
+    easter-eggs --> choose-chorus
     choose-chorus__out_winning_chorus --> write-lyrics
     choose-chorus__out_runner_up_choruses --> write-lyrics
     choose-chorus__out_all_scored_text --> write-lyrics
     choose-chorus__out_selection_text --> write-lyrics
     choose-chorus__out_chorus_guide --> write-lyrics
     choose-chorus__out_total_generated --> write-lyrics
-    write-lyrics --> emotional-reviews__emotional-architecture
-    write-lyrics --> emotional-reviews__narrative
-    write-lyrics --> emotional-reviews__imagery
-    write-lyrics --> emotional-reviews__stranger-summary
     emotional-reviews__emotional-architecture__out_review_text --> format-emotional-reviews
     emotional-reviews__narrative__out_review_text --> format-emotional-reviews
     emotional-reviews__imagery__out_review_text --> format-emotional-reviews

--- a/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/01-batch-cache-prewarm-happy/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/01-batch-cache-prewarm-happy/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/02-subworkflow-with-own-cache/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/02-subworkflow-with-own-cache/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/03-three-level-nesting/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/03-three-level-nesting/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/04-parallel-batch-with-cache/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/13-happy-path-interactions/04-parallel-batch-with-cache/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/14-pitfall-19-defenses/01-dotted-path-chunk/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/14-pitfall-19-defenses/01-dotted-path-chunk/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/14-pitfall-19-defenses/02-multi-segment-dotted-path/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/14-pitfall-19-defenses/02-multi-segment-dotted-path/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/14-pitfall-19-defenses/03-file-resolved-system-prompt/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/14-pitfall-19-defenses/03-file-resolved-system-prompt/expected-stdout.txt
@@ -75,7 +75,7 @@
     "models_in_use": [
       "anthropic/claude-sonnet-4-5"
     ],
-    "ir_default_model": null,
+    "ir_default_model": "gemini/gemini-2.5-flash",
     "observed_models_in_trace": [],
     "partial_cost_usd": false,
     "unavailable_models": [],

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/01-partial-trace-analyze-cache/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/01-partial-trace-analyze-cache/command.sh
@@ -3,13 +3,15 @@ set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
 
 TRACE="$BASELINE_HOME/partial-trace.json"
-python3 - <<'PY'
-import json
+uv run python - <<'PY'
 import os
 from pathlib import Path
 
+from pflow.core.trace_io import load_trace_file
+from tests.shared.trace_jsonl import write_trace_jsonl
+
 src = Path(os.environ["BASELINE_DIR"]) / "_shared/fixtures/live-gemini-translation.trace.json"
-data = json.loads(src.read_text())
+data = load_trace_file(src)
 first = data["nodes"][0]
 data["workflow_name"] = "workflow"
 data["workflow_path"] = str(Path(os.environ["BASELINE_CASE_DIR"]) / "workflow.pflow.md")
@@ -47,7 +49,7 @@ summary["total_cost_usd"] = call["cost_usd"]
 summary["models_used"] = [call["model"]]
 summary["pricing_available"] = True
 
-Path(os.environ["BASELINE_HOME"], "partial-trace.json").write_text(json.dumps(data, indent=2))
+write_trace_jsonl(Path(os.environ["BASELINE_HOME"], "partial-trace.json"), data)
 PY
 
 uv run pflow analyze-cache \

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/02-report-cache-telemetry/expected-stderr.txt
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/02-report-cache-telemetry/expected-stderr.txt
@@ -1,1 +1,21 @@
 Report generated: <BASELINE_CASE_DIR>/.run-home/report
+
+# Execution Report: workflow
+
+- Status: success
+- Duration: 7.8s
+- Nodes: 2
+- LLM calls: 2
+- Tokens: 12,083 in / 378 out
+- Total cost: $0.0013
+- Models: gemini/gemini-2.5-flash
+- Generated: <TIMESTAMP>
+
+## Pipeline
+
+| # | Node | Type | Status | Time | Tokens | Cost |
+|---|------|------|--------|------|--------|------|
+| 1 | answer-a | llm | success | 4.9s | 6,043 in / 182 out | $0.0006 |
+| 2 | answer-b | llm | success | 2.8s | 6,040 in / 196 out | $0.0007 |
+
+*Full trace: <REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/fixtures/live-gemini-translation.trace.json*

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/02-report-cache-telemetry/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/02-report-cache-telemetry/expected-stdout.txt
@@ -14,20 +14,20 @@
 
 ## Pipeline
 
-| # | Node | Type | Time | Cost | Status |
-|---|------|------|------|------|--------|
-| 1 | answer-a | LLMNode | 4918ms | $0.0006 | ok |
-| 2 | answer-b | LLMNode | 2824ms | $0.0007 | ok |
+| # | Node | Type | Status | Time | Tokens | Cost |
+|---|------|------|--------|------|--------|------|
+| 1 | answer-a | llm | success | 4.9s | 6,043 in / 182 out | $0.0006 |
+| 2 | answer-b | llm | success | 2.8s | 6,040 in / 196 out | $0.0007 |
 
 *Full trace: <REPO_ROOT>/.taskmaster/tasks/task_159/baseline/_shared/fixtures/live-gemini-translation.trace.json*
 --- 01-answer-a.md ---
 # answer-a
 
 - Type: LLMNode
-- Time: 4918ms
+- Time: 4.9s
 - Status: success
 - Model: gemini/gemini-2.5-flash
-- Tokens: 6,043 in / 182 out
+- Tokens: 6,043 in / 182 out  ·  100% of input cached
 - Thinking: 151 tokens
 - Paid this run: $0.0006
 - max_tokens: 200

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/03-report-with-only/expected-stderr.txt
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/03-report-with-only/expected-stderr.txt
@@ -2,8 +2,29 @@ Executing workflow (2 nodes):
   first... ✓ <DURATION>
 
 ✓ Workflow completed in <DURATION>
-  ⤷ Stopped after 'first' (--only), 1 remaining node skipped
+
+  ⤷ Ran only 'first' (--only), 1 other node not executed
+
+Workflow trace saved: <BASELINE_CASE_DIR>/.run-home/.pflow/debug/workflow-trace-<HASH>-<TIMESTAMP>.json
+
 cli: --only active — streaming auto-detected key 'stdout' from target 'first' to stdout.
-📊 Workflow trace saved: <BASELINE_CASE_DIR>/.run-home/.pflow/debug/workflow-trace-<HASH>-<TIMESTAMP>.json
+
+Workflow output:
+
 📋 Execution report: <BASELINE_CASE_DIR>/.run-home/.pflow/reports/workflow
+
+# Execution Report: workflow
+
+- Status: success
+- Duration: <DURATION>
+- Nodes: 1/2 (--only 'first', 1 skipped)
+- Generated: <TIMESTAMP>
+
+## Pipeline
+
+| # | Node | Type | Status | Time | Tokens | Cost |
+|---|------|------|--------|------|--------|------|
+| 1 | first | shell | success | <DURATION> | — | — |
+
+*Full trace: <BASELINE_CASE_DIR>/.run-home/.pflow/debug/workflow-trace-<HASH>-<TIMESTAMP>.json*
    → Target node: <BASELINE_CASE_DIR>/.run-home/.pflow/reports/workflow/01-first.md

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/03-report-with-only/expected-stdout.txt
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/03-report-with-only/expected-stdout.txt
@@ -14,8 +14,8 @@ FIRST_ONLY_VALUE
 
 ## Pipeline
 
-| # | Node | Type | Time | Cost | Status |
-|---|------|------|------|------|--------|
-| 1 | first | ShellNode | <DURATION> | — | ok |
+| # | Node | Type | Status | Time | Tokens | Cost |
+|---|------|------|--------|------|--------|------|
+| 1 | first | shell | success | <DURATION> | — | — |
 
 *Full trace: <BASELINE_CASE_DIR>/.run-home/.pflow/debug/workflow-trace-<HASH>-<TIMESTAMP>.json*

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/05-print-only-mode-signal/command.sh
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/05-print-only-mode-signal/command.sh
@@ -2,4 +2,9 @@
 set -uo pipefail
 cd "$BASELINE_REPO_ROOT"
 
+# Seed a full run so --only has a prior-run snapshot to restore upstream from.
+# Since #443, `--only <node>` hard-errors (OnlySnapshotMissingError) without one;
+# this case asserts the `-p --only` print-only streaming signal, so it must seed first.
+uv run pflow "$BASELINE_CASE_DIR/workflow.pflow.md" >/dev/null 2>/dev/null || exit $?
+
 uv run pflow -p "$BASELINE_CASE_DIR/workflow.pflow.md" --only step-b

--- a/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/05-print-only-mode-signal/expected-stderr.txt
+++ b/.taskmaster/tasks/task_159/baseline/15-run-flag-interactions/05-print-only-mode-signal/expected-stderr.txt
@@ -1,1 +1,1 @@
-  ⤷ Stopped after 'step-b' (--only), 1 remaining node skipped
+  ⤷ Ran only 'step-b' (--only), 2 other nodes not executed

--- a/.taskmaster/tasks/task_159/baseline/_shared/write_cache_warning_trace.py
+++ b/.taskmaster/tasks/task_159/baseline/_shared/write_cache_warning_trace.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 from typing import Any
+
+from tests.shared.trace_jsonl import write_trace_jsonl
 
 MODEL = "anthropic/claude-sonnet-4-5"
 PROVIDER_NOTE = "cache_control markers will silently no-op at the provider"
@@ -168,12 +169,11 @@ def main(argv: list[str]) -> int:
     if mode not in builders:
         print(f"unknown mode: {mode}", file=sys.stderr)
         return 2
-    # Trailing newline matches what pre-commit's pretty-format-json +
-    # end-of-file-fixer produce on the committed trace.json files. Without
-    # it, every verify.sh run strips the newline and `git status` shows
-    # drift on these 4 cases. Symmetric with run-case.sh's
-    # `_write_with_newline` helper used for expected-stdout/stderr.
-    Path(output_path).write_text(json.dumps(builders[mode](workflow_path), indent=2) + "\n", encoding="utf-8")
+    # Write the Task-172 JSONL trace format — the only on-disk format ``load_trace_file``
+    # / ``analyze-cache --from-trace`` accept since #531. ``write_trace_jsonl`` appends the
+    # trailing newline; these per-case ``trace.json`` files are gitignored (regenerated
+    # every run), so there is no committed-format or ``git status`` drift to manage.
+    write_trace_jsonl(Path(output_path), builders[mode](workflow_path))
     return 0
 
 

--- a/.taskmaster/tasks/task_159/baseline/normalize.py
+++ b/.taskmaster/tasks/task_159/baseline/normalize.py
@@ -53,7 +53,10 @@ def apply_rules(text: str) -> str:
     # write target. Suppression is correct here.
     text = re.sub(r"/tmp/[^\s\"']+", "<TMP>", text)  # noqa: S108
 
-    text = re.sub(r"\d{8}-\d{6}", "<TIMESTAMP>", text)
+    # Trace filenames use ``%Y%m%d-%H%M%S-%f`` — the trailing ``-%f`` microsecond group
+    # (issue #443, disambiguates a same-second full-run + --only pair) is non-deterministic,
+    # so absorb it into <TIMESTAMP> too or surfaces 15/03/05 drift on every run.
+    text = re.sub(r"\d{8}-\d{6}(?:-\d{6})?", "<TIMESTAMP>", text)
     text = re.sub(
         r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?",
         "<TIMESTAMP>",

--- a/.taskmaster/tasks/task_159/baseline/normalize.py
+++ b/.taskmaster/tasks/task_159/baseline/normalize.py
@@ -64,11 +64,13 @@ def apply_rules(text: str) -> str:
     )
     text = re.sub(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", "<TIMESTAMP>", text)
 
-    text = re.sub(
-        r"(workflow-trace-[A-Za-z0-9_.-]+?-)[a-f0-9]{8,16}(\.json)",
-        r"\1<HASH>\2",
-        text,
-    )
+    # Mask the wf_hash — md5(absolute workflow path)[:8], the FIRST segment after
+    # "workflow-trace-" — so the baseline is path-independent across checkouts/CI. The
+    # autoload disclosure (surfaces 03/07-09) prints the trace filename verbatim, unlike
+    # the "trace saved" message which pflow already redacts to <HASH>. (This previously
+    # targeted a TRAILING hash the real format — workflow-trace-<hash>-<name>-<ts>.json —
+    # never has, so the leading wf_hash leaked and verify.sh drifted per checkout path.)
+    text = re.sub(r"(workflow-trace-)[a-f0-9]{8,16}-", r"\1<HASH>-", text)
     text = re.sub(r"\bir-hash:[a-f0-9]{32}", "ir-hash:<HASH:32>", text)
     text = re.sub(r"\b[a-f0-9]{32}\b", "<HASH:32>", text)
     text = re.sub(r"\b[a-f0-9]{16}\b", "<HASH:16>", text)

--- a/.taskmaster/tasks/task_159/baseline/run-case.sh
+++ b/.taskmaster/tasks/task_159/baseline/run-case.sh
@@ -28,14 +28,45 @@ export BASELINE_REPO_ROOT="$REPO_ROOT"
 rm -rf "$BASELINE_HOME"
 mkdir -p "$BASELINE_HOME/.pflow/debug" "$BASELINE_HOME/.pflow/cache" "$BASELINE_HOME/.pflow/workflows"
 
+# Pin the workflow default model deterministically (issue #532). The lyrics-generator /
+# song-creator family (surfaces 10/12) is the ONLY baseline workflow set whose LLM nodes
+# declare no `- model:` — they rely on the workflow default, and their committed trace
+# fixtures are gemini. The ANTHROPIC_API_KEY below (needed for the preflight, see env -i)
+# would otherwise make auto-detect resolve that default to anthropic (auto-detect is
+# anthropic-priority), so those gemini workflows would report a spurious "trace recorded
+# gemini, now anthropic — models differ". Every anthropic-intent workflow pins its model
+# explicitly on the node, so a gemini default is cosmetic for them — it never overrides an
+# explicit model. settings.default_model wins over auto-detect (core/llm_config.py::
+# get_default_workflow_model), making default resolution independent of which keys exist.
+printf '%s\n' '{"version": "1.0.0", "llm": {"default_model": "gemini/gemini-2.5-flash"}}' \
+  > "$BASELINE_HOME/.pflow/settings.json"
+
 if [[ ! -f "$CASE_DIR/command.sh" ]]; then
   echo "ERROR: $CASE_DIR/command.sh not found" >&2
   exit 2
 fi
 
+# Each case runs in a clean-room env (`env -i`) for determinism. Three whitelist
+# additions are load-bearing (issue #532):
+#   * PYTHONPATH=$REPO_ROOT — lets case heredocs import the canonical JSONL trace
+#     helpers (`pflow.core.trace_io.load_trace_file` to read, `tests.shared.trace_jsonl.
+#     write_trace_jsonl` to write) regardless of CWD or script-file location, so they
+#     read/write the Task-172 JSONL trace format — the ONLY on-disk format since #531.
+#   * ANTHROPIC_API_KEY / GEMINI_API_KEY — fixed NON-REAL placeholders (the only two
+#     providers the fixtures use; ollama is keyless). Since #439 the validator preflights
+#     API-key *presence* at validate-time, and `analyze-cache` runs that validator, so a
+#     keyless run gains spurious `## Blocking errors → Missing API key` noise that buries
+#     the real signal. They gate ONLY the preflight — default-model resolution is pinned by
+#     the seeded settings.json above, so it does not depend on which keys are present. These
+#     satisfy the presence check WITHOUT enabling any live call:
+#     no baseline case reaches the LLM call seam (all are static analyze-cache / --dry-run
+#     / parse-validate errors / shell-only execution). If a case ever DID attempt a real
+#     call, a placeholder fails loud with an auth error instead of silently making a
+#     billed, non-deterministic call — keeping the oracle honest.
 env -i \
   HOME="$BASELINE_HOME" \
   PATH="$PATH" \
+  PYTHONPATH="$REPO_ROOT" \
   BASELINE_DIR="$BASELINE_DIR" \
   BASELINE_CASE_DIR="$CASE_DIR" \
   BASELINE_HOME="$BASELINE_HOME" \
@@ -47,6 +78,8 @@ env -i \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   TERM=dumb \
+  ANTHROPIC_API_KEY="not-a-real-key-baseline-preflight-only" \
+  GEMINI_API_KEY="not-a-real-key-baseline-preflight-only" \
   bash "$CASE_DIR/command.sh" \
   > "$CASE_DIR/.raw-stdout" 2> "$CASE_DIR/.raw-stderr"
 RC=$?


### PR DESCRIPTION
## Summary
Restores the Task-159 cache-analysis baseline (`.taskmaster/tasks/task_159/baseline/`) as a usable regression oracle. `./verify.sh` went from **74/87 drift → 87 pass / 0 drift / 0 errors**. The drift was environmental, not a pflow code regression.

Fixes #532

## Changes
- **Key-aware harness** (`run-case.sh`): non-real placeholder `*_API_KEY` to satisfy the post-#439 validate-time preflight (no baseline case reaches the LLM-call seam → no live call ever fires), `PYTHONPATH` so heredocs can import the canonical JSONL helpers, and a seeded `settings.json` pinning `default_model=gemini/gemini-2.5-flash` so the lyrics-generator/song-creator family (the only default-reliant workflows) resolves coherently with its committed gemini traces.
- **JSONL trace I/O migration**: all single-object `json.load/dumps` → canonical `core.trace_io.load_trace_file` (read) / `tests.shared.trace_jsonl.write_trace_jsonl` (write) across the affected `command.sh` heredocs, `_shared/write_cache_warning_trace.py`, and the one-shot `minimize-trace-fixture.py` authoring tool.
- **`normalize.py`**: absorb the `%f` microsecond suffix in trace filenames (#443) so they normalize deterministically.
- **2 stale test cases** (surfaced by a regression audit): `12/05` `pflow visualize`→`mermaid` (renamed command); `15/05` seeds a full run so `-p --only` streams its target again instead of hard-erroring on a missing snapshot post-#443.
- Regenerated all `expected-*.txt`.

## Explanation
Two upstream changes interacted badly with the harness:
- **#439** moved API-key validation to validate-time; `analyze-cache` runs that validator, so the keyless `env -i` harness gained a spurious `## Blocking errors → Missing API key` section on every LLM-bearing case.
- **#531** made the production trace reader JSONL-only; the harness heredocs still did single-object trace I/O, breaking the autoload / `--from-trace` cases.

Per the issue's recommended **Option A**, the harness is made key-aware (presence-only placeholders — the static `analyze-cache` path never calls a provider) and the trace I/O migrated to the blessed JSONL helpers, then regenerated once. A present key also makes the workflow default model resolve; pinning `default_model=gemini` keeps the only default-reliant workflow family coherent rather than letting anthropic-priority auto-detect hijack its gemini traces.

73 files changed, 931 insertions(+), 450 deletions(-). No `src/` or `tests/` changes (so `make test` is unaffected).

## Testing
- `./verify.sh` — **87 pass / 0 drift / 0 errors** (was 13 pass / 74 drift before the fix).
- **Regression audit** (4 agents over all 61 changed expected files): no regressions baked in. The gemini churn is the intended resolution ripple — the 6→5 recommendation drop is *correct* sub-1024-token suppression, not a loss — and the rest is genuine pflow format evolution (report tables, node-type display, guide content). The audit is what surfaced the 2 stale cases now fixed.
- **Deep-review** (`review-test-fidelity` + `review-impact-completeness`): ship, 0 Critical/Warning. test-fidelity independently re-ran `verify.sh` (0 drift) and round-tripped all 4 JSONL fixture builders through production `load_trace_file`; impact-completeness confirmed every trace-I/O site migrated and the env/settings injection applies uniformly across cases.
- `minimize-trace-fixture.py` migration verified ruff-clean + round-tripping the committed fixture through production `load_trace_file`.

## Known follow-ups (not in this PR)
- `verify.sh` is a manual oracle — confirmed **not** wired into CI/make/pre-commit. It went stale precisely because nothing runs it; wiring it into CI would prevent recurrence (root cause, vs the symptom this PR fixes).
- The baseline now bakes in resolved-gemini token/cost estimates from litellm's bundled tokenizer/pricing, so a litellm version bump could drift those numbers (a non-pflow-regression drift to expect).