### PR TITLE
test: cut `make test` 54s→17s — fix 3 UI tests that wait real 15s timeouts (#536)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check: ## Run code quality tools.
 .PHONY: test
 test: ## Test the code with pytest in parallel (excludes LLM tests that require API keys)
 	@echo "🚀 Testing code: Running non-e2e pytest in parallel with 4 workers (excluding LLM tests)"
-	@uv run python -m pytest -n 4 --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py -m "not e2e"
+	@uv run python -m pytest -n 4 --dist=worksteal --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py -m "not e2e"
 
 .PHONY: test-e2e
 test-e2e: ## Run real subprocess / shell / pipe boundary tests in parallel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ Documentation = "https://docs.pflow.run"
 [dependency-groups]
 dev = [
     "pytest>=7.2.0",
-    "pytest-xdist>=3.0.0",
+    "pytest-xdist>=3.2.0",
     "pre-commit>=2.20.0",
     "tox-uv>=1.11.3",
     "deptry>=0.23.0",

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -380,3 +380,8 @@ Unit tests that mock the boundary you're testing will pass while the real pipeli
 - Single layer's tests pass; the integration breaks because each layer is "right by itself"
 
 Pattern: build the IR dict, run through `WorkflowRunner`, assert on `result.shared_after["__failures__"]` and the structured `result.diagnostics[i].context` rather than mocking `_extract_runtime_warnings` or `build_execution_steps` in isolation.
+
+### 21. A Mock That Misses the Code Path Makes a Timeout Test Pass — Slowly
+A timeout-gated test that passes but runs ≈ the *production* timeout (e.g. 15s) means the mock never reached the running code — it slept the real wait (green, testing nothing). Two ways to miss, both seen in `test_ui_*`:
+- **Wrong seam:** patch the function the code *actually calls*. A `time.monotonic()` deadline ignores `patch("time.sleep")`; a poll via `httpx.get` ignores `patch("httpx.request")`.
+- **Right name, wrong object:** `patch("pkg.mod.CONST")` targets `sys.modules["pkg.mod"]`, but the running closure may read a *different* module object via `fn.__globals__` (duplicated/reloaded module — pitfall #2), so the patch silently no-ops. Use `patch.dict(fn.__globals__, {...})` instead, and cap real awaits with a small `wait_for` so a future miss fails fast.

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -270,12 +270,21 @@ class TestPointCommands:
         with (
             patch("httpx.request", side_effect=[_response(200, zero), _response(200, connected)]) as request,
             patch("webbrowser.open") as open_browser,
+            # The open-loop polls the cheap /api/health window count (via _probe_health),
+            # NOT the command endpoint. Simulate the Viewer registering its SSE
+            # connection on the second poll so the loop exercises its real
+            # break-on-connect path. Without this the probe (unmocked httpx.get to a
+            # dead port) returns None every iteration and the loop spins the full
+            # _OPEN_TIMEOUT_S (15s) — patching time.sleep does NOT help, the deadline
+            # is a real-wall-clock time.monotonic() bound.
+            patch.object(ui_module, "_probe_health", side_effect=[{"windows": 0}, {"windows": 1}]) as probe,
             patch("time.sleep"),
         ):
             result = runner.invoke(ui_module.ui_cmd, ["focus", "demo", "greet", "--open"])
 
         assert result.exit_code == 0, result.output
         assert request.call_count == 2
+        assert probe.call_count == 2  # polled until the window registered
         open_browser.assert_called_once_with("http://127.0.0.1:8765/?workflow=demo&focus=greet")
         assert "sent to 1 window" in result.output
 
@@ -286,6 +295,9 @@ class TestPointCommands:
         with (
             patch("httpx.request", side_effect=[_response(200, zero), _response(200, connected)]) as request,
             patch("webbrowser.open") as open_browser,
+            # See sibling test: mock the health poll so the loop breaks on connect
+            # instead of spinning to the real 15s _OPEN_TIMEOUT_S deadline.
+            patch.object(ui_module, "_probe_health", side_effect=[{"windows": 0}, {"windows": 1}]) as probe,
             patch("time.sleep"),
         ):
             result = runner.invoke(
@@ -295,6 +307,7 @@ class TestPointCommands:
 
         assert result.exit_code == 0, result.output
         assert request.call_count == 2
+        assert probe.call_count == 2  # polled until the window registered
         open_browser.assert_called_once_with("http://127.0.0.1:8765/?workflow=demo")
         assert "sent to 1 window" in result.output
 

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -9,10 +9,11 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from urllib.parse import urlencode
 
+from starlette.requests import Request
 from starlette.testclient import TestClient
 
 from pflow.core.workflow.manager import WorkflowManager
-from pflow.ui.server import _ACTIVITY_MAX, _Hub, _workflow_key, create_app
+from pflow.ui.server import _ACTIVITY_MAX, _Hub, _workflow_key, create_app, events
 from tests.shared.markdown_utils import write_workflow_file
 
 _VALID_IR = {
@@ -356,55 +357,54 @@ def test_sse_disconnect_unregisters_connection_via_raw_asgi(tmp_path: Path) -> N
 
 
 def test_idle_connection_emits_keepalive_frames(tmp_path: Path) -> None:
-    """An idle SSE connection periodically emits a `:` comment frame.
+    """An idle SSE connection emits a `:` keepalive comment frame, then cleans up.
 
-    This keepalive is load-bearing: on ASGI spec >=2.4 ``StreamingResponse`` has
-    no disconnect listener, so a silently-dropped socket only surfaces when the
-    next ``send`` fails — and the keepalive is the only ``send`` an idle stream
-    makes. Here we drive the real generator (spec 2.3 so the listener tears it
-    down cleanly once a keepalive is seen) and assert the keepalive actually
-    fires and cleanup still runs."""
+    The keepalive is load-bearing: on ASGI spec >=2.4 ``StreamingResponse`` has no
+    disconnect listener, so a silently-dropped socket only surfaces when the next
+    ``send`` fails — and the keepalive is the only ``send`` an idle stream makes.
+
+    Two robustness fixes here, both learned from this one test roughly tripling
+    ``make test`` wall time:
+
+    1. Drive the response body generator directly, not the whole ASGI app. Driving
+       the app made teardown hinge on Starlette's disconnect listener winning a
+       scheduler race against the keepalive loop — not the behavior under test.
+    2. Patch ``_KEEPALIVE_S`` on ``events.__globals__`` (the dict the running
+       generator actually reads), NOT by the dotted path ``"pflow.ui.server"``. In
+       the full suite that module is sometimes a *different* object than the one
+       this file imported ``events`` from — a duplicated/reloaded module (see
+       tests/CLAUDE.md pitfall #2). A dotted-path patch then lands on the wrong
+       object, the generator keeps the real 15s interval, and the test passes but
+       sleeps 15s. Patching the closure's own globals is immune to that skew.
+
+    The 2s ``wait_for`` caps turn any future interval-patch regression into a fast
+    failure instead of a 15s hang."""
     workflow = _workflow(tmp_path)
     app = create_app()
-    frames: list[dict[str, object]] = []
-    request_sent = False
-    keepalive_seen = asyncio.Event()
-
-    def _is_comment(message: dict[str, object]) -> bool:
-        body = message.get("body")
-        return isinstance(body, bytes) and body.strip().startswith(b":")
-
-    async def receive() -> dict[str, object]:
-        nonlocal request_sent
-        if not request_sent:
-            request_sent = True
-            return {"type": "http.request", "body": b"", "more_body": False}
-        await keepalive_seen.wait()  # end the stream once the keepalive has fired
-        return {"type": "http.disconnect"}
-
-    async def send(message: dict[str, object]) -> None:
-        frames.append(message)
-        if _is_comment(message):
-            keepalive_seen.set()
-
     scope = {
         "type": "http",
-        "asgi": {"version": "3.0", "spec_version": "2.3"},
-        "http_version": "1.1",
         "method": "GET",
-        "scheme": "http",
         "path": "/api/events",
-        "raw_path": b"/api/events",
         "query_string": urlencode({"workflow": str(workflow), "visibility": "visible"}).encode(),
         "headers": [],
-        "client": ("127.0.0.1", 12345),
-        "server": ("127.0.0.1", 8765),
-        "root_path": "",
+        "app": app,
     }
 
-    with patch("pflow.ui.server._KEEPALIVE_S", 0.01):
-        asyncio.run(app(scope, receive, send))
+    async def _drive() -> tuple[str, str]:
+        response = await events(Request(scope))
+        body = response.body_iterator
+        # Each pull resumes stream() to its next yield: the first returns the
+        # connected handshake, the second blocks on the keepalive timeout (0.01s)
+        # and returns the comment frame. aclose() then raises GeneratorExit at the
+        # yield, so stream()'s finally unregisters the connection.
+        connected = await asyncio.wait_for(body.__anext__(), timeout=2.0)
+        keepalive = await asyncio.wait_for(body.__anext__(), timeout=2.0)
+        await body.aclose()
+        return connected, keepalive
 
-    assert keepalive_seen.is_set()
-    assert any(_is_comment(frame) for frame in frames)
+    with patch.dict(events.__globals__, {"_KEEPALIVE_S": 0.01}):
+        connected, keepalive = asyncio.run(_drive())
+
+    assert '"type": "connected"' in connected
+    assert keepalive.strip().startswith(":")  # the idle keepalive comment frame
     assert app.state.hub.windows_for(str(workflow.resolve())) == []

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ dev = [
     { name = "mypy", specifier = ">=0.991" },
     { name = "pre-commit", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=7.2.0" },
-    { name = "pytest-xdist", specifier = ">=3.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.2.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.11.5" },
     { name = "starlette", specifier = ">=0.40" },


### PR DESCRIPTION
## Summary

`make test` regressed from ~20–25s to ~54s over the last week or two. The entire regression was **three UI tests** (added 2026-06-22/23) that each wait out a real 15s timeout because their mocks never reach the code path the timeout lives on — they passed, so the slowdown was invisible except in wall time. This fixes all three and adds a guardrail.

Fixes #536

## Changes

- **`test_ui_commands.py`** — the two `focus --open` poll-until-connect tests now mock `_probe_health` (the seam the loop actually polls, via `httpx.get`) instead of only `httpx.request`. They run instantly **and** finally exercise the "viewer connects → break" branch they're named for — the old tests passed off the 15s timeout fallback regardless of whether connect-detection worked (slow *and* shallow). A new `probe.call_count == 2` assertion makes the loop behavior load-bearing.
- **`test_ui_interaction_server.py`** — the keepalive test now drives the SSE response generator directly and patches `events.__globals__` (the dict the running closure reads) instead of `"pflow.ui.server._KEEPALIVE_S"` by dotted path, which under full-suite load landed on a *different* module object and silently no-op'd. A 2s `wait_for` cap turns any future interval-patch miss into a fast failure instead of a 15s hang.
- **`tests/CLAUDE.md`** — pitfall #21 documents the silent-slow-pass mock pattern (wrong seam / right name, wrong object).
- **`Makefile`** — `make test` now uses `--dist=worksteal` (already used by `test-e2e` / `test-all-local`) for slightly better worker balance.

## Explanation

Two distinct mock-miss mechanisms, one symptom — a timeout-gated test that passes but sleeps the real timeout:

1. **Wrong seam:** `patch("time.sleep")` can't shorten a `time.monotonic()` deadline, and `patch("httpx.request")` doesn't touch a loop that polls via `httpx.get`. So the `--open` loop ran its full 15s deadline and the connect→break branch was never covered. The two tests share a class, so xdist `--dist=load` serialized them on one worker → 30s on the critical path.
2. **Right name, wrong object:** confirmed by instrumentation — the running generator read `_KEEPALIVE_S=15.0` while the patch set `0.01` on a different module object (`events.__globals__ is not sys.modules["pflow.ui.server"].__dict__` under suite load). Patching the closure's own globals is immune to that.

4 files changed, 61 insertions(+), 43 deletions(-). Deselecting just the three tests drops the suite 53.9s → 16.1s; with the fixes the suite is the same speed but the tests now actually run and assert correctly.

## Testing

- `test_open_loads_then_reposts_non_edge_target_when_viewer_connects` / `test_edge_open_reposts_until_viewer_connects` — now ~0.005s call; assert `probe.call_count == 2` so the poll-until-connect loop is exercised (a regressed break-condition → a 3rd `_probe_health` call → `StopIteration` → test fails, where the old test passed).
- `test_idle_connection_emits_keepalive_frames` — now ~0.005s call; asserts the `connected` handshake, the `:` keepalive comment frame, and hub cleanup (unregister). Stable across full-suite runs that previously produced the 15s flake.
- Full suite: `make test` → **8119 passed**; deselect-3 baseline confirmed **53.9s → 16.1s** (`-n 4`).
