### PR TITLE
fix: release the browser's 6-connection cap for multi-tab live-overlay viewers (#539)

### DIFF
--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -456,7 +456,15 @@ def serve_cmd(
                 health = _probe_health(port, reuse_workflow)
                 if health is not None and _int_field(health, "windows") > 0:
                     _point_request(ctx, port, reuse_workflow, "select-run", run, output_json=False)
-                    click.echo(f"pflow UI already showing {reuse_workflow} — switched it to run {run}", err=True)
+                    # `windows > 0` can't tell a live-visible tab from a just-backgrounded tab's ≤15s
+                    # lingering-closed connection, and `select-run` isn't latched (Issue #539) — so report
+                    # honestly rather than assert success; an agent can re-run to open a fresh tab if nothing
+                    # changed. (A future fix could open a pinned tab here instead of trusting `windows`.)
+                    click.echo(
+                        f"pflow UI already showing {reuse_workflow} — asked it to switch to run {run}. "
+                        f"If the view didn't change, that tab was closing; re-run to open a fresh pinned tab.",
+                        err=True,
+                    )
                     ctx.exit(0)
                     return
             url = _serve_url(port, reuse_workflow, no_auto_update, run=run)

--- a/src/pflow/cli/commands/ui.py
+++ b/src/pflow/cli/commands/ui.py
@@ -456,15 +456,10 @@ def serve_cmd(
                 health = _probe_health(port, reuse_workflow)
                 if health is not None and _int_field(health, "windows") > 0:
                     _point_request(ctx, port, reuse_workflow, "select-run", run, output_json=False)
-                    # `windows > 0` can't tell a live-visible tab from a just-backgrounded tab's ≤15s
-                    # lingering-closed connection, and `select-run` isn't latched (Issue #539) — so report
-                    # honestly rather than assert success; an agent can re-run to open a fresh tab if nothing
-                    # changed. (A future fix could open a pinned tab here instead of trusting `windows`.)
-                    click.echo(
-                        f"pflow UI already showing {reuse_workflow} — asked it to switch to run {run}. "
-                        f"If the view didn't change, that tab was closing; re-run to open a fresh pinned tab.",
-                        err=True,
-                    )
+                    # `select-run` is latched (Issue #539), so this steers the open window whether it's
+                    # visible (live) or backgrounded (caught up on return) — even if `windows` was counting a
+                    # just-closing tab, the latch still delivers on reopen. So report the steer plainly.
+                    click.echo(f"pflow UI already showing {reuse_workflow} — steering it to run {run}", err=True)
                     ctx.exit(0)
                     return
             url = _serve_url(port, reuse_workflow, no_auto_update, run=run)

--- a/src/pflow/guide/features/ui.md
+++ b/src/pflow/guide/features/ui.md
@@ -44,6 +44,9 @@ windows and Watch what they deliberately click:
 - `pflow ui clear-focus <workflow>` — clear the current focus.
 - `pflow ui user-activity [workflow]` — read recent clicks and view changes.
 
+`focus`/`frame`/`clear-focus` reach every matching Viewer — including one whose tab is
+currently backgrounded; the highlight is applied when the user returns to it.
+
 **A target is just the name you already read in the `.pflow.md` — there is no
 separate notation to learn:**
 

--- a/src/pflow/ui/CLAUDE.md
+++ b/src/pflow/ui/CLAUDE.md
@@ -175,13 +175,26 @@ is `run_node.read_run_inputs`; sync handler, threadpooled, touches no hub state)
   run), plus the Task-173 run/overlay stream (`run-snapshot`/`run-events`/
   `run-complete`/`run-reset`/`run-not-found`/`run-stopped`/`run-stale`). (An earlier
   note here claimed the envelope "defines no run/trace event schema" — Task 173
-  invalidated that; the run-* schema is the overlay's, see `run_tailer`.)
+  invalidated that; the run-* schema is the overlay's, see `run_tailer`.) The `connected`
+  frame also carries a per-process **`boot_id`** (Issue #539 restart-fence for the
+  Point-epoch dedup). Connection **presence** is now visibility-driven: the frontend
+  CLOSES this stream when the tab is hidden (freeing one of the browser's ~6 per-origin
+  HTTP/1.1 connection slots) and reopens on show, so a graph tab holds a slot only while
+  visible. On every (re)subscribe the server replays `snapshot()` + the latched Point
+  (below) to catch the tab up.
 - `POST /api/command` validates a `focus`/`frame` target against a fresh graph, or
   broadcasts `clear` / `select-run` (both pass-through — `clear` before the target is
   read, `select-run` after, carrying the run id in `target` with NO graph resolution;
   a stale run id surfaces the frontend's `run-not-found`, never a server error). It
   reports `sent_to`, per-window visibility, and the canonical `workflow_key` — messages
-  queued to live connections, not browser apply acknowledgments.
+  queued to live connections, not browser apply acknowledgments. **Issue #539:** each
+  `focus`/`frame`/`clear` also carries a monotonic **`epoch`** and is **latched** per
+  `workflow_key` (the latest replaces the prior), which `/api/events` replays after the
+  snapshot so a tab that was hidden when the command fired — or a brand-new tab — catches
+  up to the agent's current highlight; the client dedups by `epoch` (re-baselined on a
+  `boot_id` change) so the replay is idempotent. `select-run` is **not** latched — each
+  tab keeps its own `?run=` pin — so a `select-run` to a hidden tab is dropped (it reaches
+  a visible tab, or `--run` opens one).
 - `POST /api/interaction` records deliberate user actions; `GET /api/activity`
   returns the bounded, newest-first snapshot. `POST /api/visibility` updates one
   connection. All POSTs require `application/json`.
@@ -190,11 +203,19 @@ is `run_node.read_run_inputs`; sync handler, threadpooled, touches no hub state)
   resolvable `workflow` is supplied (`windows = len(windows_for(key))`, **no graph
   build**). An unresolvable workflow reports identity only (no 404 — a liveness probe
   must answer regardless, unlike `events()`/`command()`). It reads the hub, so it is
-  `async def` per the invariant below. **`windows` can transiently over-count by 1**
-  for up to one `_KEEPALIVE_S` cycle after a Viewer's `onerror` reconnect to *this*
-  server (the dropped connection lingers until its next keepalive write fails); a
-  server *restart* frees the whole hub, so that path is clean. Benign for a local
-  single-user viewer; the count self-corrects.
+  `async def` per the invariant below. **`windows` can transiently over-count**
+  for up to one `_KEEPALIVE_S` cycle after a Viewer reconnects to *this* server (the
+  dropped connection lingers until its next keepalive write fails); a server *restart*
+  frees the whole hub, so that path is clean. Since Issue #539 a hidden tab CLOSES its
+  stream (rather than reporting `visibility:hidden`), so `windows` also **drops** a
+  backgrounded tab after its ≤`_KEEPALIVE_S` linger, `_dispatch_report`'s per-window
+  `visibility` no longer surfaces a `hidden` window (a live conn is always a visible tab),
+  and rapid hide/show can over-count by more than 1 (several lingering-closed conns
+  coexist). All benign for a local single-user viewer; the count self-corrects. **Caveat
+  (`pflow ui X --run Y`):** the reuse guard keys on `windows>0`, which can't tell a
+  live-visible tab from a lingering-closed one — if the sole tab was hidden <`_KEEPALIVE_S`
+  ago it POSTs `select-run` (unlatched) to a dead connection and exits without opening a
+  tab; a re-run after the linger fixes it. (Known ≤15 s limitation.)
 
 Name-opened and path-opened Viewers share one resolved workflow key. Point targets
 cross the wire only as structural refs; never send positional flat ids between

--- a/src/pflow/ui/server.py
+++ b/src/pflow/ui/server.py
@@ -135,6 +135,12 @@ class _Hub:
         # `_conns`/tailers): a brand-new tab minutes after the last one closed must still catch up, so pruning
         # on last-window-close would defeat the feature — bounded by O(#workflows ever pointed at), negligible.
         self._points: dict[str, dict[str, object]] = {}
+        # The agent's current run selection per workflow_key: `select-run` is latched the same way, so the
+        # agent can STEER an open window to a run whether it's visible (delivered live) or backgrounded
+        # (caught up on return). Separate from `_points` because focus and run selection are orthogonal
+        # state — a returning tab catches up to BOTH. Shares `_point_epoch`; the client dedups it on a
+        # SEPARATE baseline. Same never-evicted rationale as `_points`.
+        self._selected_run: dict[str, dict[str, object]] = {}
         self._point_epoch = itertools.count(1)
         self.boot_id = uuid.uuid4().hex
         # Task 173: one live-run tailer per (workflow_key, run_id) — started on first viewer subscribe and
@@ -182,23 +188,42 @@ class _Hub:
         run-events. A subset of ``windows_for`` (which spans every run of the workflow, for Point)."""
         return [c for c in self._conns.values() if c.workflow_key == workflow_key and c.run_id == run_id]
 
-    def set_point(self, workflow_key: str, message: dict[str, object]) -> dict[str, object]:
-        """Latch the agent's current Point for a workflow and return the broadcast envelope with its epoch.
+    def _stamp(self, message: dict[str, object]) -> dict[str, object]:
+        """A fresh, immutable-once-minted envelope carrying the next monotonic Point epoch.
 
-        Issue #539: focus/frame/clear are transient broadcasts with no snapshot replay, so a tab whose SSE
-        was closed while hidden would miss them. We stamp each with a monotonic ``epoch`` and remember the
-        latest per workflow_key; ``events()`` replays it to every new/reconnecting Viewer, and the client's
-        epoch-dedup applies it only if newer than what it already showed — a returning tab catches up without
-        clobbering the user's own navigation. The epoch encodes BROADCAST order, not request-arrival order
-        (``clear`` stamps before focus/frame's off-loop build), which matches what live clients already see.
-
-        The returned envelope is stored in ``_points`` AND broadcast to every conn as the SAME dict — it is
-        immutable once minted (this method always builds a fresh dict; no consumer mutates it, only
-        ``json.dumps``), so sharing the reference between the latch and the broadcast queues is torn-read-free.
+        Always a NEW dict (the store and the broadcast queues share this one reference; no consumer mutates
+        it, only ``json.dumps``), so cross-queue sharing is torn-read-free. The epoch encodes BROADCAST order,
+        not request-arrival order (``clear`` stamps before focus/frame's off-loop build) — what live clients
+        already see. Shared by both latches so focus and run selection stay on one monotonic sequence.
         """
-        envelope = {**message, "epoch": next(self._point_epoch)}
+        return {**message, "epoch": next(self._point_epoch)}
+
+    def set_point(self, workflow_key: str, message: dict[str, object]) -> dict[str, object]:
+        """Latch the agent's current Point (focus/frame/clear) and return the epoch-stamped broadcast envelope.
+
+        Issue #539: these are transient broadcasts with no snapshot replay, so a tab whose SSE was closed
+        while hidden would miss them. We remember the latest per workflow_key; ``events()`` replays it to every
+        new/reconnecting Viewer, and the client's epoch-dedup applies it only if newer than what it already
+        showed — a returning tab catches up without clobbering the user's own navigation.
+        """
+        envelope = self._stamp(message)
         self._points[workflow_key] = envelope
         return envelope
+
+    def set_run(self, workflow_key: str, message: dict[str, object]) -> dict[str, object]:
+        """Latch the agent's current run selection (``select-run``) and return the epoch-stamped envelope.
+
+        Mirrors ``set_point`` on a separate store so the agent can STEER an open window to a run: a visible
+        window gets it live, a backgrounded one catches up on return via the ``events()`` replay. The
+        client dedups it on its own baseline, so re-steering works and a user's later manual run pick isn't
+        clobbered by a replay of an already-applied selection.
+        """
+        envelope = self._stamp(message)
+        self._selected_run[workflow_key] = envelope
+        return envelope
+
+    def run_for(self, workflow_key: str) -> dict[str, object] | None:
+        return self._selected_run.get(workflow_key)
 
     def point_for(self, workflow_key: str) -> dict[str, object] | None:
         return self._points.get(workflow_key)
@@ -575,10 +600,11 @@ async def events(request: Request) -> Response:
             # it. The epoch-carrying envelope is deduped client-side, so replaying it is idempotent. Unlike
             # the snapshot above there is NO follow-up stream to re-sync this, but the trigger for a dropped
             # replay is near-impossible (the fresh 64-slot queue holds only the snapshot at this point).
-            latched = hub.point_for(workflow_key)
-            if latched is not None:
-                with contextlib.suppress(asyncio.QueueFull):
-                    conn.queue.put_nowait(latched)
+            # ...and to the agent's current run selection, so `select-run` steers a returning/new window too.
+            for latched in (hub.point_for(workflow_key), hub.run_for(workflow_key)):
+                if latched is not None:
+                    with contextlib.suppress(asyncio.QueueFull):
+                        conn.queue.put_nowait(latched)
             while conn.active:
                 try:
                     message = await asyncio.wait_for(conn.queue.get(), timeout=_KEEPALIVE_S)
@@ -665,10 +691,11 @@ async def command(request: Request) -> Response:
     # skips resolve_target entirely (a run isn't a node/edge). The browser's selectRun applies it (honoring
     # its own re-pick guard); a stale/unknown id surfaces the frontend's run-not-found path in the open
     # Viewer, never a server error — so no server-side run validation. Placed AFTER `target` is read (unlike
-    # `clear`, which returns before it) since the id lives in `target`.
+    # `clear`, which returns before it) since the id lives in `target`. Issue #539: latched (like Point) so
+    # the agent can steer a backgrounded/returning window to the run, not just a currently-visible one.
     if command_type == "select-run":
-        conns = hub.broadcast(workflow_key, {"type": "select-run", "run": target})
-        return _json(_dispatch_report(workflow_key, conns))
+        steered = hub.set_run(workflow_key, {"type": "select-run", "run": target})
+        return _json(_dispatch_report(workflow_key, hub.broadcast(workflow_key, steered)))
 
     try:
         # Validation/build can recurse through large nested workflows. Keep it

--- a/src/pflow/ui/server.py
+++ b/src/pflow/ui/server.py
@@ -131,7 +131,9 @@ class _Hub:
         # highlight. `boot_id` fences the epoch across a server restart: a fresh process restarts the counter
         # at 1, so the client resets its `lastAppliedEpoch` baseline when this nonce changes on reconnect,
         # else a surviving tab would silently skip the new server's lower-numbered Points. Loop-owned like the
-        # rest of the hub (mutated only from command(), on the event loop).
+        # rest of the hub (mutated only from command(), on the event loop). Deliberately NEVER evicted (unlike
+        # `_conns`/tailers): a brand-new tab minutes after the last one closed must still catch up, so pruning
+        # on last-window-close would defeat the feature — bounded by O(#workflows ever pointed at), negligible.
         self._points: dict[str, dict[str, object]] = {}
         self._point_epoch = itertools.count(1)
         self.boot_id = uuid.uuid4().hex
@@ -189,6 +191,10 @@ class _Hub:
         epoch-dedup applies it only if newer than what it already showed — a returning tab catches up without
         clobbering the user's own navigation. The epoch encodes BROADCAST order, not request-arrival order
         (``clear`` stamps before focus/frame's off-loop build), which matches what live clients already see.
+
+        The returned envelope is stored in ``_points`` AND broadcast to every conn as the SAME dict — it is
+        immutable once minted (this method always builds a fresh dict; no consumer mutates it, only
+        ``json.dumps``), so sharing the reference between the latch and the broadcast queues is torn-read-free.
         """
         envelope = {**message, "epoch": next(self._point_epoch)}
         self._points[workflow_key] = envelope

--- a/src/pflow/ui/server.py
+++ b/src/pflow/ui/server.py
@@ -125,6 +125,16 @@ class _Hub:
         self._conns: dict[str, _Conn] = {}
         self._activity: deque[dict[str, object]] = deque(maxlen=_ACTIVITY_MAX)
         self._counter = itertools.count(1)
+        # Issue #539 (Point latch): the agent's current Point per workflow_key — the last focus/frame/clear
+        # envelope, carrying its epoch — replayed to a Viewer on (re)subscribe so a tab that was HIDDEN when
+        # the command fired (its SSE closed to free a connection slot), or a brand-new tab, catches up to the
+        # highlight. `boot_id` fences the epoch across a server restart: a fresh process restarts the counter
+        # at 1, so the client resets its `lastAppliedEpoch` baseline when this nonce changes on reconnect,
+        # else a surviving tab would silently skip the new server's lower-numbered Points. Loop-owned like the
+        # rest of the hub (mutated only from command(), on the event loop).
+        self._points: dict[str, dict[str, object]] = {}
+        self._point_epoch = itertools.count(1)
+        self.boot_id = uuid.uuid4().hex
         # Task 173: one live-run tailer per (workflow_key, run_id) — started on first viewer subscribe and
         # stopped when its last viewer leaves (ref-counted via windows_for_run). DR-1: keying on the run_id
         # too (None = the unpinned live overlay) means a pinned replay and the unpinned overlay of the same
@@ -169,6 +179,23 @@ class _Hub:
         """Viewers watching one specific run (Task 173) — ref-counts a run-scoped tailer and scopes its
         run-events. A subset of ``windows_for`` (which spans every run of the workflow, for Point)."""
         return [c for c in self._conns.values() if c.workflow_key == workflow_key and c.run_id == run_id]
+
+    def set_point(self, workflow_key: str, message: dict[str, object]) -> dict[str, object]:
+        """Latch the agent's current Point for a workflow and return the broadcast envelope with its epoch.
+
+        Issue #539: focus/frame/clear are transient broadcasts with no snapshot replay, so a tab whose SSE
+        was closed while hidden would miss them. We stamp each with a monotonic ``epoch`` and remember the
+        latest per workflow_key; ``events()`` replays it to every new/reconnecting Viewer, and the client's
+        epoch-dedup applies it only if newer than what it already showed — a returning tab catches up without
+        clobbering the user's own navigation. The epoch encodes BROADCAST order, not request-arrival order
+        (``clear`` stamps before focus/frame's off-loop build), which matches what live clients already see.
+        """
+        envelope = {**message, "epoch": next(self._point_epoch)}
+        self._points[workflow_key] = envelope
+        return envelope
+
+    def point_for(self, workflow_key: str) -> dict[str, object] | None:
+        return self._points.get(workflow_key)
 
     def _send_or_evict(self, conn: _Conn, message: dict[str, object]) -> bool:
         """Enqueue one message to one connection; EVICT it if its bounded queue is full. A socket that
@@ -524,7 +551,10 @@ async def events(request: Request) -> Response:
     async def stream() -> AsyncIterator[str]:
         conn = hub.register(workflow_key, visibility, run_id)
         try:
-            yield f"data: {json.dumps({'type': 'connected', 'conn_id': conn.conn_id})}\n\n"
+            # `boot_id` fences the Point epoch across a server restart (Issue #539): the client resets its
+            # dedup baseline when this nonce changes, so a reconnecting tab doesn't skip a fresh process's
+            # lower-numbered Points.
+            yield f"data: {json.dumps({'type': 'connected', 'conn_id': conn.conn_id, 'boot_id': hub.boot_id})}\n\n"
             # Task 173: attach this Viewer to the (workflow_key, run_id) tailer and hand it the current run
             # state so a viewer that opened mid-run catches up without replaying the file (and the per-conn
             # queue can't overflow on replay). Future deltas arrive as run-scoped `run-events`.
@@ -534,6 +564,15 @@ async def events(request: Request) -> Response:
             # governs from here. Mirrors broadcast's graceful degrade (deep-review R7).
             with contextlib.suppress(asyncio.QueueFull):
                 conn.queue.put_nowait(tailer.snapshot())
+            # Issue #539: catch this Viewer up to the agent's current Point (focus/frame/clear). A tab that
+            # was hidden when the command fired closed its SSE and missed the broadcast; a new tab never got
+            # it. The epoch-carrying envelope is deduped client-side, so replaying it is idempotent. Unlike
+            # the snapshot above there is NO follow-up stream to re-sync this, but the trigger for a dropped
+            # replay is near-impossible (the fresh 64-slot queue holds only the snapshot at this point).
+            latched = hub.point_for(workflow_key)
+            if latched is not None:
+                with contextlib.suppress(asyncio.QueueFull):
+                    conn.queue.put_nowait(latched)
             while conn.active:
                 try:
                     message = await asyncio.wait_for(conn.queue.get(), timeout=_KEEPALIVE_S)
@@ -607,7 +646,10 @@ async def command(request: Request) -> Response:
 
     hub: _Hub = request.app.state.hub
     if command_type == "clear":
-        return _json(_dispatch_report(workflow_key, hub.broadcast(workflow_key, {"type": "clear"})))
+        # Issue #539: latch the cleared state (stamped with its epoch) so a returning/new tab catches up to
+        # the clear rather than replaying a stale highlight.
+        cleared = hub.set_point(workflow_key, {"type": "clear"})
+        return _json(_dispatch_report(workflow_key, hub.broadcast(workflow_key, cleared)))
 
     target = _string_field(body, "target")
     if target is None:
@@ -639,9 +681,12 @@ async def command(request: Request) -> Response:
     if resolution.matched != 1 or resolution.descriptor is None:
         return _json(response)
 
+    # Issue #539: latch the resolved point (stamped with its epoch) BEFORE broadcasting, so a tab that was
+    # hidden when this fired — or a new tab — catches up to it on (re)subscribe. Only a unique match reaches
+    # here (the resolution.matched != 1 early-return above), so a zero/ambiguous match never mints an epoch.
     conns = hub.broadcast(
         workflow_key,
-        {"type": command_type, "target": resolution.descriptor},
+        hub.set_point(workflow_key, {"type": command_type, "target": resolution.descriptor}),
     )
     response.update(_dispatch_report(workflow_key, conns))
     return _json(response)

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -104,7 +104,10 @@ class TestServeRun:
             result = runner.invoke(ui_module.ui_cmd, ["demo", "--run", "abc123"])
         assert result.exit_code == 0, result.output
         assert request.call_args.kwargs["json"] == {"workflow": "demo", "type": "select-run", "target": "abc123"}
-        assert "switched it to run abc123" in result.output
+        # Reports honestly (Issue #539): windows>0 can't distinguish a live tab from a just-closing one, so
+        # the message tells the agent it may need to re-run rather than asserting the switch succeeded.
+        assert "asked it to switch to run abc123" in result.output
+        assert "re-run to open a fresh pinned tab" in result.output
         wb_open.assert_not_called()  # no duplicate tab
 
     def test_reuse_without_a_viewer_opens_a_pinned_tab(self) -> None:

--- a/tests/test_cli/test_ui_commands.py
+++ b/tests/test_cli/test_ui_commands.py
@@ -104,10 +104,9 @@ class TestServeRun:
             result = runner.invoke(ui_module.ui_cmd, ["demo", "--run", "abc123"])
         assert result.exit_code == 0, result.output
         assert request.call_args.kwargs["json"] == {"workflow": "demo", "type": "select-run", "target": "abc123"}
-        # Reports honestly (Issue #539): windows>0 can't distinguish a live tab from a just-closing one, so
-        # the message tells the agent it may need to re-run rather than asserting the switch succeeded.
-        assert "asked it to switch to run abc123" in result.output
-        assert "re-run to open a fresh pinned tab" in result.output
+        # select-run is latched (Issue #539), so this reliably steers the open window (live or on return) —
+        # report the steer plainly rather than hedging.
+        assert "steering it to run abc123" in result.output
         wb_open.assert_not_called()  # no duplicate tab
 
     def test_reuse_without_a_viewer_opens_a_pinned_tab(self) -> None:

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -106,6 +106,25 @@ class TestHub:
         assert filtered[0]["sequence"] == _ACTIVITY_MAX + 4
         assert filtered[-1]["sequence"] == 6
 
+    def test_set_point_latches_the_latest_command_with_a_monotonic_epoch(self) -> None:
+        # Issue #539: the hub remembers the agent's current Point per workflow_key, stamped with a
+        # strictly-increasing epoch, so events() can replay the LATEST one to a new/reconnecting Viewer.
+        hub = _Hub()
+        assert hub.point_for("/a.pflow.md") is None
+        first = hub.set_point("/a.pflow.md", {"type": "focus", "target": {"kind": "node"}})
+        second = hub.set_point("/a.pflow.md", {"type": "clear"})
+        assert first["epoch"] == 1 and second["epoch"] == 2  # broadcast order → monotonic epoch
+        assert hub.point_for("/a.pflow.md") == {"type": "clear", "epoch": 2}  # latch holds the latest
+        assert hub.point_for("/other.pflow.md") is None  # scoped per workflow_key
+
+    def test_boot_id_is_a_stable_per_process_nonce(self) -> None:
+        # The restart-fence the client resets its epoch baseline against: stable within a process,
+        # distinct across _Hub instances (a server restart mints a fresh one, restarting the counter).
+        hub = _Hub()
+        assert isinstance(hub.boot_id, str) and hub.boot_id
+        assert hub.boot_id == hub.boot_id
+        assert hub.boot_id != _Hub().boot_id
+
 
 class TestHealthEndpoint:
     """``/api/health`` — the discovery/reuse probe. It TOUCHES THE HUB, so the
@@ -174,6 +193,7 @@ class TestInteractionEndpoints:
                 "kind": "node",
                 "ref": {"node_id": "greet", "ancestor_path": [], "port": None},
             },
+            "epoch": 1,  # Issue #539: focus/frame/clear carry a monotonic epoch for latch dedup
         }
 
     def test_clear_does_not_require_a_target(self, tmp_path: Path) -> None:
@@ -188,7 +208,7 @@ class TestInteractionEndpoints:
 
         assert response.status_code == 200
         assert response.json()["sent_to"] == 1
-        assert conn.queue.get_nowait() == {"type": "clear"}
+        assert conn.queue.get_nowait() == {"type": "clear", "epoch": 1}  # Issue #539: epoch stamp
 
     def test_select_run_broadcasts_the_run_id_as_pass_through(self, tmp_path: Path) -> None:
         # Task 175: select-run carries a RUN id in `target` and is PASS-THROUGH — broadcast as
@@ -210,6 +230,47 @@ class TestInteractionEndpoints:
         workflow = _workflow(tmp_path)
         response = _client().post("/api/command", json={"workflow": str(workflow), "type": "select-run"})
         assert response.status_code == 400
+
+    def test_focus_latches_the_point_even_with_no_live_windows(self, tmp_path: Path) -> None:
+        # Issue #539: the latch exists precisely to reach a tab that was NOT connected when the command
+        # fired, so storing it must not depend on there being live windows.
+        workflow = _workflow(tmp_path)
+        app = create_app()
+        key = str(workflow.resolve())
+
+        response = _client(app).post(
+            "/api/command", json={"workflow": str(workflow), "type": "focus", "target": "greet"}
+        )
+
+        assert response.json()["sent_to"] == 0  # nobody connected
+        assert app.state.hub.point_for(key) == {
+            "type": "focus",
+            "target": {"kind": "node", "ref": {"node_id": "greet", "ancestor_path": [], "port": None}},
+            "epoch": 1,
+        }
+
+    def test_clear_replaces_the_latched_focus_with_a_higher_epoch(self, tmp_path: Path) -> None:
+        workflow = _workflow(tmp_path)
+        app = create_app()
+        key = str(workflow.resolve())
+        client = _client(app)
+
+        client.post("/api/command", json={"workflow": str(workflow), "type": "focus", "target": "greet"})
+        client.post("/api/command", json={"workflow": str(workflow), "type": "clear"})
+
+        # The latch holds the LATEST command (the clear), so a reopening tab catches up to the clear rather
+        # than re-applying a stale highlight; its epoch is higher than the focus it superseded.
+        assert app.state.hub.point_for(key) == {"type": "clear", "epoch": 2}
+
+    def test_select_run_does_not_latch(self, tmp_path: Path) -> None:
+        # select-run is excluded from the latch (it conflicts with each tab's own ?run= pin): it broadcasts
+        # live only, leaving the Point latch untouched so a reopening tab keeps its own run.
+        workflow = _workflow(tmp_path)
+        app = create_app()
+
+        _client(app).post("/api/command", json={"workflow": str(workflow), "type": "select-run", "target": "run-abc"})
+
+        assert app.state.hub.point_for(str(workflow.resolve())) is None
 
     def test_unknown_command_verb_is_rejected(self, tmp_path: Path) -> None:
         # The verb whitelist still rejects anything outside {focus, frame, clear, select-run}.
@@ -248,6 +309,8 @@ class TestInteractionEndpoints:
         assert response.json()["resolved"] == {"matched": 0, "suggestions": ["greet"]}
         assert response.json()["sent_to"] == 0
         assert conn.queue.empty()
+        # A zero/ambiguous match neither broadcasts NOR latches — no epoch is minted (Issue #539).
+        assert app.state.hub.point_for(str(workflow.resolve())) is None
 
     def test_unknown_workflow_name_is_actionable_404(self) -> None:
         response = _client().post(
@@ -595,6 +658,48 @@ def test_idle_connection_emits_keepalive_frames(tmp_path: Path) -> None:
         connected, snapshot, keepalive = asyncio.run(_drive())
 
     assert '"type": "connected"' in connected
+    assert '"boot_id"' in connected  # Issue #539: the restart-fence nonce rides the handshake
     assert '"type": "run-snapshot"' in snapshot  # Task-173 catch-up frame for new viewers
     assert keepalive.strip().startswith(":")  # the idle keepalive comment frame
     assert app.state.hub.windows_for(str(workflow.resolve())) == []
+
+
+def test_events_replays_the_latched_point_to_a_new_connection(tmp_path: Path) -> None:
+    """Issue #539: a Viewer connecting AFTER an agent Point catches up to it.
+
+    A focus issued while a tab was hidden (its SSE closed to free a connection slot) — or before a new tab
+    opened — is latched server-side; every new /api/events stream replays it right after the run snapshot,
+    so the tab adopts the agent's current highlight. Drives the response generator directly (same technique
+    as the keepalive test) to read the ordered frames without racing the ASGI disconnect listener."""
+    workflow = _workflow(tmp_path)
+    app = create_app()
+
+    # An agent points at a node while no tab of this workflow is connected.
+    _client(app).post("/api/command", json={"workflow": str(workflow), "type": "focus", "target": "greet"})
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/events",
+        "query_string": urlencode({"workflow": str(workflow), "visibility": "visible"}).encode(),
+        "headers": [],
+        "app": app,
+    }
+
+    async def _drive() -> tuple[str, str, str]:
+        response = await events(Request(scope))
+        body = response.body_iterator
+        connected = await asyncio.wait_for(body.__anext__(), timeout=2.0)
+        snapshot = await asyncio.wait_for(body.__anext__(), timeout=2.0)
+        latched = await asyncio.wait_for(body.__anext__(), timeout=2.0)  # the Point replay, after the snapshot
+        await body.aclose()
+        return connected, snapshot, latched
+
+    connected, snapshot, latched = asyncio.run(_drive())
+
+    assert '"type": "connected"' in connected
+    assert '"type": "run-snapshot"' in snapshot
+    payload = json.loads(latched.removeprefix("data: ").strip())
+    assert payload["type"] == "focus"
+    assert payload["target"]["ref"]["node_id"] == "greet"
+    assert payload["epoch"] == 1  # the client dedups against this so the replay is idempotent

--- a/tests/test_cli/test_ui_interaction_server.py
+++ b/tests/test_cli/test_ui_interaction_server.py
@@ -117,6 +117,17 @@ class TestHub:
         assert hub.point_for("/a.pflow.md") == {"type": "clear", "epoch": 2}  # latch holds the latest
         assert hub.point_for("/other.pflow.md") is None  # scoped per workflow_key
 
+    def test_set_run_latches_on_a_separate_store_sharing_the_epoch(self) -> None:
+        # Issue #539: the run selection latches independently of the Point latch (orthogonal state, both
+        # replayed on subscribe), but on ONE monotonic epoch sequence so they stay comparably ordered.
+        hub = _Hub()
+        assert hub.run_for("/a.pflow.md") is None
+        point = hub.set_point("/a.pflow.md", {"type": "focus"})
+        run = hub.set_run("/a.pflow.md", {"type": "select-run", "run": "r1"})
+        assert point["epoch"] == 1 and run["epoch"] == 2  # one shared monotonic sequence
+        assert hub.run_for("/a.pflow.md") == {"type": "select-run", "run": "r1", "epoch": 2}
+        assert hub.point_for("/a.pflow.md") == {"type": "focus", "epoch": 1}  # separate stores, both kept
+
     def test_boot_id_is_a_stable_per_process_nonce(self) -> None:
         # The restart-fence the client resets its epoch baseline against: stable within a process,
         # distinct across _Hub instances (a server restart mints a fresh one, restarting the counter).
@@ -224,7 +235,8 @@ class TestInteractionEndpoints:
 
         assert response.status_code == 200
         assert response.json()["sent_to"] == 1
-        assert conn.queue.get_nowait() == {"type": "select-run", "run": "run-abc"}
+        # Issue #539: select-run now carries a monotonic `epoch` (it's latched for steering, like Point).
+        assert conn.queue.get_nowait() == {"type": "select-run", "run": "run-abc", "epoch": 1}
 
     def test_select_run_requires_a_target(self, tmp_path: Path) -> None:
         workflow = _workflow(tmp_path)
@@ -262,15 +274,17 @@ class TestInteractionEndpoints:
         # than re-applying a stale highlight; its epoch is higher than the focus it superseded.
         assert app.state.hub.point_for(key) == {"type": "clear", "epoch": 2}
 
-    def test_select_run_does_not_latch(self, tmp_path: Path) -> None:
-        # select-run is excluded from the latch (it conflicts with each tab's own ?run= pin): it broadcasts
-        # live only, leaving the Point latch untouched so a reopening tab keeps its own run.
+    def test_select_run_latches_the_run_selection(self, tmp_path: Path) -> None:
+        # Issue #539: select-run is latched (on its OWN store) so the agent can steer a backgrounded/returning
+        # window to a run. It does NOT touch the Point latch — focus and run selection are orthogonal state.
         workflow = _workflow(tmp_path)
         app = create_app()
+        key = str(workflow.resolve())
 
         _client(app).post("/api/command", json={"workflow": str(workflow), "type": "select-run", "target": "run-abc"})
 
-        assert app.state.hub.point_for(str(workflow.resolve())) is None
+        assert app.state.hub.run_for(key) == {"type": "select-run", "run": "run-abc", "epoch": 1}
+        assert app.state.hub.point_for(key) is None  # the focus latch is untouched
 
     def test_unknown_command_verb_is_rejected(self, tmp_path: Path) -> None:
         # The verb whitelist still rejects anything outside {focus, frame, clear, select-run}.
@@ -703,3 +717,38 @@ def test_events_replays_the_latched_point_to_a_new_connection(tmp_path: Path) ->
     assert payload["type"] == "focus"
     assert payload["target"]["ref"]["node_id"] == "greet"
     assert payload["epoch"] == 1  # the client dedups against this so the replay is idempotent
+
+
+def test_events_replays_the_latched_run_selection_to_a_new_connection(tmp_path: Path) -> None:
+    """Issue #539: `select-run` is latched, so a window that connects AFTER the agent steered the workflow to
+    a run catches up to it — this is what lets the agent steer a backgrounded/returning window, not just a
+    live one. Only the run is latched here, so the replay is the third frame (connected → snapshot → run)."""
+    workflow = _workflow(tmp_path)
+    app = create_app()
+
+    # The agent steers the workflow to a run while no tab is connected.
+    _client(app).post("/api/command", json={"workflow": str(workflow), "type": "select-run", "target": "run-xyz"})
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/events",
+        "query_string": urlencode({"workflow": str(workflow), "visibility": "visible"}).encode(),
+        "headers": [],
+        "app": app,
+    }
+
+    async def _drive() -> tuple[str, str, str]:
+        response = await events(Request(scope))
+        body = response.body_iterator
+        connected = await asyncio.wait_for(body.__anext__(), timeout=2.0)
+        snapshot = await asyncio.wait_for(body.__anext__(), timeout=2.0)
+        steered = await asyncio.wait_for(body.__anext__(), timeout=2.0)  # the run replay, after the snapshot
+        await body.aclose()
+        return connected, snapshot, steered
+
+    connected, snapshot, steered = asyncio.run(_drive())
+
+    assert '"type": "connected"' in connected
+    assert '"type": "run-snapshot"' in snapshot
+    assert json.loads(steered.removeprefix("data: ").strip()) == {"type": "select-run", "run": "run-xyz", "epoch": 1}

--- a/web/src/api/events.test.ts
+++ b/web/src/api/events.test.ts
@@ -19,10 +19,15 @@ class FakeEventSource {
   }
 
   emit(message: unknown): void {
+    if (this.closed) return; // WHATWG: a closed source dispatches no further events
     this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(message) }));
   }
 
   fail(): void {
+    // WHATWG: once close() sets readyState=CLOSED, a source never re-fires onerror. The subscribe()
+    // single-flight safety leans on this (a stale handler can't reach a later source), so the double
+    // must honor it — else the hide/show tests would exercise a browser-impossible interleaving.
+    if (this.closed) return;
     this.onerror?.(new Event("error"));
   }
 
@@ -181,6 +186,136 @@ describe("subscribe reconnect", () => {
     first.fail(); // an error after teardown must not resurrect a connection
     vi.advanceTimersByTime(5000);
     expect(FakeEventSource.instances).toHaveLength(1);
+  });
+});
+
+describe("subscribe visibility presence (#539)", () => {
+  // Close the SSE when hidden (freeing one of the browser's 6-per-origin slots) and reopen on visible.
+  const handlers = () => ({ focus: vi.fn(), frame: vi.fn(), clear: vi.fn(), selectRun: vi.fn() });
+  const setVisibility = (value: "visible" | "hidden"): void => {
+    Object.defineProperty(document, "visibilityState", { configurable: true, value });
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+  const live = (): FakeEventSource[] => FakeEventSource.instances.filter((s) => !s.closed);
+
+  it("stays dormant when the tab starts hidden, and opens on first show", () => {
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    const unsubscribe = subscribe("wf", handlers());
+    expect(FakeEventSource.instances).toHaveLength(0); // a background-tab mount holds no slot
+
+    setVisibility("visible");
+    expect(live()).toHaveLength(1);
+    unsubscribe();
+  });
+
+  it("closes the source on hidden and reopens a fresh one on visible", () => {
+    const unsubscribe = subscribe("wf", handlers());
+    const first = FakeEventSource.instances[0]!;
+
+    setVisibility("hidden");
+    expect(first.closed).toBe(true); // slot released
+    expect(live()).toHaveLength(0);
+
+    setVisibility("visible");
+    expect(live()).toHaveLength(1); // reopened
+    expect(FakeEventSource.instances).toHaveLength(2);
+    unsubscribe();
+  });
+
+  it("keeps exactly one live source across rapid hide/show (no duplicates)", () => {
+    const unsubscribe = subscribe("wf", handlers());
+    setVisibility("hidden");
+    setVisibility("visible");
+    setVisibility("hidden");
+    setVisibility("visible");
+    expect(live()).toHaveLength(1);
+    unsubscribe();
+  });
+
+  it("cancels a pending onerror-reconnect when hidden, and reopens cleanly on show", () => {
+    vi.useFakeTimers();
+    const unsubscribe = subscribe("wf", handlers());
+    FakeEventSource.instances[0]!.fail(); // schedules a reconnect timer
+    setVisibility("hidden"); // must cancel it — a hidden tab must not reconnect behind our back
+    expect(vi.getTimerCount()).toBe(0); // close() cleared the pending retry (not merely gated by open())
+    vi.advanceTimersByTime(5000);
+    expect(live()).toHaveLength(0);
+
+    setVisibility("visible");
+    expect(live()).toHaveLength(1);
+    unsubscribe();
+    vi.useRealTimers();
+  });
+});
+
+describe("subscribe point epoch dedup (#539)", () => {
+  // The latch replay is idempotent: a point applies only if strictly newer than the last one shown, so a
+  // returning tab catches up to a newer highlight without re-applying (clobbering) what it already has.
+  const handlers = () => ({ focus: vi.fn(), frame: vi.fn(), clear: vi.fn(), selectRun: vi.fn() });
+  const focus = (epoch?: number) => ({ type: "focus", target: { kind: "node", ref }, ...(epoch !== undefined ? { epoch } : {}) });
+
+  it("applies a point only when its epoch is newer than the last applied", () => {
+    const h = handlers();
+    const unsubscribe = subscribe("wf", h);
+    const source = FakeEventSource.instances[0]!;
+
+    source.emit(focus(3)); // 3 > 0 → applied
+    source.emit(focus(2)); // stale → skipped
+    source.emit(focus(3)); // already applied → skipped
+    source.emit(focus(4)); // newer → applied
+
+    expect(h.focus).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it("does not re-apply an already-shown latch after a reopen, but catches up to a newer one", () => {
+    const h = handlers();
+    const unsubscribe = subscribe("wf", h);
+    const first = FakeEventSource.instances[0]!;
+    first.emit({ type: "connected", conn_id: "v1", boot_id: "boot-A" });
+    first.emit(focus(5));
+    expect(h.focus).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    document.dispatchEvent(new Event("visibilitychange"));
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+    document.dispatchEvent(new Event("visibilitychange"));
+    const reopened = FakeEventSource.instances[1]!;
+    reopened.emit({ type: "connected", conn_id: "v2", boot_id: "boot-A" }); // SAME server → no baseline reset
+
+    reopened.emit(focus(5)); // the replayed latch it already showed → skipped
+    expect(h.focus).toHaveBeenCalledTimes(1);
+    reopened.emit(focus(6)); // a point issued while hidden → applied
+    expect(h.focus).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it("resets the epoch baseline when the server boot_id changes (restart-fence)", () => {
+    const h = handlers();
+    const unsubscribe = subscribe("wf", h);
+    const source = FakeEventSource.instances[0]!;
+    source.emit({ type: "connected", conn_id: "v1", boot_id: "boot-A" });
+    source.emit(focus(10));
+    expect(h.focus).toHaveBeenCalledTimes(1);
+
+    // Reconnect to a RESTARTED server: new boot_id, and its epoch counter has restarted low.
+    source.emit({ type: "connected", conn_id: "v2", boot_id: "boot-B" });
+    source.emit(focus(1)); // would be stale vs 10, but the boot_id changed → baseline reset → applied
+    expect(h.focus).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it("applies a point with no epoch (old server / back-compat) without bumping the baseline", () => {
+    const h = handlers();
+    const unsubscribe = subscribe("wf", h);
+    const source = FakeEventSource.instances[0]!;
+
+    source.emit(focus(7)); // baseline → 7
+    source.emit(focus()); // no epoch → always applies, does NOT bump the baseline
+    source.emit(focus(7)); // still <= 7 → skipped (the epoch-less emit didn't move the baseline)
+
+    expect(h.focus).toHaveBeenCalledTimes(2);
+    unsubscribe();
   });
 });
 

--- a/web/src/api/events.test.ts
+++ b/web/src/api/events.test.ts
@@ -317,6 +317,32 @@ describe("subscribe point epoch dedup (#539)", () => {
     expect(h.focus).toHaveBeenCalledTimes(2);
     unsubscribe();
   });
+
+  it("dedups select-run on its own channel (newer steer applies, stale/duplicate skipped)", () => {
+    const h = handlers();
+    const unsubscribe = subscribe("wf", h);
+    const source = FakeEventSource.instances[0]!;
+
+    source.emit({ type: "select-run", run: "r1", epoch: 2 }); // applied
+    source.emit({ type: "select-run", run: "r0", epoch: 1 }); // stale → skipped
+    source.emit({ type: "select-run", run: "r1", epoch: 2 }); // duplicate (replayed latch) → skipped
+    source.emit({ type: "select-run", run: "r2", epoch: 3 }); // newer steer → applied
+
+    expect(h.selectRun.mock.calls.map((c) => c[0])).toEqual(["r1", "r2"]);
+    unsubscribe();
+  });
+
+  it("keeps the point and run dedup baselines independent", () => {
+    const h = handlers();
+    const unsubscribe = subscribe("wf", h);
+    const source = FakeEventSource.instances[0]!;
+
+    source.emit(focus(5)); // point channel → 5
+    source.emit({ type: "select-run", run: "r1", epoch: 3 }); // run channel: 3 > 0 → applied, NOT skipped
+    expect(h.focus).toHaveBeenCalledTimes(1);
+    expect(h.selectRun).toHaveBeenCalledTimes(1); // a lower run epoch isn't gated by the higher point epoch
+    unsubscribe();
+  });
 });
 
 describe("reportInteraction", () => {

--- a/web/src/api/events.ts
+++ b/web/src/api/events.ts
@@ -71,12 +71,21 @@ function asRunComplete(value: unknown): RunComplete | null {
 const RETRY_MS = 1000; // localhost single-user: a fixed beat beats exponential backoff's moving parts
 
 /**
- * Subscribe one Viewer to Point commands. Drives its OWN reconnect on drop —
- * native EventSource auto-reconnect is unreliable for backgrounded/slept/frozen
- * tabs (it may stay in CONNECTING and never re-register). On any `onerror` we
- * explicitly close the dead source and reopen a fresh one after a fixed delay,
- * trigger-agnostic: recovers from server restart, sleep/wake, network blip, and
- * tab freeze uniformly, without ever reading `readyState` or `visibilityState`.
+ * Subscribe one Viewer to Point + run-overlay commands. TWO separate concerns share the state below:
+ *
+ * - RECOVERY (unchanged): native EventSource auto-reconnect is unreliable for backgrounded/slept/frozen
+ *   tabs (it may stay in CONNECTING and never re-register). On any `onerror` we explicitly drop the dead
+ *   source and reopen after a fixed delay — trigger-agnostic, recovering from server restart, sleep/wake,
+ *   network blip and tab freeze uniformly, without ever reading `readyState` or `visibilityState`.
+ * - PRESENCE (Issue #539): a graph tab holds a persistent SSE and browsers cap ~6 connections per origin
+ *   over HTTP/1.1, so several open tabs starve new ones. We CLOSE the source when the tab is hidden (freeing
+ *   its slot) and reopen when it's shown. Only `open()`'s gate reads `visibilityState`; recovery stays
+ *   visibility-agnostic. That single `open()` chokepoint (guarded on `source`/`stopped`/hidden) keeps at
+ *   most one live EventSource and one pending reconnect across every hide/show/error interleave.
+ *
+ * A reopened (or brand-new) tab catches up: the server replays the run `snapshot()` and the latched Point,
+ * epoch-deduped against `lastAppliedEpoch` (re-baselined when the server's `boot_id` changes on restart) so
+ * it adopts a newer highlight without clobbering the user's own navigation.
  */
 export function subscribe(
   workflow: string,
@@ -87,6 +96,11 @@ export function subscribe(
   let connId: string | null = null;
   let retry: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
+  // Issue #539 Point-latch dedup: the highest Point epoch this Viewer has applied, and the server identity
+  // it counts against. Both survive the internal close/reopen (same closure); a fresh subscribe() resets
+  // them. A replayed latch with epoch <= lastAppliedEpoch is skipped — idempotent catch-up, no clobber.
+  let lastAppliedEpoch = 0;
+  let serverBootId: string | null = null;
 
   const reportVisibility = (): void => {
     if (connId === null) return;
@@ -98,8 +112,38 @@ export function subscribe(
     }).catch(() => undefined);
   };
 
-  const connect = (): void => {
-    if (stopped) return; // defensive: a fired-but-not-yet-cleared timer must not resurrect a connection
+  // True if a Point (focus/frame/clear) should be applied — i.e. it is not a replayed latch this Viewer has
+  // already superseded — bumping the baseline when it is. A missing/non-number epoch (old server, or a
+  // direct test emit) always admits and never bumps. Callers gate this AFTER payload validation, so a
+  // malformed message never bumps the baseline.
+  const admitEpoch = (rawEpoch: unknown): boolean => {
+    const epoch = typeof rawEpoch === "number" ? rawEpoch : null;
+    if (epoch !== null && epoch <= lastAppliedEpoch) return false;
+    if (epoch !== null) lastAppliedEpoch = epoch;
+    return true;
+  };
+
+  const dropSource = (): void => {
+    // Null `source` so open()'s single-flight gate can reconnect; a closed EventSource never fires onerror
+    // again (WHATWG), so no stale handler reaches a later source.
+    source?.close();
+    source = null;
+    connId = null;
+  };
+
+  // Release the slot (hidden) or tear down for good (unsubscribe); also cancel any pending reconnect so a
+  // hidden/torn-down tab can't reconnect behind our back.
+  const close = (): void => {
+    if (retry !== null) clearTimeout(retry);
+    retry = null;
+    dropSource();
+  };
+
+  const open = (): void => {
+    // Single chokepoint: never a second live source, and never connect while hidden — so a queued reconnect
+    // can't resurrect a backgrounded tab and a background-tab mount stays dormant until first shown. This is
+    // the ONLY place connection PRESENCE reads visibility; RECOVERY (onerror below) stays trigger-agnostic.
+    if (stopped || source !== null || visibility() === "hidden") return;
     const params = new URLSearchParams({ workflow, visibility: visibility() });
     if (runId) params.set("run", runId); // Task 173 DR-1: pin this Viewer to one run (replay / one of N)
     source = new EventSource(`/api/events?${params.toString()}`);
@@ -113,15 +157,21 @@ export function subscribe(
       }
       if (!isRecord(message) || typeof message.type !== "string") return;
       if (message.type === "connected" && typeof message.conn_id === "string") {
+        // A restarted server restarts its Point epoch at 1; reset the dedup baseline when its `boot_id`
+        // changes so a reconnecting tab doesn't skip the new process's lower-numbered Points (Issue #539).
+        if (typeof message.boot_id === "string" && message.boot_id !== serverBootId) {
+          serverBootId = message.boot_id;
+          lastAppliedEpoch = 0;
+        }
         connId = message.conn_id;
         // A reconnect reopens with the original URL, whose visibility value may
         // now be stale. Correct every newly registered connection immediately;
         // do not wait for another visibility transition.
         reportVisibility();
       } else if (message.type === "clear") {
-        handlers.clear();
+        if (admitEpoch(message.epoch)) handlers.clear();
       } else if ((message.type === "focus" || message.type === "frame") && isTarget(message.target)) {
-        handlers[message.type](message.target);
+        if (admitEpoch(message.epoch)) handlers[message.type](message.target);
       } else if (message.type === "select-run" && typeof message.run === "string") {
         handlers.selectRun(message.run); // Task 175: switch the open Viewer to the broadcast run id
       } else if (message.type === "run-events" && Array.isArray(message.events)) {
@@ -150,31 +200,33 @@ export function subscribe(
     };
 
     source.onerror = (): void => {
-      // Any drop (restart/sleep/blip/freeze). Tear down the dead source and reopen
-      // against the live server — do NOT trust native retry, do NOT read readyState.
-      // The single-flight guard (retry === null) + close-before-schedule mean at most
-      // one reconnect is ever pending and at most one EventSource is ever live.
-      source?.close();
-      connId = null;
+      // Any drop (restart/sleep/blip/freeze). Tear down the dead source and reopen against the live server —
+      // do NOT trust native retry, do NOT read readyState/visibilityState here. dropSource() nulls `source`
+      // (else open()'s gate would deadlock reconnection); the `retry === null` guard + the wrapper (which
+      // nulls `retry` before reopening) keep at most one reconnect pending, timed from the first drop.
+      dropSource();
       if (!stopped && retry === null) {
         retry = setTimeout(() => {
           retry = null;
-          connect();
+          open();
         }, RETRY_MS);
       }
     };
   };
 
-  connect();
-  // visibilitychange reports visible/hidden ONLY; it never drives reconnection.
-  document.addEventListener("visibilitychange", reportVisibility);
+  open(); // no-ops if the tab starts hidden — onVisibilityChange opens it when first shown
+  // PRESENCE keys on visibility (close-on-hidden frees the 6-per-origin slot, reopen on show); RECOVERY
+  // (onerror) never does.
+  const onVisibilityChange = (): void => {
+    if (visibility() === "hidden") close();
+    else open();
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
 
   return () => {
     stopped = true;
-    if (retry !== null) clearTimeout(retry);
-    document.removeEventListener("visibilitychange", reportVisibility);
-    source?.close();
-    connId = null;
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    close();
   };
 }
 

--- a/web/src/api/events.ts
+++ b/web/src/api/events.ts
@@ -83,9 +83,9 @@ const RETRY_MS = 1000; // localhost single-user: a fixed beat beats exponential 
  *   visibility-agnostic. That single `open()` chokepoint (guarded on `source`/`stopped`/hidden) keeps at
  *   most one live EventSource and one pending reconnect across every hide/show/error interleave.
  *
- * A reopened (or brand-new) tab catches up: the server replays the run `snapshot()` and the latched Point,
- * epoch-deduped against `lastAppliedEpoch` (re-baselined when the server's `boot_id` changes on restart) so
- * it adopts a newer highlight without clobbering the user's own navigation.
+ * A reopened (or brand-new) tab catches up: the server replays the run `snapshot()`, the latched Point, and
+ * the latched run selection (`select-run`) — each epoch-deduped on its own baseline (re-based when the
+ * server's `boot_id` changes on restart) so it adopts newer agent state without clobbering the user's own.
  */
 export function subscribe(
   workflow: string,
@@ -96,10 +96,11 @@ export function subscribe(
   let connId: string | null = null;
   let retry: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
-  // Issue #539 Point-latch dedup: the highest Point epoch this Viewer has applied, and the server identity
-  // it counts against. Both survive the internal close/reopen (same closure); a fresh subscribe() resets
-  // them. A replayed latch with epoch <= lastAppliedEpoch is skipped — idempotent catch-up, no clobber.
-  let lastAppliedEpoch = 0;
+  // Issue #539 latch dedup: the highest epoch this Viewer has applied on each channel (`point` = focus/
+  // frame/clear; `run` = select-run — orthogonal state, so separate baselines), and the server identity they
+  // count against. All survive the internal close/reopen (same closure); a fresh subscribe() resets them.
+  // A replayed latch with epoch <= its channel's baseline is skipped — idempotent catch-up, no clobber.
+  const applied = { point: 0, run: 0 };
   let serverBootId: string | null = null;
 
   const reportVisibility = (): void => {
@@ -112,14 +113,14 @@ export function subscribe(
     }).catch(() => undefined);
   };
 
-  // True if a Point (focus/frame/clear) should be applied — i.e. it is not a replayed latch this Viewer has
-  // already superseded — bumping the baseline when it is. A missing/non-number epoch (old server, or a
-  // direct test emit) always admits and never bumps. Callers gate this AFTER payload validation, so a
+  // True if a latched command on this channel should be applied — i.e. it is not a replay this Viewer has
+  // already superseded — bumping the channel's baseline when it is. A missing/non-number epoch (old server,
+  // or a direct test emit) always admits and never bumps. Callers gate this AFTER payload validation, so a
   // malformed message never bumps the baseline.
-  const admitEpoch = (rawEpoch: unknown): boolean => {
+  const admitEpoch = (rawEpoch: unknown, channel: "point" | "run"): boolean => {
     const epoch = typeof rawEpoch === "number" ? rawEpoch : null;
-    if (epoch !== null && epoch <= lastAppliedEpoch) return false;
-    if (epoch !== null) lastAppliedEpoch = epoch;
+    if (epoch !== null && epoch <= applied[channel]) return false;
+    if (epoch !== null) applied[channel] = epoch;
     return true;
   };
 
@@ -157,11 +158,12 @@ export function subscribe(
       }
       if (!isRecord(message) || typeof message.type !== "string") return;
       if (message.type === "connected" && typeof message.conn_id === "string") {
-        // A restarted server restarts its Point epoch at 1; reset the dedup baseline when its `boot_id`
-        // changes so a reconnecting tab doesn't skip the new process's lower-numbered Points (Issue #539).
+        // A restarted server restarts its epoch counter at 1; reset BOTH channel baselines when its
+        // `boot_id` changes so a reconnecting tab doesn't skip the new process's lower-numbered commands.
         if (typeof message.boot_id === "string" && message.boot_id !== serverBootId) {
           serverBootId = message.boot_id;
-          lastAppliedEpoch = 0;
+          applied.point = 0;
+          applied.run = 0;
         }
         connId = message.conn_id;
         // A reconnect reopens with the original URL, whose visibility value may
@@ -169,11 +171,13 @@ export function subscribe(
         // do not wait for another visibility transition.
         reportVisibility();
       } else if (message.type === "clear") {
-        if (admitEpoch(message.epoch)) handlers.clear();
+        if (admitEpoch(message.epoch, "point")) handlers.clear();
       } else if ((message.type === "focus" || message.type === "frame") && isTarget(message.target)) {
-        if (admitEpoch(message.epoch)) handlers[message.type](message.target);
+        if (admitEpoch(message.epoch, "point")) handlers[message.type](message.target);
       } else if (message.type === "select-run" && typeof message.run === "string") {
-        handlers.selectRun(message.run); // Task 175: switch the open Viewer to the broadcast run id
+        // Task 175: switch the open Viewer to the broadcast run id. Issue #539: latched + epoch-deduped on
+        // its own channel, so the agent can steer a backgrounded/returning window, not just a live one.
+        if (admitEpoch(message.epoch, "run")) handlers.selectRun(message.run);
       } else if (message.type === "run-events" && Array.isArray(message.events)) {
         handlers.runEvents?.(message.events.filter(isRunEvent));
       } else if (message.type === "run-snapshot" && Array.isArray(message.nodes)) {

--- a/web/src/hooks/CLAUDE.md
+++ b/web/src/hooks/CLAUDE.md
@@ -65,9 +65,15 @@ expansion anchor (a port id is never a rendered node — unresolved, the follow 
 its camera fit (rAF-driven) never runs and is not re-issued on return, leaving the node
 off-screen (agent Point at a backgrounded Viewer, user-confirmed 2026-06-23). The hook captures
 a change-while-hidden and re-fits on `visibilitychange → visible` — change-while-hidden ONLY, so
-an ordinary tab return where focus didn't move leaves the viewport alone. This is the ONE place a
-camera concern legitimately keys on `visibilitychange`; SSE *connection* recovery (`api/events.ts`)
-deliberately must NOT (it's `onerror`-driven).
+an ordinary tab return where focus didn't move leaves the viewport alone. Two visibility concerns now
+legitimately key on `visibilitychange`: this camera re-frame, and SSE connection **PRESENCE** (Issue
+#539 — `api/events.ts` CLOSES its `EventSource` when the tab is hidden to free one of the browser's
+6-per-origin connection slots, and reopens on show; a reopened tab catches up via the run `snapshot()` +
+the epoch-deduped Point latch). What still must NOT key on visibility is SSE connection **RECOVERY**:
+the `onerror` reconnect stays trigger-agnostic (recovers from restart / sleep / blip / freeze uniformly,
+never reading `readyState`/`visibilityState`). Only `open()`'s single chokepoint reads `visibilityState`
+— that gate is *presence*, not recovery — and both share ONE single-flight state machine
+(`source`/`retry`/`connId`/`stopped`).
 
 ## `usePanelPair` — the two side panes
 


### PR DESCRIPTION
## Summary

`pflow ui` graph tabs each held a **persistent SSE** for the tab's whole life. Browsers cap ~6 concurrent connections per origin over HTTP/1.1, so once ~6 graph tabs each held their SSE open, a new tab's startup fetches queued behind the held-open streams forever and the tab hung on "loading".

This closes the SSE when a graph tab is **hidden** (freeing its connection slot) and reopens it when **shown**, so a slot is held only per *visible* graph tab. A reopened/new tab catches up via server-side **latches** replayed on (re)subscribe — for the run overlay, the agent's current **Point** (focus/frame/clear), **and** the agent's current **run selection** (`select-run`), so the agent can steer an open window whether it's visible or backgrounded.

Fixes #539

## Changes

- **Cap fix (`web/src/api/events.ts`)** — refactor `subscribe()` into `dropSource`/`close`/`open`; `open()` is the single connection chokepoint (guarded on `source`/`stopped`/hidden) that closes on `visibilitychange → hidden` and reopens on visible. `onerror` recovery stays trigger-agnostic (never reads `visibilityState`); only `open()`'s gate does. Single-flight (one live `EventSource`, one pending retry) holds across every hide/show/error/unsubscribe interleave.
- **Point latch (`src/pflow/ui/server.py`)** — `focus`/`frame`/`clear` carry a monotonic `epoch`; the latest is remembered per workflow (`_Hub.set_point`/`point_for`) and replayed to any (re)subscribing Viewer after the run snapshot, so a Point sent while a tab was hidden still lands on return.
- **Steer an open window to a run (`select-run` latch)** — `select-run` is latched the same way (`set_run`/`run_for`, its own store, sharing the epoch counter), so the agent can steer a window to a run whether it's **visible** (delivered live) or **backgrounded** (caught up on return). This also removes a silent-failure: `pflow ui X --run Y`'s reuse guard can't tell a live tab from a just-closing one, but the latch now delivers on reopen regardless, so the message is honest again (`steering it to run …`).
- **Epoch dedup + restart fence (`events.ts`)** — the client applies a latched command only if its `epoch` is newer than the last it showed **on that channel** (`point` vs `run` are independent), so a returning/new tab catches up without clobbering the user's own navigation; a per-process `boot_id` on the `connected` frame re-bases the epochs across a server restart.
- **Docs** — `web/src/hooks/CLAUDE.md` (recovery-vs-presence invariant), `src/pflow/ui/CLAUDE.md` (latch + windows semantics), `src/pflow/guide/features/ui.md` (agent-facing note).

## Explanation

The reconnect machinery Task 173 built is deliberately `onerror`-driven and must NOT key on `visibilitychange` — so the fix separates two concerns that share one single-flight state machine: connection **recovery** (still `onerror`-driven, trigger-agnostic) and connection **presence** (new: visibility-gated in `open()`). Run-overlay state is fully reopen-safe — a fresh `RunTailer` reconstructs the run from the trace, and `snapshot()` carries node statuses + the `stopped`/`stale_version` latches. Task 175's run launch is a detached subprocess, so closing a tab can't kill a run.

The epoch is the minimal mechanism that lets the client distinguish "a latch I already applied" (skip) from "an agent command issued while I was hidden" (apply) without the server tracking per-connection delivery; `boot_id` fences it against a fresh process restarting the counter at 1. Latching `select-run` on a separate channel makes the latch — not the laggy connection count — the delivery guarantee for steering.

## Follow-up

- **#549** — remove the now-vestigial per-connection visibility machinery (`/api/visibility`, `set_visibility`, `_Conn.visibility`, the `?visibility=` param, the per-window `visibility` field). With close-on-hidden + latching, a live connection is always visible, so the whole apparatus can only ever report `"visible"`. Kept out of this PR because it's a wire-contract change.

## Testing

Server (`tests/test_cli/test_ui_interaction_server.py`): hub latch + monotonic epoch (`set_point`/`set_run`, separate stores, shared sequence); `boot_id` restart fence; focus/clear/select-run latch with no live windows; clear supersedes focus; zero/ambiguous match mints no epoch; `events()` replays the latched **Point** and the latched **run selection** to a new connection (frame order `connected → snapshot → point → run`). CLI (`test_ui_commands.py`): `--run` reuse steers via `select-run` and reports the steer.

Frontend (`web/src/api/events.test.ts`): starts-hidden→no-connect; hidden→close/visible→reopen; rapid hide/show→single source; retry-cancel-on-hidden (`vi.getTimerCount() === 0`); epoch dedup (newer applies / stale + already-shown skipped across a reopen); `select-run` dedup on its own channel + point/run channel independence; `boot_id` reset; absent-epoch back-compat. The `FakeEventSource` double was hardened to model WHATWG closed-source event suppression.

Suites: **web 693 passed** (tsc clean); **Python 8283 passed**; `make check` (ruff + mypy 239 files + deptry) clean.

Manual verification (real browser + real HTTP against a running server):
- hide→show reopened **exactly one** EventSource (`openedAfterToggle: 1`); a `focus` latched while hidden **panned the camera** to an off-screen node on return; a live `focus` to a visible tab delivered instantly.
- steering a workflow to a run with **no viewer connected** latched it, and a fresh viewer caught up (`connected → run-snapshot → select-run`).
- `windows` drops to 0 after a tab is backgrounded (the slot released); the `connected` frame carries `boot_id`.

Two `/deep-review` passes (plan + code: concurrency, silent-failures, feature-interactions, test-fidelity, simplicity): 0 confirmed Critical/Warning; a flagged camera-pan regression was empirically refuted; suggestions applied. An external review's findings were addressed (honest `--run` message → now a confident steer via the latch; latch-invariant code comments).