### PR TITLE
feat: human-in-the-loop approval gates + escalation (Task 125)

### DIFF
--- a/.taskmaster/tasks/task_125/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_125/implementation/implementation-plan.md
@@ -315,15 +315,14 @@ CLI's `finally` finalizes the trailer.
 ### 3.2 Status ripple (complete consumer map — every site verified)
 
 - `WorkflowStatus.DENIED = "denied"` (`core/workflow/status.py:6-21`; str-Enum, additive).
-- Runner **[review-fix — both exceptions]**: dedicated arms in `run()` BEFORE the generic
-  `except Exception` (`runner.py:185-189`): `except GateDenied` →
-  `ExecutionResult(success=False, status=WorkflowStatus.DENIED, ...)` with a denial
-  diagnostic carrying the `GateRequest`; `except GateNotInteractiveError` →
-  `ExecutionResult(success=False, status=FAILED, diagnostics=e.to_diagnostics())` (payload
-  intact — never through the generic `_exception_to_result` flattening). MUST convert to
-  results (not propagate): the CLI's trace finalize at `run.py:340-347` only runs when
-  `result` is non-None — propagating would leave an `incomplete` trace. `_determine_status`
-  (`runner.py:626-642`) never sees these (exception path) — no change there.
+- Runner **[AS-IMPLEMENTED — simpler than reviewed]**: NO dedicated except arms. The generic
+  `_exception_to_result` was verified (session-1 pin) to preserve payload diagnostics via
+  `exception_to_diagnostics` → `to_diagnostics()` — it never flattened them — so DENIED is a
+  one-line status derivation inside it (`isinstance(exception, GateDenied)`), and
+  `GateNotInteractiveError` needed zero runner changes. Both still convert to results (not
+  propagate): the CLI's trace finalize at `run.py:340-347` only runs when `result` is
+  non-None. `_determine_status` (`runner.py:626-642`) never sees these (exception path) —
+  no change there.
 - CLI `_display_execution_result` (`run.py:358-394`): new first branch on
   `result.status is WorkflowStatus.DENIED` → denial output + `ctx.exit(3)`.
   **Denied output is format-aware** **[review-fix]**: text mode → the prose denial line;
@@ -417,9 +416,13 @@ Long preview values: truncate in the renderer only (e.g. 200 chars + `… (N cha
 
 ### 3.4 Flags
 
-- `--auto-approve` (`multiple=True`) in `run.py` → `RunnerConfig.auto_approve:
-  tuple[str, ...] = ()` (`execution/result.py:13-32`, frozen, shared CLI/MCP) → runner builds
-  the resolver. Unknown node-id in the flag: warn at start, don't fail — match against ALL
+- `--auto-approve` (`multiple=True`) in `run.py`. **[AS-IMPLEMENTED]** NO
+  `RunnerConfig.auto_approve` field: the resolver travels as a `runner.run(gate_resolver=...)`
+  kwarg mirroring `progress_callback` end-to-end (CLI and MCP each build their own via
+  `build_gate_resolver`; the CLI pre-flight warnings scan `ir_data` CLI-side in
+  `_prepare_gate_resolver`). Also add the flag to `_PFLOW_FLAGS` (run.py:615 — the
+  misplaced-flag guard pin enforces this). Unknown node-id in the flag: warn at start,
+  don't fail — match against ALL
   top-level node ids (a child gate id is legitimate but invisible here; phrase as
   "no top-level step named X") with a fuzzy suggestion via
   `core/suggestion_utils.find_similar_items` and the list of gated top-level ids
@@ -619,6 +622,9 @@ Verification section of task-125.md, concretely:
 1. Baseline `make test` / `make check` — DONE 2026-07-02: 8283 passed / 0 failed; check green.
 2. Phases 1 → 2 → 3 → 4 → 5 → 6, tests as you go (test-as-you-code norm), then Phase 7 gaps.
    **OWNER DIRECTIVE 2026-07-02: implement Phases 1–2 ONLY, then STOP for review.**
+   **STATUS: Phases 1–2 DONE + reviewed + committed (2e533e2f, 301a002c). Phases 3–4 DONE
+   (session 2, uncommitted — see progress log; Phase 4 needed zero new code). Next
+   increment: Phases 5 → 6 → remaining 7 pins (dry-run parity is the big one).**
 3. Re-run `make test` / `make check`; report the delta against the baseline.
 4. Run the `/verify` skill on the TTY flow (a real gated workflow in a terminal) — tests
    can't exercise a real prompt.

--- a/.taskmaster/tasks/task_125/implementation/implementation-plan.md
+++ b/.taskmaster/tasks/task_125/implementation/implementation-plan.md
@@ -1,0 +1,627 @@
+# Task 125 — Blocking Approval Gates: Implementation Plan
+
+> **Status: ready to implement.** Written 2026-07-02 during the start-work session, for an
+> implementing agent working in isolation. Every file:line ref was verified against this
+> worktree (branch `feat/human-loop-approval-gates` @ c9998727, clean tree) by seven
+> pflow-codebase-searcher passes. If `main` has moved under you, re-verify refs before
+> editing — this area absorbs ~20 merges/week.
+>
+> Read first: `task-125.md` (the spec), then this. The spec's engine-seam claims are
+> verified exact; this plan CORRECTS the spec in three places, each marked **[spec-correction]**.
+> Glossary terms (Gate, Approval, Escalation, Denial) are in `context/CONTEXT.md`.
+> ADR-0009 (the payload is the seam; approval surfaces are out-of-process bridges) governs.
+>
+> **Deep-reviewed 2026-07-02** (7-agent battery: plan, silent-failures, impact-completeness,
+> validation-consistency, feature-interactions, agent-ux, concurrency-safety). All confirmed
+> findings are FOLDED IN below — sections marked **[review-fix]** changed as a result. The
+> four criticals were: (1) the trace reconstruct reader raises on unknown line kinds, so the
+> `gate` kind needs a known-but-ignored arm (Phase 4); (2) `WorkflowExecutor.exec`'s generic
+> `except Exception` converts nested gate exceptions into routable node failures (Boundary
+> inventory); (3) the batch retry/worker arms retry-then-swallow gate exceptions
+> (`retriable = False` fixes it); (4) a blanket main-thread guard would break MCP
+> `--auto-approve` (MCP runs the engine via `asyncio.to_thread`) — replaced by
+> resolver-substitution in parallel workers. Baselines captured pre-change: 8283 tests pass,
+> `make check` fully green.
+
+## Decisions (all resolved — nothing open)
+
+| # | Decision | Resolution |
+|---|---|---|
+| 1 | Batch-host gates | REJECTED at validation (owner-locked). "Gate the step before or after the batch." |
+| 2 | `gate` trace event | IN scope (owner-locked). Observe-only; no tailer/SSE forwarding. |
+| 3 | Auto-approve | `--auto-approve=<node-id>`, repeatable, per-node only. NO blanket flag (owner-locked; the friction is the point). |
+| 4 | Non-TTY failure timing | Fail AT the gate + warn at run start (owner-confirmed rec). No pre-flight hard fail (conditional branches may never reach the gate). |
+| 5 | Denial semantics | Clean stop: `GateDenied` exception → `WorkflowStatus.DENIED` → exit code **3** → trailer `final_status: "denied"`. Never a node failure, never `error`-successor routing (owner-confirmed rec). |
+| 6 | Escalation scope | IN this task (owner, 2026-07-02) — the schema-retry self-heal (`claude_code.py` `_exec_async`/`_coerce_structured_output`) de-risks the marker trigger. |
+| 7 | Escalation trigger | Reserved `escalation` key **inside a node's `result` dict** (not namespace top level — claude-code can only emit through `result`). Node-type-agnostic. |
+| 8 | Escalation continue | Engine writes the human's decision into the node's namespace; the AUTHOR wires the response (backward edge / `loop:` + carry). No engine re-run machinery. "Escalation re-forks by design." |
+| 9 | Gate plumbing to nested engines | A `__gate_resolver__` callable in the shared store, propagated exactly like `__progress_callback__` (`workflow_executor.py:144` `_PROPAGATED_KEYS`). NOT engine constructor args (child engines are built with only `trace_collector` + `only_node`, `workflow_executor.py:425`). |
+| 10 | Escalating results are never cached | An escalation is an incomplete work product. Skip in-process + memo cache writes when the fresh result carries a truthy `escalation` (else a memo hit silently replays the escalation as resolved-without-a-decision — the cache-hit early-return would skip the check). |
+| 11 | **[review-fix]** Gate exceptions are never-swallow-never-retry | `GateDenied` + `GateNotInteractiveError` both get `retriable = False` (the field exists on `PflowError`, `core/exceptions.py:47`, default True) and explicit re-raise arms at EVERY generic `except Exception` between the gate and the runner — see Boundary inventory. Otherwise a nested denial becomes an error-routable node failure and `error_action: continue` runs past a human's "no". |
+| 12 | **[review-fix; AS-IMPLEMENTED]** Parallel workers get a `__gate_prompt_allowed__ = False` flag, not a thread guard | NO blanket main-thread check (MCP runs the engine on an `asyncio.to_thread` worker — `execution_tools.py:87` — a guard would kill MCP auto-approve with a lying "parallel batch" message). Implemented as a boolean in each parallel worker's `item_shared` (set next to the progress-buffer swap, `batch_executor.py` `process_item`), propagated via `_PROPAGATED_KEYS`, and passed to the resolver per call (`resolver(request, allow_prompt=...)`). The reviewed resolver-SUBSTITUTION variant was rejected at implementation: it needed runtime code to construct an execution-layer resolver (layering violation). Same guarantees: auto-approve works in workers (flag lookup is thread-safe), `parallel_batch=True` is truthful (only source is `allow_prompt=False`), sequential items inherit the parent resolver — prompting per item works; a denial cleanly stops the whole run via Decision 11. |
+| 13 | **[review-fix]** Decision is written INTO the marker | The human's choice lands at `result.escalation.decision` (via careful setdefault, never bare index) and detection SKIPS markers already carrying `decision`. Idempotent by construction: a child workflow exposing the escalating node's `result` upward can't re-trigger the prompt, and the batch scan can't false-fire on an already-answered escalation. Carry template: `${step.result.escalation.decision}`. |
+| 14 | **[review-fix]** Gate prompt TTY check is stdin+stderr, not `is_interactive()` | The prompt renders on stderr and reads stdin — stdout piping (`pflow wf \| jq`, `> out.json`) must not disable gates at a real terminal. New check: not print-mode AND `stdin_tty` AND `stderr_tty` (fields already captured on OutputController). `is_interactive()`'s stdout requirement stays for its existing consumers. |
+
+## Deferred-by-design — do NOT build (spec + braindumps; re-merging = wrong)
+
+No `ApprovalSurface` ABC (resolution = a plain closure). No blanket `--auto-approve`. No batch
+gates. No web/Slack approval (Task 176). No `on_pause` hook. No durable tokens / pause
+serialization / `pflow resume` (Task 171). No tailer/SSE arm for the `gate` event (Task 176).
+`route_action` stays pure — both seams live in `_execute_node`, not the routing kernel. No
+`"denied"` in the `--only` snapshot-loader allowlist (`load_full_run_events`,
+`workflow_trace.py:259-261` skips it — safe default; lifting it is a Task-171-adjacent
+follow-up). No code-block form for `approval:` (only `batch`/`loop` have code-block routing,
+`markdown_parser.py:1183-1203`). **[review-fix]** No `approval` field on the Graph model /
+static canvas rendering (GraphNode in `core/workflow/graph/build.py` surfaces `loop`/`batch`
+but NOT `approval` in v1 — the visual gate marker is deliberately deferred to the Task
+155/176 web-approval work; recorded here so its absence reads as a decision, not a miss). No
+path-qualified `--auto-approve` ids — the id namespace is FLAT across the workflow tree (a
+child gate with the same node-id as a flagged parent id IS auto-approved); documented in the
+guide, path-qualification is 171 territory.
+
+## Boundary inventory **[review-fix]** — every generic catch a gate exception must pass
+
+The gate verdict (`GateDenied` / `GateNotInteractiveError`) is a control-flow signal that must
+cross every exception-conversion boundary between the gate and the runner UN-converted. The
+codebase has FOUR (the original plan named one — three were found by review; this is the same
+boundary class as the historical CompilationError-swallowed-by-continue fix):
+
+| # | Boundary | Fix |
+|---|---|---|
+| 1 | `WorkflowEngine._execute_node` `except Exception` (`engine.py:1276`) | `except (GateDenied, GateNotInteractiveError): raise` BEFORE it — no `record_trace(error=)`, no error callback, no `mark_node_failed`, no `_pflow_node_id` |
+| 2 | `WorkflowExecutor.exec` `except Exception` (`workflow_executor.py:448` → `_child_failure_result` → `error_action` routing) | same re-raise arm BEFORE it — else a nested denial becomes error-routable and `error_action: continue` runs past a human's "no"; the payload diagnostic is flattened to `fallback_summary` |
+| 3 | Batch item retry loop (`batch_executor.py:327-343`) + worker arm (`:693-696`) | `retriable = False` on both exception classes — the existing non-retriable re-raise arms then propagate (no batch_executor edit needed beyond the parallel resolver substitution); without it a denied human is RE-PROMPTED per batch retry, then the deny is aggregated into an item error |
+| 4 | Runner `except Exception` (`runner.py:185-189`) | dedicated arms BEFORE it: `GateDenied` → `ExecutionResult(success=False, status=DENIED)`; `GateNotInteractiveError` → `ExecutionResult(FAILED)` with its payload diagnostics intact |
+
+Why `GateNotInteractiveError` is exempted everywhere too (not just `GateDenied`): the
+post-exec escalation raises it AFTER the node's success was already traced — the generic arm
+would emit a second (error) event for the same node, fire a duplicate completion callback,
+and `mark_node_failed` would archive a *completed* output into `__failures__`. Exempting it
+keeps the node's honest success record; the RUN still fails via boundary 4, and the trailer
+still reads `"failed"` via the collector gate-outcome flag (Phase 4).
+
+`KeyboardInterrupt` needs nothing — it is `BaseException` and passes every arm already.
+
+## Architecture in one paragraph
+
+One payload (`GateRequest`), one resolver seam, two engine hook points. A **pre-exec approval
+gate** fires in `_execute_node` after the cache-miss decision and before the start callback —
+before any trace marker, so a denied node simply never appears in the trace. A **post-exec
+escalation check** detects a reserved `escalation` key in a fresh result, lets the node's own
+completion trace/callbacks finish normally, then pauses; the human's choice is written into
+the node's namespace before the walk's loop-re-entry check reads the store. Resolution is a
+plain closure (`__gate_resolver__` in the shared store): the CLI installs a TTY-capable one,
+the MCP server installs an auto-approve-only one, absence means non-interactive → a loud,
+payload-carrying error. Both hook points emit `gate` trace events; a denied resolution sets a
+collector flag that `_determine_trace_status` reads first (the trailer has NO channel from the
+runner's status — without the flag a denied run's own trace would say `"success"`).
+
+## New files
+
+| File | Contents |
+|---|---|
+| `src/pflow/runtime/engine/gate.py` | `GateRequest`, `GateResolution` (frozen dataclasses), `GateDenied`, `GateNotInteractiveError` re-export or definition site per exceptions convention (put the exceptions in `core/exceptions.py` — see Phase 3.1 — and the dataclasses here) |
+| `src/pflow/core/workflow/gate_validation.py` | `check_approval_allowed(node_data) -> Optional[str]` (mirrors `loop_validation.py::check_loop_polarity` exactly — module docstring states the two-call-site anti-drift rationale) |
+| `src/pflow/execution/gate_prompt.py` | `build_gate_resolver(...)` + the TTY renderers (click lives HERE, never in runtime/) |
+| `src/pflow/guide/features/approval.md` | Agent-facing feature doc incl. the agent-operator playbook |
+| `docs/how-it-works/approval-gates.mdx` | User doc (+ `docs/docs.json` nav entry, sibling of `"how-it-works/loops"` at `docs.json:124`) |
+
+## The payload
+
+```python
+# runtime/engine/gate.py — JSON-native by construction; the SAME dict feeds the TTY
+# prompt, the gate trace event, the GateNotInteractiveError diagnostic, and (171) persistence.
+@dataclass(frozen=True)
+class GateRequest:
+    node_id: str
+    node_type: str
+    kind: Literal["action_approval", "decision_escalation"]
+    preview: dict[str, Any]                      # approval: resolved params (str-coerced leaves)
+    question: str | None = None                  # escalation only
+    options: tuple[dict[str, str], ...] = ()     # escalation: {label, description, tradeoffs?}
+    recommendation: str | None = None            # escalation only
+
+@dataclass(frozen=True)
+class GateResolution:
+    approved: bool                               # escalation: True unless aborted
+    resolved_via: Literal["prompt", "flag"]      # 176 adds "ui"
+    chosen: str | None = None                    # escalation: option label or free text
+    notes: str | None = None                     # escalation: free-text remainder
+```
+
+Preview coercion: build from `plan.resolved_params`; coerce non-JSON-native leaves via `str()`
+at construction. Do NOT truncate the payload (trace interning dedupes string leaves ≥ 1KB for
+free via `_flush_line` → `intern_event_leaves`, `trace_io.py:77-115`); truncate only in the
+TTY *renderer*. Payload keys must avoid `RESERVED_LINE_KEYS = {"kind", "id", "seq",
+"parent_id", "run_id", "ancestor_path", "port"}` (`trace_io.py:51`) at the event's top level —
+nest everything under `"request"`.
+
+## Phase 1 — config plumbing (`approval:` as a hoisted top-level field)
+
+Mirror `prewarm` (the simplest scalar hoisted field) end to end:
+
+1. **Parser**: add `"approval"` to the hoist tuple at `markdown_parser.py:1610`
+   (`for top_level_field in ("batch", "loop", "retry", "cache", "prompt_cache", "prewarm")`).
+   `- approval: required` arrives as the string `"required"` via `_coerce_yaml_scalar`
+   (`markdown_parser.py:904-960`, raw-string fallthrough at `:960`). No code-block routing.
+2. **IR schema**: `ir_schema.py` node-properties object (`:245-304`; `additionalProperties:
+   False` at `:303` makes this mandatory): `"approval": {"type": "string", "enum":
+   ["required"], "description": "Pause for human approval before this step runs"}`.
+   `approval: banana` then fails as a validator diagnostic with path `nodes[N].approval`
+   (via `validate_ir` → `SchemaValidationError` → `WorkflowValidator._validate_structure`,
+   `validator.py:255-262`). **[review-fix]** Add an approval-path arm to `_get_suggestion`
+   (`ir_schema.py:582-626`): the likeliest agent mistake is `- approval: true` (YAML-coerces
+   to bool), and the generic type-arm would suggest `approval: "true"` — the arm says
+   `"The only supported value is 'approval: required'"` for both the bool-type and enum
+   failure shapes.
+3. **Compiler**: `_extract_approval(node_data) -> bool` mirroring `_extract_prewarm`
+   (`compiler.py:675-690` — strict check, `CompilationError(phase="validation",
+   suggestion=...)` if present-but-not-"required"); wire `approval=_extract_approval(node_data)`
+   into the `NodeConfig(...)` construction at `compiler.py:373-385`.
+4. **NodeConfig**: `approval: bool = False` in `runtime/engine/types.py:56-71`.
+5. **Batch-host rejection** (Decision 1), one shared rule, two call sites (the
+   `check_loop_polarity` pattern, `loop_validation.py:6-19`):
+   - `gate_validation.py::check_approval_allowed(node_data)`: returns an error message when
+     `node_data.get("approval")` and `node_data.get("batch")` are both present:
+     `"approval: is not supported on batch steps — gate the step before or after the batch instead."`
+   - Call site A: `data_flow.py`, alongside the batch/loop-exclusion + loop rules
+     (`_validate_loop_node_combos` area, `data_flow.py:546-601`) → Diagnostic, so
+     `--validate-only` and `pflow save` catch it.
+   - Call site B: `compiler.py` `_create_node_and_config` → `CompilationError` (pattern:
+     batch+loop exclusion at `compiler.py:356-357`).
+   - **[spec-correction]** The spec pointed at validator Step 9; the loop/batch combo rules
+     actually live in `data_flow.py` — follow the code, not the spec.
+6. **Guide topic hook**: `_node_topics` (`guide/__init__.py:152-176`) — add
+   `if node.get("approval") is not None: topics.add("approval")` (matches the existing
+   `batch`/`loop`/`retry`/`prewarm` lines).
+
+## Phase 2 — the engine seams (`_execute_node`, `engine.py:994`)
+
+### 2a. Pre-exec approval gate
+
+Placement: after the in-process hash-invalidation check (`:1094-1097`), **before** step 8
+`call_start_callback` (`:1100`) and step 8.5 `trace.begin_node` (`:1102-1109`). Consequences
+(all intended): cached nodes never gate (early-return at `:1045-1086` is upstream); a denied
+node has NO `node.start` marker and NO completion event — it never appears in the trace; the
+progress display has no open partial line at prompt time (the previous node's line closed at
+its completion).
+
+```
+if config.approval:
+    request = build approval GateRequest from plan.resolved_params (fallback: static params
+              when the node has no templates — plan_node returns resolved_params=None then)
+    resolution = _resolve_gate(request, shared)   # helper below
+    (emit gate pause event before resolving; emit resolution event after — Phase 4)
+    if not resolution.approved: raise GateDenied(request)
+```
+
+`_resolve_gate(request, shared)` **[review-fix — no thread guard]**:
+```
+resolver = shared.get("__gate_resolver__")
+if resolver is None:
+    raise GateNotInteractiveError(request)
+return resolver(request)     # may itself raise GateNotInteractiveError (non-TTY, no flag)
+```
+Isolation for parallel-batch workers is by RESOLVER SUBSTITUTION, not thread identity
+(Decision 12): in the parallel path, next to the `__progress_callback__` buffer swap
+(`batch_executor.py:765`), replace `__gate_resolver__` in `item_shared` with
+`build_gate_resolver(auto_approve, output_controller=None, parallel_batch=True)` — the
+non-prompting configuration. It honors pre-approvals and raises
+`GateNotInteractiveError(parallel_batch=True)` otherwise, and because the key is in
+`_PROPAGATED_KEYS` the substitution reaches every descendant sub-workflow engine. Sequential
+batch items and nested sub-workflows (`workflow_executor.py:436` — synchronous `engine.run`)
+inherit the parent resolver and prompt normally. The ONLY `workflow_executor.py` edits are:
+`"__gate_resolver__"` in `_PROPAGATED_KEYS` (`:144`) and the boundary-2 re-raise arm (`:448`).
+
+### 2b. Post-exec escalation
+
+Two-point structure inside the non-batch branch (required by cache-write ordering — Decision 10):
+
+1. **Detect** immediately after `action = node._run(store)` (`:1131`), **only when the action
+   is a clean success** **[review-fix]** (skip for error actions — step 17.5 pops
+   `shared[node_id]` into `__failures__`, and a pause writing a decision afterwards would
+   recreate the namespace and break the shared-XOR-failures invariant; skip likewise means
+   the api-warning early-return at `:1147-1169` never bypasses a pending pause). Read
+   `shared.get(config.node_id, {}).get("result", {}).get("escalation")` with isinstance
+   guards at each level (namespaced nodes only — the standard case). **Skip markers that
+   already carry a `decision` key** (Decision 13 — idempotency across re-exposure).
+   Lenient-but-loud shape ladder **[review-fix]**:
+   - dict without `decision` → escalate (missing `question`/`options`/`recommendation`
+     render as absent, never crash);
+   - non-empty **string** → escalate with the string as `question` (clearly-intended marker);
+   - any other truthy value, or an **empty dict** → do NOT pause; write a degrading
+     `shared["__warnings__"][node_id]` entry: `"step emitted 'escalation' with an unusable
+     shape (<type>) — expected {question, options, recommendation}; the run did NOT pause"`;
+   - `result` is a raw string AND `_schema_error` is present in the namespace AND the string
+     contains `"escalation"` → same degrading warning ("a schema soft-failure may have
+     swallowed an escalation attempt; the run did NOT pause"). The guide REQUIRES
+     `output_schema` on escalation-capable claude-code steps.
+2. **Skip cache writes** when escalating: gate step 11 `cache_result` (`:1172`) and step 13
+   `write_memo_cache` (`:1179-1187`). (Output content never feeds the cache KEY —
+   `plan_node` computed it from config + inputs — so no hash concern.)
+3. Let steps 12–17.5 run untouched (duration, metrics, `record_trace` at `:1209-1225`,
+   `call_completion_callback` at `:1228-1235` — the node's own completion is traced normally,
+   and the decision written later stays OUT of the node's trace event because `record_trace`
+   reads `shared[node_id]` at call time).
+4. **Pause** after `:1235`, before `return action` (`:1274`): build the escalation
+   `GateRequest`, same `_resolve_gate` helper, then write the decision INTO the marker
+   (Decision 13): `result["escalation"]["decision"] = {"chosen": ..., "notes": ...}` —
+   using the already-validated dict reference (string markers: replace the marker with
+   `{"question": <string>, "decision": {...}}`), never a bare index into a maybe-absent key.
+   The walk's loop-re-entry check (`_run_inner:725-730` → `_loop_should_reenter`) runs AFTER
+   `_execute_node` returns, so a `loop:` + carry wiring sees the decision — that's the
+   continue mechanism (`${step.result.escalation.decision}` in the re-forked agent's inputs).
+   There is no deny for an escalation: the resolver returns a choice (number picks an option
+   label; anything else is free text → `chosen=<text>`). Ctrl-C aborts the run (below).
+5. **Batch guard** (fail loudly, never silently skip): in the batch branch after
+   `execute_batch` (`:1113`), scan `shared[node_id]["results"][i]` (batch output shape:
+   `{results, count, ...}`, `batch_executor.py:1062-1066`; each element is the item's
+   namespace snapshot — successes only, failed items are error-reported already) for
+   UNDECIDED escalation markers (same isinstance ladder; markers carrying `decision` were
+   answered inside a sequential sub-workflow item — skip them). Any hit → raise a
+   `PflowError` that carries the item index and the question **[review-fix]**:
+   `"Step '<id>' raised an escalation from batch item <i> of <n>: \"<question, truncated>\" —
+   escalations inside a batch are not supported; restructure so the escalating step runs
+   outside the batch."` (Normal failure path, exit 1.)
+6. Loop interplay: every iteration passes the full seam (re-entry is an engine-walk
+   `continue`, `engine.py:726-729`) — an `approval:` gate prompts EVERY iteration (each
+   iteration is a new action; document in the guide), and revisit cache-suppression
+   (`enforce_loop_guard` invalidation + memo suppression for `visit_count > 1`) means cache
+   hits never skip mid-loop gates. `--only <gated-node>` goes through `_execute_node`
+   (`:787`) — the gate fires; fine, the `--only` user is at a TTY.
+
+### 2c. The gate-exception exemptions **[review-fix — see Boundary inventory]**
+
+Insert `except (GateDenied, GateNotInteractiveError): raise` BEFORE the generic
+`except Exception` arm at `engine.py:1276` — a gated node must get NO
+`record_trace(error=...)`, NO error completion-callback, NO `mark_node_failed`, NO
+`_pflow_node_id` (for the post-exec escalation case the node's success record already exists
+and must stand un-contradicted). The SAME arm goes into `WorkflowExecutor.exec` before
+`workflow_executor.py:448` (boundary 2), and both exception classes set `retriable = False`
+(boundary 3). `_run_inner` has no except handler (only `finally`). Both exceptions still pass
+through `runner.py:307-329` (harmless: `failed_node` was never set, so no stale annotation;
+`_pflow_shared_store` attachment is useful). Emit the gate RESOLUTION trace event (denied /
+non-interactive) BEFORE raising, so the collector's gate-outcome flag is set by the time the
+CLI's `finally` finalizes the trailer.
+
+## Phase 3 — status, resolver, CLI/MCP surfaces
+
+### 3.1 Exceptions (`core/exceptions.py`)
+
+- `GateDenied(PflowError)` — carries the `GateRequest`. Not agent-remediation-oriented (it's
+  a human verdict); message: `"Denied at gate '<node_id>'."`
+- `GateNotInteractiveError(PflowError)` — carries the `GateRequest` and a `parallel_batch`
+  flag; `retriable = False` on both classes (Decision 11). Its `to_diagnostics()` MUST
+  include: the cause ("this run is non-interactive — launched from the web UI, MCP, or a
+  pipe; no terminal to prompt on" / "raised inside a parallel batch item"), the full
+  `GateRequest` payload as structured data (the operating agent must be able to show its
+  human WHAT was about to happen — approving blind defeats the gate; mask secret-like param
+  values via `security_utils.mask_sensitive_value` **[review-fix]**), and a
+  **surface-aware, truthful remediation ladder** **[review-fix]**:
+  - Always first: **"If you are an AI agent: ask your human before continuing — this gate
+    exists so a person reviews the action."**
+  - Approval gate, not parallel-batch: "With their OK: CLI `--auto-approve=<node-id>`; MCP
+    `workflow_execute`: `auto_approve=[\"<node-id>\"]` (approves only this gate)."
+  - `parallel_batch=True`: auto-approve DOES work here too (the worker stub honors it) —
+    say so, and add the structural fixes: "or move `approval:` to a step outside the batch,
+    or set `parallel: false` on the batch."
+  - Escalation: "escalations cannot be pre-approved — run interactively, or re-run with the
+    answer supplied as a workflow input."
+  - Never reference internal task numbers; close with "pflow cannot yet hold a gate open for
+    a later answer" instead of "Task 171".
+  MCP renders diagnostics verbatim (`execution_service.py:298-311` →
+  `RuntimeError(_build_error_text(...))`), so this text reaches the calling agent as-is.
+
+### 3.2 Status ripple (complete consumer map — every site verified)
+
+- `WorkflowStatus.DENIED = "denied"` (`core/workflow/status.py:6-21`; str-Enum, additive).
+- Runner **[review-fix — both exceptions]**: dedicated arms in `run()` BEFORE the generic
+  `except Exception` (`runner.py:185-189`): `except GateDenied` →
+  `ExecutionResult(success=False, status=WorkflowStatus.DENIED, ...)` with a denial
+  diagnostic carrying the `GateRequest`; `except GateNotInteractiveError` →
+  `ExecutionResult(success=False, status=FAILED, diagnostics=e.to_diagnostics())` (payload
+  intact — never through the generic `_exception_to_result` flattening). MUST convert to
+  results (not propagate): the CLI's trace finalize at `run.py:340-347` only runs when
+  `result` is non-None — propagating would leave an `incomplete` trace. `_determine_status`
+  (`runner.py:626-642`) never sees these (exception path) — no change there.
+- CLI `_display_execution_result` (`run.py:358-394`): new first branch on
+  `result.status is WorkflowStatus.DENIED` → denial output + `ctx.exit(3)`.
+  **Denied output is format-aware** **[review-fix]**: text mode → the prose denial line;
+  `--output-format json` → a JSON document on stdout
+  `{"success": false, "status": "denied", "error": "Denied at gate '<id>'", "gate": {<GateRequest>}}`
+  (without this, JSON mode would emit NOTHING on deny — the denied branch bypasses
+  `output_error`, which is the only path to the existing JSON emitter). Do NOT route through
+  `output_error`/`_emit_failure_tag` (failure rendering). Update the exit-code contract doc
+  `cli/CLAUDE.md:142` (0 success/degraded, 1 failed, **3 denied**, 130 interrupted).
+- `workflow_output._format_workflow_completion_status` (`workflow_output.py:701-726`):
+  ⚠️ falls through to "✓" for unknown statuses — add an explicit `denied` arm.
+- **Trailer channel** (⚠️ the trap): `_determine_trace_status` (`workflow_trace.py:1323-1346`)
+  derives from trace events only — a denied run would read `"success"`. Fix
+  **[review-fix — generalized]**: `record_gate` sets a collector gate-outcome field on
+  terminal resolutions: `"denied"` → trailer `"denied"` (checked first);
+  `"non_interactive"` → trailer `"failed"` (else a post-exec escalation that failed
+  non-interactively would ALSO read "success" — same trap, second door). No literal
+  validation exists on write; readers verified safe: `load_full_run_events` skips denied
+  (wanted), `run_tailer` forwards verbatim, `RunSelector.tsx` degrades to a neutral dot.
+- **Web** **[review-fix — complete list]**: three render sites + CSS, verified via the
+  `screenshot-pflow-web-ui` skill: `RunProgress.tsx:23-31` `runBadgeStatus` (falls through to
+  a green ✓ — add `"denied"` arm styled like `"stopped"`), `RunProgress.tsx:133` outcome line
+  class `run-<status>`, `GraphView.tsx:914-915` run banner `run-banner run-<status>`, and
+  `web/src/index.css` needs `run-denied` rules for banner + outcome (neutral/gray family).
+- `prompt_cache_analysis/stages/summary.py:383-384` (truncated-label) and
+  `prompt_cache_analysis/trace_loading.py:246` (`_non_reusable_outcome_label` says "failed
+  run") won't special-case denied traces — accepted cosmetics, note both in the PR.
+
+### 3.3 The resolver (`execution/gate_prompt.py`)
+
+`build_gate_resolver(auto_approve: frozenset[str], output_controller: OutputController | None,
+parallel_batch: bool = False) -> Callable[[GateRequest], GateResolution]` — ONE builder,
+three configurations (CLI interactive / MCP non-TTY / parallel-batch stub). Behavior:
+
+1. `request.node_id in auto_approve` → approval gates only: `GateResolution(approved=True,
+   resolved_via="flag")`. Thread-safe (frozenset lookup) — works in all three
+   configurations, including the parallel-batch stub. Escalations NEVER auto-resolve (you
+   can't pre-answer an unknown question) — fall through. Note the id namespace is FLAT
+   across the workflow tree (documented; see Deferred).
+2. Can prompt (**[review-fix]** not `is_interactive()` — that requires stdout TTY and would
+   disable gates under `pflow wf | jq`; the gate check is: not print-mode AND
+   `output_controller.stdin_tty` AND `output_controller.stderr_tty`) → render + prompt
+   (below), `resolved_via="prompt"`.
+3. Else → raise `GateNotInteractiveError(request, parallel_batch=parallel_batch)`.
+
+Prompt mechanics: close any open partial line defensively via an OutputController seam
+(add a tiny `prepare_for_prompt()` that closes the partial line AND terminates an open
+batch-progress `\r` counter line **[review-fix]** — `_handle_batch_progress` rewrites in
+place without setting `_partial_line_open`, so sequential-batch prompts would otherwise
+overprint it), render to stderr, read via `click.confirm(default=False)` (approval) /
+`click.prompt` (escalation). Mask secret-like values in the rendered preview
+(`mask_sensitive_value`) **[review-fix]** — the trace event stays unmasked (consistent with
+the trace's existing `template_resolutions`).
+⚠️ **Ctrl-C trap**: `click.confirm`/`click.prompt` raise `click.exceptions.Abort` — an
+`Exception` subclass the engine's generic arm would archive as a node failure. The resolver
+MUST catch `Abort` and raise `KeyboardInterrupt` → existing clean path (`runner.py:185`
+re-raises; CLI `run.py:322-324` exits 130; incomplete-but-readable trace is documented
+expected behavior).
+
+Installation (mirror `__progress_callback__` end-to-end): CLI builds the resolver next to the
+progress callback (`run.py:309` area) and threads it into the shared store the same way;
+`_PROPAGATED_KEYS` gets `"__gate_resolver__"`. The MCP server installs
+`build_gate_resolver(auto_approve, output_controller=None)` — auto-approve works, prompting
+never does.
+
+TTY UX (design anchor: `terraform apply`; **show-before-code: mock these exact renderings in
+the PR description**):
+
+```text
+⏸  Approval required: notify-slack (mcp-composio-slack-SLACK_SEND_MESSAGE)
+
+   channel:        #releases
+   markdown_text:  v0.9.0 released with 3 features: …
+
+   Run this step? [y/N]:
+```
+```text
+⏸  Escalation from implement-chunk:
+   The plan assumes one config file, but the code has per-env configs.
+
+   1. Merge into one file        — simpler, but breaks env overrides
+   2. Template per-env (rec)     — matches existing pattern, more files
+
+   Choose 1-2, or type an answer:
+```
+```text
+✗ Denied at gate 'notify-slack'. Workflow stopped cleanly before the step ran. (exit 3)
+✓ Gate 'notify-slack' pre-approved via --auto-approve=notify-slack
+```
+Long preview values: truncate in the renderer only (e.g. 200 chars + `… (N chars)`).
+
+### 3.4 Flags
+
+- `--auto-approve` (`multiple=True`) in `run.py` → `RunnerConfig.auto_approve:
+  tuple[str, ...] = ()` (`execution/result.py:13-32`, frozen, shared CLI/MCP) → runner builds
+  the resolver. Unknown node-id in the flag: warn at start, don't fail — match against ALL
+  top-level node ids (a child gate id is legitimate but invisible here; phrase as
+  "no top-level step named X") with a fuzzy suggestion via
+  `core/suggestion_utils.find_similar_items` and the list of gated top-level ids
+  **[review-fix]**: `"--auto-approve=notify_slack does not match any top-level step. Did you
+  mean 'notify-slack'? Gated steps: notify-slack, deploy."`
+- Run-start warning (Decision 4): when the compiled workflow has `approval` NodeConfigs, the
+  run cannot prompt, and not all gated ids are in `auto_approve` → one stderr warning that
+  carries the consequence and the fix: `"This run is non-interactive and will fail at gate
+  'notify-slack' unless pre-approved (--auto-approve=notify-slack)."` **Documented
+  limitation** **[review-fix]**: the scan sees top-level NodeConfigs only — a gate that
+  exists solely inside a sub-workflow gets no run-start warning and fails at the gate
+  (Decision 4 makes fail-at-gate primary, so this is acceptable; say so in the guide).
+- MCP: add `auto_approve` as the third `Annotated` param on `workflow_execute`
+  (`mcp_server/tools/execution_tools.py:19-28`), thread through
+  `ExecutionService.execute_workflow` (`execution_service.py:232`, RunnerConfig at `:283`).
+
+## Phase 4 — `gate` trace events
+
+New `WorkflowTraceCollector.record_gate(...)` flushing via the normal `_flush_line` path
+(streaming guards `stream_to_disk`/`_stream_failed` apply; interning free). Two lines per gate:
+
+```jsonc
+{"kind": "gate", "phase": "pause",      "node_id": "...", "gate_kind": "action_approval|decision_escalation", "request": {<GateRequest>}}
+{"kind": "gate", "phase": "resolution", "node_id": "...", "gate_kind": "...", "resolution": "approved|denied|auto|choice", "resolved_via": "prompt|flag", "decision": {"chosen": ..., "notes": ...}|null}
+```
+
+- The pause event is emitted BEFORE prompting; resolution after (and BEFORE raising on
+  denied / non-interactive). Round-tripping `request` through JSON must reproduce the
+  `GateRequest` — this event IS Task 171's serialization test.
+- Terminal resolutions set the collector's gate-outcome field (Phase 3.2 trailer channel):
+  `denied` → trailer `"denied"`; `non_interactive` → trailer `"failed"`.
+- **[review-fix — CRITICAL]** Gate lines are **DISK-ONLY**, mirroring `node.start` exactly:
+  `record_gate` flushes via `_flush_line` but NEVER appends to `self.events` (else the gate
+  resolution line becomes the node's "final event" in `final_events_by_node` — it has no
+  `node_output`, so `seed_snapshot_into_shared` would silently skip seeding that node and a
+  later `--only` run gets unresolved `${node.*}` refs). AND the reconstruct reader MUST learn
+  the kind: `_partition_trace_lines` (`core/trace_io.py:130-172`) raises
+  `json.JSONDecodeError("unknown trace line kind ...")` on anything outside its closed set —
+  without a known-but-ignored `gate` arm (copy the `node.start` arm + comment at
+  `trace_io.py:149-154`), EVERY gated run's trace (approved ones included) becomes
+  "corrupt": `pflow report` fails, `--only` loses the run as a snapshot source
+  (`OnlySnapshotMissingError`), analyze-cache skips it. Test: run a gated+approved workflow,
+  then assert `pflow report` renders it and `--only <downstream-node>` can seed from it.
+  (Task 171 reads gate lines with its own explicit reader — reconstruct ignoring them is
+  correct for v1.) Check `tests/shared/trace_jsonl.py` in case fixtures need the kind.
+- Verified tolerant downstream: `run_tailer._handle` ignores unknown kinds
+  (`run_tailer.py:573-600`); the web frontend never sees raw kinds. NO tailer arm, NO SSE
+  type — observe-only (Decision 2 scope).
+- Nested: child engines get `trace_collector=trace_for_child` (`workflow_executor.py:425`) —
+  add one integration test asserting a child gate's events land in the run's streamed trace.
+
+## Phase 5 — dry-run parity
+
+**[spec-correction]** The spec's precedent ("Task 166 loop landed with zero plan.py edits")
+is false — loop planning added `_annotate_loop_entry` (`plan.py:847-867`); and that annotation
+renders NO text (it's a cost multiplier). The rendered-text precedent is `_tag_from_entry`'s
+`cache: false` suffix (`plan_formatter.py:304-315`).
+
+1. `PlanEntry.approval: bool = False` (`execution/result.py:107-142`, frozen —
+   `dataclasses.replace` stamping, house style).
+2. **[review-fix]** Stamp it in the shared `_annotate_loop_entry` funnel (`plan.py:847-867`)
+   — LIFTED ABOVE its `loop_config is None` early-return (rename/split so the function's
+   name stays honest, e.g. `_annotate_entry`) — because BOTH dispatch paths route every
+   entry through it (`plan.py:783/:785/:844`), which covers standard AND sub-workflow
+   entries. Stamping only in `_plan_standard_node` would miss gated workflow-type nodes
+   (they dispatch to `_plan_sub_workflow`) — a parity lie for a shape the ledger explicitly
+   allows. NO new `PlanEntry.status`, NO `_classify`/`_advance` edits (dry-run assumes
+   approval; a gate doesn't change routing).
+3. Render via `_tag_from_entry`: gated entries show `[<type>, approval]`
+   (e.g. `▸ notify-slack  [mcp, approval]`). No cost logic (orthogonal to
+   `_format_stats_annotation`). **[review-fix]** Also: (a) add `approval` to
+   `_entry_to_dict` (`plan_formatter.py:352-375`) — JSON dry-run and the MCP dry-run
+   service are the gate-discovery surface for exactly the agents that need it; (b) one
+   footer line when any entry is gated: `"1 step pauses for approval at run time
+   (notify-slack); non-interactive runs need --auto-approve=notify-slack"` — makes the
+   playbook self-discoverable without the guide.
+4. Escalation is invisible to the planner by design (runtime result content) — no annotation,
+   record the asymmetry in the guide doc.
+5. **Drift pin, mutation-verified** (house style: `tests/test_execution/test_plan_drift.py`,
+   e.g. `test_plan_matches_execution_for_fresh_workflow:73` — assert plan entries against an
+   engine-side observable from a REAL run): `{entry.node_id for gated plan entries}` ⟺
+   `{node_id of gate pause events in the trace}` — **by node-id SET, not count**
+   **[review-fix]** (a gated loop node = 1 entry but N pause events). Fixture includes a
+   standard gated node AND a gated sub-workflow node (run with `--auto-approve` equivalents
+   so the test never prompts) + a JSON-mode assertion on `_entry_to_dict`. Mutation-verify:
+   re-fork one side (e.g. stamp `approval=False` in the funnel), confirm the pin fails,
+   revert.
+
+## Phase 6 — docs
+
+- `src/pflow/guide/features/approval.md`: syntax, both gate kinds, the escalation `result`
+  contract (`{escalation: {question, options: [{label, description, tradeoffs}],
+  recommendation}}` — `output_schema` REQUIRED on escalation-capable claude-code steps), the
+  continue-via-loop/carry recipe (`${step.result.escalation.decision}`), **the
+  agent-operator playbook** (`--dry-run` to discover gates → show the preview to your human
+  → run with `--auto-approve=<id>` for the gates they OK'd; never pass the flag without
+  asking), **[review-fix] the failure-mode half**: exit code 3 semantics, non-interactive
+  behavior + run-start-warning top-level-only limitation, both batch restrictions
+  (batch-host `approval:` rejected; batch-item escalation errors; sequential-batch
+  sub-workflow gates prompt per item), per-iteration loop prompting, the flat
+  `--auto-approve` id namespace across nested workflows, and the MCP `auto_approve`
+  parameter.
+- **[review-fix]** `guide/core.md:307`: add `approval` to the enumerated top-level node
+  controls (`batch, loop, retry, cache, prompt_cache, prewarm`) — agents reading only the
+  core guide must learn the field exists.
+- `docs/how-it-works/approval-gates.mdx` + `docs.json` nav entry.
+- Update `cli/CLAUDE.md:142` (exit code 3) and the relevant engine/runtime CLAUDE.md sections
+  (new seam steps, `__gate_resolver__` propagated key, gate event kind, trailer literal).
+- `.taskmaster/tasks/task_133/design/d1-event-schema.md`: mark the reserved `gate` kind as
+  shipped (pointer only).
+
+## Phase 7 — tests (baseline `make test` + `make check` FIRST — record the delta)
+
+Verification section of task-125.md, concretely:
+
+- **Approval**: gate halts before exec (side-effect file proves node never ran on deny);
+  preview shows resolved values; approve → continues; deny → exit 3, trailer `denied`, NO
+  `__failures__` entry, node absent from trace; multiple sequential gates; gate on `--only`
+  target fires; gate on loop node prompts per iteration; cached node never gates (pin).
+- **Escalation** **[review-fix — updated contract]**: dict marker (no `decision`) pauses
+  after the node's normal completion trace; decision written INTO the marker
+  (`result.escalation.decision`); marker WITH `decision` never re-pauses (idempotency);
+  string marker pauses with it as `question`; empty-dict / other-truthy shapes → degrading
+  warning, NO pause; string result + `_schema_error` + "escalation" substring → degrading
+  warning; absent key never pauses; escalation fires only on clean-success actions
+  (error-action + marker: no pause, no shared/`__failures__` invariant break); escalating
+  result NOT memo-cached (re-run re-executes); loop+carry round trip
+  (`${step.result.escalation.decision}`); `code`-node escalation works; direct-batch item
+  escalation → loud `PflowError` carrying item index + question; decided markers in batch
+  results do NOT false-fire the scan.
+- **Boundary inventory pins** **[review-fix]**: denial inside a sub-workflow → exit 3 /
+  DENIED / trailer `denied` / run STOPS even with `error_action: continue`;
+  `GateNotInteractiveError` from a nested gate keeps its payload diagnostics through the
+  WorkflowExecutor boundary; denial inside a sequential-batch sub-workflow item stops the
+  run without re-prompting (`retriable=False` honored by the batch retry loop); post-exec
+  escalation non-interactive → single success trace event for the node (no duplicate error
+  event, no `__failures__` entry), run FAILED, trailer `failed` via the gate-outcome flag.
+- **Non-interactive**: no resolver → `GateNotInteractiveError` with payload in diagnostics;
+  parallel-batch worker stub honors `auto_approve` and otherwise raises with
+  `parallel_batch=True` + batch-specific remediation; run-start warning fires (and doesn't
+  when all gates pre-approved); browser-launch case covered by the non-TTY path
+  (`server.py:853-861` `stdin=DEVNULL`); escalation ignores `--auto-approve`.
+- **Flags**: `--auto-approve` approves only the named node (second gate still prompts/fails);
+  repeatable; unknown id warns with fuzzy suggestion; `resolved_via` correct
+  (`flag` vs `prompt`); MCP `auto_approve` works end-to-end (off-main-thread via
+  `asyncio.to_thread` — pins the no-thread-guard design).
+- **Ctrl-C at prompt**: `Abort` → `KeyboardInterrupt` → exit 130, incomplete-but-readable
+  trace (no node failure recorded).
+- **Validation**: batch-host `approval:` rejected at `--validate-only` (diagnostic) AND at
+  compile (`CompilationError`); `approval: banana` fails schema with path `nodes[N].approval`;
+  `approval: true` gets the "only supported value is required" suggestion; `--validate-only`
+  accepts a valid gate (no unknown-field noise).
+- **Parity**: the mutation-verified drift pin (Phase 5.5, node-id SET comparison, includes a
+  gated sub-workflow node); dry-run tag renders; `approval` present in JSON dry-run
+  (`_entry_to_dict`) and the footer line renders.
+- **Trace** **[review-fix]**: gate events round-trip JSON == payload; gated+APPROVED run
+  stays readable post-hoc (`pflow report` works; `--only <downstream>` seeds from it — the
+  `_partition_trace_lines` gate arm); `record_gate` never appends to `self.events`;
+  child-workflow gate events in the streamed trace; denied trailer literal;
+  `load_full_run_events` skips denied traces.
+- **MCP parity** (`test_cli_mcp_parity.py`): gated workflow via `workflow_execute` fails
+  loudly with the payload-carrying message; `auto_approve` param works.
+- **Status ripple**: `_format_workflow_completion_status` denied arm (no ✓); denied JSON
+  document emitted in JSON mode (`{"success": false, "status": "denied", ..., "gate": ...}`);
+  web denied arms — `runBadgeStatus`, outcome-line class, GraphView banner + `run-denied`
+  CSS (screenshot verify); prompt works with stdout piped to a file.
+
+## Edge-case ledger (decided behaviors — do not re-litigate silently)
+
+| Case | Behavior |
+|---|---|
+| Gate on cached node | Never fires (seam is after cache early-return) — nothing to approve |
+| Gate on batch host | Validation + compile error (Decision 1) |
+| Escalation from a DIRECT batch item | Loud `PflowError` with item index + question, exit 1 |
+| Gate/escalation in sub-workflow (main thread) | Works — resolver propagates in via `_PROPAGATED_KEYS`; verdict propagates OUT via the boundary-2 re-raise (never error-routable) |
+| Gate in sub-workflow inside PARALLEL batch | Worker's substituted resolver: `auto_approve` honored; else `GateNotInteractiveError(parallel_batch=True)` with batch-specific remediation |
+| Gate in sub-workflow inside SEQUENTIAL batch | Prompts per item (spec's supported surface); a denial stops the WHOLE run cleanly (DENIED, no retry re-prompt via `retriable=False`) |
+| Escalation in sub-workflow inside SEQUENTIAL batch | Prompts per item; decided marker skipped by the parent batch scan |
+| Node returns error action AND escalation marker | No pause (clean-success gating); normal error handling; marker visible in `__failures__` payload |
+| Gate on loop node | Prompts every iteration |
+| Gate on `--only` target | Fires (user is at a TTY) |
+| Gate on never-reached conditional branch | Never fires; non-TTY run start still warns (Decision 4) |
+| Gated run with stdout piped (`\| jq`, `> file`) | Prompts fine (stderr+stdin TTY check — Decision 14) |
+| `--auto-approve` with unknown node id | Warn at start with fuzzy suggestion, continue (child gate ids are legitimate but invisible — phrased "top-level") |
+| `--auto-approve` naming an escalating node | Ignored for escalation — prompts or fails |
+| Same node-id gated in parent and child | FLAT namespace: flag approves both (documented; path-qualification is 171 territory) |
+| Ctrl-C at prompt | Exit 130, incomplete trace (documented expected) |
+| Denied run as `--only` snapshot source | Skipped by loader allowlist (deliberate; 171 follow-up) |
+| APPROVED gated run as `--only` snapshot source | MUST work — pinned by the trace-reader test (Phase 4) |
+| Non-namespaced node escalation | Out of v1 contract (standard nodes are namespaced) |
+| Workflow-type (sub-workflow) node with `approval:` | Allowed — gates the whole sub-workflow; preview = its inputs; planner stamps it via the shared funnel |
+| Malformed escalation marker (empty dict, bool, number) | No pause + degrading warning naming the expected shape |
+| Escalation attempt lost to schema soft-fail (string result) | Degrading warning when `_schema_error` present and string mentions "escalation" |
+
+## Implementation order & guardrails
+
+1. Baseline `make test` / `make check` — DONE 2026-07-02: 8283 passed / 0 failed; check green.
+2. Phases 1 → 2 → 3 → 4 → 5 → 6, tests as you go (test-as-you-code norm), then Phase 7 gaps.
+   **OWNER DIRECTIVE 2026-07-02: implement Phases 1–2 ONLY, then STOP for review.**
+3. Re-run `make test` / `make check`; report the delta against the baseline.
+4. Run the `/verify` skill on the TTY flow (a real gated workflow in a terminal) — tests
+   can't exercise a real prompt.
+5. Deep-review battery before the PR; pair `review-silent-failures` +
+   `review-impact-completeness` (the pairing that caught the planner-mirror divergence).
+6. Do NOT commit/push without explicit instruction (project norm).

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -500,3 +500,63 @@ stash, per the session-1 lesson).
 
 Next: update this log (done) → `/create-pr` follow-up (push + note on the existing
 PR #554, since it already exists — no new PR).
+
+## 2026-07-02 — Session 4: post-implementation verification sweep + fixes
+
+Owner asked for an independent plan-vs-code verification of the whole task
+(6 parallel searcher agents + direct confirmation of the consequential claims).
+Verdict: all 7 phases, all 14 locked decisions, and all recorded deviations
+check out against the code; the four criticals from the plan review all landed.
+The sweep surfaced 6 new findings (none critical); owner said fix all — all
+fixed this session:
+
+1. **Batch-escalation error named the wrong item number** (real bug, message-only):
+   `scan_batch_escalations` indexed the success-filtered `results` list, so with
+   an earlier failed item the escalating item's reported position was off.
+   Fixed by reconstructing original indices from the authoritative `errors[].index`
+   set. Test (mutation-verified — old `i+1` math fails it):
+   `test_batch_escalation_reports_original_item_index_when_earlier_item_failed`.
+2. **Unexpected resolver exception corrupted the node record** (design smell →
+   hardened): a resolver bug at the post-exec escalation seam fell to the
+   generic except arm — duplicate error trace event + a genuinely successful
+   node archived into `__failures__`. The wrong-return-type case raised a plain
+   `PflowError` with the same conversion hazard. New `GateResolverError`
+   (`retriable=False`, carries the request, payload-masked diagnostics) raised
+   by `resolve_gate` for both cases; added to BOTH boundary re-raise tuples
+   (engine gate arm — which also gives it the host-frame orphan fix + the
+   `gate_outcome="failed"` stamp — and `WorkflowExecutor.exec`); gate seams emit
+   a `resolution: "error"` gate line before it escapes; `record_gate` maps
+   `"error"` → trailer `"failed"`. Tests (mutation-verified — removing the
+   exception from the engine tuple fails both): `TestGateResolverFailure` (node
+   success record stands, no `__failures__` entry) +
+   `test_resolver_crash_emits_error_resolution_and_trailer_says_failed`.
+3. **Escalation cost trap undocumented**: non-interactive escalation aborts
+   AFTER the step ran and the escalating result is (correctly — Decision 10)
+   never cached, so a re-run re-pays the whole agent step. Verified Decision 10
+   is the right side of the tradeoff (a cached escalation would replay as
+   resolved-without-a-decision because the cache-hit early-return precedes the
+   detect seam); the gap was documentation only. `guide/features/approval.md`
+   now states the discarded-work cost explicitly.
+4. **Latent denied→✓ fallthrough in `format_success_as_text`** (unreachable
+   today): defensive `denied` arm added + pin
+   (`TestDeniedStatusRendering`) so a future routing change can't render a
+   denied run as success.
+5. **Missing end-to-end Ctrl-C-at-gate pin**: added
+   `test_ctrl_c_at_gate_prompt_exits_130_and_step_never_runs` (CliRunner,
+   Abort at the prompt → exit 130, step never runs) — pins the resolver→engine→
+   runner→CLI interrupt seam whose halves were only unit-tested.
+6. **Stale docs**: `core/workflow/CLAUDE.md` + `core/CLAUDE.md` still called
+   `WorkflowStatus` tri-state (now four states incl. DENIED); `guide/CLAUDE.md`
+   features inventory was missing `approval.md`/`ui.md`; task-review invariant
+   updated for the third gate exception. CLAUDE.md exception tree + engine seam
+   diagram updated for `GateResolverError`.
+
+Also verified and left as-is: worker gate-line drop (documented v1 audit
+limitation), `__gate_prompt_allowed__` cannot leak to the parent store,
+nested denial trailers, warning/resolver `can_prompt` consistency (same
+function by construction), no double-prompt under node retries.
+
+Process note: repeated the session-1 git lesson the hard way — a
+`git checkout -- <file>` used to revert a mutation also wiped the session's
+uncommitted edits to that file (re-applied immediately; later mutations used
+temporary Edit + revert as the log already prescribes).

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -138,6 +138,22 @@ Tests (+47, all green; full suite 8330 passed / 0 failed):
   restored from HEAD; the stash list is intact (pop-on-conflict never drops).
   Lesson recorded: never mutation-verify via git stash on untracked files.
 
+### Session 1 committed
+
+- **Commit `2e533e2f`** on `feat/human-loop-approval-gates` (owner-instructed):
+  phases 1–2 substrate + tests + plan/progress-log/handoff-braindump. 26 files,
+  +2544/−37. Working tree clean after commit.
+- Pre-commit caught two `Optional[str]` annotations (UP007) and one unused unpack
+  (RUF059) in the new test file + reformatted two files — fixed, all hooks green
+  on the committing run.
+- Handoff artifacts for the next agent (all committed):
+  `starting-context/braindump-2026-07-02-phase12-handoff.md` (read FIRST — carries
+  the standing-order changes: NO fable for subagents; phased human-review cadence),
+  then `implementation/implementation-plan.md`, then this log. The 48 tests are the
+  substrate's behavior spec.
+- Still uncommitted anywhere: nothing. Still unpushed: everything (no push
+  instruction given).
+
 ### Behavioral note discovered while implementing
 
 Escalation detection requires a CLEAN-SUCCESS action (`""`/`"default"`/`"end"`/None),

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -188,3 +188,194 @@ node using dynamic `next:` routing cannot escalate from the same execution (its 
 is the route target). The escalating step should be the agent step (action "default"),
 with routing decided downstream. Document in the guide (Phase 6); add to the plan's
 edge ledger if the owner wants it surfaced earlier.
+
+## 2026-07-02 — Session 2: Phases 3–4 (OWNER DIRECTIVE: implement 3+4, then STOP for human review)
+
+Baseline re-captured at session start: 8335 passed (matches session-1 close), check green.
+
+### Phase 4 gap check — already complete, nothing added
+
+Every Phase 4 bullet verified shipped by session 1: `record_gate` (disk-only, gate_outcome
+trailer channel, `workflow_trace.py:650`), `trace_io._partition_trace_lines` gate arm,
+pause-before-prompt / resolution-before-raise ordering (in `runtime/engine/gate.py`),
+`resolved_via` on resolutions, round-trip + child-stream + trailer pins (test_gate_trace.py
++ commit 301a002c). Phase 4 required zero session-2 code.
+
+### Phase 3 implemented
+
+New file:
+- `src/pflow/execution/gate_prompt.py` — `build_gate_resolver` (ONE builder, every surface:
+  CLI interactive / MCP `output_controller=None` / parallel-batch via `allow_prompt=False`),
+  `can_prompt` (stdin+stderr TTY, NOT `is_interactive()` — Decision 14, verified live:
+  JSON mode with stdout piped still prompts), TTY renderers (aligned masked truncated
+  preview; escalation numbered options + `(rec)` + free text), click `Abort` →
+  `KeyboardInterrupt` (the engine-archives-Abort-as-node-failure trap).
+
+Modified:
+- `core/workflow/status.py` — `WorkflowStatus.DENIED = "denied"`.
+- `execution/runner.py` — `run(gate_resolver=...)` kwarg mirroring `progress_callback`
+  end-to-end (→ `_initialize_shared_store` → `shared["__gate_resolver__"]`);
+  `_exception_to_result` derives DENIED from `isinstance(exception, GateDenied)`.
+- `core/output_controller.py` — `prepare_for_prompt()` public seam (closes the partial
+  line; batch `\r` counters ride the same physical line, so no extra state).
+- `cli/commands/run.py` — `--auto-approve` (multiple, in `_PFLOW_FLAGS`);
+  `_prepare_gate_resolver` (builds resolver + two pre-flight warnings: unknown flag id
+  with fuzzy suggestion via `find_similar_items`, non-interactive-with-unapproved-gates;
+  both scan TOP-LEVEL ir_data nodes only — documented limitation — and are `-p`-suppressed);
+  `_display_execution_result` DENIED first-branch → `_display_denied_result` (text prose
+  with steps-completed count, or JSON document `{success:false, status:"denied", error,
+  gate:{...masked payload}}` — the denied branch bypasses `output_error`, so JSON mode
+  needed its own emitter) → `ctx.exit(3)`.
+- `cli/workflow_output.py` — `denied` arm in `_format_workflow_completion_status`
+  (the ✓-fallthrough silent-misbehavior site).
+- `mcp_server/tools/execution_tools.py` + `services/execution_service.py` —
+  `auto_approve` param on `workflow_execute` → `build_gate_resolver(frozenset(...), None)`
+  → `runner.run(gate_resolver=...)`; docstring tells agents to ask their human.
+- Web: `RunProgress.tsx` `runBadgeStatus` denied arm (amber "stopped" badge, never green ✓);
+  `index.css` `.run-banner.run-denied` + `.run-progress-outcome.run-denied` (amber family).
+  GraphView banner + outcome-line classes are template-derived (`run-${final_status}`) —
+  no TSX change needed there, CSS only.
+- CLAUDE.md updates: cli (exit-code contract + flags list), execution (gate_prompt.py entry).
+
+### Deviations from the reviewed plan (all simplifications, record for review)
+
+1. **No `RunnerConfig.auto_approve` field.** The resolver travels as a `run()` kwarg
+   (mirroring `progress_callback` exactly — the plan's own installation section); CLI and
+   MCP each build their own resolver, and the CLI's pre-flight warnings scan `ir_data`
+   CLI-side. RunnerConfig stays execution-only config; nothing needed the tuple.
+2. **No dedicated runner `except GateDenied/GateNotInteractiveError` arms.** The generic
+   `_exception_to_result` already preserves payload diagnostics via `to_diagnostics()`
+   (pinned in session 1); DENIED is a one-line status derivation inside it.
+   `GateNotInteractiveError` needed zero runner changes.
+3. **`prepare_for_prompt` closes only the partial line** — the plan's separate
+   batch-`\r`-counter concern is moot: batch progress rewrites the SAME physical line
+   opened by `node_start` (`_partial_line_open` stays true until completion).
+
+### Verification (session 2 close)
+
+- `make test`: **8362 passed / 0 failed** (session-1 close 8335 → +27, zero regressions).
+- `make test-e2e`: 43 passed. `make check`: fully green (fresh run post-format; mypy 243 files).
+- Web: `tsc --noEmit` clean; `npx vitest run` 693 passed.
+- **Live CLI verification (real pty via `script`, no mocks):** deny → exit 3 + amber
+  "stopped cleanly" line + steps-completed count; approve → exit 0, step runs; JSON deny →
+  the denied document with resolved preview; `--auto-approve=guarded-step` → exit 0 with
+  the visible "pre-approved" stderr line; typo'd id → fuzzy "Did you mean" warning;
+  non-interactive → run-start warning then loud fail at gate (exit 1) with the
+  ask-your-human ladder; resolved preview shows the actual substituted command.
+- New tests (+27): `tests/test_execution/test_gate_prompt.py` (15 — resolver contract,
+  Decision-14 TTY rule, Abort→KI, masking/truncation/options rendering);
+  `tests/test_cli/test_approval_gate_cli.py` (8 — exit 3, JSON document, auto-approve,
+  fuzzy warning, non-interactive warn+fail, `-p` suppression, completion-status arm);
+  `tests/test_runtime/test_approval_gate.py` (+2 — runner DENIED contract, resolver
+  reaches nested child engines); `tests/test_integration/test_cli_mcp_parity.py` (+2 —
+  MCP loud-fail with remediation ladder, `auto_approve` off-main-thread via
+  `asyncio.to_thread`, pinning the no-thread-guard design).
+
+### Open at the review boundary (all CLOSED later this session — see Phases 5–7 below)
+
+- Web denied-state screenshot → taken (Phases 5–7 section).
+- Phases 5–6 + remaining pins → implemented (below).
+- Accepted cosmetics carried forward (prompt_cache_analysis denied-trace labels;
+  run-start warning is top-level-only).
+
+## 2026-07-02 — Session 2 (continued): Phases 5–7 + loose-ends audit (owner: "continue, fully happy, then /deep-review → fix → /create-pr")
+
+### Phase 5 — dry-run parity
+
+- `PlanEntry.approval: bool = False` (`execution/result.py`).
+- **`_annotate_loop_entry` renamed `_annotate_entry`** (the plan's own instruction — the
+  name stays honest) and stamps `approval` from NodeConfig BEFORE the loop early-return.
+  All three call sites updated; `execution/CLAUDE.md` gained a "Cross-cutting entry
+  stamps" section.
+- Render: `_tag_from_entry` appends `approval` (→ `[shell, approval]`); explicit
+  `, approval` suffix on the sub-workflow and opaque lines (they bypass the tag helper);
+  `_entry_to_dict` emits sparse `"approval": true`; new `_append_gate_footer` (extracted
+  to keep `format_plan_text` under C901 — fold, not noqa) renders
+  `⏸ N step(s) pause for approval … non-interactive runs need --auto-approve=…`,
+  collecting gated ids RECURSIVELY through nested sub_plans (first-seen dedup).
+- **Drift pin** `test_plan_would_pause_matches_engine_gate_pauses`
+  (tests/test_execution/test_plan_drift.py): plan-side flattened gated-id set ⟺ engine
+  gate PAUSE events from a real streamed run, across all allowed shapes (standard node,
+  gated workflow-type node, gate INSIDE the child, gated loop node). Compared by node-id
+  SET; an explicit count assert proves the loop node pauses per iteration (2) while being
+  one entry. **Mutation-verified BOTH sides** (plan-side stamp disabled → fail; engine-side
+  pause event suppressed → fail; reverted, green). Plus
+  `test_dry_run_renders_approval_tag_and_footer` (text tag, sub-workflow tag, footer, JSON).
+- **Bug found by the pin: `tests/shared/markdown_utils.ir_to_markdown` silently DROPPED
+  the `approval` field** — a gated fixture written through it tested nothing. Fixed
+  (emits `- approval: <value>` beside `cache`); this is the shared utility 30+ test files
+  use, so future gated fixtures can't silently de-gate.
+
+### Phase 6 — docs
+
+- `src/pflow/guide/features/approval.md` (new): both gate kinds, declaration rules,
+  the agent-operator playbook (dry-run discovery → ask your human → scoped
+  `--auto-approve`), the escalation `result.escalation` contract (`output_schema`
+  REQUIRED on claude-code escalators; string-marker form; decision write-back +
+  idempotency), the loop+carry re-fork recipe, calibration guidance, batch restrictions,
+  clean-success-action rule, observability (resolved_via audit, exit 3, denied trace).
+- Topic wiring per guide/CLAUDE.md's checklist: `_node_topics` hook (+
+  `test_detect_approval_gate`), `entry.md` features row, `approval` in
+  `RESERVED_WORKFLOW_NAMES` (save_service.py), `guide/core.md` node-fields line.
+- `docs/how-it-works/approval-gates.mdx` (+ `docs.json` nav), `--auto-approve` row in
+  `docs/reference/cli/index.mdx`.
+- `d1-event-schema.md`: reserved `gate` kind marked SHIPPED with the disk-only pointer.
+- Root `CLAUDE.md`: Task 125 → Recently Completed; removed from Next.
+
+### Phase 7 / loose ends closed
+
+- **Web denied-state verified visually** (screenshot-pflow-web-ui, headless Chrome, real
+  denied trace `final_status: "denied"` + 2 gate lines): amber "Run denied · 1 nodes"
+  banner, amber outcome + stopped-badge in the run callout, gated step shows *pending*
+  (never failed), zero green ✓. Screenshot at scratchpad
+  `gated-db73b1c8-…-t125-….png`.
+- Frontend pin added: `RunProgress.test.tsx` denied arm (amber badge + `run-denied` class,
+  never the success fallthrough).
+- Live CLI: dry-run text shows `[shell, approval]` + the ⏸ footer; JSON carries
+  `"approval": true` (verified against a real workflow).
+
+### Final verification (Phases 5–7 close)
+
+- `make test`: **8365 passed** (session-2 midpoint 8362 → +3: drift pin, render test,
+  guide detection; net +30 over session-1 close). `make test-e2e`: 43. `make check`:
+  fully green (fresh run). Web: `tsc --noEmit` clean, **694 vitest passed** (+1).
+- One C901 trip (`format_plan_text` 11>10) fixed by folding the footer into
+  `_append_gate_footer` — the braindump's predicted boundary, handled per house rule.
+- Still uncommitted: everything from session 2. Next: /deep-review → fix verified
+  findings → update this log → /create-pr (owner instruction).
+
+### Deep-review (Phases 3–7 diff, 6 agents) — 6 confirmed findings, all fixed
+
+Battery: silent-failures + impact-completeness (the owner-mandated pairing) +
+feature-interactions + agent-ux + test-fidelity + simplicity. Zero criticals; zero
+disputed. Fixes (each pinned by a test unless noted):
+
+1. **Denied JSON ≠ unified failure shape** (agent-ux) → `_display_denied_result` now
+   emits `errors` + `diagnostics` arrays (superset of `format_error_json`'s contract)
+   alongside `gate`.
+2. **Unmatched `--auto-approve` id phrased as a typo verdict** (agent-ux) —
+   contradicted the dry-run footer for legitimate nested-gate ids (flat namespace).
+   Reworded to a neutral note: nested-match possibility first, closest top-level
+   match second. Test + cli/CLAUDE.md updated.
+3. **Cached-but-gated entries stamped `approval: true`** (silent-failures) — plan
+   promised a pause a cache hit never makes. `_annotate_entry` skips `cached`
+   entries; new two-sided pin `test_cached_gated_node_not_stamped_and_engine_skips_gate`.
+4. **`runMark` denied fallthrough** (impact-completeness) — the third web status
+   surface (RunSelector + CatalogView) rendered denied as grey "stale". Amber
+   `run-denied` arm + CSS; stale status-enum comments refreshed.
+5. **Non-interactive `--only` warned about unreachable gates** (feature-interactions)
+   — gate scan now scopes to the `--only` target (+ None-id guard); new test.
+6. **Gate events inside batch-item sub-workflows don't reach the trace**
+   (feature-interactions) — CONFIRMED, DIFFERENT FIX: buffered child events must not
+   carry gate lines (that recreates the --only-seeding hazard the disk-only invariant
+   prevents), and Task 171 reworks gate records; documented as a v1 audit limitation
+   in guide/features/approval.md ("gate outside the batch if you need the record").
+   Flag for Task 171: batch-item gate records.
+
+Suggestion applied: denied-JSON preview assertion tightened to the exact resolved
+value (test-fidelity). Deliberately NOT acted on: `GateResolution.notes` (forward-shape
+for 171/176), masking rule in two render surfaces (different media) — both simplicity
+take-or-leave notes.
+
+Post-fix gates: `make test` **8367** (+2 pins) / e2e 43 / `make check` green /
+web tsc + **694** vitest green.

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -379,3 +379,124 @@ take-or-leave notes.
 
 Post-fix gates: `make test` **8367** (+2 pins) / e2e 43 / `make check` green /
 web tsc + **694** vitest green.
+
+## 2026-07-02 — Session 3: GitHub PR review evaluation + fixes (`/evaluate-review`)
+
+Two real reviews on PR #554: a `claude[bot]` comment (1 Warning + 2 Suggestions,
+seam-focused: concurrency, cross-boundary control flow, validation↔runtime parity)
+and a Codex inline review (4 findings across 4 files). Evaluated with 4 parallel
+`pflow-codebase-searcher` verification agents + direct reads of the two most
+consequential fix sites (engine.py gate-exception handler, workflow_trace.py
+`descend()`/`tree()`) before proposing a plan. **5 confirmed, 1 disputed, 0
+needs-investigation** — user approved the full plan; all 5 implemented and
+mutation-verified (temporary Edit + revert per fix, never git stash).
+
+### 1. Orphaned trace event on a nested gate stop — CONFIRMED, different fix (most severe)
+
+Real bug, but the reviewer's mechanism was subtly off. Root cause: `WorkflowExecutor.
+descend()` reserves a seq for a sub-workflow host; children record with `parent_id` =
+that seq; the host's OWN completion event is normally written at engine step 16
+(`record_trace`, reusing `node._host_frame` — read only AFTER `node._run()` returns).
+But the Task 125 gate-exception arm `raise`s instead of returning (by design — a
+denial can't be error-routed), so step 16 never runs and the reserved seq gets no
+event. If an earlier SIBLING step inside that sub-workflow already recorded, its
+event orphans. **Actual impact (verified live, not the reviewer's framing): NOT a
+later disk-read crash** — `finalize()` itself calls `tree()` in-memory and raises
+*before* writing the `run.complete` trailer; `runner.py`'s `contextlib.suppress`
+silently swallows it, so the run exits with the right code but **the trace file is
+silently lost** (one easy-to-miss log line). Also a **latent hard-crash surface**:
+`error_formatter.py:85-88`'s `collect_llm_calls()` → `tree()` raises outright for
+any caller threading `metrics_collector` + `shared_storage` together.
+
+Fix (`runtime/engine/engine.py`, the `except (GateDenied, GateNotInteractiveError)`
+handler): `host_frame = getattr(node, "_host_frame", None)`; if set, call
+`record_trace(..., success=True, frame=host_frame)` before re-raising — the *node*
+itself didn't error, the run's denied/failed verdict is already carried
+independently by `gate_outcome`. Fires once per nesting level for free (the same
+exception re-raises through each ancestor's own `_execute_node`, each checking its
+own node's `_host_frame`) — no `workflow_executor.py` change needed.
+
+Tests (`tests/test_runtime/test_gate_trace.py`, both mutation-verified — reverting
+the fix reproduces the exact `orphan event: parent_id ... not found`
+`JSONDecodeError`): `test_denied_nested_gate_after_sibling_event_does_not_orphan_trace`,
+`test_noninteractive_nested_gate_after_sibling_event_does_not_orphan_trace` — a
+sub-workflow with an earlier sibling step then a gated step; assert `run.complete`
+IS written, `final_status` is `denied`/`failed` (not silently `incomplete`), and
+`tree()` rebuilds without raising.
+
+### 2. Gate preview masking doesn't recurse into dict/list values — CONFIRMED
+
+`claude[bot]` (Suggestion) and Codex (P1) independently flagged the same gap:
+`gate_prompt.py::_format_preview` and `exceptions.py::_masked_gate_payload` both
+masked only `isinstance(value, str)` — a nested secret (`headers: {Authorization:
+"Bearer ..."}`) rendered/serialized verbatim, reaching the TTY prompt AND
+`GateNotInteractiveError.to_diagnostics()` (→ `--output-format json` / MCP tool
+responses). Fix: reuse the existing recursive `sanitize_parameters()`
+(`core/security_utils.py`) for non-string preview values in both sites — top-level
+string masking (`mask_sensitive_value`) unchanged, so the existing 200-char preview
+truncation behavior isn't disturbed. Tests (both mutation-verified): nested-dict and
+nested-list-of-dicts cases in `test_gate_prompt.py`
+(`test_nested_secret_in_dict_value_is_redacted`,
+`test_nested_secret_in_list_of_dicts_is_redacted`) and
+`test_approval_gate.py::test_secret_nested_in_dict_value_masked_in_diagnostic`
+(diagnostic masked, in-memory `request.preview` stays unmasked — trace-consistent).
+
+### 3. Auto-approve echo races a parallel-batch worker thread — CONFIRMED
+
+`claude[bot]` (Warning). `_echo_auto_approved` fired unconditionally on `auto_approve`
+match, ignoring `allow_prompt` — but `__gate_resolver__` propagates into worker
+`item_shared` UNCHANGED (only `__gate_prompt_allowed__`/the progress callback are
+swapped/buffered), so a flagged nested gate inside a parallel-batch sub-workflow item
+called `output_controller.prepare_for_prompt()` + `click.echo(err=True)` on the
+WORKER thread — exactly the race the per-worker progress buffer exists to prevent.
+The existing parallel-batch test used a `RecordingResolver` test double with no
+`OutputController`, so this was genuinely uncovered. Fix: gate the echo on
+`allow_prompt` in the resolver closure (worker output is buffered anyway; the flag
+was already an explicit human pre-approval). Tests (mutation-verified):
+`test_flag_echo_suppressed_on_worker_thread_with_real_output_controller` (real
+`build_gate_resolver` + fake-but-real-shaped `OutputController`, `allow_prompt=False`
+→ zero `prepare_for_prompt()` calls, zero stderr) +
+`test_flag_echo_still_fires_on_main_thread` (positive case).
+
+### 4. Batch-of-sub-workflow dry-run drops the child's `approval` flag — CONFIRMED
+
+Codex (P2). `_aggregate_batch_child_plans` (`execution/plan.py`) builds fresh
+synthetic `PlanEntry` objects per node-id when collapsing per-item batch-of-workflow
+plans — `approval` wasn't in the copied-fields list, silently defaulting to `False`
+even though the child gates correctly at runtime (resolver namespace is flat).
+Fix: `approval=any(entry.approval for entry in entries_for_node)`. Test
+(mutation-verified): `test_plan_batch_sub_workflow_preserves_child_approval_flag`
+in `test_plan_drift.py` — batch-of-workflow whose child has a gated step; assert the
+aggregated entry shows `approval=True`.
+
+### 5. `sorted()` on a set that could contain `None` — CONFIRMED (unreachable today, cheap fix)
+
+`claude[bot]` (Suggestion). `_prepare_gate_resolver`'s `node_ids` set could contain
+`None` if a node dict lacked `"id"`, crashing `sorted()` with a mixed-type
+`TypeError`. Verified unreachable in practice (the markdown parser always sets
+`"id"`; no CLI path passes a bare dict IR that skips it) but the guard costs
+nothing. Fix: filter falsy ids at construction. Test (mutation-verified,
+reproduces the exact `TypeError`):
+`test_prepare_gate_resolver_tolerates_node_missing_id`.
+
+### Disputed
+
+**Docs example flag placement** (Codex P2) — claimed `pflow my-workflow
+--auto-approve=notify-slack` wouldn't work (flag after the workflow name). Verified
+empirically wrong: `run`'s `allow_interspersed_args=True` + `--auto-approve` being a
+*recognized* Click option means position doesn't matter (tested all 4 orderings by
+parsing the real command). No doc change.
+
+### Post-fix verification
+
+`make test`: **8376 passed** (session-2 close 8367 → +9: 2 orphan-trace tests, 2
+nested-secret masking tests (gate_prompt) + 1 (exceptions/approval_gate), 2
+worker-echo tests, 1 batch-approval-plan test, 1 sorted-None test). `make test-e2e`:
+43. `make check`: fully green (one RUF012 lint on the new test's fake-ctx class,
+fixed by switching to `types.SimpleNamespace`). Web: `tsc --noEmit` clean, 694
+vitest passed (untouched by this session — web wasn't in scope for any confirmed
+finding). All 5 fixes mutation-verified via temporary Edit + revert (never git
+stash, per the session-1 lesson).
+
+Next: update this log (done) → `/create-pr` follow-up (push + note on the existing
+PR #554, since it already exists — no new PR).

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -595,3 +595,84 @@ Evaluated claude[bot]'s review of 9fe66c96 (PR #554): no blockers, 1 Warning,
   naturally excludes it — no code change existed); integration point corrected
   from `sanitize_parameters` to `is_sensitive_parameter`; engine handler tuple
   and Read First list updated for GateResolverError/masked_preview.
+
+## 2026-07-02 — Session 5: adversarial end-to-end CLI verification (no code changes)
+
+Owner asked for a break-it verification pass driving the REAL `pflow` CLI with
+hand-written `.pflow.md` workflows — treating the test suite as context, not
+evidence (an LLM's own tests can be happy-path / mock-heavy). 17 throwaway
+workflows + a **PTY harness** (`pty.fork`) to exercise live prompts that unit
+tests structurally cannot reach (stdin+stderr both real TTYs). **No real defects
+found; no code changed.** Scratchpad deleted afterward.
+
+### What was driven through the real CLI (all as documented)
+
+- **Validation/static**: batch-host `approval:` rejected at `--validate-only`,
+  `run`, AND `--dry-run` (three paths); `approval: banana` and `approval: true`
+  (YAML bool trap) both give the `nodes[N].approval` schema error + "only
+  supported value is `required`" suggestion; `--dry-run` text (`[shell,
+  approval]` tag + `⏸` footer) and JSON (`"approval": true`, sparse) parity.
+- **Approval, non-interactive**: upstream runs, then loud fail exit 1, marker
+  file never written, full ask-your-human ladder; run-start warning fires;
+  trace trailer `failed` with `nodes_failed: 0`; gate pause line carries the
+  RESOLVED command (not `${...}`); `pflow report` renders the trace.
+- **Approval, real TTY (PTY)**: approve (`y`) → node runs, exit 0, `resolution
+  approved via prompt`, trailer `success`. Deny (`n`) → **exit 3**, clean amber
+  "stopped cleanly" line, marker not written, `resolution denied via prompt`,
+  trailer `denied`, node never traced. `--auto-approve` → `via flag`.
+- **Sub-workflow denial NOT error-routed** (the load-bearing security claim): a
+  gated child under a parent with `on-error: recover` — denial (TTY exit 3) and
+  non-interactive (exit 1) both STOP the run; the `recover` handler never fired.
+- **Orphan-trace regression**: sibling step recorded before a gate in a child,
+  then deny → trace stays complete & readable (`run.complete` present,
+  `final_status: denied`, `pflow report` rebuilds — no silent trace loss).
+- **Escalation** (via `code` node, node-type-agnostic path): non-interactive →
+  step runs then escalation-specific loud fail; TTY → numbered options + `(rec)`,
+  choosing `2` maps to the option LABEL (`chosen: "per-env"`), flows downstream;
+  empty-dict marker → degrading warning, no pause; already-`decision`ed marker →
+  no re-pause (idempotent); escalation inside a batch → loud `PflowError` naming
+  the original item index.
+- **Loop gate** prompts every iteration (2 prompts, counter=2).
+- **Auto-approve scoping**: `--auto-approve=gate-one` runs only that gate,
+  gate-two still blocks; unknown id → neutral flat-namespace note + fuzzy
+  suggestion; both flags → exit 0.
+- **Denied `--output-format json`**: parseable doc (`status: "denied"` +
+  `errors[]`/`diagnostics[]` with the full resolved `gate` payload).
+- **Ctrl-C at prompt** → exit 130, marker not written.
+- **Sequential batch** deny → 1 prompt then whole-run stop, no re-prompt
+  (`retriable=False`); **parallel batch** worker can't prompt even at a TTY →
+  non-interactive fail with batch-specific remediation.
+- **No-regression**: a plain non-gated workflow behaves identically (no warnings,
+  no gate lines); mermaid renders a gated workflow without choking on `approval`.
+
+### Two false alarms chased down (both VALIDATE the design)
+
+1. "Auto-approve success run's trailer said `failed`" → a shell `ls`→`eza` alias
+   mis-sorted `-t`, selecting a stale trace. Reliable `stat`-based selection:
+   `approved`/`success`. No bug.
+2. "Denied JSON exited 1 not 3" → the probe used `2>/dev/null`, removing the
+   stderr TTY, which CORRECTLY makes the run non-interactive (exit 1). Isolated
+   deny+JSON+TTY = exit 3. This precisely confirms Decision 14 (a prompt needs
+   stdin AND stderr at a terminal; stdout piping alone doesn't disable gates —
+   separately confirmed by a stdout→file deny that still prompted).
+
+### Honest gaps (environment-bound, not avoidance)
+
+- Cached-node-never-gates not exercised at runtime (needs an `llm` cache hit; no
+  API here) — the safe direction (gate fails to fire, not fires wrongly), covered
+  by `test_cached_gated_node_not_stamped_and_engine_skips_gate` + confirmed
+  dry-run doesn't stamp cached entries.
+- MCP `workflow_execute auto_approve` and web-UI amber denial not driven (no MCP
+  server / browser) — covered by `test_cli_mcp_parity.py` + vitest/screenshot
+  pins; the shared `build_gate_resolver` both use WAS exercised via the CLI.
+- claude-code-specific `_schema_error` prose-swallow warning branch not hit
+  (used `code`-node escalation, same detect/pause/resolve machinery).
+
+### Suite (context, not evidence)
+
+Gate-specific: 138 passed (`test_approval_gate` / `test_gate_trace` /
+`test_gate_prompt` / `test_approval_gate_cli` / `test_approval_field` /
+`test_plan_drift`). Adjacent regression slice: 395 passed
+(`test_workflow_executor` / `test_batch_node` / `test_loop_control` /
+`test_plan_drift` / `test_plan_batch_sub_workflow` / `test_runner`). Consistent
+with observed behavior.

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -1,0 +1,148 @@
+# Task 125 — Implementation Progress Log
+
+> Companion to `implementation-plan.md` (same dir). Records decisions, deviations,
+> and discoveries as they happen. Baseline before any change: 8283 tests passed,
+> `make check` fully green (2026-07-02).
+
+## 2026-07-02 — Session 1: plan + deep-review + Phases 1–2
+
+### Plan-stage (before code)
+
+- Spec verified by 4 parallel searchers; two spec corrections found (batch/loop combo
+  rules live in `data_flow.py` not validator Step 9; Task 166 loop parity was NOT
+  zero-plan.py-edits — rendering precedent is `_tag_from_entry`'s `cache: false` tag).
+- Owner decisions locked: escalation IN scope (schema-retry self-heal de-risks the
+  marker trigger); decisions 4 (fail at gate + warn at start) and 5 (clean denial,
+  exit 3, DENIED status) confirmed as recommended.
+- 7-agent deep-review (plan mode): 4 criticals, ~10 warnings, 0 disputed — ALL folded
+  into the plan. Criticals: trace reader raises on unknown line kinds (gate needs a
+  known-but-ignored arm); `WorkflowExecutor.exec` generic except converts gate
+  exceptions into error-routable child failures; batch retry loop re-prompts/swallows
+  denials (`retriable=False` fixes); blanket main-thread guard would break MCP
+  auto-approve (MCP runs the engine via `asyncio.to_thread`).
+
+### OWNER DIRECTIVE: implement Phases 1–2 ONLY, then stop for human review.
+
+### Phases 1–2 implemented (this session)
+
+New files:
+- `src/pflow/core/gate.py` — `GateRequest`/`GateResolution` (payload IS the seam,
+  ADR-0009), `build_approval_request`/`build_escalation_request`, `json_safe`.
+- `src/pflow/runtime/engine/gate.py` — engine-side seam helpers: `resolve_gate`,
+  `run_approval_gate`, `detect_escalation` (lenient-but-loud shape ladder),
+  `run_escalation_gate` (decision written INTO the marker), `scan_batch_escalations`.
+- `src/pflow/core/workflow/gate_validation.py` — `check_approval_allowed` (shared
+  batch-host rule, two call sites: data_flow diagnostic + compiler CompilationError).
+
+Modified:
+- `core/exceptions.py` — `GateDenied`, `GateNotInteractiveError` (both
+  `retriable=False`; payload-carrying `to_diagnostics()` with the surface-aware,
+  ask-your-human remediation ladder; preview secrets masked via
+  `mask_sensitive_value` in diagnostics only).
+- `core/markdown_parser.py:1610` — `"approval"` added to the hoist tuple.
+- `core/ir_schema.py` — `approval` enum property + `_get_suggestion` approval arm.
+- `core/workflow/data_flow.py` — `_validate_approval_node_combos` wired into
+  `validate_data_flow` (covers --validate-only, save, --dry-run, compile-path
+  wrapped diagnostics, recursive child validation, MCP).
+- `runtime/compilation/compiler.py` — `_extract_approval` (strict value + batch
+  check, prewarm pattern) → `NodeConfig.approval` (`engine/types.py`).
+- `runtime/engine/engine.py` — step 7.5 approval gate (before start callback /
+  node.start → denied node never in trace); step 9 batch escalation scan; step 10.5
+  escalation detect (clean-success, non-batch) gating BOTH cache writes; step 17.7
+  escalation pause (after completion trace, before loop re-entry reads the store);
+  gate-exception re-raise arm stamping `trace.gate_outcome`.
+- `runtime/workflow_executor.py` — `__gate_resolver__` + `__gate_prompt_allowed__`
+  in `_PROPAGATED_KEYS`; gate-exception re-raise arm before the generic child-failure
+  conversion.
+- `runtime/engine/batch_executor.py` — parallel workers get
+  `item_shared["__gate_prompt_allowed__"] = False` (next to the progress-buffer swap).
+- `runtime/workflow_trace.py` — `record_gate` (DISK-ONLY like node.start; never in
+  `self.events`), `gate_outcome` field, `_determine_trace_status` gate arms
+  (denied→"denied", non_interactive→"failed" — without this a gate-stopped run's
+  trailer would read "success").
+- `core/trace_io.py` — `gate` known-but-ignored reader arm (mirrors node.start).
+- engine/runtime CLAUDE.md sections updated (seam steps, propagated keys).
+
+Tests (+47, all green; full suite 8330 passed / 0 failed):
+- `tests/test_core/test_approval_field.py` (13) — hoist, schema enum + suggestion,
+  validator + compiler batch rejection, recursive child validation, NodeConfig,
+  cache-hash unchanged.
+- `tests/test_runtime/test_approval_gate.py` (29) — approve/deny/non-interactive,
+  masked diagnostics, cached-never-gates, per-iteration loop prompts, escalation
+  ladder (dict/decided/string/malformed/schema-softfail), never-cached escalations,
+  batch scan with item context, gate-before-batch pattern, sub-workflow boundary
+  (deny crosses unconverted, error_action:continue can't route it, sequential-batch
+  deny with no retry re-prompt, parallel-batch stub + flag approval works).
+- `tests/test_runtime/test_gate_trace.py` (5) — pause/resolution lines, payload
+  round-trip, disk-only invariant, reader tolerance (`pflow report`/`--only` source
+  works for approved runs), denied/failed trailers, escalation event ordering.
+
+### Deviations from the reviewed plan (both simplifications, record for review)
+
+1. **`GateRequest`/`GateResolution` live in `core/gate.py`, not `runtime/engine/gate.py`**
+   — `core/exceptions.py` must carry the payload and core cannot import runtime.
+   The engine-side helpers stay in `runtime/engine/gate.py` as planned.
+2. **Parallel-worker isolation = `__gate_prompt_allowed__` flag + `allow_prompt`
+   resolver arg, NOT resolver substitution** — substitution would need batch_executor
+   (runtime) to build a Phase-3 resolver (execution layer): a layering violation.
+   Same guarantees: auto-approve works in workers (flag lookup is thread-safe),
+   `parallel_batch=True` is truthful (its only source is `allow_prompt=False`),
+   no thread-identity heuristics (MCP's `asyncio.to_thread` unaffected).
+3. **Guide topic hook (`_node_topics`) deferred to Phase 6** — the plan had it in
+   Phase 1, but the hook would point at a not-yet-written `features/approval.md`.
+
+### Known intermediate state (Phase 3 closes these — deliberate, not loose ends)
+
+- `GateDenied` reaching the runner is converted by the GENERIC `_exception_to_result`
+  → result FAILED / exit 1, while the trace trailer correctly says "denied". Phase 3
+  adds the dedicated runner arms + `WorkflowStatus.DENIED` + exit 3 + denied JSON doc.
+- No resolver is installed anywhere yet (CLI/MCP Phase 3) — every gated run today
+  fails loudly at the gate with the payload-carrying error. Correct pre-Phase-3
+  behavior (never hangs, never silently approves).
+- Dry-run shows gated nodes as plain execute until Phase 5 (PlanEntry stamp + tag +
+  drift pin).
+
+### Final verification (session 1 close)
+
+- `make test`: 8330 passed / 0 failed (baseline 8283 → +47, zero regressions).
+- `make test-e2e`: 43 passed.
+- `make check`: fully green (ruff, ruff-format, mypy 242 files, deptry, pre-commit hooks).
+- Three C901 limits tripped by one-added-branch each; fixed by folding, not `noqa`:
+  `_partition_trace_lines` merged the `node.start`/`gate` known-but-ignored arms;
+  `WorkflowExecutor.exec` extracted the duplicated child-buffer stash into
+  `_stash_child_buffer` (also removed pre-existing duplication); `_get_suggestion`
+  extracted the validator-keyword fallback chain into `_suggest_for_general_error`.
+- `GATE_KIND_*` constants typed as `Literal[...]` for mypy.
+- CLAUDE.md updated where code changed: core (exceptions hierarchy + gate.py),
+  core/workflow (gate_validation.py), runtime (reserved keys), runtime/engine
+  (seam step diagram + gate except arm).
+
+### Post-review audit (owner asked "fully happy? loose ends?")
+
+- **Found + fixed one real leak**: engine bookkeeping keys in params (e.g.
+  `_python_source_line` on code-block params) leaked into the approval preview.
+  `build_approval_request` now filters `_`-prefixed keys (the display-surface
+  convention). Pinned by a MUTATION-VERIFIED test (fails with the filter removed):
+  `test_markdown_parsed_gate_preview_has_no_bookkeeping_keys`. Suite: 8331 passed.
+- **Real-CLI end-to-end verification performed** (uv run pflow, no mocks):
+  `--validate-only` accepts a gated workflow and rejects a batch-host gate with the
+  restructure message; running a gated workflow non-interactively executes upstream,
+  then fails AT the gate with the full ask-your-human ladder (exit 1 — becomes 3 only
+  for DENIED in Phase 3); the streamed trace carries the gate pause line (resolved
+  preview) + `non_interactive` resolution + `final_status: "failed"` trailer; and
+  `pflow report` renders the gated trace (pre-fix this failed as unknown-kind
+  corruption).
+- Process incident, resolved with no data loss: a `git stash -- <untracked>` +
+  `pop` mistake briefly applied a pre-existing stash (`commit3-wip`, other branch)
+  into the tree; all 12 affected paths were disjoint from Task 125 work and were
+  restored from HEAD; the stash list is intact (pop-on-conflict never drops).
+  Lesson recorded: never mutation-verify via git stash on untracked files.
+
+### Behavioral note discovered while implementing
+
+Escalation detection requires a CLEAN-SUCCESS action (`""`/`"default"`/`"end"`/None),
+mirroring the api-warning detector's "the node's verdict stands" rule — so a `code`
+node using dynamic `next:` routing cannot escalate from the same execution (its action
+is the route target). The escalating step should be the agent step (action "default"),
+with routing decided downstream. Document in the guide (Phase 6); add to the plan's
+edge ledger if the owner wants it surfaced earlier.

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -154,6 +154,32 @@ Tests (+47, all green; full suite 8330 passed / 0 failed):
 - Still uncommitted anywhere: nothing. Still unpushed: everything (no push
   instruction given).
 
+### High-value test audit (owner: "the bar isn't passing, it's passing the right thing")
+
+Stepped back and asked: where do the existing tests verify a CLAIM I made by reading
+code rather than BEHAVIOR I proved? Four gaps found, four tests added (+4, suite 8335):
+
+1. `test_escalation_decision_feeds_loop_carry_reentry` — the escalate → decide →
+   carry re-entry round trip (the continue mechanism, i.e. the reason escalation
+   exists) had NEVER been executed; the decision-before-loop-eval and
+   decision-before-carry-resolution orderings were line-number reasoning until now.
+2. `test_parallel_batch_child_gate_with_live_collector_never_crashes` — the traceless
+   parallel test could not see the worker-thread `record_gate` path; if a parallel
+   child ever got the run collector instead of a buffer, `_assert_owner_thread` would
+   CRASH production runs. Now pinned with a real streaming collector.
+3. `test_nested_child_gate_events_land_in_run_stream` — the plan's pending Phase 4
+   item: child gates (the harness's primary shape) share the run collector, gate
+   lines land in the stream, trace stays readable.
+4. `test_noninteractive_gate_through_runner_keeps_payload_diagnostics` — first test
+   through `WorkflowRunner` (tests/CLAUDE.md pitfall #20): the gate diagnostic
+   survives runner conversion with its payload, is JSON-serializable, and the run
+   fails as a RESULT not a propagated exception. Explicitly documents that Phase 3
+   must consciously update the denied half of this contract.
+
+Shallowness audit verdict: no existing test asserts the wrong thing; none removed.
+The one under-asserting test (traceless parallel gate) is kept for its resolver-level
+pins and superseded on the trace dimension by #2.
+
 ### Behavioral note discovered while implementing
 
 Escalation detection requires a CLEAN-SUCCESS action (`""`/`"default"`/`"end"`/None),

--- a/.taskmaster/tasks/task_125/implementation/progress-log.md
+++ b/.taskmaster/tasks/task_125/implementation/progress-log.md
@@ -560,3 +560,38 @@ Process note: repeated the session-1 git lesson the hard way — a
 `git checkout -- <file>` used to revert a mutation also wiped the session's
 uncommitted edits to that file (re-applied immediately; later mutations used
 temporary Edit + revert as the log already prescribes).
+
+## 2026-07-02 — Session 4 (continued): PR-review warning fix — gate-preview masking rework
+
+Evaluated claude[bot]'s review of 9fe66c96 (PR #554): no blockers, 1 Warning,
+2 optional suggestions. Actions:
+
+- **Warning CONFIRMED and fixed** (the earlier "accepted as-is" call was made on
+  a wrong premise): `sanitize_parameters` cuts nested strings >100 chars to
+  **20 chars** (`value[:20] + "...<truncated>"`, security_utils.py:138-139) —
+  the task-review had recorded it as "truncates to 100 chars". A gated http
+  `json:` body or sub-workflow `inputs:` field showed the approver 20 chars, on
+  BOTH decision surfaces (TTY prompt + MCP/JSON diagnostic). Fix: new shared
+  `core/gate.py::masked_preview` — recursive redaction of secret-NAMED keys via
+  `is_sensitive_parameter`, NO truncation (truncation stays renderer-only: the
+  TTY 200-char step; diagnostics carry full masked values, per the plan's
+  untruncated-payload rule). Both render sites now delegate — this also closes
+  the task-review's "two hand-written masking call sites" wart. Tests
+  (mutation-verified against the old sanitize path):
+  `test_long_nonsecret_nested_value_survives_to_display_budget` (gate_prompt) +
+  `test_long_nonsecret_nested_value_intact_in_diagnostic` (approval_gate).
+  Behavior delta accepted knowingly: nested non-secret values are no longer
+  length-limited in diagnostics (the trace already carried them in full).
+- **Suggestion 1 (batch-host edge note)**: added the one-line comment in the
+  engine gate-arm (batch hosts never set `_host_frame` — batch-item children
+  use buffered collectors, no `descend()`). No new test — the guard is
+  defensive and the path is exercised by existing sequential-batch deny pins.
+- **Suggestion 2 (comment density)**: reviewer requested no change; none made.
+- **Task-review accuracy pass** (owner request): commit list extended
+  (5f161e4e + this fix); the two stale masking paragraphs replaced with the
+  masked_preview invariant + its history; added GateResolverError and the
+  non-interactive-escalation cost trap to Gotchas (flagged for Task 171
+  designers); "allowlist extended to reject denied" corrected (the allowlist
+  naturally excludes it — no code change existed); integration point corrected
+  from `sanitize_parameters` to `is_sensitive_parameter`; engine handler tuple
+  and Read First list updated for GateResolverError/masked_preview.

--- a/.taskmaster/tasks/task_125/starting-context/braindump-2026-07-02-phase12-handoff.md
+++ b/.taskmaster/tasks/task_125/starting-context/braindump-2026-07-02-phase12-handoff.md
@@ -1,0 +1,143 @@
+# Braindump: Task 125 handoff — Phases 1–2 done, you implement Phases 3–7
+
+> Written 2026-07-02 at the owner-directed review boundary. Read order: this file →
+> `../implementation/implementation-plan.md` (the authoritative spec for what you build;
+> deep-reviewed by 7 agents, corrected against implementation) →
+> `../implementation/progress-log.md` (what happened, deviations, intermediate states).
+> The 48 tests in `tests/test_core/test_approval_field.py`,
+> `tests/test_runtime/test_approval_gate.py`, `tests/test_runtime/test_gate_trace.py`
+> ARE the behavior spec for the substrate you're building on. Everything below is ONLY
+> what those files don't say.
+
+## ⚠️ Standing-order changes from the owner (this session, verbatim-ish)
+
+1. **"from now on we should NOT use fable for subagents"** — this SUPERSEDES the
+   2026-07-02 decision-session braindump's "in this harness use fable for delegated
+   work". Use the normal default models for `pflow-codebase-searcher` / review agents /
+   `test-writer-fixer`; do not pass a fable model override.
+2. **Phased human review is the cadence now.** The owner's exact instruction pattern:
+   "only implement phase 1 and 2 and then stop for review... by review I mean human
+   review, so stop and dont continue at all after phase 2 is completed and you are FULLY
+   happy with the implementation so far with no loose ends." ASSUMPTION (unconfirmed):
+   the same applies to you — propose a stopping point (I'd suggest: Phase 3 complete)
+   and get explicit approval before continuing. Do not run Phases 3→7 in one shot
+   without asking.
+3. Nothing is committed. One-big-PR convention (the whole task = one PR at the end).
+   NEVER git add/commit/push without explicit instruction.
+
+## Where I am / where you start
+
+Phases 1–2 are complete, green (8331 unit + 43 e2e, `make check` clean), human review of
+them is pending or done by the time you read this. Your work is Phases 3→7 in the plan.
+Everything you need consumes three frozen contracts — `GateRequest`/`GateResolution`
+(`src/pflow/core/gate.py`, the docstring is the resolver contract), the
+`__gate_resolver__`/`__gate_prompt_allowed__` shared-store protocol, and the two gate
+exceptions in `core/exceptions.py`. **Nothing remaining requires reopening
+`_execute_node`** — if you find yourself editing the engine seams, stop and re-read the
+plan; you're probably re-solving something.
+
+## User's mental model (this session's words)
+
+- Escalation inclusion: **"yes escalation, we implemented a retry fix for claude code
+  agents on schema fail"** — i.e., the schema-retry self-heal is WHY the
+  structured-output marker trigger is trusted. If escalation reliability ever comes up,
+  that retry mechanism (`claude_code.py` `schema_retries` + coercion) is the load-bearing
+  assumption to check.
+- The agent-as-operator concern (their scenario framing): "the human just asks the human
+  then resumes... but there is nothing stopping the agent from skipping to ask the human
+  and just continue anyway." Accepted resolution: the gate is **deliberate + visible +
+  auditable** against the operating agent, not enforcement; `resolved_via` on the gate
+  resolution event is the audit hook; real convenience arrives with Tasks 171+176. The
+  analysis is recorded in `task-176.md` "The agent-operated run".
+- Recurring standard (they restated it when scoping this handoff): simplicity of the
+  FINAL code / top-10%-of-similar-codebases / no over-engineering / "optimized for AI
+  agents to understand and add features to."
+- Interaction style: they sometimes go AFK — two `AskUserQuestion` calls timed out this
+  session. Substantive prose messages get answered; prefer presenting
+  findings-with-recommendation in text over blocking question dialogs.
+- They DENIED a command that deleted files under `~/.pflow` — never touch the user's
+  home artifacts without asking.
+
+## Tacit knowledge for Phase 3 specifically
+
+- **Show the prompt UX before wiring it.** The mocks in the plan (§3.3) were shown in
+  chat but never explicitly approved as final renderings. The project norm (CLAUDE.md
+  "Show Before You Code") + the split-session braindump both demand it. Render the four
+  states (approval prompt, escalation prompt, denied line, non-interactive error) and
+  get a nod first.
+- **`__progress_callback__` wiring is asserted, not traced.** The plan says "mirror
+  `__progress_callback__` end-to-end" for installing the resolver. NEEDS VERIFICATION:
+  I never read the exact hop from `cli/commands/run.py:309` (callback creation) into the
+  runner into the shared store. Trace it before copying the pattern — searcher reports
+  said "threaded via shared['__progress_callback__']" but the plumbing site is unread.
+- **Exit-code truth**: a `GateNotInteractiveError` run exits 1 today (verified live).
+  Only DENIED gets the new exit 3. Click owns exit 2.
+- **The denied JSON emitter gap is real, not theoretical** — I confirmed live that the
+  denied branch as planned bypasses `output_error` (the only path to the JSON emitter).
+  The plan's §3.2 denied-JSON document spec is the fix; don't "simplify" it away.
+- **`run.py` swallows unknown flags as workflow params.** `--validate` (no `-only`)
+  got parsed as a workflow input named `validate` with a did-you-mean error. When adding
+  `--auto-approve`, test the misspelling behavior — an agent typo'ing the flag should
+  get something sane.
+- **C901 is at the boundary in this codebase.** Three functions tripped 10→11 from ONE
+  added branch in Phase 2. `run.py`'s and `runner.py`'s big functions may be similarly
+  close. House rule: fold/extract (see `_stash_child_buffer`,
+  `_suggest_for_general_error` for the pattern), never `noqa`.
+- **Pre-commit ruff gave a false green mid-session** (cached). Always run a fresh
+  `make check` at the very end, not just after each edit burst.
+- **The trailer channel is belt-and-braces**: `record_gate` sets
+  `collector.gate_outcome` AND the engine's gate-exception arm re-stamps it at every
+  engine level (root last). Phase 3's runner arms do NOT need to set it — but if you see
+  a denied run with a wrong trailer in some exotic nesting, that's where to look.
+
+## Small pending item (10 minutes, do it early)
+
+The plan's Phase 4 bullet "integration test: a CHILD workflow's gate events land in the
+run's streamed trace" is NOT yet written — my trace tests cover top-level gates only.
+The machinery works (NEW-path children share the run collector), it just lacks a pin.
+
+## Environment gotchas (cost me real time)
+
+- The shell is **zsh**: unquoted `$VAR` does NOT word-split; `python` doesn't exist
+  (use `python3` / `uv run python`); `$?` after a pipe is the LAST command's status.
+- **NEVER `git stash` to mutation-verify** — untracked files don't stash, and my `pop`
+  applied the owner's pre-existing `commit3-wip` stash from another branch (recovered,
+  no loss — details in progress log). Mutation-verify with a temporary Edit + revert.
+- Two leftover demo traces in the user's real `~/.pflow/debug/`
+  (`workflow-trace-*gated-demo*`). Owner declined deletion; leave them unless asked.
+- Code-node test fixtures: inputs need type annotations in the code string
+  (`i: int\nresult: ...`); engine-direct tests must NOT declare workflow `inputs:`
+  (that forces runner-style seeding) — seed `shared` directly.
+
+## Suspicions / judgment calls you may need to defend
+
+- **Escalation can't fire from a dynamic-`next:` routing node** (clean-success actions
+  only — `""`/`"default"`/`"end"`). I believe this is RIGHT (mirrors the api-warning
+  "node's verdict stands" rule) and matches the harness shape (agent escalates, guard
+  routes), but the owner hasn't explicitly blessed it. It's in the progress log's
+  "behavioral note" — surface it during the Phase 1–2 review if they haven't seen it.
+- **`resolve_gate` hard-fails on a non-`GateResolution` return** ("broken resolver
+  installation"). Deliberate: a broken resolver silently approving would be the worst
+  failure mode. If Phase 3's resolver tests find this annoying, the strictness is the
+  point.
+- CONSIDER: the run-start non-interactive warning (plan §3.4) can only see top-level
+  gates — documented limitation, but when you write the guide (Phase 6) make sure the
+  limitation text survives; reviewers flagged it twice.
+- UNEXPLORED: what `pflow ui`'s run form should do about gated workflows pre-176
+  (today: launch → fail at gate with the browser-launched non-TTY error). Nobody asked
+  for UI-side warnings; don't build them, but the owner may ask.
+
+## What I'd tell myself starting Phase 3
+
+Start with the status ripple (§3.2) — it's pure wiring against an enumerated consumer
+map and unlocks the denied CLI tests. Then the resolver + flags (§3.3/3.4) with the
+UX-mock checkpoint. MCP param + parity test next (`test_cli_mcp_parity.py` — the
+split-session braindump called MCP "the non-TTY case in production"). Web arms last
+(tiny; verify with `screenshot-pflow-web-ui`). Then 5 → 6 → 7 are small. Finish with
+`/verify` on a real TTY (tests cannot exercise a real prompt) and the deep-review
+battery — pair `review-silent-failures` + `review-impact-completeness` on the diff (the
+pairing that caught what five other passes missed, twice now).
+
+> **Note to next agent**: Read this document fully before taking any action. When
+> ready, confirm you've read and understood by summarizing the key points, then state
+> you're ready to proceed.

--- a/.taskmaster/tasks/task_125/task-125.md
+++ b/.taskmaster/tasks/task_125/task-125.md
@@ -9,7 +9,10 @@ Add pause/resume capability to pflow workflows so execution halts at designated 
 > **Refreshed 2026-07-02 against main (post Tasks 172/173/175, #529/#531/#539/#540)** — see task_164's lineage section for the attempt-chain design.
 
 ## Status
-not started
+done
+
+## Completed
+2026-07-02
 
 ## Priority
 

--- a/.taskmaster/tasks/task_125/task-review.md
+++ b/.taskmaster/tasks/task_125/task-review.md
@@ -1,0 +1,218 @@
+# Task 125 Review: Human-in-the-Loop Approval Gates (blocking mode)
+
+## Metadata
+
+- Implemented 2026-07-02, branch `feat/human-loop-approval-gates`, PR #554 (open, not yet merged).
+- Commits: `2e533e2f` (phases 1-2, engine substrate), `301a002c` (phase 1-2 test pins), `2593884c`
+  (phases 3-7: resolver, DENIED status, `--auto-approve`, dry-run parity, docs), `9fe66c96`
+  (5 code-review fixes post-PR).
+- Chronological journey (plan, deviations, deep-review findings, day-by-day): see
+  `implementation/progress-log.md` — this review does not re-narrate it.
+- Project stakes: pflow is MVP-feature-complete on PyPI but explicitly has "no users yet — no
+  external compatibility to preserve" (root CLAUDE.md). Read this task's integration points as
+  load-bearing for the CODEBASE'S OWN forward development (Tasks 164/171/176 build directly on
+  this substrate), not as production-outage risk.
+
+## Read First — the load-bearing block
+
+**What exists now**: any `.pflow.md` step can declare `approval: required` (pauses for a
+terminal yes/no before it runs) or a `claude-code`/`code` step can raise a decision
+**escalation** via `result.escalation` (pauses for a choice). Both are one payload
+(`GateRequest`) resolved by one pluggable function (`__gate_resolver__`). Denial is a clean
+stop (`WorkflowStatus.DENIED`, exit 3), not a failure. Durable/non-TTY gates are **out of
+scope** — Task 171 builds on this substrate without changing the payload shape.
+
+**Read these first**:
+- `src/pflow/core/gate.py` — `GateRequest`/`GateResolution` (the payload IS the seam, ADR-0009).
+- `src/pflow/runtime/engine/gate.py` — `resolve_gate`, `run_approval_gate`, `detect_escalation`,
+  `run_escalation_gate`, `scan_batch_escalations` (the engine-side "when").
+- `src/pflow/runtime/engine/engine.py:994` `_execute_node` — seams at step 7.5 (pre-exec
+  approval), 10.5/17.7 (post-exec escalation detect/pause), and the
+  `except (GateDenied, GateNotInteractiveError)` handler (~line 1324) — the ONLY place a gate
+  verdict is distinguished from a node failure.
+- `src/pflow/execution/gate_prompt.py` — `build_gate_resolver` (the "how" — CLI TTY / MCP /
+  parallel-worker, ONE function).
+- `src/pflow/execution/plan.py::_annotate_entry` (renamed from `_annotate_loop_entry`) — the
+  single funnel stamping `PlanEntry.approval` for dry-run parity.
+
+**Invariants that must NOT break**:
+- **Gate trace lines (`kind: "gate"`) must stay DISK-ONLY** — never appended to
+  `collector.events`. Violating this makes a gate line the node's "final event" in
+  `final_events_by_node`, and `--only` snapshot seeding silently skips that node.
+- **`GateDenied`/`GateNotInteractiveError` must be re-raised UN-converted at every generic
+  `except Exception`** between the gate and the runner (engine `_execute_node`,
+  `WorkflowExecutor.exec`, batch retry loops via `retriable=False`). Losing this exemption at
+  any ONE of these four boundaries makes a human's "no" become error-routable —
+  `error_action: continue` would silently run past a denial.
+- **A sub-workflow host's own trace event must be recorded even on a gate stop** (see Gotchas
+  below) — skipping this orphans any sibling event recorded before the gate fired, and
+  `finalize()`/`tree()` raise in-memory, silently losing the run's trace file.
+- **Any new `PlanEntry` field that should affect dry-run parity must be forwarded in BOTH**
+  `_annotate_entry` (single-item path) **and** `_aggregate_batch_child_plans` (batch-of-workflow
+  path) — the second site already dropped `approval` once; it builds fresh `PlanEntry` objects
+  and does not inherit fields by default.
+- **`sorted()` on the parser IR at `_prepare_gate_resolver` must filter falsy node ids first** —
+  the IR hasn't been schema-validated yet at that call site.
+
+## What Was Built (actual vs. planned)
+
+The full plan (7 phases) is in `implementation/implementation-plan.md`; the real build tracked
+it closely but diverged in a few places worth knowing:
+
+- **`GateRequest`/`GateResolution` live in `core/gate.py`, not `runtime/engine/gate.py`** as
+  originally planned — `core/exceptions.py` needs to carry the payload on `GateDenied`/
+  `GateNotInteractiveError`, and `core/` cannot import `runtime/`. The engine-side *behavior*
+  (when to gate) still lives in `runtime/engine/gate.py`; only the payload dataclasses moved.
+- **Parallel-batch worker isolation is a boolean flag (`__gate_prompt_allowed__` →
+  `allow_prompt` kwarg), not resolver substitution.** The reviewed plan called for swapping in a
+  non-prompting resolver inside the worker's `item_shared`, mirroring the progress-callback
+  buffer pattern — rejected at implementation because building that resolver requires
+  `execution.gate_prompt.build_gate_resolver`, and `batch_executor.py` lives in `runtime/`,
+  which cannot import `execution/` (layering violation). The flag-plus-kwarg shape gets the
+  same guarantee (auto-approve works, prompting never does) without the cross-layer call.
+- **No `RunnerConfig.auto_approve` field.** The resolver travels as a `WorkflowRunner.run(...,
+  gate_resolver=...)` keyword argument, mirroring `progress_callback` end-to-end — CLI and MCP
+  each build their own via `build_gate_resolver`. `RunnerConfig` stayed execution-config-only.
+- **No dedicated `except GateDenied`/`except GateNotInteractiveError` arms in the runner.** The
+  plan assumed the generic `_exception_to_result` would need new arms; verification showed it
+  already preserves payload diagnostics correctly via `exception_to_diagnostics()`. `DENIED` vs
+  `FAILED` is now a one-line `isinstance` check inside the existing generic path.
+- **Escalation is in scope** (a mid-implementation owner decision, not in the original spec) —
+  the trigger is a reserved `result.escalation` key (works for any node type, not a new node
+  type), with a lenient-but-loud shape ladder (dict/string/malformed/schema-soft-fail-adjacent)
+  that never silently drops an escalation attempt without at least a degrading warning.
+- **`approval` is explicitly NOT stamped on `cached` `PlanEntry`s** (added during the deep-review
+  pass, not the original plan) — the engine's gate seam sits after the cache-hit early-return, so
+  a cache hit never gates; stamping it would make the dry-run footer/JSON promise a pause that
+  never happens.
+- **Guide topic hook deferred from Phase 1 to Phase 6** — it needed `guide/features/approval.md`
+  to exist first.
+
+## Patterns & Anti-Patterns
+
+**The payload-is-the-seam pattern (ADR-0009) paid off repeatedly** — one `GateRequest.to_dict()`
+feeds the TTY prompt, the `gate` trace event, the masked `GateNotInteractiveError` diagnostic,
+and (unchanged) will feed Task 171's persistence. When a review flagged masking as broken, the
+fix touched exactly the two render sites, not the payload itself. **Reuse this for any future
+human-decision or cross-surface payload**: one JSON-native dataclass, resolved by a plain
+function, never an ABC/strategy hierarchy (`ApprovalSurface` was explicitly proposed and
+rejected — "one adapter is a hypothetical seam" per project language).
+
+**One resolver builder, N configurations** (`build_gate_resolver(auto_approve,
+output_controller)` → CLI passes a real controller, MCP passes `None`, parallel workers pass
+`allow_prompt=False`) beats three parallel resolver implementations. `can_prompt` is reused for
+both the resolver's internal gate AND the CLI's pre-flight warning — no re-derivation.
+
+**Cross-cutting compile-time flags belong in ONE shared planner funnel.** `_annotate_entry`
+(the renamed `_annotate_loop_entry`) is the single place a `NodeConfig` fact gets projected onto
+a `PlanEntry`, covering both dispatch paths (standard node, sub-workflow). The lesson from the
+`_aggregate_batch_child_plans` bug: **a third path exists for batch-of-workflow aggregation,
+and it does NOT automatically inherit funnel-stamped fields** — it builds fresh `PlanEntry`
+objects from scratch. Any future NodeConfig flag needing dry-run visibility must explicitly
+check this third site too.
+
+**Anti-pattern, tried and reverted twice this session**: `git stash` to mutation-verify a fix.
+Untracked files don't stash, and in an earlier session this accidentally applied an unrelated
+stash from another branch. **Mutation-verify with a temporary `Edit` + revert instead** — used
+successfully 7 times across this task's two review-fix rounds, every time confirming the new
+test actually fails against the un-fixed code before trusting it.
+
+## Gotchas & Non-Obvious Coupling
+
+**The orphaned-trace-event bug (found by code review, not the original test suite) is the
+sharpest gotcha in this codebase.** `WorkflowExecutor.exec()` reserves a trace seq via
+`trace.descend()` before running a sub-workflow; the host's OWN completion event is normally
+written at engine step 16 (`record_trace`, reusing that reserved seq) — but only when
+`node._run()` *returns*. The Task 125 design deliberately makes gate exceptions `raise` instead
+of returning (so a denial can't be error-routed) — which means step 16 never runs, and the
+reserved seq gets no event. If a SIBLING step inside that sub-workflow already recorded before
+the gate fired, its event is now orphaned. The failure mode is NOT what it looks like: it's not
+a later "corrupt trace file" read error — `WorkflowTraceCollector.finalize()` itself calls
+`tree()` **in-memory** and raises there, *before* the `run.complete` trailer is ever written.
+`runner.py`'s `contextlib.suppress` swallows this silently, so a perfectly normal-looking denied
+run silently has no trace file at all (one easy-to-miss log line). The fix
+(`engine.py`'s gate-exception handler reading `getattr(node, "_host_frame", None)` and calling
+`record_trace(..., success=True, frame=host_frame)` before re-raising) is a genuinely
+non-obvious cross-file coupling: **`engine.py` now reaches into a `WorkflowExecutor`-instance
+attribute (`_host_frame`) that only exists because that specific node type happens to set it.**
+If `_host_frame`'s name or set-timing ever changes in `workflow_executor.py`, this silently
+regresses — the two mutation-verified tests in `test_gate_trace.py`
+(`test_denied_nested_gate_after_sibling_event_does_not_orphan_trace` and its non-interactive
+sibling) are the only thing that would catch it.
+
+**`resolved_via` disambiguates prompt vs. flag, but there's no `ui` value yet** — Task 176
+(web bridge) is expected to add it; don't be surprised the enum looks incomplete.
+
+**Escalation only fires on a CLEAN-SUCCESS action** (`""`/`"default"`/`"end"`/`None`) — a `code`
+node using dynamic `next:` routing cannot escalate from the same execution (its action IS the
+route target, and the detector defers to a node's own routing verdict, mirroring the existing
+api-warning-detector rule). Escalate from the agent step; route on the decision downstream.
+
+**The masking fix lives in two independent call sites** (`gate_prompt.py::_format_preview` and
+`exceptions.py::_masked_gate_payload`), both now calling `sanitize_parameters()` for non-string
+values but as separate, hand-written call expressions — there is no single shared "mask a gate
+preview" function. If the masking policy changes again, both sites need editing; nothing
+enforces they stay in sync beyond code review.
+
+**`sanitize_parameters()` truncates long strings to 100 chars** — a side effect of reusing it
+for nested-value masking that's more aggressive than `_format_preview`'s own 200-char
+truncation. Deliberately left as-is (applies only to previously-untruncated nested dict/list
+values, not top-level strings, which keep their existing 200-char path) — but if a preview ever
+looks unexpectedly short, this is why.
+
+**Batch-item gate events do not reach the trace** (deliberately NOT fixed — a known v1
+limitation, documented in `guide/features/approval.md`). A gate answered inside a `batch:`
+item's sub-workflow is honored correctly but leaves no audit trail, because batch-item children
+run under buffered (non-run-scoped) trace collectors. Flagged as Task 171's problem, since that
+task reworks how gate records persist anyway.
+
+## Integration Points
+
+**Depends on** (pre-existing, unmodified by this task): the `--only` snapshot machinery
+(`seed_snapshot_into_shared`, the loader's status allowlist — extended to reject `"denied"` too,
+same shape as `"failed"`), the `_PROPAGATED_KEYS` shared-store propagation mechanism (gained two
+new keys: `__gate_resolver__`, `__gate_prompt_allowed__`), `sanitize_parameters()` (a third
+consumer added), the streamed-trace disk-only-line convention (`node.start` was the only
+precedent; `gate` is the second).
+
+**Now depended on by** (forward): Task 171 (durable/non-TTY gates) persists `GateRequest`/
+`GateResolution` **unchanged** — do not casually restructure either dataclass without checking
+that task's plan. Task 176 (web approval bridge) will add a third `resolved_via` value (`"ui"`)
+and a tailer/SSE arm for the `gate` event kind (deliberately NOT built here — the event is
+observe-only in v1). Task 164 (failure-resume) shares the same checkpoint/restore/continue
+substrate conceptually but was not touched by this task.
+
+**Contract/shape changes**: `WorkflowStatus` gained `DENIED` (additive `str` enum value — every
+consumer verified to handle or safely degrade on it: CLI text/JSON, trace trailer via
+`gate_outcome`, three separate web status-render surfaces). `PlanEntry` gained `approval: bool
+= False`. New CLI flag `--auto-approve=<node-id>` (repeatable). New MCP `workflow_execute`
+parameter `auto_approve`. New exit code `3` (denied; click still owns `2`).
+
+## Tests That Matter
+
+- `tests/test_runtime/test_gate_trace.py::test_denied_nested_gate_after_sibling_event_does_not_orphan_trace`
+  + its non-interactive sibling — **mutation-verified**, reproduces the exact
+  `orphan event: parent_id ... not found` `JSONDecodeError` when the host-frame recording fix
+  is reverted. Run these whenever touching `WorkflowExecutor.exec`'s `_host_frame` handling or
+  the engine's gate-exception arm.
+- `tests/test_execution/test_plan_drift.py::test_plan_would_pause_matches_engine_gate_pauses` —
+  the parity pin (plan-side gated-id set vs. real engine gate-pause events from a streamed run),
+  covering standard/sub-workflow/loop shapes; separately
+  `test_plan_batch_sub_workflow_preserves_child_approval_flag` for the batch-aggregation path
+  specifically (the one that already dropped `approval` once — **mutation-verified**).
+- `tests/test_execution/test_gate_prompt.py::test_flag_echo_suppressed_on_worker_thread_with_real_output_controller`
+  — the ONLY test using the real `build_gate_resolver` with a real-shaped `OutputController` in
+  a worker-thread configuration; the pre-existing parallel-batch test used a test-double
+  resolver and could never have caught the echo race. **Mutation-verified.**
+- `tests/test_runtime/test_approval_gate.py::test_secret_nested_in_dict_value_masked_in_diagnostic`
+  + `test_gate_prompt.py`'s nested-secret tests — **mutation-verified**, guard the
+  credential-disclosure surface specifically (not just "masking exists," but "masking recurses").
+- `tests/test_runtime/test_approval_gate.py::TestRunnerBoundary` class — end-to-end through
+  `WorkflowRunner().run()` (not just the engine), pins that `GateDenied` → `WorkflowStatus.DENIED`
+  and `GateNotInteractiveError` → `FAILED` with intact payload diagnostics survive the full
+  runner conversion, and that `__gate_resolver__` propagates into nested child engines.
+
+---
+*Distilled from the implementation context of Task 125. The chronological journey — plan-stage
+verification, the 7-agent and 6-agent deep-review batteries, session-by-session deviations —
+lives in `implementation/progress-log.md`.*

--- a/.taskmaster/tasks/task_125/task-review.md
+++ b/.taskmaster/tasks/task_125/task-review.md
@@ -5,7 +5,9 @@
 - Implemented 2026-07-02, branch `feat/human-loop-approval-gates`, PR #554 (open, not yet merged).
 - Commits: `2e533e2f` (phases 1-2, engine substrate), `301a002c` (phase 1-2 test pins), `2593884c`
   (phases 3-7: resolver, DENIED status, `--auto-approve`, dry-run parity, docs), `9fe66c96`
-  (5 code-review fixes post-PR).
+  (5 code-review fixes post-PR), `5f161e4e` (verification-sweep fixes: batch-item index,
+  `GateResolverError`, escalation cost-trap doc, CLAUDE.md audit), plus the gate-preview
+  masking rework (mask-only `masked_preview`, no truncation — progress log session 4).
 - Chronological journey (plan, deviations, deep-review findings, day-by-day): see
   `implementation/progress-log.md` — this review does not re-narrate it.
 - Project stakes: pflow is MVP-feature-complete on PyPI but explicitly has "no users yet — no
@@ -23,13 +25,14 @@ stop (`WorkflowStatus.DENIED`, exit 3), not a failure. Durable/non-TTY gates are
 scope** — Task 171 builds on this substrate without changing the payload shape.
 
 **Read these first**:
-- `src/pflow/core/gate.py` — `GateRequest`/`GateResolution` (the payload IS the seam, ADR-0009).
+- `src/pflow/core/gate.py` — `GateRequest`/`GateResolution` (the payload IS the seam, ADR-0009)
+  + `masked_preview` (THE masking policy for every gate render surface — mask-only, never truncates).
 - `src/pflow/runtime/engine/gate.py` — `resolve_gate`, `run_approval_gate`, `detect_escalation`,
   `run_escalation_gate`, `scan_batch_escalations` (the engine-side "when").
 - `src/pflow/runtime/engine/engine.py:994` `_execute_node` — seams at step 7.5 (pre-exec
   approval), 10.5/17.7 (post-exec escalation detect/pause), and the
-  `except (GateDenied, GateNotInteractiveError)` handler (~line 1324) — the ONLY place a gate
-  verdict is distinguished from a node failure.
+  `except (GateDenied, GateNotInteractiveError, GateResolverError)` handler (~line 1324) — the
+  ONLY place a gate verdict is distinguished from a node failure.
 - `src/pflow/execution/gate_prompt.py` — `build_gate_resolver` (the "how" — CLI TTY / MCP /
   parallel-worker, ONE function).
 - `src/pflow/execution/plan.py::_annotate_entry` (renamed from `_annotate_loop_entry`) — the
@@ -95,8 +98,10 @@ it closely but diverged in a few places worth knowing:
 
 **The payload-is-the-seam pattern (ADR-0009) paid off repeatedly** — one `GateRequest.to_dict()`
 feeds the TTY prompt, the `gate` trace event, the masked `GateNotInteractiveError` diagnostic,
-and (unchanged) will feed Task 171's persistence. When a review flagged masking as broken, the
-fix touched exactly the two render sites, not the payload itself. **Reuse this for any future
+and (unchanged) will feed Task 171's persistence. When reviews flagged masking twice (nested
+secrets rendered verbatim; then non-secrets over-truncated), the fixes converged on ONE
+`masked_preview` beside the payload — render sites merely delegate, and the payload itself never
+changed. **Reuse this for any future
 human-decision or cross-surface payload**: one JSON-native dataclass, resolved by a plain
 function, never an ABC/strategy hierarchy (`ApprovalSurface` was explicitly proposed and
 rejected — "one adapter is a hypothetical seam" per project language).
@@ -151,17 +156,32 @@ node using dynamic `next:` routing cannot escalate from the same execution (its 
 route target, and the detector defers to a node's own routing verdict, mirroring the existing
 api-warning-detector rule). Escalate from the agent step; route on the decision downstream.
 
-**The masking fix lives in two independent call sites** (`gate_prompt.py::_format_preview` and
-`exceptions.py::_masked_gate_payload`), both now calling `sanitize_parameters()` for non-string
-values but as separate, hand-written call expressions — there is no single shared "mask a gate
-preview" function. If the masking policy changes again, both sites need editing; nothing
-enforces they stay in sync beyond code review.
+**Gate-preview masking is ONE shared function and it must never truncate**:
+`core/gate.py::masked_preview` (recursive redaction of secret-NAMED keys via
+`is_sensitive_parameter`), delegated to by both render sites (`gate_prompt.py::_format_preview`
+and `exceptions.py::_masked_gate_payload`). History that must not repeat: the first version
+routed nested values through `sanitize_parameters()`, whose side effect cuts any nested string
+over 100 chars down to ~20 — blinding the approver to an http `json:` body or sub-workflow
+`inputs:` field (PR #554 review warning; the tradeoff was originally accepted on the wrong
+belief it truncated "to 100 chars"). Length truncation belongs to each renderer only (the TTY
+prompt's 200-char step; diagnostics carry full masked values, matching the untruncated-payload
+rule). Pinned by the mutation-verified `long_nonsecret` tests in `test_gate_prompt.py` and
+`test_approval_gate.py`.
 
-**`sanitize_parameters()` truncates long strings to 100 chars** — a side effect of reusing it
-for nested-value masking that's more aggressive than `_format_preview`'s own 200-char
-truncation. Deliberately left as-is (applies only to previously-untruncated nested dict/list
-values, not top-level strings, which keep their existing 200-char path) — but if a preview ever
-looks unexpectedly short, this is why.
+**A resolver bug is gate-scoped, not a node failure (`GateResolverError`)** — added after an
+independent verification sweep: an unexpected resolver exception (or wrong return type) at the
+post-exec escalation seam previously fell to the generic except arm, which recorded a duplicate
+error event and archived the node's genuinely-successful output into `__failures__`. The new
+exception shares the gate exemptions (`retriable=False`, both boundary re-raise tuples, the
+host-frame trace fix), emits a `resolution: "error"` gate line, and reads `failed` in the
+trailer via `gate_outcome`.
+
+**Non-interactive escalation discards completed work** — the escalating step ran to completion,
+but its result is deliberately never cached (Decision 10: a cached escalation would replay on a
+later run as resolved-without-a-decision, because cache hits early-return before the detect
+seam), so the abort-and-rerun path re-pays the whole agent step. Documented in
+`guide/features/approval.md`; the real fix is Task 171 holding the gate open. Task 171 designers:
+this is the cost trap your feature eliminates.
 
 **Batch-item gate events do not reach the trace** (deliberately NOT fixed — a known v1
 limitation, documented in `guide/features/approval.md`). A gate answered inside a `batch:`
@@ -172,11 +192,12 @@ task reworks how gate records persist anyway.
 ## Integration Points
 
 **Depends on** (pre-existing, unmodified by this task): the `--only` snapshot machinery
-(`seed_snapshot_into_shared`, the loader's status allowlist — extended to reject `"denied"` too,
-same shape as `"failed"`), the `_PROPAGATED_KEYS` shared-store propagation mechanism (gained two
-new keys: `__gate_resolver__`, `__gate_prompt_allowed__`), `sanitize_parameters()` (a third
-consumer added), the streamed-trace disk-only-line convention (`node.start` was the only
-precedent; `gate` is the second).
+(`seed_snapshot_into_shared`; the loader's success/degraded allowlist naturally excludes
+`"denied"` — no code change was needed for that), the `_PROPAGATED_KEYS` shared-store
+propagation mechanism (gained two new keys: `__gate_resolver__`, `__gate_prompt_allowed__`),
+`is_sensitive_parameter()` (the shared word-aware secret-name rule, consumed by
+`core/gate.py::masked_preview`), the streamed-trace disk-only-line convention (`node.start` was
+the only precedent; `gate` is the second).
 
 **Now depended on by** (forward): Task 171 (durable/non-TTY gates) persists `GateRequest`/
 `GateResolution` **unchanged** — do not casually restructure either dataclass without checking
@@ -209,7 +230,9 @@ parameter `auto_approve`. New exit code `3` (denied; click still owns `2`).
   resolver and could never have caught the echo race. **Mutation-verified.**
 - `tests/test_runtime/test_approval_gate.py::test_secret_nested_in_dict_value_masked_in_diagnostic`
   + `test_gate_prompt.py`'s nested-secret tests — **mutation-verified**, guard the
-  credential-disclosure surface specifically (not just "masking exists," but "masking recurses").
+  credential-disclosure surface specifically (not just "masking exists," but "masking recurses");
+  the `long_nonsecret` pins in both files guard the opposite failure ("masking doesn't
+  over-truncate what the human is approving").
 - `tests/test_runtime/test_approval_gate.py::TestRunnerBoundary` class — end-to-end through
   `WorkflowRunner().run()` (not just the engine), pins that `GateDenied` → `WorkflowStatus.DENIED`
   and `GateNotInteractiveError` → `FAILED` with intact payload diagnostics survive the full

--- a/.taskmaster/tasks/task_125/task-review.md
+++ b/.taskmaster/tasks/task_125/task-review.md
@@ -39,11 +39,14 @@ scope** — Task 171 builds on this substrate without changing the payload shape
 - **Gate trace lines (`kind: "gate"`) must stay DISK-ONLY** — never appended to
   `collector.events`. Violating this makes a gate line the node's "final event" in
   `final_events_by_node`, and `--only` snapshot seeding silently skips that node.
-- **`GateDenied`/`GateNotInteractiveError` must be re-raised UN-converted at every generic
-  `except Exception`** between the gate and the runner (engine `_execute_node`,
+- **`GateDenied`/`GateNotInteractiveError`/`GateResolverError` must be re-raised UN-converted at
+  every generic `except Exception`** between the gate and the runner (engine `_execute_node`,
   `WorkflowExecutor.exec`, batch retry loops via `retriable=False`). Losing this exemption at
   any ONE of these four boundaries makes a human's "no" become error-routable —
-  `error_action: continue` would silently run past a denial.
+  `error_action: continue` would silently run past a denial. (`GateResolverError` — a resolver
+  bug, added post-review — needs the same exemption for a different reason: at the post-exec
+  escalation seam the node's success is already traced, and the generic arm would archive a
+  successful node into `__failures__` with a duplicate error event.)
 - **A sub-workflow host's own trace event must be recorded even on a gate stop** (see Gotchas
   below) — skipping this orphans any sibling event recorded before the gate fired, and
   `finalize()`/`tree()` raise in-memory, silently losing the run's trace file.

--- a/.taskmaster/tasks/task_133/design/d1-event-schema.md
+++ b/.taskmaster/tasks/task_133/design/d1-event-schema.md
@@ -226,7 +226,10 @@ The retry-aggregated `llm_usage` dict. **LLMNode** carries (all always unless no
   first-class events (today inline) — which also requires teaching `_rebuild_event_tree`/`tree()` to
   re-nest `batch_items` (today only `sub_workflow_events`), so batch-promotion and the `tree()` view are
   coupled — and the **parallel-batch `seq` ordering** choice (completion vs index order).
-- **`gate`/escalation `kind`** for Task 125 HITL (a non-result event — schema must allow it).
+- **`gate`/escalation `kind`** for Task 125 HITL — **SHIPPED (2026-07-02)**: `kind: "gate"`
+  lines (pause carrying the `GateRequest` + resolution with `resolved_via`), DISK-ONLY like
+  `node.start` (never in `collector.events`); the reconstruct reader treats the kind as
+  known-but-ignored (`trace_io._partition_trace_lines`). Writer: `WorkflowTraceCollector.record_gate`.
 - **OTel exporter:** align field names so export is a rename; build only when a second real consumer
   appears.
 

--- a/.taskmaster/tasks/task_164/starting-context/braindump-2026-07-02-task125-trace-contract-aftermath.md
+++ b/.taskmaster/tasks/task_164/starting-context/braindump-2026-07-02-task125-trace-contract-aftermath.md
@@ -1,0 +1,89 @@
+# Braindump: how Task 125's landing changed the trace contract under task-164.md's feet
+
+> Written 2026-07-02 at the close of the Task 125 verification/fix sessions (PR #554 branch
+> `feat/human-loop-approval-gates`), by the agent that ran the 6-agent plan-vs-code sweep and
+> the post-review fixes. Everything durable from those sessions is in task_125's task-review
+> and progress log — this file carries ONLY what is written nowhere and matters to 164.
+
+## The headline: "failed" traces now come in two flavors, and task-164.md assumes one
+
+`task-164.md:53` says failed runs persist `final_status:"failed"` + `failed_node_ids`, and
+`:66` designs the resume-scoped loader as "accepts `failed` (entry = first of
+`failed_node_ids`)". **Both statements predate Task 125 and are now incomplete:**
+
+1. **Node failure** (164's designed case): trailer `failed`, non-empty `failed_node_ids`,
+   the failed node has an error event. Loader design holds.
+2. **Gate failure** (new): a non-interactive gate (`GateNotInteractiveError`) or resolver bug
+   (`GateResolverError`) also yields trailer `failed` — but via the collector's
+   `gate_outcome` field, with **EMPTY `failed_node_ids` and NO failed node event**. For a
+   PRE-exec approval gate the gated node has **no events at all** (deliberate: no
+   `node.start`, no completion — it never ran). "Entry = first of failed_node_ids" hits an
+   empty list here. There is also a third terminal literal now, `final_status:"denied"`
+   (clean human "no", exit 3), which the `--only` allowlist deliberately excludes.
+
+What the loader should probably do (my recommendation, not decided anywhere): treat
+empty-`failed_node_ids` `failed` traces and `denied` traces as *gate-stopped*, and either
+(a) refuse with an actionable "this run stopped at gate '<id>' — re-run it" message, or
+(b) treat the gated node as the re-entry point. The re-entry node_id is recoverable ONLY from
+the raw `gate` JSONL lines (`kind:"gate"`, `phase:"pause"`, carries the full `GateRequest`)
+— these are **disk-only and invisible to `load_trace_file`** (the reconstruct reader skips
+the kind; reading them needs a raw line pass). Option (b) is literally Task 171's substrate
+(resume-at-a-gate), which is the argument for designing the loader arm so 171 plugs in
+rather than special-casing gate traces away. **Flag this in 164's plan phase and update
+task-164.md's loader section** — I did not edit it (that's 164's planning call).
+
+## NEEDS VERIFICATION: seeding can replay an undecided escalation silently
+
+Decision 10 (task 125 plan) skips BOTH cache writes for escalating results because "a memo
+hit silently replays the escalation as resolved-without-a-decision" — the cache-hit
+early-return sits before the detection seam. **The generalization nobody wrote down: that
+rationale applies to EVERY state-replay channel, and 164 is building a new one.**
+
+Concrete scenario: a non-interactive escalation abort leaves the escalating node's SUCCESS
+event in the trace with the undecided `result.escalation` marker inside `node_output`
+(post-exec seam: the node completed and was traced before the pause failed). That trace is
+trailer-`failed`, which today's `--only` allowlist rejects — but 164's resume-scoped loader
+*accepts failed traces by design*. If `seed_snapshot_into_shared` seeds that node as
+completed upstream, the undecided marker re-enters shared state where NO detection seam will
+ever fire (detection runs only on fresh execution in `_execute_node` step 10.5) and flows
+into downstream templates as if a human had decided. Rule to carry into the design: **an
+undecided `escalation` marker means the node is NOT valid upstream state** — treat that node
+as the re-entry point (re-run it) or refuse the resume. I'm ~85% sure the scenario is real
+(verified each link separately; never ran the combination end-to-end).
+
+## Smaller unwritten couplings 164 will trip on
+
+- **The trailer trap has three doors and 164 may add a fourth.** `_determine_trace_status`
+  has no signal for a run that stops without a failed node event; `gate_outcome` (stamped by
+  `record_gate` AND re-stamped by the engine's gate-except arm at every nesting level, root
+  last) is what keeps denied/gate-failed trailers honest. If 164's substrate introduces any
+  new stop-without-node-failure point (e.g. a `paused` trailer), it needs its own channel of
+  this shape or the trace self-reports `success`.
+- **Any new generic `except Exception` between engine and runner must preserve the
+  three-way gate exemption** (`GateDenied`/`GateNotInteractiveError`/`GateResolverError`,
+  all `retriable=False`). 164's restore/continue code paths are exactly where a new
+  conversion boundary tends to appear. The boundary inventory is in task_125's
+  implementation-plan + task-review invariants — grep before adding a handler.
+- **A resumed run through a gated node prompts again.** Gates are per-execution by design
+  ("each iteration is a new action" — same rule as loop re-prompting). 164's
+  resume-and-continue will run gated downstream nodes; say in the UX docs that resume does
+  not inherit prior approvals (`--auto-approve` works as usual).
+- **Escalation decisions are written into the marker BEFORE the walk's loop-re-entry check
+  reads the store** (step 17.7 vs `_run_inner`'s re-entry). If 164's continue mechanism
+  re-enters the walk through a new path, preserve that ordering or `loop:`+carry escalation
+  workflows break.
+
+## Context for reading the branch state
+
+- At the time of writing, everything through commit `5f161e4e` is committed; the
+  gate-preview masking rework (`core/gate.py::masked_preview`) + task-review accuracy pass
+  may still be uncommitted — check `git log` before assuming file contents match a hash.
+- The user's operating emphasis across these sessions, in their words: verify plan-vs-code
+  independently, "note any contradictions... and if they lead to any bad outcomes in the
+  code", fix everything found, and keep the durable docs "as accurate and relevant as
+  possible for future agents". Expect the same bar for 164: mutation-verified pins,
+  baseline-then-delta test reporting, deviations recorded as they happen.
+
+> **Note to next agent**: Read this document fully before taking any action. When ready,
+> confirm you've read and understood by summarizing the key points, then state you're ready
+> to proceed.

--- a/.taskmaster/tasks/task_176/task-176.md
+++ b/.taskmaster/tasks/task_176/task-176.md
@@ -49,6 +49,28 @@ Any approval surface = **read the gate → render `GateRequest` → deliver the 
 Earlier sizing estimate: ~50 lines of bridge. If it grows past "small," something is wrong — the
 engine and payload were designed so surfaces are cheap (the payload is the seam).
 
+## The agent-operated run (added 2026-07-02 — from the 125 planning session)
+
+The scenario this bridge really serves: the run's *operator* is an AI agent (Claude Code via
+shell, or the MCP server), but the gate's *approver* must be the human behind it. Named
+honestly during 125 planning:
+
+- **The gate is not a security boundary against the operating agent.** An agent with shell
+  access under the user's account can pass `--auto-approve=<node-id>`, run `pflow resume
+  <token> --approve`, or simply edit the workflow to delete the gate. No local design
+  prevents this — true prevention needs a secret outside the agent's reach, which doesn't
+  exist within one account.
+- What the design provides instead is **deliberate + visible + auditable** bypass: the flag
+  names the exact gate (and appears verbatim in the command the agent's own harness asks the
+  human to approve, one layer up); every gate resolution event carries `resolved_via:
+  prompt | flag | ui` (125 ships `prompt|flag`; this task adds `ui`), so "which gates were
+  self-approved by an agent" is a trivial trace audit; and 125's non-TTY gate error
+  explicitly instructs agents to ask their human before using `--auto-approve`.
+- This task's UI button is the **convenient human path** for agent-operated runs: the agent
+  relays the link, the human clicks approve in a surface the agent isn't driving. That's the
+  practical answer to "how does the human stay in the loop when an agent runs the workflow"
+  — convenience + audit, not enforcement.
+
 ## Explicitly out of scope
 
 - **Slack / email / webhook / any external surface.** Deliberately NOT tasked (Core Directive:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,11 +233,11 @@ MVP feature-complete. Published to PyPI (initial release v0.8.0; current version
 - ✅ Task 172: Streamable trace
 - ✅ Task 173: Live execution overlay
 - ✅ Task 175: Run workflows from the UI
+- ✅ Task 125: Human-in-the-Loop Approval Gates (blocking mode: `approval: required` + agent escalation; durable gates → Task 171)
 
 ### Planned Features (in order of priority)
 
 **Next?** (in build order)
-- Task 125: Human-in-the-Loop Approval Gates
 - Task 164: Resume Workflow From a Failed Node
 - Task 171: Durable Resume Tokens & Non-TTY Gates
 - Task 176: Web-UI Approval Bridge

--- a/context/CONTEXT.md
+++ b/context/CONTEXT.md
@@ -81,6 +81,22 @@ every *prior* step's output reused from the most recent full run, so only the ta
 re-executes and upstream side effects never re-fire. Requires a prior full run.
 _Avoid_: replay, restore, checkpoint.
 
+**Gate** — a pause in a Run where execution halts for a human decision before continuing.
+Two kinds: an Approval (author-declared) and an Escalation (agent-raised). The decision
+payload is structured data, rendered by whatever surface the human is on.
+_Avoid_: breakpoint, checkpoint, pause (unqualified).
+
+**Approval** — an author-declared Gate on a step: the Run halts *before* the step fires,
+shows the resolved action about to happen, and a human approves or denies it. Its position
+is known before the Run starts. _Avoid_: confirmation, ack, gate (unqualified).
+
+**Escalation** — an agent-raised Gate: mid-Run, an agent surfaces a decision it won't make
+alone (options, tradeoffs, a recommendation) and the human's choice feeds back into the
+work. Unpredictable — zero to many per Run. _Avoid_: interrupt, question, exception.
+
+**Denial** — the human's "no" at an Approval: the Run stops cleanly before the gated step
+runs. A human verdict, not a Failed run — nothing broke. _Avoid_: rejection, abort, failure.
+
 **Prompt cache** — provider-side reuse of a static prompt *prefix* across LLM calls, declared
 in a workflow's `## Cache` block (or per-step `prompt_cache:`). Discounts input tokens; the
 step still executes and calls the provider every time. _Avoid_: cache (unqualified), KV cache.
@@ -160,6 +176,14 @@ Auto-update is the *Viewer* watching the *source `.pflow.md`* to live-rebuild th
 with `--no-auto-update`); Watch is the *agent* watching the *user's* interactions (read via
 `user-activity`); Overlay is the *Viewer* watching a *Run's trace* to draw live execution state.
 Different watcher, different watched, every time.
+
+**Approval vs Escalation** — both halt a Run for a human. Discriminator: who knows about it
+before the Run — an Approval is authored at a known step (approve/deny a known action); an
+Escalation is raised by an agent at runtime (choose among options nobody could list in
+advance).
+
+**Denial vs Failed** — both end a Run early. Discriminator: Denial is a human's verdict at a
+Gate (the gated step never ran; nothing broke); Failed is a fatal error (something did).
 
 **Workflow vs Run** — both name "the thing that ran." Discriminator: the Workflow is the reusable
 `.pflow.md` *definition* (authored once); a Run is one *execution* of it (one per `pflow run`). One

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -123,6 +123,7 @@
           "how-it-works/template-variables",
           "how-it-works/loops",
           "how-it-works/batch-processing",
+          "how-it-works/approval-gates",
           "how-it-works/prompt-caching"
         ]
       },

--- a/docs/how-it-works/approval-gates.mdx
+++ b/docs/how-it-works/approval-gates.mdx
@@ -1,0 +1,56 @@
+---
+title: "Approval Gates"
+description: "Pause a workflow for a human decision with approval: required"
+---
+
+Add `approval: required` to any step and the run pauses before that step, shows what is about to happen, and waits for a yes/no. This is how you trust a workflow with real-world actions — sending messages, creating issues, deploying — without giving up the final say.
+
+```md
+### notify-slack
+
+Post the release summary to Slack.
+
+- type: mcp-composio-slack-SLACK_SEND_MESSAGE
+- channel: ${slack_channel}
+- markdown_text: ${create-summary.result}
+- approval: required
+```
+
+At a terminal:
+
+```text
+⏸  Approval required: notify-slack (mcp-composio-slack-SLACK_SEND_MESSAGE)
+
+   channel:        #releases
+   markdown_text:  v0.9.0 released with 3 features: …
+
+   Run this step? [y/N]:
+```
+
+The preview shows **resolved values** — the actual message text, not `${...}` templates. You approve what will happen, not the abstract definition.
+
+## Denying
+
+Answering no stops the run cleanly **before the step runs**: nothing fired, nothing failed. The exit code is `3` (distinct from `1` for failures — a human verdict is not an error), and the trace records `final_status: "denied"`.
+
+## Pre-approving gates
+
+For CI or agent-operated runs, pre-approve specific gates by step name:
+
+```bash
+pflow my-workflow --auto-approve=notify-slack
+```
+
+The flag is per-step and repeatable — there is deliberately no approve-everything form. Each pre-approval is recorded in the trace (`resolved_via: flag`), so you can always audit which gates a human answered live versus approved in advance.
+
+## Non-interactive runs
+
+A run with no terminal (piped, launched from the web UI, or via the MCP server) cannot prompt. A gate reached without pre-approval fails immediately and loudly — never hangs — with instructions that tell an operating AI agent to ask its human before continuing. A warning also fires at run start when the workflow has unapproved top-level gates.
+
+Use `--dry-run` to discover gates before running: gated steps are tagged `[…, approval]` and summarized in a `⏸` footer.
+
+## Escalations — the agent asks you
+
+The second gate kind is raised by an agent step at runtime instead of declared by you. When a `claude-code` step discovers a decision it should not make alone, it returns an `escalation` object (question, options, recommendation) in its structured output — the run pauses, you choose (pick an option or type an answer), and your decision is written back into the step's result for the workflow to act on, typically by re-running the agent with the decision via `loop:`.
+
+See `pflow guide approval` for the escalation contract, the re-fork recipe, and the full rules (batch steps can't be gated — gate around them; loop steps prompt every iteration; cached steps never prompt).

--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -81,6 +81,7 @@ pflow ~/workflows/analysis.pflow.md param=value
 | `--no-trace` | Disable workflow trace saving |
 | `--cache/--no-cache` | Enable/disable memoization cache reads (default: enabled) |
 | `--only NODE` | Re-run just this node against a snapshot of the last full run (upstream restored, not re-executed; needs a prior full run) |
+| `--auto-approve NODE` | Pre-approve one approval gate by step name (repeatable; no approve-all form). See [Approval gates](/how-it-works/approval-gates) |
 | `--validate-only` | Validate workflow without running |
 | `--dry-run` | Preview which nodes would run or serve from cache, without executing |
 | `--help` | Show help message |

--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -260,7 +260,7 @@ See `core/CLAUDE.md` (shell_integration section) for FIFO detection, StdinData m
 | Source file | Primary test file(s) |
 |------------|---------------------|
 | `main.py` | `test_cli.py`, `test_main.py` |
-| `commands/run.py` | `test_workflow_resolution.py`, `test_dual_mode_stdin.py`, `test_parse_error_handling.py`, `test_workflow_output_handling.py`, `test_validate_only.py`, `test_validation_before_execution.py`, `test_dry_run.py` |
+| `commands/run.py` | `test_workflow_resolution.py`, `test_dual_mode_stdin.py`, `test_parse_error_handling.py`, `test_workflow_output_handling.py`, `test_validate_only.py`, `test_validation_before_execution.py`, `test_dry_run.py`, `test_approval_gate_cli.py` |
 | `error_output.py` | `test_unified_error_output.py`, `test_enhanced_error_output.py` |
 | `workflow_output.py` | `test_shell_stderr_warnings.py`, `test_direct_execution_helpers.py`, `test_workflow_output_source_simple.py` |
 | `workflow_resolution.py` | `test_workflow_resolution.py` |

--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -139,7 +139,7 @@ Error output is unified: `output_error()` in `error_output.py` handles JSON/text
 
 ### Exit Codes
 
-Completed workflows exit `0`, including `WorkflowStatus.DEGRADED` runs with runtime warnings. Failed workflows exit `1`; interrupted workflows exit `130`. Warning/degraded status remains visible through stderr, JSON, trace, and reports.
+Completed workflows exit `0`, including `WorkflowStatus.DEGRADED` runs with runtime warnings. Failed workflows exit `1`; interrupted workflows exit `130`; a run DENIED at an approval gate exits `3` (Task 125 — a human verdict, not a failure; click owns `2` for usage errors). The denied branch in `_display_execution_result` renders its own output (text prose on stderr, or a JSON document with the `gate` payload on stdout) and never routes through `output_error`/`_emit_failure_tag`. Warning/degraded status remains visible through stderr, JSON, trace, and reports.
 
 ## Command Flags
 
@@ -157,6 +157,7 @@ Completed workflows exit `0`, including `WorkflowStatus.DEGRADED` runs with runt
 --no-trace             # Disable automatic workflow trace saving
 --cache/--no-cache     # Enable/disable memoization cache reads (default: --cache). Writes always happen.
 --only <node>          # Re-run just this node against a snapshot of the most recent full run (upstream restored, not re-executed — no re-fire). Needs a prior full run; dotted/nested targets rejected (issue #443).
+--auto-approve <id>    # Pre-approve ONE approval gate by step name (repeatable, per-node only — no blanket form by design, Task 125). Escalations never pre-approve. Flat namespace across the workflow tree: a nested gate matches by name. An id naming no TOP-LEVEL step → informational note (closest match + gated list), never an error — it may be a legitimate nested gate.
 --validate-only        # Validate without executing (exit 0/1), auto-normalizes IR
 --dry-run              # Build execution plan without side effects
 --report               # Generate execution report

--- a/src/pflow/cli/commands/CLAUDE.md
+++ b/src/pflow/cli/commands/CLAUDE.md
@@ -131,7 +131,7 @@ LLM model resolution chain (genuinely hard to discover):
 
 | Command file | Test file(s) | Key mock.patch targets |
 |-------------|-------------|----------------------|
-| `run.py` | `test_workflow_resolution.py`, `test_validate_only.py`, `test_validate_verb_redirect.py`, `test_workflow_commands.py`, `test_dual_mode_stdin.py`, `test_dry_run.py` | `pflow.cli.commands.run.WorkflowManager`, `.execute_json_workflow` |
+| `run.py` | `test_workflow_resolution.py`, `test_validate_only.py`, `test_validate_verb_redirect.py`, `test_workflow_commands.py`, `test_dual_mode_stdin.py`, `test_dry_run.py`, `test_approval_gate_cli.py` | `pflow.cli.commands.run.WorkflowManager`, `.execute_json_workflow` |
 | `list.py` | `test_workflow_commands.py` | `pflow.cli.commands.list.WorkflowManager` |
 | `describe.py` | `test_workflow_commands.py` | `pflow.cli.commands.describe.WorkflowManager` |
 | `history.py` | `test_workflow_commands.py` | `pflow.cli.commands.history.WorkflowManager` |

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -369,7 +369,11 @@ def _prepare_gate_resolver(
 
     auto_approve = frozenset(ctx.obj.get("auto_approve") or ())
     nodes = ir_data.get("nodes", [])
-    node_ids = {node.get("id") for node in nodes}
+    # Defensive: schema validation (which requires "id" on every node) hasn't
+    # run yet at this call site. Filtering falsy ids here (rather than at each
+    # sorted() call below) keeps a malformed node dict from raising TypeError
+    # on a mixed None/str sort.
+    node_ids = {node.get("id") for node in nodes if node.get("id")}
     # Under --only, only the target executes (upstream is snapshot-seeded) — a gate
     # anywhere else cannot fire, so warning about it would be a false alarm.
     only_node = ctx.obj.get("only_node")

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -295,6 +295,7 @@ def execute_json_workflow(  # noqa: C901
 
     output_controller = _get_output_controller(ctx)
     progress_enabled = not print_flag
+    gate_resolver = _prepare_gate_resolver(ctx, ir_data, output_controller)
 
     if effective_verbose:
         click.echo(f"cli: Starting workflow execution with {ctx.obj['total_nodes']} node(s)", err=True)
@@ -312,6 +313,7 @@ def execute_json_workflow(  # noqa: C901
             params,
             config,
             progress_callback=progress_callback,
+            gate_resolver=gate_resolver,
             workflow_manager=WorkflowManager() if ctx.obj.get("workflow_source") == "library" else None,
             workflow_name=workflow_name,
         )
@@ -347,6 +349,108 @@ def execute_json_workflow(  # noqa: C901
         _cleanup_temp_files(stdin_data, effective_verbose)
 
 
+def _prepare_gate_resolver(
+    ctx: click.Context,
+    ir_data: dict[str, Any],
+    output_controller: OutputController,
+) -> Any:
+    """Build this run's gate resolver + emit the gate pre-flight warnings.
+
+    Warnings (stderr, suppressed by -p) fire per Task 125 Decision 4:
+    - an ``--auto-approve`` id matching no top-level step (typo guard — child
+      gate ids are legitimate but invisible here, hence "top-level" phrasing);
+    - declared gates that will fail because this run cannot prompt (fail-at-gate
+      is the primary contract; this warning preserves visibility up front).
+    Both scans see TOP-LEVEL nodes only — a gate inside a sub-workflow warns
+    nowhere and fails at the gate (documented limitation).
+    """
+    from pflow.core.suggestion_utils import find_similar_items
+    from pflow.execution.gate_prompt import build_gate_resolver, can_prompt
+
+    auto_approve = frozenset(ctx.obj.get("auto_approve") or ())
+    nodes = ir_data.get("nodes", [])
+    node_ids = {node.get("id") for node in nodes}
+    # Under --only, only the target executes (upstream is snapshot-seeded) — a gate
+    # anywhere else cannot fire, so warning about it would be a false alarm.
+    only_node = ctx.obj.get("only_node")
+    gated = [
+        node.get("id")
+        for node in nodes
+        if node.get("approval") and node.get("id") and (only_node is None or node.get("id") == only_node)
+    ]
+
+    if not ctx.obj.get("print_flag", False):
+        for flag_id in sorted(auto_approve - node_ids):
+            # This scan sees TOP-LEVEL steps only, but the resolver's namespace is
+            # flat across the workflow tree — a gate inside a sub-workflow (which
+            # the --dry-run footer legitimately names) matches this flag and works.
+            # So this must read as a note covering both cases, never as a
+            # confident "typo" verdict that contradicts the dry-run footer.
+            similar = find_similar_items(flag_id, gated or sorted(node_ids), method="fuzzy", max_results=1)
+            hint = f" If it is a typo: closest top-level match is '{similar[0]}'." if similar else ""
+            gated_list = f" Top-level gated steps: {', '.join(gated)}." if gated else ""
+            click.echo(
+                f"Note: --auto-approve={flag_id} does not name a top-level step. A gate inside a "
+                f"sub-workflow still matches by name.{hint}{gated_list}",
+                err=True,
+            )
+        unapproved = [gate_id for gate_id in gated if gate_id not in auto_approve]
+        if unapproved and not can_prompt(output_controller):
+            flags = " ".join(f"--auto-approve={gate_id}" for gate_id in unapproved)
+            click.echo(
+                f"Warning: this run is non-interactive and will fail at approval "
+                f"gate(s) [{', '.join(unapproved)}] unless pre-approved ({flags}).",
+                err=True,
+            )
+
+    return build_gate_resolver(auto_approve, output_controller)
+
+
+def _display_denied_result(ctx: click.Context, result: Any, output_format: str) -> None:
+    """Render a DENIED run: prose on stderr, or a JSON document on stdout.
+
+    The JSON document exists because the denied branch bypasses ``output_error``
+    (the only path to the failure JSON emitter) — without it, ``--output-format
+    json`` would emit NOTHING on deny.
+    """
+    gate_diag = next(
+        (d for d in result.diagnostics if d.context and d.context.get("category") == "gate"),
+        None,
+    )
+    node_id = gate_diag.node_id if gate_diag else None
+    message = gate_diag.message if gate_diag else "Denied at gate."
+
+    if output_format == "json":
+        # A strict superset of the unified `success: false` shape (error_output.py
+        # emits {success, status, error, errors, diagnostics, ...}) — agents that
+        # branch on success==false and iterate .diagnostics/.errors must find the
+        # denial there, not only in the bespoke `gate` key.
+        diagnostics = [d.to_dict() for d in result.diagnostics]
+        document = {
+            "success": False,
+            "status": "denied",
+            "error": message,
+            "errors": [d.to_dict() for d in result.errors],
+            "diagnostics": diagnostics,
+            "gate": gate_diag.context.get("gate") if gate_diag else None,
+        }
+        click.echo(json.dumps(document, indent=2, default=str))
+        return
+
+    execution = result.shared_after.get("__execution__", {}) if result.shared_after else {}
+    completed = len(execution.get("completed_nodes", []))
+    total = ctx.obj.get("total_nodes") if ctx.obj else None
+    progress = f" Steps completed: {completed} of {total}." if total else ""
+    gate_name = f" '{node_id}'" if node_id else ""
+    click.echo(
+        click.style(
+            f"✗ Denied at gate{gate_name}. Workflow stopped cleanly before the step ran.{progress} (exit 3)",
+            fg="yellow",
+        ),
+        err=True,
+    )
+
+
 def _emit_failure_tag(ctx: click.Context, metrics: Any | None) -> None:
     """Emit one-line failure tag to stderr for agent observability."""
     print_flag = ctx.obj.get("print_flag", False) if ctx.obj else False
@@ -365,6 +469,14 @@ def _display_execution_result(
 ) -> None:
     """Display execution result and set exit code."""
     from pflow.cli.error_output import output_error
+    from pflow.core.workflow.status import WorkflowStatus
+
+    if result.status is WorkflowStatus.DENIED:
+        # A human's "no" at an approval gate (Task 125 Decision 5): clean stop,
+        # its own rendering + exit code 3 — never the failure path (no ❌ tag,
+        # no error formatter; a workflow must not read denial as a failure).
+        _display_denied_result(ctx, result, output_format)
+        ctx.exit(3)
 
     if result.success:
         _handle_workflow_success(
@@ -536,6 +648,7 @@ _PFLOW_FLAGS = frozenset({
     "--cache",
     "--no-cache",
     "--only",
+    "--auto-approve",
 })
 
 
@@ -1007,6 +1120,17 @@ def _handle_invalid_workflow_input(workflow: tuple[str, ...]) -> None:
     default=None,
     help="Re-run just this node against a snapshot of the most recent full run — upstream is restored, not re-executed, so side-effecting upstream does not re-fire. Requires a prior full run (errors otherwise). Targeting a node inside a sub-workflow is not supported. A loop node runs one iteration.",
 )
+@click.option(
+    "--auto-approve",
+    "auto_approve",
+    multiple=True,
+    metavar="NODE_ID",
+    help=(
+        "Pre-approve ONE approval gate by step name (repeatable; no blanket form). "
+        "For AI agents: ask your human before passing this — the gate exists so a "
+        "person reviews the action. Escalations cannot be pre-approved."
+    ),
+)
 @click.argument("workflow", nargs=-1, type=click.UNPROCESSED)
 def run(
     ctx: click.Context,
@@ -1020,6 +1144,7 @@ def run(
     dry_run: bool,
     cache: bool,
     only_node: str | None,
+    auto_approve: tuple[str, ...],
     workflow: tuple[str, ...],
 ) -> None:
     """Execute a workflow file or saved workflow."""
@@ -1047,6 +1172,7 @@ def run(
         ctx.obj["report"] = report_dir or ("auto" if report_enabled else None)
         ctx.obj["cache"] = cache
         ctx.obj["only_node"] = only_node
+        ctx.obj["auto_approve"] = auto_approve
 
         print_flag = ctx.obj.get("print_flag", False)
         output_format = ctx.obj.get("output_format", "text")

--- a/src/pflow/cli/workflow_output.py
+++ b/src/pflow/cli/workflow_output.py
@@ -710,7 +710,7 @@ def _format_workflow_completion_status(
 
     Args:
         duration_s: Execution duration in seconds
-        status: Workflow status ("success", "degraded", "failed")
+        status: Workflow status ("success", "degraded", "failed", "denied")
         has_stderr_warnings: Whether any shell node produced stderr with exit_code=0
         cache_hits: Number of nodes served from cache (0 = no cache stats shown)
         nodes_executed: Total completed nodes (used to compute fresh executions)
@@ -723,6 +723,11 @@ def _format_workflow_completion_status(
 
     if status == "degraded":
         return f"⚠️ Workflow completed with warnings in {duration_s:.3f}s{cache_suffix}"
+    if status == "denied":
+        # Task 125: explicit arm — the success fallthrough below must never
+        # render a human's "no" as ✓. (The denied CLI path has its own display;
+        # this guards any other caller passing the status through.)
+        return f"✗ Workflow denied at gate after {duration_s:.3f}s{cache_suffix}"
     if status == "failed":
         if warning_count:
             return f"❌ Workflow failed ({warning_count} warnings) after {duration_s:.3f}s{cache_suffix}"

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -11,6 +11,7 @@ src/pflow/core/
 ├── __init__.py              # Public API exports
 ├── node.py                  # Node lifecycle primitives (BaseNode, Node, wiring operators)
 ├── exceptions.py            # Exception hierarchy (incl. CompilationError, MaxNodeVisitsError)
+├── gate.py                  # Task 125: GateRequest/GateResolution — the human-decision payload (ADR-0009: the payload is the seam)
 ├── diagnostic.py            # Diagnostic type, exception conversion, dedup
 ├── diagnostic_render.py     # format_diagnostic text renderer
 ├── ir_schema.py             # IR schema definition and validation
@@ -80,6 +81,12 @@ PflowError(Exception)                    <- base for all pflow errors
   |- UnsupportedCacheTTLError            <- cache TTL not supported by provider (Task 159)
   |- ReportGenerationError               <- trace report generation failure
   |- OnlySnapshotMissingError            <- --only has no prior full-run trace to restore upstream from (issue #443)
+  |- GateDenied                          <- Task 125: human denied an approval gate. retriable=False. NEVER a node
+  |                                         failure — exempted (re-raised untouched) at every generic except between
+  |                                         the gate and the runner (engine, WorkflowExecutor, batch retry loops)
+  |- GateNotInteractiveError             <- Task 125: gate fired with no human channel (no resolver / parallel-batch
+  |                                         worker). retriable=False, same exemptions. to_diagnostics() carries the
+  |                                         full GateRequest (secrets masked) + the ask-your-human remediation ladder
   |- LoopConditionError                  <- loop `until`/condition evaluation failed (raised by runtime/engine/loop_control.py)
   |- LoopCarryError                      <- loop carry-state propagation failed (raised by runtime/engine/loop_control.py)
   |- LLMCallError                        <- LLM adapter base for ALL provider errors (raised by llm_client)

--- a/src/pflow/core/CLAUDE.md
+++ b/src/pflow/core/CLAUDE.md
@@ -56,7 +56,7 @@ src/pflow/core/
 │   ├── save_service.py      # Shared save operations (CLI + MCP)
 │   ├── validator.py         # Unified validation orchestrator
 │   ├── data_flow.py         # Execution order and dependency validation
-│   ├── status.py            # SUCCESS/DEGRADED/FAILED tri-state enum
+│   ├── status.py            # SUCCESS/DEGRADED/FAILED/DENIED status enum
 │   ├── skill_service.py     # Publish workflows as AI agent skills (symlinks)
 │   ├── context.py           # Workflow context for discovery (build_workflows_context)
 │   ├── discovery.py         # LLM-powered workflow discovery (find_workflow)
@@ -87,6 +87,10 @@ PflowError(Exception)                    <- base for all pflow errors
   |- GateNotInteractiveError             <- Task 125: gate fired with no human channel (no resolver / parallel-batch
   |                                         worker). retriable=False, same exemptions. to_diagnostics() carries the
   |                                         full GateRequest (secrets masked) + the ask-your-human remediation ladder
+  |- GateResolverError                   <- Task 125: the resolver itself raised or returned a non-GateResolution
+  |                                         (a resolver-installation bug). retriable=False, same exemptions — at the
+  |                                         post-exec escalation seam the node's success is already traced, and the
+  |                                         generic arm would archive a successful node into __failures__
   |- LoopConditionError                  <- loop `until`/condition evaluation failed (raised by runtime/engine/loop_control.py)
   |- LoopCarryError                      <- loop carry-state propagation failed (raised by runtime/engine/loop_control.py)
   |- LLMCallError                        <- LLM adapter base for ALL provider errors (raised by llm_client)

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -1041,12 +1041,19 @@ def _masked_gate_payload(request: GateRequest) -> dict[str, Any]:
     The diagnostic reaches agents/humans through error text and MCP responses —
     secrets don't inform an approval decision. (The trace's gate event carries
     the unmasked payload, consistent with the trace's ``template_resolutions``.)
+
+    ``mask_sensitive_value`` only checks the TOP-LEVEL key, so a dict/list value
+    (``headers: {Authorization: ...}``) recurses through ``sanitize_parameters``
+    instead — code-review fix: previously such a nested secret reached MCP/JSON
+    error surfaces unmasked.
     """
-    from pflow.core.security_utils import mask_sensitive_value
+    from pflow.core.security_utils import mask_sensitive_value, sanitize_parameters
 
     payload = request.to_dict()
     payload["preview"] = {
-        key: mask_sensitive_value(key, value) if isinstance(value, str) else value
+        key: mask_sensitive_value(key, value)
+        if isinstance(value, str)
+        else sanitize_parameters({key: value}).get(key, value)
         for key, value in payload.get("preview", {}).items()
     }
     return payload

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -1035,6 +1035,42 @@ class GateNotInteractiveError(PflowError):
         ]
 
 
+class GateResolverError(PflowError):
+    """The installed gate resolver itself failed (Task 125).
+
+    Raised when a resolver raises an unexpected exception or returns the wrong
+    type — a bug in the resolver installation, NOT a human verdict and NOT a
+    node failure. It shares the gate exceptions' exemptions (``retriable=False``,
+    re-raised untouched at every generic boundary) for one reason: the post-exec
+    escalation seam runs AFTER the node's success was traced, and the generic
+    arm would record a second (error) event for the node and archive its
+    genuinely-successful output into ``__failures__``. The run still fails —
+    the runner surfaces it as a normal FAILED result.
+    """
+
+    retriable = False
+
+    def __init__(self, request: GateRequest, *, detail: str):
+        self.request = request
+        super().__init__(f"Gate resolver failed at gate '{request.node_id}': {detail}")
+
+    def to_diagnostics(self) -> list[Diagnostic]:
+        return [
+            Diagnostic(
+                severity=Severity.ERROR,
+                message=str(self),
+                title="Gate resolver failed",
+                node_id=self.request.node_id,
+                source="runtime",
+                suggestions=[
+                    "This is a bug in the gate resolver installation (CLI, MCP, or a custom surface), "
+                    "not in the workflow — the gated step was not silently approved or denied."
+                ],
+                context={"category": "gate", "gate": _masked_gate_payload(self.request)},
+            )
+        ]
+
+
 def _masked_gate_payload(request: GateRequest) -> dict[str, Any]:
     """GateRequest as a dict with secret-like preview values redacted.
 

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from pflow.core.cache_ttl import build_unsupported_cache_ttl_diagnostic, unsupported_cache_ttl_message
 from pflow.core.diagnostic import LLM_FAILURE_CATEGORY, Diagnostic, Severity
+from pflow.core.gate import GATE_KIND_APPROVAL, GateRequest
 from pflow.core.llm_providers import detect_provider, extract_provider_prefix
 
 # Typed discriminators for LLMCallError subclasses. Carried as Literal so
@@ -941,6 +942,114 @@ class OnlySnapshotMissingError(PflowError):
                 context={"category": "execution_failure"},
             )
         ]
+
+
+class GateDenied(PflowError):
+    """A human denied an approval Gate (Task 125).
+
+    A human verdict, NOT a node failure: the gated node never ran, nothing broke.
+    This exception is pure control flow — it must cross every generic
+    ``except Exception`` between the gate and the runner UN-converted (engine
+    ``_execute_node``, ``WorkflowExecutor.exec``, batch retry loops via
+    ``retriable=False``), where the runner maps it to a clean DENIED result.
+    Never route it through ``error_action``/on-error edges — a workflow must not
+    "handle" a human's no.
+    """
+
+    retriable = False
+
+    def __init__(self, request: GateRequest):
+        self.request = request
+        super().__init__(f"Denied at gate '{request.node_id}'.")
+
+    def to_diagnostics(self) -> list[Diagnostic]:
+        return [
+            Diagnostic(
+                severity=Severity.ERROR,
+                message=str(self),
+                title="Gate denied",
+                node_id=self.request.node_id,
+                source="runtime",
+                context={"category": "gate", "gate": _masked_gate_payload(self.request)},
+            )
+        ]
+
+
+class GateNotInteractiveError(PflowError):
+    """A Gate fired but this run has no way to ask a human (Task 125).
+
+    Carries the full ``GateRequest`` so the operating agent can show its human
+    exactly WHAT was about to happen — approving blind defeats the gate. Like
+    ``GateDenied``, it is exempted from every generic exception-conversion
+    boundary (``retriable=False`` keeps batch retry loops from re-firing the
+    gate); the runner surfaces it as a normal FAILED result with these
+    diagnostics intact.
+    """
+
+    retriable = False
+
+    def __init__(self, request: GateRequest, *, parallel_batch: bool = False):
+        self.request = request
+        self.parallel_batch = parallel_batch
+        if parallel_batch:
+            cause = "it fired inside a parallel batch item, which cannot host a prompt"
+        else:
+            cause = "this run is non-interactive (launched from the web UI, MCP, or a pipe — no terminal to prompt on)"
+        kind = "approval" if request.kind == GATE_KIND_APPROVAL else "escalation"
+        super().__init__(f"Step '{request.node_id}' requires a human {kind} decision, but {cause}.")
+
+    def to_diagnostics(self) -> list[Diagnostic]:
+        suggestions = [
+            "If you are an AI agent: ask your human before continuing — this gate exists so a person reviews the action."
+        ]
+        if self.request.kind == GATE_KIND_APPROVAL:
+            suggestions.append(
+                f"With their OK, pre-approve ONLY this gate: CLI `--auto-approve={self.request.node_id}`; "
+                f'MCP workflow_execute: `auto_approve=["{self.request.node_id}"]`.'
+            )
+            if self.parallel_batch:
+                suggestions.append(
+                    "Or restructure: move `approval:` to a step outside the batch, "
+                    "or set `parallel: false` on the batch."
+                )
+        else:
+            suggestions.append(
+                "Escalations cannot be pre-approved — run interactively, "
+                "or re-run with the answer supplied as a workflow input."
+            )
+        suggestions.append("pflow cannot yet hold a gate open for a later answer.")
+        return [
+            Diagnostic(
+                severity=Severity.ERROR,
+                message=str(self),
+                title="Gate needs a human",
+                node_id=self.request.node_id,
+                source="runtime",
+                suggestions=suggestions,
+                context={
+                    "category": "gate",
+                    "gate": _masked_gate_payload(self.request),
+                    "parallel_batch": self.parallel_batch,
+                },
+            )
+        ]
+
+
+def _masked_gate_payload(request: GateRequest) -> dict[str, Any]:
+    """GateRequest as a dict with secret-like preview values redacted.
+
+    The diagnostic reaches agents/humans through error text and MCP responses —
+    secrets don't inform an approval decision. (The trace's gate event carries
+    the unmasked payload, consistent with the trace's ``template_resolutions``.)
+    """
+    from pflow.core.security_utils import mask_sensitive_value
+
+    payload = request.to_dict()
+    payload["preview"] = {
+        key: mask_sensitive_value(key, value) if isinstance(value, str) else value
+        for key, value in payload.get("preview", {}).items()
+    }
+    return payload
 
 
 class MaxNodeVisitsError(RuntimeError):

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -1072,26 +1072,18 @@ class GateResolverError(PflowError):
 
 
 def _masked_gate_payload(request: GateRequest) -> dict[str, Any]:
-    """GateRequest as a dict with secret-like preview values redacted.
+    """GateRequest as a dict with secret-named preview values redacted.
 
     The diagnostic reaches agents/humans through error text and MCP responses —
-    secrets don't inform an approval decision. (The trace's gate event carries
-    the unmasked payload, consistent with the trace's ``template_resolutions``.)
-
-    ``mask_sensitive_value`` only checks the TOP-LEVEL key, so a dict/list value
-    (``headers: {Authorization: ...}``) recurses through ``sanitize_parameters``
-    instead — code-review fix: previously such a nested secret reached MCP/JSON
-    error surfaces unmasked.
+    secrets don't inform an approval decision, but everything ELSE must survive
+    in full (approving blind defeats the gate). Delegates to the shared
+    ``masked_preview`` (mask-only, recursive, no truncation); the trace's gate
+    event carries the unmasked payload, consistent with ``template_resolutions``.
     """
-    from pflow.core.security_utils import mask_sensitive_value, sanitize_parameters
+    from pflow.core.gate import masked_preview
 
     payload = request.to_dict()
-    payload["preview"] = {
-        key: mask_sensitive_value(key, value)
-        if isinstance(value, str)
-        else sanitize_parameters({key: value}).get(key, value)
-        for key, value in payload.get("preview", {}).items()
-    }
+    payload["preview"] = masked_preview(payload.get("preview", {}))
     return payload
 
 

--- a/src/pflow/core/gate.py
+++ b/src/pflow/core/gate.py
@@ -1,0 +1,99 @@
+"""Human-decision gate payloads (Task 125).
+
+``GateRequest`` is the seam (ADR-0009): the SAME payload feeds the TTY prompt, the
+``gate`` trace event, the non-interactive error diagnostic, and (Task 171) durable
+persistence. It is JSON-native by construction — building one coerces every leaf
+through a JSON round-trip so no consumer ever needs a ``default=str`` rescue.
+
+Resolution is a plain callable, not a strategy object. The contract:
+
+    resolver(request: GateRequest, *, allow_prompt: bool) -> GateResolution
+
+The resolver lives in the shared store under ``__gate_resolver__`` (installed by the
+CLI / MCP layer, propagated to sub-workflow engines like ``__progress_callback__``).
+``allow_prompt=False`` means the call site cannot host an interactive prompt (a
+parallel-batch worker) — the resolver may still auto-approve from its flag set, but
+must raise ``GateNotInteractiveError(..., parallel_batch=True)`` instead of prompting.
+"""
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal, Optional
+
+GATE_KIND_APPROVAL: Literal["action_approval"] = "action_approval"
+GATE_KIND_ESCALATION: Literal["decision_escalation"] = "decision_escalation"
+
+
+def json_safe(value: Any) -> Any:
+    """Coerce ``value`` to JSON-native types (non-native leaves become ``str()``)."""
+    return json.loads(json.dumps(value, default=str))
+
+
+@dataclass(frozen=True)
+class GateRequest:
+    """One human decision: what is being asked, with everything needed to decide.
+
+    Self-contained by contract — a remote human (web UI, Task 176) must be able to
+    decide from this payload alone.
+    """
+
+    node_id: str
+    node_type: str
+    kind: Literal["action_approval", "decision_escalation"]
+    # Approval: the node's resolved params — what is ABOUT to happen.
+    preview: dict[str, Any] = field(default_factory=dict)
+    # Escalation: the decision the agent raised. All optional — render leniently.
+    question: Optional[str] = None
+    options: tuple[dict[str, Any], ...] = ()
+    recommendation: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["options"] = list(self.options)
+        return data
+
+
+@dataclass(frozen=True)
+class GateResolution:
+    """The human's (or flag's) answer to a GateRequest."""
+
+    approved: bool
+    resolved_via: Literal["prompt", "flag"]
+    # Escalation only: the chosen option label (or free text), plus any extra notes.
+    chosen: Optional[str] = None
+    notes: Optional[str] = None
+
+
+def build_approval_request(node_id: str, node_type: str, params: Any) -> GateRequest:
+    """Approval payload from the node's (resolved) params.
+
+    ``_``-prefixed keys are parser/engine bookkeeping (``_source_line``, ...), not
+    part of the action — filtered here like every other display surface
+    (node_output_formatter / trace_report convention).
+    """
+    if not isinstance(params, dict):
+        return GateRequest(node_id=node_id, node_type=node_type, kind=GATE_KIND_APPROVAL)
+    preview = {key: json_safe(value) for key, value in params.items() if not key.startswith("_")}
+    return GateRequest(node_id=node_id, node_type=node_type, kind=GATE_KIND_APPROVAL, preview=preview)
+
+
+def build_escalation_request(node_id: str, node_type: str, marker: Any) -> GateRequest:
+    """Escalation payload from a node's ``result.escalation`` marker.
+
+    Lenient by design: a string marker becomes the question; dict fields that are
+    missing or oddly shaped render as absent — never crash at the pause point.
+    """
+    if isinstance(marker, str):
+        return GateRequest(node_id=node_id, node_type=node_type, kind=GATE_KIND_ESCALATION, question=marker)
+    question = marker.get("question")
+    raw_options = marker.get("options")
+    options = tuple(json_safe(o) for o in raw_options if isinstance(o, dict)) if isinstance(raw_options, list) else ()
+    recommendation = marker.get("recommendation")
+    return GateRequest(
+        node_id=node_id,
+        node_type=node_type,
+        kind=GATE_KIND_ESCALATION,
+        question=str(question) if question is not None else None,
+        options=options,
+        recommendation=str(recommendation) if recommendation is not None else None,
+    )

--- a/src/pflow/core/gate.py
+++ b/src/pflow/core/gate.py
@@ -20,6 +20,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal, Optional
 
+from pflow.core.security_utils import is_sensitive_parameter
+
 GATE_KIND_APPROVAL: Literal["action_approval"] = "action_approval"
 GATE_KIND_ESCALATION: Literal["decision_escalation"] = "decision_escalation"
 
@@ -97,3 +99,27 @@ def build_escalation_request(node_id: str, node_type: str, marker: Any) -> GateR
         options=options,
         recommendation=str(recommendation) if recommendation is not None else None,
     )
+
+
+def masked_preview(preview: dict[str, Any]) -> dict[str, Any]:
+    """Preview with secret-NAMED values redacted (recursively) — never truncated.
+
+    THE masking policy for every gate render surface (TTY prompt, error
+    diagnostics); the trace's gate event stays unmasked, consistent with the
+    trace's ``template_resolutions``. Masking only — length truncation belongs
+    to each renderer (the TTY prompt's 200-char step): routing values through
+    ``sanitize_parameters`` here cut long non-secret nested values (an http
+    ``json:`` body, a sub-workflow ``inputs:`` field) to ~20 chars, blinding
+    the approver to what they were approving (PR #554 review warning).
+    """
+
+    def mask(key: Optional[str], value: Any) -> Any:
+        if key is not None and is_sensitive_parameter(key):
+            return "<REDACTED>"
+        if isinstance(value, dict):
+            return {k: mask(str(k), v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [mask(None, item) for item in value]
+        return value
+
+    return {key: mask(key, value) for key, value in preview.items()}

--- a/src/pflow/core/ir_schema.py
+++ b/src/pflow/core/ir_schema.py
@@ -282,6 +282,16 @@ FLOW_IR_SCHEMA: dict[str, Any] = {
                             "as cache reads."
                         ),
                     },
+                    "approval": {
+                        "type": "string",
+                        "enum": ["required"],
+                        "description": (
+                            "Human approval gate (Task 125). `approval: required` pauses the run before "
+                            "this step executes, shows the resolved params, and waits for a human "
+                            "approve/deny. Not supported on batch steps — gate a step before or after "
+                            "the batch instead."
+                        ),
+                    },
                     "_source_line": {
                         "type": "integer",
                         "description": (
@@ -603,27 +613,34 @@ def _get_suggestion(error: JsonSchemaValidationError) -> tuple[str, dict[str, An
     if "outputs" in path_str:
         return _get_output_suggestion(error, path_str), {}
 
-    # GENERAL ERROR HANDLING (existing cases)
+    # `approval:` (Task 125) — the likeliest agent mistake is `- approval: true`
+    # (YAML-coerced to bool); the generic type-arm would suggest the string "true",
+    # which then fails the enum. One arm covers both the type and enum shapes.
+    if path_list and path_list[-1] == "approval":
+        return "The only supported value is `approval: required`", {}
+
+    return _suggest_for_general_error(error, path_str), {}
+
+
+def _suggest_for_general_error(error: JsonSchemaValidationError, path_str: str) -> str:
+    """Validator-keyword fallback suggestions (no field-specific knowledge)."""
     if error.validator == "required":
         # Extract field name from message like "'field_name' is a required property"
         match = error.message.split("'")
         if len(match) >= 2:
-            field_name = match[1]
-            return f"Add the required field '{field_name}'", {}
-        return "Add the missing required field", {}
-    elif error.validator == "type":
+            return f"Add the required field '{match[1]}'"
+        return "Add the missing required field"
+    if error.validator == "type":
         expected = error.validator_value
         actual = type(error.instance).__name__
-        return f"Change type from '{actual}' to '{expected}'", {}
-    elif error.validator == "pattern":
-        if "ir_version" in path_str:
-            return "Use semantic versioning format, e.g., '0.1.0'", {}
-    elif error.validator == "additionalProperties":
-        return "Remove unknown properties or check field names", {}
-    elif error.validator == "minItems":
-        return "Add at least one node to the workflow", {}
-
-    return "", {}
+        return f"Change type from '{actual}' to '{expected}'"
+    if error.validator == "pattern" and "ir_version" in path_str:
+        return "Use semantic versioning format, e.g., '0.1.0'"
+    if error.validator == "additionalProperties":
+        return "Remove unknown properties or check field names"
+    if error.validator == "minItems":
+        return "Add at least one node to the workflow"
+    return ""
 
 
 def validate_ir(data: Union[dict[str, Any], str]) -> None:

--- a/src/pflow/core/markdown_parser.py
+++ b/src/pflow/core/markdown_parser.py
@@ -1607,7 +1607,10 @@ def _build_node_dict(entity: _Entity) -> tuple[dict[str, Any], dict[str, Any]]:
     #   prompt_cache / prewarm — Task 159 LLM cache opt-ins; top-level so the
     #     ``cache.invalid-on-non-llm`` rule and IR-schema check (B2.2/B2.3) see them
     #     and validator step 8 doesn't silently allow them on non-LLM nodes.
-    for top_level_field in ("batch", "loop", "retry", "cache", "prompt_cache", "prewarm"):
+    #   approval     — Task 125 human approval gate; top-level so it never leaks
+    #     into node exec params or the cache hash, and the batch-exclusion rule
+    #     can inspect node["approval"] directly.
+    for top_level_field in ("batch", "loop", "retry", "cache", "prompt_cache", "prewarm", "approval"):
         if top_level_field in all_params:
             node[top_level_field] = all_params.pop(top_level_field)
 

--- a/src/pflow/core/output_controller.py
+++ b/src/pflow/core/output_controller.py
@@ -140,6 +140,16 @@ class OutputController:
         # Rules 2 & 3: Both stdin AND stdout must be TTY for interactive
         return self.stdin_tty and self.stdout_tty
 
+    def prepare_for_prompt(self) -> None:
+        """Public seam for interactive prompts (Task 125 gate prompt).
+
+        Terminates any open ``node_id...`` partial line (which also carries the
+        batch ``\\r`` counter rewrites — they ride the same physical line) so a
+        prompt renders on a fresh line instead of concatenating onto progress
+        output. Safe to call when no line is open.
+        """
+        self._close_partial_line()
+
     def _close_partial_line(self) -> None:
         """Terminate any open partial line so the next write starts fresh.
 

--- a/src/pflow/core/trace_io.py
+++ b/src/pflow/core/trace_io.py
@@ -147,11 +147,14 @@ def _partition_trace_lines(
             meta = line
         elif kind == "event":
             event_lines.append(line)
-        elif kind == "node.start":
-            # Task 173: a LIVE-ONLY in-flight marker the overlay tailer consumes (a node has BEGUN but
-            # not completed). It carries no completion data and is deliberately DROPPED from the
-            # reconstructed trace — the matching `event` line (which reuses its seq) is the source of
-            # truth. Known-but-ignored here, NOT unknown-kind corruption: skip without bucketing.
+        elif kind in ("node.start", "gate"):
+            # DISK-ONLY sideband kinds, known-but-ignored (NOT unknown-kind corruption):
+            # - `node.start` (Task 173): a LIVE-ONLY in-flight marker the overlay tailer consumes.
+            #   It carries no completion data; the matching `event` line (which reuses its seq) is
+            #   the source of truth.
+            # - `gate` (Task 125): a human-decision pause/resolution record. Bucketing it into
+            #   event_lines would make a gate resolution the node's "final event" and break --only
+            #   snapshot seeding; Task 171's resume reader consumes gate lines explicitly.
             continue
         elif kind == "run.complete":
             run_complete = line

--- a/src/pflow/core/workflow/CLAUDE.md
+++ b/src/pflow/core/workflow/CLAUDE.md
@@ -14,6 +14,7 @@ core/workflow/
 ├── validator.py             # Unified 10-step validation orchestrator
 ├── data_flow.py             # Execution order (topological sort) and dependency validation
 ├── loop_validation.py        # check_loop_polarity: shared while/until exactly-one-of rule (compiler + validate path)
+├── gate_validation.py        # Task 125 — check_approval_allowed: shared approval-not-on-batch rule (compiler + validate path)
 ├── graph/                   # Renderer-agnostic workflow graph model + renderers
 │   ├── __init__.py          # Re-exports build_graph, render_mermaid, model dataclasses
 │   ├── model.py             # GraphModel, NodeId, Node/Edge/Container dataclasses

--- a/src/pflow/core/workflow/CLAUDE.md
+++ b/src/pflow/core/workflow/CLAUDE.md
@@ -25,7 +25,7 @@ core/workflow/
 │       └── react_flow.py    # GraphModel -> React Flow JSON contract (Task 168)
 ├── mermaid/                 # Compatibility shim for generate_mermaid
 │   └── __init__.py          # Delegates to graph.build_graph + graph.render_mermaid
-├── status.py                # WorkflowStatus enum: SUCCESS/DEGRADED/FAILED
+├── status.py                # WorkflowStatus enum: SUCCESS/DEGRADED/FAILED/DENIED
 ├── skill_service.py         # Publish workflows as AI agent skills (symlinks)
 ├── context.py               # Build workflow context for discovery (build_workflows_context)
 ├── discovery.py             # LLM-powered workflow discovery (find_workflow → WorkflowMatch)
@@ -77,7 +77,7 @@ No cycles. All heavy imports are lazy (inside functions).
 | `data_flow.py` | `validate_data_flow`, `build_execution_order`, `CycleError` |
 | `graph/` | `build_graph`, `render_mermaid`, `render_react_flow`, `GraphModel`, `NodeId`, `EdgeKind` |
 | `mermaid/` | `generate_mermaid` |
-| `status.py` | `WorkflowStatus` (enum: SUCCESS, DEGRADED, FAILED) |
+| `status.py` | `WorkflowStatus` (enum: SUCCESS, DEGRADED, FAILED, DENIED) |
 | `skill_service.py` | `SkillInfo`, `enrich_workflow`, `create_skill_symlink`, `find_pflow_skills`, `remove_skill`, `re_enrich_if_skill` |
 
 ## External Consumers
@@ -168,7 +168,7 @@ Publishes workflows as AI agent skills for Claude Code, Cursor, Codex, Copilot. 
 
 ### status.py
 
-Tri-state: `SUCCESS` (all nodes clean), `DEGRADED` (completed with warnings, e.g., unresolved templates in permissive mode), `FAILED` (errors).
+Four states: `SUCCESS` (all nodes clean), `DEGRADED` (completed with warnings, e.g., unresolved templates in permissive mode), `FAILED` (errors), `DENIED` (a human denied an approval gate — Task 125; exit 3, never error-routed).
 
 ## Known Issues
 

--- a/src/pflow/core/workflow/data_flow.py
+++ b/src/pflow/core/workflow/data_flow.py
@@ -21,6 +21,7 @@ from pflow.core.diagnostic import (
 )
 from pflow.core.suggestion_utils import find_similar_items
 from pflow.core.types import is_template_reserved_internal_key
+from pflow.core.workflow.gate_validation import check_approval_allowed
 from pflow.core.workflow.loop_validation import check_loop_polarity
 from pflow.runtime.template_resolver import TemplateResolver
 
@@ -466,6 +467,7 @@ def validate_data_flow(
         valid_simple_refs.add("__iteration__")
 
     diagnostics.extend(_validate_loop_node_combos(workflow_ir))
+    diagnostics.extend(_validate_approval_node_combos(workflow_ir))
 
     # Build execution order
     try:
@@ -623,6 +625,34 @@ def _validate_loop_carry_value_self_ref(node_id: Optional[str], key: Any, value:
     if root == node_id:
         return []
     return [_make_loop_carry_self_ref_diagnostic(node_id, key, value)]
+
+
+def _validate_approval_node_combos(workflow_ir: dict[str, Any]) -> list[Diagnostic]:
+    """Reject unsupported ``approval:`` combinations (Task 125).
+
+    Mirrors the compiler's fail-fast check so the save / ``--validate-only`` path —
+    which never compiles — rejects them too (same dual as the batch/loop exclusion).
+    """
+    diagnostics: list[Diagnostic] = []
+    for node in workflow_ir.get("nodes", []):
+        error = check_approval_allowed(node)
+        if error is not None:
+            node_id = node.get("id")
+            diagnostics.append(
+                Diagnostic(
+                    severity=Severity.ERROR,
+                    source="validator",
+                    title="Validation Error",
+                    node_id=node_id,
+                    message=f"Node '{node_id}': {error}",
+                    suggestions=[
+                        "Move `approval: required` to the step before or after the batch — "
+                        "that is where a whole-batch review belongs.",
+                    ],
+                    context={"category": "validation", "path": f"nodes[id={node_id}].approval"},
+                )
+            )
+    return diagnostics
 
 
 def _make_loop_namespacing_diagnostic(node_id: Optional[str]) -> Diagnostic:

--- a/src/pflow/core/workflow/gate_validation.py
+++ b/src/pflow/core/workflow/gate_validation.py
@@ -1,0 +1,22 @@
+"""Shared validation helpers for the ``approval:`` gate field (Task 125)."""
+
+from typing import Any, Optional
+
+
+def check_approval_allowed(node_data: dict[str, Any]) -> Optional[str]:
+    """Return an error message when ``approval:`` is declared on a batch step, else ``None``.
+
+    A batch host skips top-level template resolution (per-item resolution happens
+    inside the batch executor), so a gate at the engine's pre-exec seam would
+    preview unresolved ``${item}`` templates — a misleading approval. Rejected at
+    validation instead: gate a step before or after the batch.
+
+    This rule is enforced by both the compiler path and the validate-only/save
+    path. Keeping it here prevents those two integration points from drifting.
+    """
+    if node_data.get("approval") is not None and node_data.get("batch") is not None:
+        return (
+            "`approval:` is not supported on batch steps — the approval preview cannot "
+            "show resolved per-item values. Gate a step before or after the batch instead."
+        )
+    return None

--- a/src/pflow/core/workflow/graph/CLAUDE.md
+++ b/src/pflow/core/workflow/graph/CLAUDE.md
@@ -4,7 +4,10 @@ Renderer-agnostic workflow structure for Task 155. This package is the static
 "see" substrate: it carries nodes, edges, containers, loop/batch metadata,
 authored params, and source pointers. It must not carry runtime status, outputs,
 timings, or render syntax (Mermaid / React Flow / ELK layout) — that purity is
-mechanized by `tests/test_core/test_graph_model_purity.py`.
+mechanized by `tests/test_core/test_graph_model_purity.py`. The `approval:` gate
+field (Task 125) is deliberately NOT surfaced on GraphNode — the visual gate
+marker is deferred to the Task 155/176 web-approval work; its absence is a
+decision, not a miss.
 
 ## File Map
 

--- a/src/pflow/core/workflow/save_service.py
+++ b/src/pflow/core/workflow/save_service.py
@@ -56,6 +56,7 @@ RESERVED_WORKFLOW_NAMES: frozenset[str] = frozenset({
     "loop",
     "branching",
     "error-handling",
+    "approval",
     "sub-workflows",
     "prompt-caching",
     "patterns",

--- a/src/pflow/core/workflow/status.py
+++ b/src/pflow/core/workflow/status.py
@@ -4,18 +4,23 @@ from enum import Enum
 
 
 class WorkflowStatus(str, Enum):
-    """Tri-state workflow execution status.
+    """Workflow execution status.
 
-    Distinguishes between perfect success, degraded completion, and failure.
+    Distinguishes between perfect success, degraded completion, failure, and a
+    human denial at an approval Gate.
 
     - SUCCESS: All nodes completed successfully without warnings
     - DEGRADED: Workflow completed but some nodes had warnings or non-fatal issues
     - FAILED: Workflow failed to complete due to errors
+    - DENIED: A human denied an approval Gate (Task 125) — the run stopped cleanly
+      BEFORE the gated node ran. A human verdict, not a failure: nothing broke.
+      CLI exit code 3 (vs 1 for FAILED); trace trailer ``final_status: "denied"``.
 
-    This tri-state model provides better observability than binary success/failure,
+    This model provides better observability than binary success/failure,
     allowing users to distinguish between "all perfect" and "completed with issues".
     """
 
     SUCCESS = "success"
     DEGRADED = "degraded"
     FAILED = "failed"
+    DENIED = "denied"

--- a/src/pflow/execution/CLAUDE.md
+++ b/src/pflow/execution/CLAUDE.md
@@ -12,6 +12,15 @@ src/pflow/execution/
 ├── workflow_resolver.py     # Unified workflow resolution (file, library, markdown, dict → ResolvedWorkflow)
 ├── executor_service.py      # Internal utility: error extraction helpers (build_error_list, determine_error_category, etc.)
 ├── execution_state.py       # Per-node execution state building (shared CLI/MCP)
+├── gate_prompt.py           # Task 125 gate resolver: build_gate_resolver() + TTY prompt renderers.
+│                            #   ONE builder, every surface: CLI interactive (prompts on stderr,
+│                            #   reads stdin — can_prompt() is stdin+stderr TTY, deliberately NOT
+│                            #   is_interactive(), so `pflow wf | jq` still gates), MCP (output_controller
+│                            #   =None → auto-approve only), parallel-batch worker (allow_prompt=False).
+│                            #   click lives HERE, never in runtime/. Ctrl-C: click Abort → KeyboardInterrupt.
+│                            #   Installed via runner.run(gate_resolver=...) → shared["__gate_resolver__"]
+│                            #   (mirrors progress_callback end-to-end). Denial surfaces as
+│                            #   WorkflowStatus.DENIED (derived in _exception_to_result from GateDenied).
 ├── plan.py                  # Dry-run planner — graph walker with explicit `Transition` state machine
 └── formatters/              # Shared output formatters (return strings/dicts, NEVER print)
     ├── error_formatter.py
@@ -124,9 +133,17 @@ When `_plan_sub_workflow(cause="downstream")` recurses into a child, it passes `
 
 Load-bearing: without recursion in BFS mode, any sub-workflow reached post-first-miss became a leaf entry with no `sub_plan`, hiding every nested LLM cost. Agents cost-gating after an upstream edit silently under-reported — the #1 iteration pattern. Mutation-tested: `tests/test_execution/test_plan_drift.py::test_plan_bfs_recurses_into_sub_workflow_carrying_child_stats`.
 
-### Loop-node planning (`_annotate_loop_entry`, issue #445)
+### Cross-cutting entry stamps (`_annotate_entry` — the shared funnel)
 
-The planner walks a `loop:` node's body exactly ONCE — re-entry is not a graph edge, so the walker never repeats it — then `_annotate_loop_entry` stamps `loop_iterations` = the resolved `max_iterations` cap (`resolve_loop_cap`; falls back to `MAX_NODE_VISITS` when the cap is a plan-time-unresolvable template, rather than crashing the dry run). `_summarize` multiplies that single-pass cost/duration (and any `sub_plan` rollup) by `loop_iterations` and flips the plan to `cost_basis="upper_bound"`. A loop is a do-while with unknown real iteration count, so the cap is the honest worst case for a cost gate.
+EVERY entry, standard and sub-workflow alike, routes through `_annotate_entry` — the one place
+plan-time NodeConfig facts land on entries. It stamps `approval` (Task 125: gated nodes render
+`[<type>, approval]` + the footer pause line; dry-run is the agent's gate-discovery surface, and
+the drift suite pins plan-says-pause ⟺ engine-pauses) and `loop_iterations` (below). Stamping in
+`_plan_standard_node` instead would miss gated workflow-type nodes — a parity lie.
+
+### Loop-node planning (issue #445)
+
+The planner walks a `loop:` node's body exactly ONCE — re-entry is not a graph edge, so the walker never repeats it — then `_annotate_entry` stamps `loop_iterations` = the resolved `max_iterations` cap (`resolve_loop_cap`; falls back to `MAX_NODE_VISITS` when the cap is a plan-time-unresolvable template, rather than crashing the dry run). `_summarize` multiplies that single-pass cost/duration (and any `sub_plan` rollup) by `loop_iterations` and flips the plan to `cost_basis="upper_bound"`. A loop is a do-while with unknown real iteration count, so the cap is the honest worst case for a cost gate.
 
 ### Placeholder child inputs in downstream mode
 

--- a/src/pflow/execution/CLAUDE.md
+++ b/src/pflow/execution/CLAUDE.md
@@ -135,11 +135,16 @@ Load-bearing: without recursion in BFS mode, any sub-workflow reached post-first
 
 ### Cross-cutting entry stamps (`_annotate_entry` — the shared funnel)
 
-EVERY entry, standard and sub-workflow alike, routes through `_annotate_entry` — the one place
-plan-time NodeConfig facts land on entries. It stamps `approval` (Task 125: gated nodes render
-`[<type>, approval]` + the footer pause line; dry-run is the agent's gate-discovery surface, and
-the drift suite pins plan-says-pause ⟺ engine-pauses) and `loop_iterations` (below). Stamping in
-`_plan_standard_node` instead would miss gated workflow-type nodes — a parity lie.
+EVERY walked entry, standard and sub-workflow alike, routes through `_annotate_entry` — the one
+place plan-time NodeConfig facts land on entries. It stamps `approval` (Task 125: gated nodes
+render `[<type>, approval]` + the footer pause line; dry-run is the agent's gate-discovery
+surface, and the drift suite pins plan-says-pause ⟺ engine-pauses) and `loop_iterations` (below).
+Stamping in `_plan_standard_node` instead would miss gated workflow-type nodes — a parity lie.
+Two traps: (1) `approval` is NOT stamped on `cached` entries — the engine's gate seam sits after
+the cache early-return, so a cache hit never pauses and stamping would promise one; (2)
+`_aggregate_batch_child_plans` builds fresh synthetic `PlanEntry`s that do NOT inherit funnel
+stamps — every flag needing dry-run visibility must be forwarded there explicitly
+(`approval=any(...)`; it already silently dropped `approval` once).
 
 ### Loop-node planning (issue #445)
 

--- a/src/pflow/execution/formatters/plan_formatter.py
+++ b/src/pflow/execution/formatters/plan_formatter.py
@@ -121,6 +121,8 @@ def format_plan_text(plan: Plan) -> str:
             "totals above exclude their cost/duration"
         )
 
+    _append_gate_footer(lines, plan.entries)
+
     if plan.diagnostics:
         lines.append("")
         for diagnostic in plan.diagnostics:
@@ -218,17 +220,18 @@ def _render_entry_line(entry: PlanEntry, indent: str) -> str:
         return f"{indent}{click.style('↻', fg='blue', dim=True)} {entry.node_id}{age}"
 
     tag = f"  [{_tag_from_entry(entry)}]"
+    approval_tag = ", approval" if entry.approval else ""
     if entry.status == "sub_workflow":
         ref = entry.sub_plan.workflow if entry.sub_plan else "<unknown>"
         count = entry.sub_plan.summary.total if entry.sub_plan else 0
         suffix = "s" if count != 1 else ""
-        return f"{indent}▸ {entry.node_id}  [sub-workflow '{ref}' ({count} node{suffix})]"
+        return f"{indent}▸ {entry.node_id}  [sub-workflow '{ref}' ({count} node{suffix}){approval_tag}]"
 
     if entry.status == "opaque":
         reason = (
             "batch downstream, item count unreliable" if entry.cause == "downstream_batch" else "dynamic, cannot plan"
         )
-        return f"{indent}▸ {entry.node_id}  [sub-workflow: {reason}]"
+        return f"{indent}▸ {entry.node_id}  [sub-workflow: {reason}{approval_tag}]"
 
     if entry.status == "routing_error":
         return f"{indent}▸ {entry.node_id}{tag}  [routing error]"
@@ -296,6 +299,41 @@ def _format_stats_annotation(entry: PlanEntry) -> str | None:
     return body
 
 
+def _append_gate_footer(lines: list[str], entries: list[PlanEntry]) -> None:
+    """Task 125: one footer line naming every gated step + its pre-approve flag.
+
+    Makes the agent-operator playbook self-discoverable — the plan is where an
+    agent learns a run will pause, BEFORE side effects fire. No-op when nothing
+    is gated.
+    """
+    gated = _collect_gated_node_ids(entries)
+    if not gated:
+        return
+    flags = " ".join(f"--auto-approve={node_id}" for node_id in gated)
+    plural = "s" if len(gated) != 1 else ""
+    lines.append(
+        f"⏸ {len(gated)} step{plural} pause{'' if plural else 's'} for approval at run time "
+        f"({', '.join(gated)}); non-interactive runs need {flags}"
+    )
+
+
+def _collect_gated_node_ids(entries: list[PlanEntry]) -> list[str]:
+    """All gated node ids in plan order, including inside nested sub-plans.
+
+    First-seen dedup: a child workflow planned per batch item (or reached via
+    several paths) must not repeat its gate in the footer.
+    """
+    seen: list[str] = []
+    for entry in entries:
+        if entry.approval and entry.node_id not in seen:
+            seen.append(entry.node_id)
+        if entry.sub_plan is not None:
+            for child_id in _collect_gated_node_ids(entry.sub_plan.entries):
+                if child_id not in seen:
+                    seen.append(child_id)
+    return seen
+
+
 def _is_llm_entry(entry: PlanEntry) -> bool:
     """Identify LLM-family entries for cost rendering."""
     return entry.node_type in ("LLMNode", "ClaudeCodeNode")
@@ -312,6 +350,11 @@ def _tag_from_entry(entry: PlanEntry) -> str:
     tag = node_type_tag(entry.node_type)
     if entry.cause == "cache_disabled" and entry.node_type == "LLMNode":
         tag = f"{tag}, cache: false"
+    if entry.approval:
+        # Task 125: dry-run must show gated nodes as would-pause — a plan that
+        # renders a gated node as plain execute is a parity lie (the cached
+        # path correctly skips this: a cache hit never gates).
+        tag = f"{tag}, approval"
     return tag
 
 
@@ -371,6 +414,10 @@ def _entry_to_dict(entry: PlanEntry) -> dict[str, Any]:
         result["sub_plan"] = format_plan_json(entry.sub_plan)
     if entry.diagnostic is not None:
         result["diagnostic"] = entry.diagnostic.to_dict()
+    if entry.approval:
+        # Task 125: JSON dry-run is the gate-discovery surface for agent
+        # operators (discover gates → ask your human → --auto-approve).
+        result["approval"] = True
     return result
 
 

--- a/src/pflow/execution/formatters/success_formatter.py
+++ b/src/pflow/execution/formatters/success_formatter.py
@@ -315,6 +315,11 @@ def format_success_as_text(  # noqa: C901
 
     if status == "degraded":
         lines.append(f"⚠️ Workflow completed with warnings in {duration_sec:.3f}s{cache_suffix}")
+    elif status == "denied":
+        # Defensive: denied results normally route through the error path (CLI
+        # intercepts DENIED before this formatter; MCP goes via success=False),
+        # but a denied run must never render the success ✓ if that ever changes.
+        lines.append(f"⊘ Workflow denied at an approval gate after {duration_sec:.3f}s{cache_suffix}")
     elif status == "failed":
         if warning_count:
             lines.append(f"❌ Workflow failed ({warning_count} warnings) after {duration_sec:.3f}s{cache_suffix}")

--- a/src/pflow/execution/gate_prompt.py
+++ b/src/pflow/execution/gate_prompt.py
@@ -25,7 +25,7 @@ import click
 from pflow.core.exceptions import GateNotInteractiveError
 from pflow.core.gate import GATE_KIND_APPROVAL, GateRequest, GateResolution
 from pflow.core.output_controller import OutputController
-from pflow.core.security_utils import mask_sensitive_value
+from pflow.core.security_utils import mask_sensitive_value, sanitize_parameters
 
 GateResolver = Callable[..., GateResolution]
 
@@ -59,7 +59,8 @@ def build_gate_resolver(
 
     def resolver(request: GateRequest, *, allow_prompt: bool = True) -> GateResolution:
         if request.kind == GATE_KIND_APPROVAL and request.node_id in auto_approve:
-            _echo_auto_approved(request, output_controller)
+            if allow_prompt:
+                _echo_auto_approved(request, output_controller)
             return GateResolution(approved=True, resolved_via="flag")
         if allow_prompt and output_controller is not None and can_prompt(output_controller):
             return _prompt(request, output_controller)
@@ -69,7 +70,19 @@ def build_gate_resolver(
 
 
 def _echo_auto_approved(request: GateRequest, output_controller: Optional[OutputController]) -> None:
-    """One stderr line so a pre-approved gate is visible, never silent."""
+    """One stderr line so a pre-approved gate is visible, never silent.
+
+    Code-review fix: the CALLER gates this on ``allow_prompt`` — ``allow_prompt=
+    False`` means this resolver call is running on a parallel-batch WORKER
+    thread (``__gate_prompt_allowed__``), where ``output_controller`` is the
+    real, shared one (not buffered, unlike the progress callback). Echoing
+    there would call ``prepare_for_prompt()``/``click.echo(err=True)``
+    concurrently with the main thread's progress drain — exactly the race the
+    per-worker progress buffer exists to prevent (see `engine/CLAUDE.md`
+    "Per-worker progress buffer"). Worker output is buffered anyway and the
+    flag was already an explicit human pre-approval, so silence there is an
+    acceptable trade for correctness.
+    """
     if output_controller is None or output_controller.print_flag:
         return
     output_controller.prepare_for_prompt()
@@ -139,14 +152,22 @@ def _format_preview(preview: dict[str, Any]) -> list[str]:
 
     Values are flattened to one line each (newlines escaped) so the block stays
     scannable; the full unmasked payload lives in the gate trace event.
+
+    ``mask_sensitive_value`` only checks the TOP-LEVEL key, so a dict/list value
+    (``headers: {Authorization: ...}``) is recursed through the existing
+    ``sanitize_parameters`` sanitizer instead — code-review fix: previously such
+    a nested secret rendered verbatim in the approval prompt.
     """
     if not preview:
         return ["(no parameters)"]
     width = max(len(key) for key in preview)
     lines = []
     for key, value in preview.items():
-        text = value if isinstance(value, str) else _compact_json(value)
-        text = mask_sensitive_value(key, text) if isinstance(value, str) else text
+        if isinstance(value, str):
+            text = mask_sensitive_value(key, value)
+        else:
+            masked_value = sanitize_parameters({key: value}).get(key, value)
+            text = _compact_json(masked_value)
         text = text.replace("\n", "\\n")
         if len(text) > _PREVIEW_VALUE_CHARS:
             text = f"{text[:_PREVIEW_VALUE_CHARS]}… ({len(text)} chars)"

--- a/src/pflow/execution/gate_prompt.py
+++ b/src/pflow/execution/gate_prompt.py
@@ -23,9 +23,8 @@ from typing import Any, Callable, Optional
 import click
 
 from pflow.core.exceptions import GateNotInteractiveError
-from pflow.core.gate import GATE_KIND_APPROVAL, GateRequest, GateResolution
+from pflow.core.gate import GATE_KIND_APPROVAL, GateRequest, GateResolution, masked_preview
 from pflow.core.output_controller import OutputController
-from pflow.core.security_utils import mask_sensitive_value, sanitize_parameters
 
 GateResolver = Callable[..., GateResolution]
 
@@ -151,23 +150,17 @@ def _format_preview(preview: dict[str, Any]) -> list[str]:
     """Aligned ``key: value`` lines, secret-masked and display-truncated.
 
     Values are flattened to one line each (newlines escaped) so the block stays
-    scannable; the full unmasked payload lives in the gate trace event.
-
-    ``mask_sensitive_value`` only checks the TOP-LEVEL key, so a dict/list value
-    (``headers: {Authorization: ...}``) is recursed through the existing
-    ``sanitize_parameters`` sanitizer instead — code-review fix: previously such
-    a nested secret rendered verbatim in the approval prompt.
+    scannable; the full unmasked payload lives in the gate trace event. Masking
+    is the shared ``masked_preview`` (recursive, mask-only); truncation happens
+    ONLY here, at the 200-char display budget — never inside the masking step,
+    so a long non-secret nested value stays reviewable.
     """
     if not preview:
         return ["(no parameters)"]
     width = max(len(key) for key in preview)
     lines = []
-    for key, value in preview.items():
-        if isinstance(value, str):
-            text = mask_sensitive_value(key, value)
-        else:
-            masked_value = sanitize_parameters({key: value}).get(key, value)
-            text = _compact_json(masked_value)
+    for key, value in masked_preview(preview).items():
+        text = value if isinstance(value, str) else _compact_json(value)
         text = text.replace("\n", "\\n")
         if len(text) > _PREVIEW_VALUE_CHARS:
             text = f"{text[:_PREVIEW_VALUE_CHARS]}… ({len(text)} chars)"

--- a/src/pflow/execution/gate_prompt.py
+++ b/src/pflow/execution/gate_prompt.py
@@ -1,0 +1,166 @@
+"""TTY gate resolver — the human side of Task 125 approval gates.
+
+The engine owns WHEN a gate fires (``runtime/engine/gate.py``); this module owns
+HOW a human answers. ``build_gate_resolver`` returns the plain callable the
+engine invokes via ``__gate_resolver__`` (contract in ``core/gate.py``). click
+and OutputController live HERE — never in runtime/.
+
+One builder, every configuration:
+- CLI interactive:    ``build_gate_resolver(flags, output_controller)`` — prompts on
+  stderr, reads stdin (design anchor: ``terraform apply``).
+- MCP / non-TTY:      ``build_gate_resolver(flags, None)`` — honors ``--auto-approve``
+  pre-approvals, otherwise raises the payload-carrying ``GateNotInteractiveError``.
+- Parallel-batch worker: the SAME resolver called with ``allow_prompt=False``
+  (via ``__gate_prompt_allowed__``) — auto-approve still works, prompting never does.
+
+Ctrl-C at a prompt: click raises ``Abort`` (an ``Exception`` subclass the engine
+would archive as a node failure) — converted to ``KeyboardInterrupt`` so it rides
+the existing clean interrupt path (exit 130, incomplete-but-readable trace).
+"""
+
+from typing import Any, Callable, Optional
+
+import click
+
+from pflow.core.exceptions import GateNotInteractiveError
+from pflow.core.gate import GATE_KIND_APPROVAL, GateRequest, GateResolution
+from pflow.core.output_controller import OutputController
+from pflow.core.security_utils import mask_sensitive_value
+
+GateResolver = Callable[..., GateResolution]
+
+# Display-only truncation for preview values; the trace event carries the full
+# payload (interning handles size — trace_io.intern_event_leaves).
+_PREVIEW_VALUE_CHARS = 200
+
+
+def can_prompt(output_controller: Optional[OutputController]) -> bool:
+    """True when a gate prompt can render (stderr) and be answered (stdin).
+
+    Deliberately NOT ``is_interactive()`` — that requires stdout to be a TTY,
+    but the prompt never touches stdout: ``pflow wf | jq`` at a real terminal
+    must still gate (Decision 14).
+    """
+    if output_controller is None or output_controller.print_flag:
+        return False
+    return output_controller.stdin_tty and output_controller.stderr_tty
+
+
+def build_gate_resolver(
+    auto_approve: frozenset[str],
+    output_controller: Optional[OutputController],
+) -> GateResolver:
+    """Build the ``__gate_resolver__`` callable for this run.
+
+    ``auto_approve`` pre-approves APPROVAL gates by node id (flat namespace
+    across the workflow tree — a child gate with a flagged id is approved).
+    Escalations never auto-resolve: you cannot pre-answer an unknown question.
+    """
+
+    def resolver(request: GateRequest, *, allow_prompt: bool = True) -> GateResolution:
+        if request.kind == GATE_KIND_APPROVAL and request.node_id in auto_approve:
+            _echo_auto_approved(request, output_controller)
+            return GateResolution(approved=True, resolved_via="flag")
+        if allow_prompt and output_controller is not None and can_prompt(output_controller):
+            return _prompt(request, output_controller)
+        raise GateNotInteractiveError(request, parallel_batch=not allow_prompt)
+
+    return resolver
+
+
+def _echo_auto_approved(request: GateRequest, output_controller: Optional[OutputController]) -> None:
+    """One stderr line so a pre-approved gate is visible, never silent."""
+    if output_controller is None or output_controller.print_flag:
+        return
+    output_controller.prepare_for_prompt()
+    click.echo(
+        click.style(f"✓ Gate '{request.node_id}' pre-approved via --auto-approve={request.node_id}", fg="green"),
+        err=True,
+    )
+
+
+def _prompt(request: GateRequest, output_controller: OutputController) -> GateResolution:
+    output_controller.prepare_for_prompt()
+    try:
+        if request.kind == GATE_KIND_APPROVAL:
+            return _prompt_approval(request)
+        return _prompt_escalation(request)
+    except click.exceptions.Abort:
+        # click's Ctrl-C wrapper is an Exception subclass — re-raise as the real
+        # interrupt so the engine's generic arm never archives it as a node failure.
+        raise KeyboardInterrupt() from None
+
+
+def _prompt_approval(request: GateRequest) -> GateResolution:
+    click.echo(f"\n⏸  Approval required: {request.node_id} ({request.node_type})\n", err=True)
+    for line in _format_preview(request.preview):
+        click.echo(f"   {line}", err=True)
+    if request.preview:
+        click.echo("", err=True)
+    approved = click.confirm("   Run this step?", default=False, err=True)
+    return GateResolution(approved=approved, resolved_via="prompt")
+
+
+def _prompt_escalation(request: GateRequest) -> GateResolution:
+    click.echo(f"\n⏸  Escalation from {request.node_id}:", err=True)
+    if request.question:
+        click.echo(f"   {request.question}", err=True)
+    click.echo("", err=True)
+    labels = _echo_options(request)
+    if labels:
+        answer = click.prompt(f"   Choose 1-{len(labels)}, or type an answer", err=True)
+    else:
+        answer = click.prompt("   Type an answer", err=True)
+    answer = str(answer).strip()
+    if answer.isdigit() and 1 <= int(answer) <= len(labels):
+        return GateResolution(approved=True, resolved_via="prompt", chosen=labels[int(answer) - 1])
+    return GateResolution(approved=True, resolved_via="prompt", chosen=answer)
+
+
+def _echo_options(request: GateRequest) -> list[str]:
+    """Render numbered options; returns the option labels in display order."""
+    labels: list[str] = []
+    for i, option in enumerate(request.options, start=1):
+        label = str(option.get("label") or f"option {i}")
+        labels.append(label)
+        rec = " (rec)" if request.recommendation and request.recommendation == label else ""
+        detail = " — ".join(str(option[key]) for key in ("description", "tradeoffs") if option.get(key))
+        suffix = f" — {detail}" if detail else ""
+        click.echo(f"   {i}. {label}{rec}{suffix}", err=True)
+    if request.recommendation and request.recommendation not in labels:
+        click.echo(f"   Recommendation: {request.recommendation}", err=True)
+    if labels:
+        click.echo("", err=True)
+    return labels
+
+
+def _format_preview(preview: dict[str, Any]) -> list[str]:
+    """Aligned ``key: value`` lines, secret-masked and display-truncated.
+
+    Values are flattened to one line each (newlines escaped) so the block stays
+    scannable; the full unmasked payload lives in the gate trace event.
+    """
+    if not preview:
+        return ["(no parameters)"]
+    width = max(len(key) for key in preview)
+    lines = []
+    for key, value in preview.items():
+        text = value if isinstance(value, str) else _compact_json(value)
+        text = mask_sensitive_value(key, text) if isinstance(value, str) else text
+        text = text.replace("\n", "\\n")
+        if len(text) > _PREVIEW_VALUE_CHARS:
+            text = f"{text[:_PREVIEW_VALUE_CHARS]}… ({len(text)} chars)"
+        lines.append(f"{key}:{' ' * (width - len(key) + 2)}{text}")
+    return lines
+
+
+def _compact_json(value: Any) -> str:
+    import json
+
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+__all__ = ["GateResolver", "build_gate_resolver", "can_prompt"]

--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -1877,6 +1877,12 @@ def _aggregate_batch_child_plans(
                 batch_items_cached=cached_count,
                 batch_items_total=items_traversed,
                 sub_plan=template_entry.sub_plan,
+                # Code-review fix: a gated step INSIDE a batched sub-workflow's
+                # child still gates at runtime (the resolver's namespace is flat
+                # across the tree) — dropping this here would make the dry-run
+                # footer/JSON silently omit a gate the engine will still pause
+                # or fail loudly on.
+                approval=any(entry.approval for entry in entries_for_node),
             )
         )
 

--- a/src/pflow/execution/plan.py
+++ b/src/pflow/execution/plan.py
@@ -780,9 +780,9 @@ def _make_downstream_entry(
             cause="downstream",
             child_only_node=child_only_node,
         )
-        return _annotate_loop_entry(sub_entry, config, shared)
+        return _annotate_entry(sub_entry, config, shared)
 
-    return _annotate_loop_entry(
+    return _annotate_entry(
         _execute_entry(config, cache, cause="downstream", workflow_path=workflow_path), config, shared
     )
 
@@ -841,22 +841,34 @@ def _plan_one_node(
         )
     else:
         entry = _plan_standard_node(curr, config, shared, cache)
-    return _annotate_loop_entry(entry, config, shared)
+    return _annotate_entry(entry, config, shared)
 
 
-def _annotate_loop_entry(entry: PlanEntry, config: NodeConfig, shared: dict[str, Any]) -> PlanEntry:
-    """Stamp ``loop_iterations`` on a ``loop:`` node's entry (issue #445).
+def _annotate_entry(entry: PlanEntry, config: NodeConfig, shared: dict[str, Any]) -> PlanEntry:
+    """Stamp cross-cutting NodeConfig facts on a finished entry.
 
-    The planner walks the loop body ONCE — re-entry is not an edge, so the
-    walker never repeats it — then records the resolved ``max_iterations`` upper
-    bound here. ``_summarize`` multiplies the entry's single-pass cost/duration
-    (and any sub_plan rollup) by this factor, and flips the plan to
-    ``upper_bound`` cost basis. A loop is by nature a do-while with an unknown
-    real iteration count, so the cap is the honest worst case for a cost gate.
+    Every entry — standard AND sub-workflow, both dispatch paths — routes
+    through this funnel, which is what makes the stamps parity-safe (stamping
+    only in ``_plan_standard_node`` would miss gated workflow-type nodes).
+
+    - ``approval`` (Task 125): the node pauses for a human before executing.
+      Dry-run is the agent's gate-discovery surface; the drift suite pins
+      plan-says-pause ⟺ engine-pauses. NOT stamped on ``cached`` entries — the
+      engine's gate seam sits after the cache early-return, so a cache hit
+      never gates (nothing to approve); stamping it would make the ⏸ footer
+      and the JSON ``approval`` field promise a pause the engine won't make.
+    - ``loop_iterations`` (issue #445): the planner walks a ``loop:`` body ONCE
+      — re-entry is not an edge — then records the resolved ``max_iterations``
+      upper bound. ``_summarize`` multiplies the entry's single-pass
+      cost/duration (and any sub_plan rollup) by this factor and flips the plan
+      to ``upper_bound`` cost basis: the honest worst case for a cost gate.
     """
+    from dataclasses import replace
+
+    if config.approval and entry.status != "cached":
+        entry = replace(entry, approval=True)
     if config.loop_config is None:
         return entry
-    from dataclasses import replace
 
     try:
         cap = resolve_loop_cap(config.loop_config, shared, config.node_id)

--- a/src/pflow/execution/result.py
+++ b/src/pflow/execution/result.py
@@ -140,6 +140,12 @@ class PlanEntry:
     # The planner plans the body once and the summary multiplies this entry's
     # single-pass cost/duration (and its sub_plan rollup) by this factor.
     loop_iterations: int | None = None
+    # Task 125: this node declares `approval: required` — the run pauses for a
+    # human before it executes. Stamped from NodeConfig in the planner's shared
+    # annotate funnel (covers standard AND sub-workflow entries); dry-run is the
+    # agent's gate-discovery surface, so plan-says-pause ⟺ engine-pauses is
+    # drift-suite pinned.
+    approval: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/pflow/execution/runner.py
+++ b/src/pflow/execution/runner.py
@@ -18,6 +18,7 @@ from pflow.core.diagnostic import (
 )
 from pflow.core.exceptions import (
     CompilationError,
+    GateDenied,
     MarkdownParseError,
     SchemaValidationError,
     WorkflowNotFoundError,
@@ -93,6 +94,7 @@ class WorkflowRunner:
         config: RunnerConfig,
         *,
         progress_callback: Optional[Callable] = None,
+        gate_resolver: Optional[Callable] = None,
         workflow_manager: Optional[WorkflowManager] = None,
         workflow_name: Optional[str] = None,
     ) -> ExecutionResult:
@@ -103,6 +105,10 @@ class WorkflowRunner:
             params: User-provided parameters. Copied at boundary.
             config: Immutable execution configuration.
             progress_callback: Optional per-node progress callback for CLI streaming.
+            gate_resolver: Optional Task 125 gate resolver (see ``core/gate.py`` for
+                the contract; built via ``execution.gate_prompt.build_gate_resolver``).
+                Installed as ``__gate_resolver__`` exactly like the progress callback.
+                None = gates fail loudly with ``GateNotInteractiveError``.
             workflow_manager: For metadata update on saved workflows. None = skip.
             workflow_name: Saved workflow name for metadata. None = skip.
 
@@ -171,6 +177,7 @@ class WorkflowRunner:
                 params,
                 config,
                 progress_callback,
+                gate_resolver,
                 workflow_manager,
                 workflow_name,
                 validation_warnings,
@@ -241,6 +248,7 @@ class WorkflowRunner:
         params: dict[str, Any],
         config: RunnerConfig,
         progress_callback: Optional[Callable],
+        gate_resolver: Optional[Callable],
         workflow_manager: Optional[WorkflowManager],
         workflow_name: Optional[str],
         validation_warnings: list[Diagnostic],
@@ -267,6 +275,7 @@ class WorkflowRunner:
             params,
             config.verbose,
             progress_callback,
+            gate_resolver,
             mcp_pool,
             cache,
             trace_collector,
@@ -572,6 +581,7 @@ class WorkflowRunner:
         params: dict[str, Any],
         verbose: bool,
         progress_callback: Optional[Callable],
+        gate_resolver: Optional[Callable],
         mcp_pool: Any,
         cache: Any,
         trace_collector: Any,
@@ -586,6 +596,9 @@ class WorkflowRunner:
 
         if progress_callback is not None:
             shared_store["__progress_callback__"] = progress_callback
+
+        if gate_resolver is not None:
+            shared_store["__gate_resolver__"] = gate_resolver
 
         shared_store["__mcp_pool__"] = mcp_pool
         shared_store["__memoization_cache__"] = cache
@@ -790,9 +803,14 @@ class WorkflowRunner:
                 diagnostic for diagnostic in diagnostics if diagnostic.severity in {Severity.WARNING, Severity.INFO}
             ])
 
+        # A denied gate is a human verdict, not a failure (Task 125 Decision 5):
+        # the gated node never ran, nothing broke. Payload diagnostics arrive
+        # intact via exception_to_diagnostics → GateDenied.to_diagnostics above;
+        # the CLI maps DENIED to its own display + exit code 3.
+        status = WorkflowStatus.DENIED if isinstance(exception, GateDenied) else WorkflowStatus.FAILED
         return ExecutionResult(
             success=False,
-            status=WorkflowStatus.FAILED,
+            status=status,
             shared_after=shared_after,
             trace=trace_collector,
             diagnostics=diagnostics,

--- a/src/pflow/guide/CLAUDE.md
+++ b/src/pflow/guide/CLAUDE.md
@@ -18,7 +18,7 @@ src/pflow/guide/
 ├── nodes/               # Per-node-type guides (static prose + dynamic interface from registry)
 │   ├── http.md, llm.md, claude-code.md, code.md, shell.md, file.md, mcp.md
 └── features/            # Per-feature guides (static content only)
-    ├── batch.md, branching.md, error-handling.md, loop.md, patterns.md, prompt-caching.md, sub-workflows.md
+    ├── approval.md, batch.md, branching.md, error-handling.md, loop.md, patterns.md, prompt-caching.md, sub-workflows.md, ui.md
 ```
 
 ## Topic Resolution
@@ -46,7 +46,7 @@ The topic is automatically discoverable — `list_topics()` scans the filesystem
 
 `detect_topics_from_ir()` walks a single IR to find relevant topics:
 - Node `type` → topic (via `_NODE_TYPE_TO_TOPIC` for non-1:1 mappings, `mcp-*` prefix → `mcp`)
-- `node["batch"]` present → `batch`; `node["loop"]` → `loop`; `node["retry"]` → `error-handling`
+- `node["batch"]` present → `batch`; `node["loop"]` → `loop`; `node["retry"]` → `error-handling`; `node["approval"]` → `approval`
 - `node["prompt_cache"]` or `node["prewarm"]` present (presence, not truthiness) → `prompt-caching`
 - Top-level `ir["cache"]` (parsed `## Cache` block) → `prompt-caching`
 - Edge with `action == "error"` → `error-handling`; any other non-`default` action → `branching`

--- a/src/pflow/guide/__init__.py
+++ b/src/pflow/guide/__init__.py
@@ -168,6 +168,8 @@ def _node_topics(node: dict, available: set[str]) -> set[str]:
         topics.add("loop")
     if node.get("retry") is not None:
         topics.add("error-handling")
+    if node.get("approval") is not None:
+        topics.add("approval")
     # Caching: per-node opt-in. Presence (not truthiness) — ``prewarm: false`` is
     # still engaging with the feature and should surface the guide.
     if node.get("prompt_cache") is not None or node.get("prewarm") is not None:

--- a/src/pflow/guide/core.md
+++ b/src/pflow/guide/core.md
@@ -304,7 +304,7 @@ Parsed record array from the fetch response.
 
 **Output fields**: `source` (template expression like `${node.key}`), `type` (optional hint), `stdout` (true|false — at most one output may set this; marks the output that streams to stdout in text mode), description as prose.
 
-**Node fields**: `type` (required), top-level controls like `batch`, `loop`, `retry`, `cache`, `prompt_cache`, and `prewarm`, then node params as `- key: value`. Code/prompts/batch go in tagged code blocks.
+**Node fields**: `type` (required), top-level controls like `batch`, `loop`, `retry`, `cache`, `prompt_cache`, `prewarm`, and `approval` (pause for a human before the step runs — see `pflow guide approval`), then node params as `- key: value`. Code/prompts/batch go in tagged code blocks.
 
 **Execution order**: Top to bottom in `## Steps`. No explicit edges.
 

--- a/src/pflow/guide/entry.md
+++ b/src/pflow/guide/entry.md
@@ -55,6 +55,8 @@ Features — when the user says X, load topic Y:
                    → "if X then Y", "classify and route", "pick a path based on data"
   error-handling   Retry, fallback, recover from failures
                    → "retry on failure", "fall back if X fails", "handle the error", "undo on failure"
+  approval         Human-in-the-loop gates — pause for a yes/no or a decision
+                   → "ask before sending", "confirm before deploying", "let me approve it", "escalate to me if unsure"
   sub-workflows    Reusable composition, bounded iteration
                    → "reuse this", "same validation as X", "iterate over a fixed count"
   prompt-caching   Provider prompt caching, ## Cache, prompt_cache:

--- a/src/pflow/guide/features/approval.md
+++ b/src/pflow/guide/features/approval.md
@@ -1,0 +1,103 @@
+# Approval gates
+
+**Use when**: a step takes a real-world action a human should review first — "ask before sending", "confirm before deploying", "let me approve the message" — or an agent step may hit a decision it should not make alone.
+
+Two gate kinds, one primitive (the run pauses, a human decides, the run continues):
+
+| | Approval | Escalation |
+|---|---|---|
+| Declared by | the workflow author (`approval: required`) | raised by an agent step at runtime |
+| Human sees | the step's **resolved** params — what is about to happen | a question + options + the agent's recommendation |
+| Human answers | yes / no | picks an option or types an answer |
+| On "no" | run stops cleanly (exit 3) — not a failure | n/a — an escalation is a choice, not a veto |
+
+## Declaring an approval gate
+
+Add `approval: required` to any step (top-level field, like `cache:`):
+
+```markdown
+### notify-slack
+
+Post the release summary to Slack.
+
+- type: mcp-composio-slack-SLACK_SEND_MESSAGE
+- channel: ${slack_channel}
+- markdown_text: ${create-summary.result}
+- approval: required
+```
+
+At a terminal the run pauses before the step and shows the resolved values (the actual message text, not `${...}`), then asks `Run this step? [y/N]`. Deny → the run stops **cleanly before the step runs**: exit code **3** (not 1 — nothing failed), trace trailer `final_status: "denied"`.
+
+Rules:
+
+- **Not on batch steps** — rejected at validation (the preview could not show resolved `${item}` values). Gate the step before or after the batch instead.
+- **Loop steps prompt every iteration** — each iteration is a new action.
+- **Cached steps never prompt** — a cache hit performs no action, so there is nothing to approve.
+- Works on `workflow` steps (gates the whole sub-workflow; the preview is its inputs) and on steps **inside** sub-workflows.
+
+## If you are an AI agent operating a gated workflow
+
+You cannot answer an interactive prompt (your runs have no terminal). The playbook:
+
+1. **Discover gates before running**: `pflow <workflow> --dry-run` marks gated steps `[<type>, approval]` and lists them in a `⏸` footer (JSON: `"approval": true` per entry). This is also how you avoid the wasteful path — a run that fails at a gate re-executes everything upstream on retry, and side-effecting steps do not cache.
+2. **Show your human the action** — the resolved preview, not just the step name. Approving blind defeats the gate.
+3. **With their OK**, pre-approve exactly the gates they approved: `--auto-approve=<step-name>` (repeatable, one per gate — there is deliberately no approve-all flag), or `auto_approve=["<step-name>"]` on the MCP `workflow_execute` tool. **Never pass these without asking your human first.**
+
+If a gate is reached without pre-approval in a non-interactive run, the run fails loudly at the gate (exit 1) with these same instructions; a warning also fires at run start when top-level gates are unapproved. Two limits to know: the run-start warning sees **top-level steps only** (a gate inside a sub-workflow still fails at the gate, just without the early warning), and `--auto-approve` names are **flat across the workflow tree** (a child step with the same name as a flagged one is also approved). pflow cannot yet hold a gate open for a later answer.
+
+A prompt needs stdin AND stderr at a terminal — stdout piping (`pflow wf | jq`) does not disable gates.
+
+## Escalation — an agent raises a decision mid-run
+
+For agent steps (`claude-code`, or a `code` guard) that may discover a lasting-impact fork the plan did not settle: the step returns an `escalation` object inside its `result`, the run pauses, the human chooses, and the choice is written back into the result for the workflow to act on.
+
+The contract — `result.escalation`, with this shape:
+
+```json
+{"escalation": {
+  "question": "The plan assumes one config file, but the code has per-env configs. Which way?",
+  "options": [
+    {"label": "merge", "description": "one file", "tradeoffs": "breaks env overrides"},
+    {"label": "per-env", "description": "template per env", "tradeoffs": "more files"}
+  ],
+  "recommendation": "per-env"
+}}
+```
+
+- **On a `claude-code` step, declare `output_schema` and put `escalation` in it** (nullable). Without a schema, an agentic session that ends on prose loses the marker — pflow then emits a degrading warning ("an escalation attempt may have been swallowed") instead of pausing. A plain string `escalation` value also works (it becomes the question).
+- After the human answers, the marker gains `decision`: `result.escalation.decision = {"chosen": ..., "notes": ...}`. A marker that already carries `decision` never re-prompts.
+- The escalating step must end on a **clean success** (`default` action). A `code` step that routes via `next:` cannot escalate from the same execution — escalate from the agent step, route on the decision downstream.
+- Escalations **cannot be pre-approved** (`--auto-approve` does not apply — the question is unknown in advance). Non-interactive runs fail loudly at the escalation.
+- Not supported from inside a `batch:` step — the run fails with a clear error; restructure so the escalating step runs outside the batch.
+
+### Continuing from the decision — the re-fork recipe
+
+The engine only records the choice; **the workflow decides what happens next**. The standard shape is a `loop:` that re-runs the agent with the decision carried in:
+
+```markdown
+### implement
+
+Implement the plan; escalate genuine lasting-impact forks.
+
+- type: claude-code
+- prompt: |
+    Implement the plan at ${plan_path}.
+    ${implement.result.escalation.decision ?? ""}
+    If you hit a decision with lasting impact the plan does not settle, return it
+    in `escalation` (question, options, recommendation) and stop. Decide routine
+    choices yourself and log them.
+- output_schema: {"type": "object", "properties": {..., "escalation": {...}}}
+- loop:
+    while: ${implement.result.escalation}
+    max_iterations: 3
+```
+
+Round 1 escalates → the human answers → round 2 re-runs the same step with `decision` resolved into the prompt. (`while:` reads the marker; a decided marker still loops one more round to fold the answer in — have the agent clear `escalation` (null) once the decision is applied, which ends the loop.)
+
+**Calibration is the contract**: instruct the agent to escalate ONLY genuine lasting-impact forks it cannot resolve from the plan — never routine choices (too eager defeats autonomy; too reluctant silently bakes in bad decisions).
+
+## Observability
+
+- Every gate emits `gate` trace events (pause with the full payload; resolution with `approved`/`denied`/`auto`/`choice` and `resolved_via: prompt|flag` — the audit trail for which gates a human answered vs. a flag). One exception: a gate answered inside a `batch:` item's sub-workflow is honored but its gate events do not reach the trace (batch-item events are rollup-only today) — if you need the audit record, gate outside the batch.
+- Denied runs: exit 3, `final_status: "denied"`, amber in `pflow ui`. A denied trace is not used as an `--only` snapshot source.
+- Ctrl-C at a prompt aborts the run like any interrupt (exit 130).

--- a/src/pflow/guide/features/approval.md
+++ b/src/pflow/guide/features/approval.md
@@ -67,7 +67,7 @@ The contract — `result.escalation`, with this shape:
 - **On a `claude-code` step, declare `output_schema` and put `escalation` in it** (nullable). Without a schema, an agentic session that ends on prose loses the marker — pflow then emits a degrading warning ("an escalation attempt may have been swallowed") instead of pausing. A plain string `escalation` value also works (it becomes the question).
 - After the human answers, the marker gains `decision`: `result.escalation.decision = {"chosen": ..., "notes": ...}`. A marker that already carries `decision` never re-prompts.
 - The escalating step must end on a **clean success** (`default` action). A `code` step that routes via `next:` cannot escalate from the same execution — escalate from the agent step, route on the decision downstream.
-- Escalations **cannot be pre-approved** (`--auto-approve` does not apply — the question is unknown in advance). Non-interactive runs fail loudly at the escalation.
+- Escalations **cannot be pre-approved** (`--auto-approve` does not apply — the question is unknown in advance). Non-interactive runs fail loudly at the escalation — **after the step has already run**, and the escalating result is deliberately never cached (a cached escalation would replay on a later run as resolved-without-a-decision). A re-run re-executes the escalating step from scratch, so an expensive agent step's work is discarded. If a workflow may escalate, run it interactively.
 - Not supported from inside a `batch:` step — the run fails with a clear error; restructure so the escalating step runs outside the batch.
 
 ### Continuing from the decision — the re-fork recipe

--- a/src/pflow/mcp_server/CLAUDE.md
+++ b/src/pflow/mcp_server/CLAUDE.md
@@ -73,7 +73,7 @@ All tools use async/sync bridge: `await asyncio.to_thread(_sync_operation)` — 
 - `registry_discover(task)` — Find nodes via LLM selection. Pass full task description.
 
 **execution_tools.py** (7 tools):
-- `workflow_execute(workflow, parameters)` — Execute with agent defaults (no repair, silent, traces saved)
+- `workflow_execute(workflow, parameters, auto_approve)` — Execute with agent defaults (no repair, silent, traces saved). MCP runs are non-interactive: a workflow with an `approval:` gate fails loudly with the gate payload unless that gate's step name is listed in `auto_approve` (ask your human first; escalations can never be pre-approved)
 - `workflow_validate(workflow)` — Static validation without execution (10 checks including sub-workflow validation)
 - `plan_workflow(workflow, parameters)` — Build execution plan JSON without side effects
 - `workflow_save(workflow, name, force)` — Save to library (accepts raw markdown or file path)

--- a/src/pflow/mcp_server/services/execution_service.py
+++ b/src/pflow/mcp_server/services/execution_service.py
@@ -229,12 +229,20 @@ class ExecutionService(BaseService):
 
     @classmethod
     @ensure_stateless
-    def execute_workflow(cls, workflow: Any, parameters: dict[str, Any] | None = None) -> str:
+    def execute_workflow(
+        cls,
+        workflow: Any,
+        parameters: dict[str, Any] | None = None,
+        auto_approve: list[str] | None = None,
+    ) -> str:
         """Execute a workflow with agent-optimized defaults.
 
         Args:
             workflow: Workflow name, path, or IR dict
             parameters: Execution parameters
+            auto_approve: Step names whose approval gates are pre-approved (Task 125).
+                MCP runs cannot prompt, so a gate NOT listed here fails loudly with
+                the ask-your-human remediation ladder. Escalations never pre-approve.
 
         Returns:
             Formatted text output matching CLI (success or error)
@@ -243,6 +251,7 @@ class ExecutionService(BaseService):
             ValueError: If workflow not found (with suggestions) or parameters fail security validation
             RuntimeError: All other failures (validation, compilation, execution)
         """
+        from pflow.execution.gate_prompt import build_gate_resolver
         from pflow.execution.result import RunnerConfig
         from pflow.execution.runner import WorkflowRunner
 
@@ -281,6 +290,11 @@ class ExecutionService(BaseService):
             # is CLI-only in v1; otherwise MCP runs would write to ~/.pflow/debug and become unintended
             # --only / analyze-cache snapshot sources.
             RunnerConfig(trace_enabled=False),
+            # MCP is the production non-TTY surface: output_controller=None means the
+            # resolver honors auto_approve pre-approvals and otherwise raises the
+            # payload-carrying GateNotInteractiveError (never hangs, never silently
+            # approves). Same builder as the CLI — one resolver, every surface.
+            gate_resolver=build_gate_resolver(frozenset(auto_approve or ()), None),
             workflow_manager=wm,
             workflow_name=workflow_name,
         )

--- a/src/pflow/mcp_server/tools/execution_tools.py
+++ b/src/pflow/mcp_server/tools/execution_tools.py
@@ -26,6 +26,17 @@ async def workflow_execute(
         dict[str, Any] | None,
         Field(description="Input parameters as key-value pairs matching the workflow's declared inputs"),
     ] = None,
+    auto_approve: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "Step names whose `approval: required` gates are pre-approved (one per gate; "
+                "no blanket form). MCP runs cannot prompt a human, so a gated step NOT listed "
+                "here fails with instructions. ASK YOUR HUMAN before passing this — the gate "
+                "exists so a person reviews the action first."
+            )
+        ),
+    ] = None,
 ) -> str:
     """Execute a workflow with natural language output.
 
@@ -41,6 +52,9 @@ async def workflow_execute(
       the workflow via the `pflow` CLI to get a saved trace for `pflow report` /
       `analyze-cache`).
     - Returns explicit errors with suggestions for fixing
+    - Steps declaring `approval: required` pause for a human. MCP runs cannot
+      prompt, so such a step fails with instructions unless its name is in
+      `auto_approve` — ask your human before pre-approving.
 
     Before executing:
     1. Call workflow_describe to understand required parameters
@@ -81,7 +95,7 @@ async def workflow_execute(
 
     def _sync_execute() -> str:
         """Synchronous execution operation."""
-        return ExecutionService.execute_workflow(workflow, parameters)
+        return ExecutionService.execute_workflow(workflow, parameters, auto_approve)
 
     # Run in thread pool to avoid blocking
     result = await asyncio.to_thread(_sync_execute)

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -185,6 +185,14 @@ shared["__failures__"] = {
 # System keys
 shared["__trace_collector__"] = WorkflowTraceCollector
 shared["__progress_callback__"] = func
+shared["__gate_resolver__"] = func            # Task 125: resolver(request, *, allow_prompt) -> GateResolution.
+                                              # Installed by the CLI/MCP layer (Phase 3); absent → any gate
+                                              # raises GateNotInteractiveError (loud, payload-carrying). In
+                                              # _PROPAGATED_KEYS so nested gates prompt through the same channel.
+shared["__gate_prompt_allowed__"] = bool      # Task 125: False ONLY inside parallel-batch worker stores (set by
+                                              # batch_executor.process_item) — the resolver may still auto-approve
+                                              # from its flag set but must not prompt. Propagated so the ban
+                                              # reaches grandchildren. Absent = True.
 shared["__warnings__"] = {}               # Node warnings → DEGRADED status.
                                           # Values may be legacy strings,
                                           # structured warning dicts, or

--- a/src/pflow/runtime/CLAUDE.md
+++ b/src/pflow/runtime/CLAUDE.md
@@ -186,8 +186,9 @@ shared["__failures__"] = {
 shared["__trace_collector__"] = WorkflowTraceCollector
 shared["__progress_callback__"] = func
 shared["__gate_resolver__"] = func            # Task 125: resolver(request, *, allow_prompt) -> GateResolution.
-                                              # Installed by the CLI/MCP layer (Phase 3); absent → any gate
-                                              # raises GateNotInteractiveError (loud, payload-carrying). In
+                                              # Installed by the CLI/MCP layer (execution/gate_prompt.py via
+                                              # runner.run(gate_resolver=...)); absent → any gate raises
+                                              # GateNotInteractiveError (loud, payload-carrying). In
                                               # _PROPAGATED_KEYS so nested gates prompt through the same channel.
 shared["__gate_prompt_allowed__"] = bool      # Task 125: False ONLY inside parallel-batch worker stores (set by
                                               # batch_executor.process_item) — the resolver may still auto-approve

--- a/src/pflow/runtime/compilation/CLAUDE.md
+++ b/src/pflow/runtime/compilation/CLAUDE.md
@@ -54,6 +54,7 @@ This is where bare nodes get created and configured. The step order is load-bear
 12. Build `BatchConfig` (if batch) then `_build_loop_config()` (if `loop:`). **Batch and loop are mutually exclusive** — both set raises `CompilationError`. Loop enforces single `while:`/`until:` polarity and bounds a literal `max_iterations` to `[1, MAX_NODE_VISITS]`; a `${template}` `max_iterations` is deferred to runtime.
 13. Build `TemplateConfig` (if any templates, OR a carry loop — round-2 carry inputs become template_params).
 14. Extract per-node cache fields (LLM nodes only): `_extract_prompt_cache_items` reads top-level `prompt_cache:` into a tuple of chunk names (rejects non-list and `tuple("string")` silent-splat); `_extract_prewarm` reads top-level `prewarm:` strict-bool. Both feed `NodeConfig.prompt_cache_items` / `NodeConfig.prewarm` (defaults: empty tuple / False).
+14.5. `_extract_approval` (Task 125) reads top-level `approval:` — only the literal string `"required"` passes (anything else → `CompilationError`) — and re-checks the shared batch-host rule (`core/workflow/gate_validation.check_approval_allowed`) as a fail-fast mirror for programmatic IRs that skip validation → `NodeConfig.approval`.
 15. Build and return `NodeConfig`
 
 ### Other functions

--- a/src/pflow/runtime/compilation/compiler.py
+++ b/src/pflow/runtime/compilation/compiler.py
@@ -20,6 +20,7 @@ from pflow.core.exceptions import CompilationError
 from pflow.core.llm_config import get_default_workflow_model, get_model_not_configured_help
 from pflow.core.node import Node
 from pflow.core.prompt_cache import CacheBlockIR, CacheChunkIR
+from pflow.core.workflow.gate_validation import check_approval_allowed
 from pflow.core.workflow.loop_validation import check_loop_polarity
 from pflow.registry import Registry
 from pflow.runtime.engine import instrumentation
@@ -381,6 +382,7 @@ def _create_node_and_config(
         prompt_cache_items=_extract_prompt_cache_items(node_data),
         prewarm=_extract_prewarm(node_data),
         loop_config=loop_config,
+        approval=_extract_approval(node_data),
     )
 
     return node_instance, node_config
@@ -687,6 +689,35 @@ def _extract_prewarm(node_data: dict[str, Any]) -> bool:
             suggestion="Set prewarm to true or false (e.g., `prewarm: true`).",
         )
     return raw
+
+
+def _extract_approval(node_data: dict[str, Any]) -> bool:
+    """Coerce ``approval:`` into a bool. Only the literal string ``"required"`` is
+    accepted (schema enforces the enum; this is the compile-path mirror for
+    programmatic IRs that skip schema validation). Also enforces the batch
+    exclusion via the shared ``check_approval_allowed`` rule so the run path
+    fails fast even when validation was bypassed."""
+    raw = node_data.get("approval")
+    if raw is None:
+        return False
+    if raw != "required":
+        raise CompilationError(
+            f"approval must be the string 'required'; got {type(raw).__name__}: {raw!r}",
+            phase="validation",
+            node_id=node_data.get("id"),
+            node_type=node_data.get("type"),
+            suggestion="The only supported value is `approval: required`.",
+        )
+    batch_error = check_approval_allowed(node_data)
+    if batch_error is not None:
+        raise CompilationError(
+            batch_error,
+            phase="validation",
+            node_id=node_data.get("id"),
+            node_type=node_data.get("type"),
+            suggestion="Move `approval: required` to the step before or after the batch.",
+        )
+    return True
 
 
 def _build_cache_block(ir_dict: dict[str, Any]) -> Optional[CacheBlockIR]:

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -37,21 +37,43 @@ WorkflowEngine(metrics, trace, only_node).run(workflow, shared) → action_strin
         │
         ├─ INSIDE try (template errors get trace recording):
         │  4-7. plan_node() → decides cached/miss and returns NodePlan
+        │  7.5. Task 125: if config.approval → run_approval_gate (gate.py) — pause,
+        │      resolve via shared["__gate_resolver__"], gate events streamed. BEFORE
+        │      step 8/8.5 so a denied node never appears in trace/progress. Deny →
+        │      GateDenied; no resolver → GateNotInteractiveError (both exempted below).
+        │      Cache hits early-return upstream — cached nodes never gate.
         │  8. call_start_callback
-        │  9. execute: batch → execute_batch() | single → node._run(namespaced_store)
+        │  9. execute: batch → execute_batch() + scan_batch_escalations (an UNDECIDED
+        │      escalation marker in an item result → loud PflowError; per-item gates
+        │      don't exist on direct batch hosts) | single → node._run(namespaced_store)
         │  10. detect_api_warning → handle_api_warning if found (returns "error").
         │      Runs ONLY for clean-success actions (_CLEAN_SUCCESS_ACTIONS); an
         │      error/custom-route action skips it — the node's verdict stands (GH #301/#474).
-        │  11. cache_result, 12. write_memo_cache (SKIP when cache_enabled=False)
+        │  10.5. Task 125: detect_escalation (non-batch, clean-success actions only) —
+        │      an undecided `result.escalation` marker. Detection here so an escalating
+        │      result (an INCOMPLETE work product) skips BOTH cache writes below; the
+        │      pause itself is step 17.7. Malformed markers → degrading warning, no pause.
+        │  11. cache_result, 12. write_memo_cache (SKIP when cache_enabled=False;
+        │      BOTH skipped when escalating)
         │  13-17. duration, metrics, record_trace, call_completion_callback
         │  17.5. if action starts with "error": mark_node_failed (archive to __failures__,
         │        + warning= when error successor exists → triggers DEGRADED, GH #246)
-        │  17.6. if config.loop_config and not error: _loop_should_reenter (loop_control)
-        │        evaluates `while:` over the node's fresh output → `continue` (re-run
-        │        the same node, byte-for-byte a backward-edge revisit) or fall through;
-        │        cap-hit stamps loop_stopped + emits an INFO advisory (issue #445)
+        │  17.7. Task 125: if escalation → run_escalation_gate — pause AFTER the node's
+        │        own completion trace/callback (its success record stands), write the
+        │        human's decision INTO the marker (result.escalation.decision — decided
+        │        markers never re-prompt), gate events streamed. Runs before the walk's
+        │        loop-re-entry check reads the store, so `loop:` + carry folds
+        │        ${step.result.escalation.decision} into the next iteration.
+        │  (17.6 loop re-entry lives in _run_inner, after _execute_node returns)
         │
-        └─ EXCEPT (error path):
+        └─ EXCEPT:
+           (GateDenied, GateNotInteractiveError) → stamp trace.gate_outcome
+           ("denied"/"failed" — the trailer channel; _determine_trace_status has no
+           other signal for a gate stop) and re-raise UNTOUCHED: no record_trace(error),
+           no error callback, no mark_node_failed — a gate verdict is control flow,
+           not a node failure. Same re-raise arm exists in WorkflowExecutor.exec, and
+           both exceptions carry retriable=False so batch retry loops re-raise too.
+           Generic error path (everything else):
            metrics, record_trace(error=e),
            call_completion_callback(action="error", error=e),
            mark_node_failed (archive to __failures__),

--- a/src/pflow/runtime/engine/CLAUDE.md
+++ b/src/pflow/runtime/engine/CLAUDE.md
@@ -40,7 +40,8 @@ WorkflowEngine(metrics, trace, only_node).run(workflow, shared) → action_strin
         │  7.5. Task 125: if config.approval → run_approval_gate (gate.py) — pause,
         │      resolve via shared["__gate_resolver__"], gate events streamed. BEFORE
         │      step 8/8.5 so a denied node never appears in trace/progress. Deny →
-        │      GateDenied; no resolver → GateNotInteractiveError (both exempted below).
+        │      GateDenied; no resolver → GateNotInteractiveError; resolver crash /
+        │      wrong return type → GateResolverError (all exempted below).
         │      Cache hits early-return upstream — cached nodes never gate.
         │  8. call_start_callback
         │  9. execute: batch → execute_batch() + scan_batch_escalations (an UNDECIDED
@@ -67,12 +68,17 @@ WorkflowEngine(metrics, trace, only_node).run(workflow, shared) → action_strin
         │  (17.6 loop re-entry lives in _run_inner, after _execute_node returns)
         │
         └─ EXCEPT:
-           (GateDenied, GateNotInteractiveError) → stamp trace.gate_outcome
+           (GateDenied, GateNotInteractiveError, GateResolverError) → stamp trace.gate_outcome
            ("denied"/"failed" — the trailer channel; _determine_trace_status has no
            other signal for a gate stop) and re-raise UNTOUCHED: no record_trace(error),
            no error callback, no mark_node_failed — a gate verdict is control flow,
-           not a node failure. Same re-raise arm exists in WorkflowExecutor.exec, and
-           both exceptions carry retriable=False so batch retry loops re-raise too.
+           not a node failure. ONE deliberate trace write in this arm: when the node is
+           a sub-workflow HOST (getattr(node, "_host_frame")), record_trace(success=True,
+           frame=host_frame) closes the seq reserved by WorkflowExecutor's descend() —
+           without it an earlier sibling child event orphans and finalize()/tree() raise,
+           silently losing the trace file. Same re-raise arm exists in
+           WorkflowExecutor.exec, and all three exceptions carry retriable=False so
+           batch retry loops re-raise too.
            Generic error path (everything else):
            metrics, record_trace(error=e),
            call_completion_callback(action="error", error=e),

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -752,6 +752,14 @@ def _execute_parallel(
         item_shared[batch_config.item_alias] = item
         item_shared["__index__"] = idx
 
+        # Task 125: a parallel worker cannot host an interactive gate prompt
+        # (its progress is buffered below; stdin is not shareable across
+        # threads). The flag reaches descendant sub-workflow engines via
+        # _PROPAGATED_KEYS. The resolver still auto-approves from its flag set —
+        # only prompting is off; unresolvable gates raise loudly
+        # (GateNotInteractiveError with parallel_batch=True), never hang.
+        item_shared["__gate_prompt_allowed__"] = False
+
         # Replace the inherited progress callback with a per-worker buffer.
         # The sub-workflow's child engine will fire its events into this
         # buffer instead of touching the shared OutputController. The main

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -1333,6 +1333,39 @@ class WorkflowEngine:
             # fired under a buffered child collector.
             if self.trace is not None:
                 self.trace.gate_outcome = "denied" if isinstance(gate_exc, GateDenied) else "failed"
+
+                # Code-review fix: a sub-workflow HOST's own completion event is
+                # normally recorded at step 16 below, reusing the seq
+                # WorkflowExecutor.exec() reserved via trace.descend(). Re-raising
+                # here means node._run() never returns, so step 16 never runs —
+                # the reserved seq gets no event. If a SIBLING step inside that
+                # sub-workflow already recorded before the gate fired, its event's
+                # parent_id now points at nothing: an in-memory tree() rebuild
+                # (finalize(), or any caller of collect_llm_calls()) raises
+                # "orphan event" — silently losing the run's own trace file (or
+                # crashing a caller that hits tree() directly). Recording the
+                # host's event here closes the reservation. success=True: the
+                # WorkflowExecutor node itself didn't error — the run's
+                # denied/failed verdict is carried independently by gate_outcome
+                # above, not by this per-node flag. Fires once per nesting level
+                # (each ancestor's own _execute_node catches this exception and
+                # checks its own node's _host_frame as it re-raises in turn).
+                host_frame = getattr(node, "_host_frame", None)
+                if host_frame is not None:
+                    record_trace(
+                        config.node_id,
+                        config.node_type_name,
+                        shared,
+                        start_time,
+                        shared_keys_before,
+                        last_resolutions,
+                        batch_trace_items,
+                        child_trace_events,
+                        node.params,
+                        self.trace,
+                        success=True,
+                        frame=host_frame,
+                    )
             raise
 
         except Exception as e:

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -1351,6 +1351,8 @@ class WorkflowEngine:
                 # above, not by this per-node flag. Fires once per nesting level
                 # (each ancestor's own _execute_node catches this exception and
                 # checks its own node's _host_frame as it re-raises in turn).
+                # Batch hosts stay None here: batch-item children run under
+                # buffered collectors (descend() is never called on that path).
                 host_frame = getattr(node, "_host_frame", None)
                 if host_frame is not None:
                     record_trace(

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -24,6 +24,7 @@ from pflow.core.exceptions import (
     CompilationError,
     GateDenied,
     GateNotInteractiveError,
+    GateResolverError,
     LoopCarryError,
     LoopConditionError,
 )
@@ -1321,7 +1322,7 @@ class WorkflowEngine:
 
             return action
 
-        except (GateDenied, GateNotInteractiveError) as gate_exc:
+        except (GateDenied, GateNotInteractiveError, GateResolverError) as gate_exc:
             # Task 125: a gate verdict is control flow, NOT a node failure — no
             # error trace event, no error callback, no mark_node_failed, no
             # _pflow_node_id. (A denied node never ran; a non-interactive

--- a/src/pflow/runtime/engine/engine.py
+++ b/src/pflow/runtime/engine/engine.py
@@ -20,7 +20,13 @@ from types import MappingProxyType
 from typing import Any, Literal, Optional
 
 from pflow.core.diagnostic import Diagnostic, Severity
-from pflow.core.exceptions import CompilationError, LoopCarryError, LoopConditionError
+from pflow.core.exceptions import (
+    CompilationError,
+    GateDenied,
+    GateNotInteractiveError,
+    LoopCarryError,
+    LoopConditionError,
+)
 from pflow.core.llm_capabilities import get_min_cache_tokens
 from pflow.core.prompt_cache import CacheRenderContext
 from pflow.core.validation_utils import VALIDATION_PLACEHOLDER
@@ -40,6 +46,7 @@ from pflow.runtime.template_resolver import TemplateResolver
 
 from .api_warning_detector import detect_api_warning
 from .batch_executor import _collect_batch_trace, execute_batch
+from .gate import detect_escalation, run_approval_gate, run_escalation_gate, scan_batch_escalations
 from .instrumentation import (
     apply_memo_hit,
     cache_result,
@@ -1096,6 +1103,22 @@ class WorkflowEngine:
                 if cached_hash != plan.config_hash:
                     invalidate_cache(config.node_id, shared)
 
+            # 7.5 Approval gate (Task 125): pause BEFORE the start callback and the
+            # node.start marker, so a denied node never appears in the trace and no
+            # progress partial line is open at prompt time. Cached nodes never reach
+            # here (early-return above) — a cache hit performs no action, so there
+            # is nothing to approve. Preview = resolved params; static params for
+            # no-template nodes (plan.resolved_params is None then). Raises
+            # GateDenied / GateNotInteractiveError — both exempted in the except
+            # arm below (a gate verdict is not a node failure).
+            if config.approval:
+                run_approval_gate(
+                    config,
+                    resolved_params if resolved_params is not None else node.params,
+                    shared,
+                    self.trace,
+                )
+
             # 8. Progress callback (node_start)
             call_start_callback(config.node_id, shared)
 
@@ -1117,6 +1140,11 @@ class WorkflowEngine:
                 # detect_api_warning, metrics) raised — the except handler's drain
                 # would then pop an already-empty buffer. Symmetry with the except
                 # path is the whole point of Bundle 8's shared-store recovery channel.
+                # Task 125: a direct batch host has no per-item gate seam — an
+                # UNDECIDED escalation marker in an item's result would be silently
+                # ignored. Fail loudly instead (decided markers, answered inside a
+                # sequential sub-workflow item, are skipped).
+                scan_batch_escalations(shared, config.node_id)
             else:
                 # Set resolved params on node and execute
                 if resolved_params is not None:
@@ -1168,15 +1196,27 @@ class WorkflowEngine:
                     frame=host_frame or start_frame,
                 )
 
+            # 10.5 Escalation detection (Task 125). Non-batch, clean-success only:
+            # an error action's data is archived by step 17.5 (pausing after that
+            # would break the shared-XOR-__failures__ invariant), and the
+            # api-warning early-return above already ended warning verdicts. The
+            # PAUSE happens at step 17.7 (after the node's own completion trace
+            # and callback); detection must run here because an escalating result
+            # is an incomplete work product and must not enter either cache below.
+            escalation = None
+            if not config.batch_config and (action is None or str(action) in _CLEAN_SUCCESS_ACTIONS):
+                escalation = detect_escalation(shared, config.node_id)
+
             # 11. Cache result (in-process only — not gated by cache_enabled)
-            cache_result(config.node_id, config_hash, action, shared)
+            if escalation is None:
+                cache_result(config.node_id, config_hash, action, shared)
 
             # 12. Duration (computed here so the memo cache write can record it
             # for --dry-run historical estimates — see plan_formatter.py).
             duration_ms = (time.perf_counter() - start_time) * 1000
 
             # 13. Memo cache write (skip for nodes with cache: false)
-            if config.cache_enabled:
+            if config.cache_enabled and escalation is None:
                 write_memo_cache(
                     config.node_id,
                     shared,
@@ -1271,7 +1311,29 @@ class WorkflowEngine:
                     warning=recovery_warning,
                 )
 
+            # 17.7 Escalation pause (Task 125). After the node's own completion
+            # trace/callback (its success record stands untouched) and before
+            # returning to the walk, whose loop-re-entry check must see the
+            # human's decision in the store. Mutually exclusive with step 17.5
+            # (detection is clean-success-only).
+            if escalation is not None:
+                run_escalation_gate(config, escalation, shared, self.trace)
+
             return action
+
+        except (GateDenied, GateNotInteractiveError) as gate_exc:
+            # Task 125: a gate verdict is control flow, NOT a node failure — no
+            # error trace event, no error callback, no mark_node_failed, no
+            # _pflow_node_id. (A denied node never ran; a non-interactive
+            # escalation's node already has its honest success record.) The
+            # trailer channel: _determine_trace_status derives from node events
+            # only, so without this flag a denied run's own trace would read
+            # "success". Set here (every engine level passes through, root last)
+            # so the flag lands on the run-scoped collector even when the gate
+            # fired under a buffered child collector.
+            if self.trace is not None:
+                self.trace.gate_outcome = "denied" if isinstance(gate_exc, GateDenied) else "failed"
+            raise
 
         except Exception as e:
             duration_ms = (time.perf_counter() - start_time) * 1000

--- a/src/pflow/runtime/engine/gate.py
+++ b/src/pflow/runtime/engine/gate.py
@@ -1,0 +1,244 @@
+"""Engine-side gate machinery (Task 125): approval + escalation seams.
+
+The engine owns WHEN a gate fires and the trace events around it; HOW the human
+answers is the installed resolver's job (``__gate_resolver__`` in the shared store
+— see ``core/gate.py`` for the resolver contract). This module holds everything
+the two ``_execute_node`` hook points need, keeping the engine additions to a few
+lines each.
+
+Escalation marker contract (documented in the guide): a node's ``result``, when a
+dict, may carry ``escalation``:
+
+    {"escalation": {"question": str, "options": [{"label", "description",
+     "tradeoffs"?}], "recommendation"?: str}}
+
+Lenient-but-loud shape ladder (review-hardened — a swallowed escalation is the
+silent-bad-decision failure this feature exists to prevent):
+- dict without a ``decision`` key      → escalate
+- non-empty string                     → escalate, string is the question
+- dict WITH ``decision``               → already answered elsewhere; never re-prompt
+- empty dict / other truthy shapes     → NO pause + degrading warning
+- string ``result`` + ``_schema_error``+ "escalation" substring → degrading warning
+  (a schema soft-failure may have swallowed an escalation attempt)
+
+The human's choice is written INTO the marker (``result.escalation.decision``) so
+re-exposure of the same result — through a sub-workflow output or a batch item
+snapshot — can never re-trigger the prompt (idempotent by construction).
+"""
+
+import logging
+from typing import Any, Optional, Union
+
+from pflow.core.diagnostic import Diagnostic, Severity
+from pflow.core.exceptions import GateDenied, GateNotInteractiveError, PflowError
+from pflow.core.gate import (
+    GateRequest,
+    GateResolution,
+    build_approval_request,
+    build_escalation_request,
+)
+
+logger = logging.getLogger(__name__)
+
+GATE_RESOLVER_KEY = "__gate_resolver__"
+GATE_PROMPT_ALLOWED_KEY = "__gate_prompt_allowed__"
+
+_QUESTION_PREVIEW_CHARS = 120
+
+
+def resolve_gate(request: GateRequest, shared: dict[str, Any]) -> GateResolution:
+    """Resolve one gate via the installed resolver.
+
+    No resolver installed → this run has no human channel → loud, payload-carrying
+    error (never hang, never silently approve). ``__gate_prompt_allowed__`` is
+    False only inside parallel-batch worker stores (set by the batch executor):
+    the resolver may still auto-approve from its flag set there, but must not
+    prompt — worker output is buffered and stdin is not shareable across threads.
+    """
+    resolver = shared.get(GATE_RESOLVER_KEY)
+    allow_prompt = bool(shared.get(GATE_PROMPT_ALLOWED_KEY, True))
+    if resolver is None:
+        raise GateNotInteractiveError(request, parallel_batch=not allow_prompt)
+    resolution = resolver(request, allow_prompt=allow_prompt)
+    if not isinstance(resolution, GateResolution):
+        raise PflowError(
+            f"gate resolver returned {type(resolution).__name__} instead of GateResolution "
+            f"for gate '{request.node_id}' — broken resolver installation"
+        )
+    return resolution
+
+
+def run_approval_gate(config: Any, params: Any, shared: dict[str, Any], trace: Any) -> None:
+    """Pre-exec approval gate: pause → resolve → continue or raise ``GateDenied``.
+
+    Sits BEFORE the start callback and the ``node.start`` trace marker, so a
+    denied node never appears in the trace and no progress line is open.
+    """
+    request = build_approval_request(config.node_id, config.node_type_name, params)
+    _record_gate(trace, request, phase="pause")
+    try:
+        resolution = resolve_gate(request, shared)
+    except GateNotInteractiveError:
+        _record_gate(trace, request, phase="resolution", resolution="non_interactive")
+        raise
+    if not resolution.approved:
+        _record_gate(trace, request, phase="resolution", resolution="denied", resolved_via=resolution.resolved_via)
+        raise GateDenied(request)
+    _record_gate(trace, request, phase="resolution", resolution="approved", resolved_via=resolution.resolved_via)
+
+
+def detect_escalation(shared: dict[str, Any], node_id: str) -> Optional[Union[dict[str, Any], str]]:
+    """Return the node's undecided escalation marker, or ``None``.
+
+    Applies the shape ladder above; unusable-but-clearly-intended shapes write a
+    degrading warning so a dropped escalation is never silent.
+    """
+    node_ns = shared.get(node_id)
+    if not isinstance(node_ns, dict):
+        return None
+    result = node_ns.get("result")
+    if isinstance(result, str):
+        if node_ns.get("_schema_error") and "escalation" in result:
+            _warn_escalation(
+                shared,
+                node_id,
+                f"Step '{node_id}' returned a raw string after a schema soft-failure and the text "
+                f"mentions 'escalation' — an escalation attempt may have been swallowed; the run did "
+                f"NOT pause. Fix the step's output_schema conformance (or raise schema_retries).",
+            )
+        return None
+    if not isinstance(result, dict):
+        return None
+    marker = result.get("escalation")
+    if marker is None or marker is False or marker == "" or marker == 0:
+        return None
+    if isinstance(marker, dict):
+        if "decision" in marker:
+            return None  # already answered; re-exposure must not re-prompt
+        if not marker:
+            _warn_escalation(
+                shared,
+                node_id,
+                f"Step '{node_id}' emitted an EMPTY 'escalation' marker — expected "
+                f"{{question, options, recommendation}}; the run did NOT pause.",
+            )
+            return None
+        return marker
+    if isinstance(marker, str):
+        return marker
+    _warn_escalation(
+        shared,
+        node_id,
+        f"Step '{node_id}' emitted 'escalation' with an unusable shape ({type(marker).__name__}) — "
+        f"expected {{question, options, recommendation}} or a question string; the run did NOT pause.",
+    )
+    return None
+
+
+def run_escalation_gate(config: Any, marker: Union[dict[str, Any], str], shared: dict[str, Any], trace: Any) -> None:
+    """Post-exec escalation gate: pause → human chooses → decision written into the marker.
+
+    Runs AFTER the node's own completion trace/callbacks (its success record
+    stands untouched) and BEFORE the walk's loop-re-entry check reads the store —
+    so ``loop:`` + carry wiring folds ``${step.result.escalation.decision}`` into
+    the re-forked agent. There is no deny: the resolver returns a choice.
+    """
+    request = build_escalation_request(config.node_id, config.node_type_name, marker)
+    _record_gate(trace, request, phase="pause")
+    try:
+        resolution = resolve_gate(request, shared)
+    except GateNotInteractiveError:
+        _record_gate(trace, request, phase="resolution", resolution="non_interactive")
+        raise
+    decision = {"chosen": resolution.chosen, "notes": resolution.notes}
+    result = shared[config.node_id]["result"]
+    if isinstance(marker, str):
+        result["escalation"] = {"question": marker, "decision": decision}
+    else:
+        marker["decision"] = decision
+    _record_gate(
+        trace,
+        request,
+        phase="resolution",
+        resolution="choice",
+        resolved_via=resolution.resolved_via,
+        decision=decision,
+    )
+
+
+def scan_batch_escalations(shared: dict[str, Any], node_id: str) -> None:
+    """Fail loudly on an UNDECIDED escalation marker in a batch item's result.
+
+    A direct batch host has no per-item gate seam, so a marker here would
+    otherwise be silently ignored. Decided markers (answered inside a sequential
+    sub-workflow item) are skipped. Failed items are already error-reported by
+    the batch machinery — ``results`` holds successes only.
+    """
+    output = shared.get(node_id)
+    if not isinstance(output, dict):
+        return
+    results = output.get("results")
+    if not isinstance(results, list):
+        return
+    total = output.get("count", len(results))
+    for i, item_ns in enumerate(results):
+        if not isinstance(item_ns, dict):
+            continue
+        result = item_ns.get("result")
+        if not isinstance(result, dict):
+            continue
+        marker = result.get("escalation")
+        if not marker or (isinstance(marker, dict) and "decision" in marker):
+            continue
+        question = marker.get("question") if isinstance(marker, dict) else marker
+        preview = str(question)[:_QUESTION_PREVIEW_CHARS] if question else "<no question>"
+        raise PflowError(
+            f"Step '{node_id}' raised an escalation from batch item {i + 1} of {total}: "
+            f'"{preview}" — escalations inside a batch are not supported; restructure so '
+            f"the escalating step runs outside the batch."
+        )
+
+
+def _record_gate(
+    trace: Any,
+    request: GateRequest,
+    *,
+    phase: str,
+    resolution: Optional[str] = None,
+    resolved_via: Optional[str] = None,
+    decision: Optional[dict[str, Any]] = None,
+) -> None:
+    if trace is None:
+        return
+    trace.record_gate(
+        request.node_id,
+        phase=phase,
+        gate_kind=request.kind,
+        request=request if phase == "pause" else None,
+        resolution=resolution,
+        resolved_via=resolved_via,
+        decision=decision,
+    )
+
+
+def _warn_escalation(shared: dict[str, Any], node_id: str, message: str) -> None:
+    logger.warning(message)
+    shared.setdefault("__warnings__", {})[node_id] = Diagnostic(
+        severity=Severity.WARNING,
+        message=message,
+        title="Escalation marker dropped",
+        node_id=node_id,
+        source="runtime",
+        context={"category": "gate", "type": "escalation_marker_dropped"},
+    )
+
+
+__all__ = [
+    "GATE_PROMPT_ALLOWED_KEY",
+    "GATE_RESOLVER_KEY",
+    "detect_escalation",
+    "resolve_gate",
+    "run_approval_gate",
+    "run_escalation_gate",
+    "scan_batch_escalations",
+]

--- a/src/pflow/runtime/engine/gate.py
+++ b/src/pflow/runtime/engine/gate.py
@@ -30,7 +30,7 @@ import logging
 from typing import Any, Optional, Union
 
 from pflow.core.diagnostic import Diagnostic, Severity
-from pflow.core.exceptions import GateDenied, GateNotInteractiveError, PflowError
+from pflow.core.exceptions import GateDenied, GateNotInteractiveError, GateResolverError, PflowError
 from pflow.core.gate import (
     GateRequest,
     GateResolution,
@@ -59,11 +59,22 @@ def resolve_gate(request: GateRequest, shared: dict[str, Any]) -> GateResolution
     allow_prompt = bool(shared.get(GATE_PROMPT_ALLOWED_KEY, True))
     if resolver is None:
         raise GateNotInteractiveError(request, parallel_batch=not allow_prompt)
-    resolution = resolver(request, allow_prompt=allow_prompt)
+    try:
+        resolution = resolver(request, allow_prompt=allow_prompt)
+    except (GateDenied, GateNotInteractiveError):
+        raise
+    except Exception as exc:
+        # A resolver bug must not fall to the engine's generic except arm: at
+        # the post-exec escalation seam the node's success was already traced,
+        # and the generic arm would record a duplicate error event and archive
+        # the successful output into __failures__. GateResolverError shares the
+        # gate exceptions' exemptions so the run fails without rewriting the
+        # node's honest record. (KeyboardInterrupt is BaseException — passes.)
+        raise GateResolverError(request, detail=f"{type(exc).__name__}: {exc}") from exc
     if not isinstance(resolution, GateResolution):
-        raise PflowError(
-            f"gate resolver returned {type(resolution).__name__} instead of GateResolution "
-            f"for gate '{request.node_id}' — broken resolver installation"
+        raise GateResolverError(
+            request,
+            detail=f"returned {type(resolution).__name__} instead of GateResolution — broken resolver installation",
         )
     return resolution
 
@@ -80,6 +91,9 @@ def run_approval_gate(config: Any, params: Any, shared: dict[str, Any], trace: A
         resolution = resolve_gate(request, shared)
     except GateNotInteractiveError:
         _record_gate(trace, request, phase="resolution", resolution="non_interactive")
+        raise
+    except GateResolverError:
+        _record_gate(trace, request, phase="resolution", resolution="error")
         raise
     if not resolution.approved:
         _record_gate(trace, request, phase="resolution", resolution="denied", resolved_via=resolution.resolved_via)
@@ -150,6 +164,9 @@ def run_escalation_gate(config: Any, marker: Union[dict[str, Any], str], shared:
     except GateNotInteractiveError:
         _record_gate(trace, request, phase="resolution", resolution="non_interactive")
         raise
+    except GateResolverError:
+        _record_gate(trace, request, phase="resolution", resolution="error")
+        raise
     decision = {"chosen": resolution.chosen, "notes": resolution.notes}
     result = shared[config.node_id]["result"]
     if isinstance(marker, str):
@@ -181,6 +198,12 @@ def scan_batch_escalations(shared: dict[str, Any], node_id: str) -> None:
     if not isinstance(results, list):
         return
     total = output.get("count", len(results))
+    # `results` is filtered to successes, so position i is NOT the original item
+    # number when earlier items failed. Reconstruct original indices from the
+    # authoritative errors list (each error carries its original "index").
+    errors = output.get("errors")
+    error_indices = {e.get("index") for e in errors if isinstance(e, dict)} if isinstance(errors, list) else set()
+    original_indices = [idx for idx in range(total) if idx not in error_indices]
     for i, item_ns in enumerate(results):
         if not isinstance(item_ns, dict):
             continue
@@ -190,10 +213,11 @@ def scan_batch_escalations(shared: dict[str, Any], node_id: str) -> None:
         marker = result.get("escalation")
         if not marker or (isinstance(marker, dict) and "decision" in marker):
             continue
+        item_number = original_indices[i] + 1 if i < len(original_indices) else i + 1
         question = marker.get("question") if isinstance(marker, dict) else marker
         preview = str(question)[:_QUESTION_PREVIEW_CHARS] if question else "<no question>"
         raise PflowError(
-            f"Step '{node_id}' raised an escalation from batch item {i + 1} of {total}: "
+            f"Step '{node_id}' raised an escalation from batch item {item_number} of {total}: "
             f'"{preview}" — escalations inside a batch are not supported; restructure so '
             f"the escalating step runs outside the batch."
         )

--- a/src/pflow/runtime/engine/types.py
+++ b/src/pflow/runtime/engine/types.py
@@ -69,6 +69,7 @@ class NodeConfig:
     prompt_cache_items: tuple[str, ...] = ()
     prewarm: bool = False  # Task 159: per-node serialize-first-then-fan-out opt-in.
     loop_config: Optional["LoopConfig"] = None  # issue #445: None if not a loop node.
+    approval: bool = False  # Task 125: pause for human approval before exec.
 
 
 @dataclass

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -7,6 +7,8 @@ from typing import Any, ClassVar, Optional
 
 from pflow.core.diagnostic import Diagnostic, format_child_provenance, normalize_runtime_warning
 from pflow.core.exceptions import (
+    GateDenied,
+    GateNotInteractiveError,
     MarkdownParseError,
     PflowError,
     WorkflowNotFoundError,
@@ -151,6 +153,11 @@ class WorkflowExecutor(BaseNode):
         # the child must inherit the active loop depth so its inner nodes also
         # suppress memo reads for the duration of the iteration.
         "__loop_active__",
+        # Task 125: gates inside sub-workflows resolve through the same human
+        # channel as the parent's — and the parallel-batch "no prompting here"
+        # flag must reach grandchildren too (a per-item heuristic would not).
+        "__gate_resolver__",
+        "__gate_prompt_allowed__",
     )
 
     def prep(self, shared: dict[str, Any]) -> dict[str, Any]:
@@ -435,19 +442,22 @@ class WorkflowExecutor(BaseNode):
         try:
             result = engine.run(compiled, child_storage)
 
-            # OLD path only (run_collector is None): hand the buffer's events to the parent engine to
-            # embed. On the NEW path the child's nodes already recorded flat into the run collector.
-            if run_collector is None and trace_for_child and trace_for_child.events:
-                self._child_trace_events = trace_for_child.events
+            self._stash_child_buffer(run_collector, trace_for_child)
 
             # Detect sub-workflow failure via action string
             if isinstance(result, str) and result.startswith("error"):
                 return self._child_failure_result(prep_res, child_storage, workflow_path)
 
             return {"success": True, "result": result, "child_storage": child_storage}
+        except (GateDenied, GateNotInteractiveError):
+            # Task 125: a gate verdict from inside the child must cross this
+            # boundary UN-converted. Folding it into _child_failure_result would
+            # make it error_action-routable — a workflow continuing past a
+            # human's denial — and would flatten the payload-carrying
+            # diagnostic. (KeyboardInterrupt already passes — BaseException.)
+            raise
         except Exception as e:
-            if run_collector is None and trace_for_child and trace_for_child.events:
-                self._child_trace_events = trace_for_child.events
+            self._stash_child_buffer(run_collector, trace_for_child)
             # A strict-mode template failure carries its structured Diagnostic
             # (unresolved_references, peer suggestions) ONLY on the exception — it
             # is never in child_storage — so capture it here for full fidelity.
@@ -575,6 +585,13 @@ class WorkflowExecutor(BaseNode):
         for key, value in child_storage.items():
             if WorkflowExecutor.is_exposable_child_key(key, child_input_keys):
                 shared[key] = value
+
+    def _stash_child_buffer(self, run_collector: Any, trace_for_child: Any) -> None:
+        """OLD path only (``run_collector is None``): hand the buffer collector's events
+        to the parent engine to embed as ``sub_workflow_events``. On the NEW path the
+        child's nodes already recorded flat into the run collector — no-op."""
+        if run_collector is None and trace_for_child and trace_for_child.events:
+            self._child_trace_events = trace_for_child.events
 
     def _child_failure_result(
         self,

--- a/src/pflow/runtime/workflow_executor.py
+++ b/src/pflow/runtime/workflow_executor.py
@@ -9,6 +9,7 @@ from pflow.core.diagnostic import Diagnostic, format_child_provenance, normalize
 from pflow.core.exceptions import (
     GateDenied,
     GateNotInteractiveError,
+    GateResolverError,
     MarkdownParseError,
     PflowError,
     WorkflowNotFoundError,
@@ -449,7 +450,7 @@ class WorkflowExecutor(BaseNode):
                 return self._child_failure_result(prep_res, child_storage, workflow_path)
 
             return {"success": True, "result": result, "child_storage": child_storage}
-        except (GateDenied, GateNotInteractiveError):
+        except (GateDenied, GateNotInteractiveError, GateResolverError):
             # Task 125: a gate verdict from inside the child must cross this
             # boundary UN-converted. Folding it into _child_failure_result would
             # make it error_action-routable — a workflow continuing past a

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -671,7 +671,7 @@ class WorkflowTraceCollector:
         """
         if resolution == "denied":
             self.gate_outcome = "denied"
-        elif resolution == "non_interactive":
+        elif resolution in ("non_interactive", "error"):
             self.gate_outcome = "failed"
         self._assert_owner_thread()
         self._open_stream()

--- a/src/pflow/runtime/workflow_trace.py
+++ b/src/pflow/runtime/workflow_trace.py
@@ -638,6 +638,53 @@ class WorkflowTraceCollector:
         # as ``node_params``); redaction happens on read. ``None`` until stamped,
         # ``{}`` for a no-input workflow.
         self.inputs: dict[str, Any] | None = None
+        # Task 125: terminal gate outcome for the trailer. _determine_trace_status
+        # derives from node events only, and a gated stop leaves NO failed node
+        # event (a denied node never ran; a non-interactive escalation's node
+        # succeeded) — without this channel a gate-stopped run's own trace would
+        # read "success". "denied" → trailer "denied"; "failed" → trailer
+        # "failed". Set by record_gate AND by the engine's gate-exception
+        # re-raise arm (which covers gates fired under buffered child collectors).
+        self.gate_outcome: str | None = None
+
+    def record_gate(
+        self,
+        node_id: str,
+        *,
+        phase: str,
+        gate_kind: str,
+        request: Any = None,
+        resolution: str | None = None,
+        resolved_via: str | None = None,
+        decision: dict[str, Any] | None = None,
+    ) -> None:
+        """Task 125: stream one ``gate`` line (``phase="pause"`` carrying the
+        GateRequest payload, or ``phase="resolution"`` carrying the verdict).
+
+        DISK-ONLY, exactly like ``node.start``: never appended to ``self.events``
+        — a gate line in the event stream would become the node's "final event"
+        in ``final_events_by_node`` and (having no ``node_output``) make
+        ``seed_snapshot_into_shared`` silently skip seeding that node for
+        ``--only``. The reconstruct reader ignores the kind
+        (``trace_io._partition_trace_lines``); Task 171 reads gate lines with
+        its own explicit reader.
+        """
+        if resolution == "denied":
+            self.gate_outcome = "denied"
+        elif resolution == "non_interactive":
+            self.gate_outcome = "failed"
+        self._assert_owner_thread()
+        self._open_stream()
+        line: dict[str, Any] = {"kind": "gate", "node_id": node_id, "phase": phase, "gate_kind": gate_kind}
+        if request is not None:
+            line["request"] = request.to_dict()
+        if resolution is not None:
+            line["resolution"] = resolution
+        if resolved_via is not None:
+            line["resolved_via"] = resolved_via
+        if decision is not None:
+            line["decision"] = decision
+        self._flush_line(line)
 
     def record_node_execution(
         self,
@@ -1335,6 +1382,12 @@ class WorkflowTraceCollector:
         Returns:
             Status string: "success", "degraded", or "failed"
         """
+        # Task 125: a gate-stopped run leaves no failed node event — the gate
+        # outcome channel is the only honest signal (see gate_outcome in __init__).
+        if self.gate_outcome == "denied":
+            return "denied"
+        if self.gate_outcome == "failed":
+            return "failed"
         if final_events is None:
             final_events = final_events_by_node(self._top_level_events())
         execution_warnings = self.execution_warnings or []

--- a/src/pflow/ui/CLAUDE.md
+++ b/src/pflow/ui/CLAUDE.md
@@ -102,7 +102,7 @@ fixing save).
 only_node, trace_file, git_root}]` — runs scanned from `~/.pflow/debug`, newest-first (Task 173 D6 run
 navigation). Bare = every run; `?workflow=X` = that workflow's history (matched on the recorded
 `meta.workflow_path`). RAW facts (the UI composes the badge): `complete` = has a `run.complete`
-trailer; `final_status` = that trailer's outcome (`success`/`degraded`/`failed`) or `null` while
+trailer; `final_status` = that trailer's outcome (`success`/`degraded`/`failed`/`denied` — the last via Task 125's gate_outcome channel) or `null` while
 not complete; `live` = not complete AND the writer still holds the trace's advisory lock (EXACT
 `flock` liveness via `is_trace_locked` — the old `_STALE_RUN_S` mtime heuristic is deleted; a
 no-`fcntl` FS falls back to "incomplete = live"); `only_node` LABELS `--only` runs (they are kept

--- a/tests/shared/markdown_utils.py
+++ b/tests/shared/markdown_utils.py
@@ -80,6 +80,10 @@ def ir_to_markdown(  # noqa: C901
             cache = node.get("cache")
             if cache is not None:
                 lines.append(f"- cache: {'true' if cache else 'false'}")
+            # Approval gate (Task 125; top-level on node like cache/batch —
+            # silently dropping it would make gated-fixture tests test nothing)
+            if node.get("approval"):
+                lines.append(f"- approval: {node['approval']}")
             # Params
             params = node.get("params", {})
             for key, value in params.items():

--- a/tests/test_cli/test_approval_gate_cli.py
+++ b/tests/test_cli/test_approval_gate_cli.py
@@ -1,0 +1,140 @@
+"""CLI surface tests for approval gates (Task 125 Phase 3).
+
+Pins the CLI half of the gate contract: exit code 3 + clean rendering on deny
+(text AND `--output-format json` — the denied branch bypasses `output_error`,
+so JSON mode needs its own document), `--auto-approve` pre-approval with the
+visible stderr line, the two pre-flight warnings (unknown flag id with fuzzy
+suggestion; non-interactive run with unapproved gates), and `-p` suppression.
+
+CliRunner/pytest stdin is never a TTY (tests/CLAUDE.md pitfall #10), so prompt
+flows patch `gate_prompt.can_prompt` → True and answer via a patched
+`click.confirm` — the rest of the pipeline (resolver → engine → runner → CLI
+display) runs for real.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.test_cli.test_workflow_commands import invoke_cli
+
+
+@pytest.fixture
+def gated_workflow(tmp_path):
+    """Two-step workflow: plain step, then a gated step with a side-effect proof file."""
+    proof = tmp_path / "proof.txt"
+    path = tmp_path / "gated.pflow.md"
+    path.write_text(
+        "# Gated Demo\n\nDemo.\n\n## Steps\n\n"
+        "### make-value\n\nProduce a value.\n\n"
+        "- type: shell\n"
+        "- command: echo hello\n\n"
+        "### guarded-step\n\nPost the value.\n\n"
+        "- type: shell\n"
+        f"- command: echo posting-${{make-value.stdout}} > {proof}; printf done\n"
+        "- approval: required\n"
+    )
+    return path, proof
+
+
+def _allow_prompting(monkeypatch, *, answer: bool):
+    monkeypatch.setattr("pflow.execution.gate_prompt.can_prompt", lambda oc: True)
+    monkeypatch.setattr("pflow.execution.gate_prompt.click.confirm", lambda *a, **k: answer)
+
+
+class TestDeniedExit:
+    def test_denied_gate_exits_3_never_ran_step_no_failure_tag(self, gated_workflow, monkeypatch):
+        path, proof = gated_workflow
+        _allow_prompting(monkeypatch, answer=False)
+        result = invoke_cli(["--no-trace", str(path)])
+        assert result.exit_code == 3
+        assert "Denied at gate 'guarded-step'" in result.stderr
+        assert "stopped cleanly" in result.stderr
+        assert not proof.exists(), "denied step must never run"
+        # Never the failure rendering — a human's no is not a workflow failure.
+        assert "Workflow failed" not in result.stderr
+        assert "❌" not in result.stderr
+
+    def test_denied_gate_json_mode_emits_denied_document(self, gated_workflow, monkeypatch):
+        path, _ = gated_workflow
+        _allow_prompting(monkeypatch, answer=False)
+        result = invoke_cli(["--no-trace", "--output-format", "json", str(path)])
+        assert result.exit_code == 3
+        document = json.loads(result.output)
+        assert document["success"] is False
+        assert document["status"] == "denied"
+        assert document["gate"]["node_id"] == "guarded-step"
+        # Superset of the unified failure shape: agents that iterate
+        # .diagnostics/.errors on success==false must find the denial there too.
+        assert any(d.get("context", {}).get("category") == "gate" for d in document["diagnostics"])
+        assert document["errors"] and document["errors"][0]["node_id"] == "guarded-step"
+        # The preview shows the RESOLVED action the human said no to — the exact
+        # substituted value, so a regression to the raw ${...} template fails here.
+        assert "posting-hello" in document["gate"]["preview"]["command"]
+
+    def test_approved_gate_runs_step_and_exits_0(self, gated_workflow, monkeypatch):
+        path, proof = gated_workflow
+        _allow_prompting(monkeypatch, answer=True)
+        result = invoke_cli(["--no-trace", str(path)])
+        assert result.exit_code == 0
+        assert proof.read_text().strip() == "posting-hello"
+
+
+class TestAutoApprove:
+    def test_auto_approve_skips_prompt_and_is_visible(self, gated_workflow):
+        path, proof = gated_workflow
+        result = invoke_cli(["--no-trace", "--auto-approve=guarded-step", str(path)])
+        assert result.exit_code == 0
+        assert proof.exists()
+        assert "pre-approved via --auto-approve=guarded-step" in result.stderr
+
+    def test_unmatched_id_notes_nested_possibility_and_closest_match(self, gated_workflow, monkeypatch):
+        # The note must NOT read as a confident "typo" verdict: a nested-gate id
+        # legitimately matches nothing top-level yet works (flat namespace), and the
+        # --dry-run footer names exactly such ids (deep-review find: the old wording
+        # contradicted the footer).
+        path, _ = gated_workflow
+        _allow_prompting(monkeypatch, answer=True)  # keep the run itself green
+        result = invoke_cli(["--no-trace", "--auto-approve=guarded_step", str(path)])
+        assert result.exit_code == 0
+        assert "--auto-approve=guarded_step does not name a top-level step" in result.stderr
+        assert "sub-workflow still matches by name" in result.stderr
+        assert "closest top-level match is 'guarded-step'" in result.stderr
+        assert "Top-level gated steps: guarded-step" in result.stderr
+
+
+class TestNonInteractive:
+    def test_warns_at_start_then_fails_at_gate_exit_1(self, gated_workflow):
+        path, proof = gated_workflow
+        result = invoke_cli(["--no-trace", str(path)])
+        # GateNotInteractiveError is a normal failure (exit 1) — only DENIED gets 3.
+        assert result.exit_code == 1
+        assert "will fail at approval gate(s) [guarded-step]" in result.stderr
+        assert "Gate needs a human" in result.stderr
+        assert "ask your human" in result.stderr
+        assert not proof.exists()
+
+    def test_print_flag_suppresses_preflight_warnings(self, gated_workflow):
+        path, _ = gated_workflow
+        result = invoke_cli(["--no-trace", "-p", str(path)])
+        assert result.exit_code == 1
+        assert "will fail at approval gate" not in result.stderr
+
+    def test_only_on_ungated_target_does_not_warn_about_unreachable_gates(self, gated_workflow):
+        # Under --only, only the target executes — a gate elsewhere cannot fire, so
+        # the non-interactive pre-flight warning must not cry wolf about it
+        # (deep-review find). The run itself errors on the missing snapshot; the
+        # assertion is only about the warning's absence.
+        path, _ = gated_workflow
+        result = invoke_cli(["--no-trace", "--only", "make-value", str(path)])
+        assert "will fail at approval gate" not in result.stderr
+
+
+def test_completion_status_denied_arm_never_renders_checkmark():
+    from pflow.cli.workflow_output import _format_workflow_completion_status
+
+    line = _format_workflow_completion_status(1.5, "denied", False)
+    assert line.startswith("✗") and "denied at gate" in line
+    assert "✓" not in line

--- a/tests/test_cli/test_approval_gate_cli.py
+++ b/tests/test_cli/test_approval_gate_cli.py
@@ -150,3 +150,23 @@ def test_completion_status_denied_arm_never_renders_checkmark():
     line = _format_workflow_completion_status(1.5, "denied", False)
     assert line.startswith("✗") and "denied at gate" in line
     assert "✓" not in line
+
+
+class TestCtrlCAtGate:
+    def test_ctrl_c_at_gate_prompt_exits_130_and_step_never_runs(self, gated_workflow, monkeypatch):
+        """End-to-end pin for the interrupt seam: click Abort at the prompt →
+        resolver raises KeyboardInterrupt → engine/runner pass it through
+        (BaseException) → CLI exits 130. Both halves were unit-tested; this
+        pins the integration, which a future `except Exception` between the
+        gate and run.py would silently break."""
+        import click
+
+        def abort(*args, **kwargs):
+            raise click.exceptions.Abort()
+
+        path, proof = gated_workflow
+        monkeypatch.setattr("pflow.execution.gate_prompt.can_prompt", lambda oc: True)
+        monkeypatch.setattr("pflow.execution.gate_prompt.click.confirm", abort)
+        result = invoke_cli(["--no-trace", str(path)])
+        assert result.exit_code == 130
+        assert not proof.exists(), "interrupted gate must never run the step"

--- a/tests/test_cli/test_approval_gate_cli.py
+++ b/tests/test_cli/test_approval_gate_cli.py
@@ -104,6 +104,18 @@ class TestAutoApprove:
         assert "closest top-level match is 'guarded-step'" in result.stderr
         assert "Top-level gated steps: guarded-step" in result.stderr
 
+    def test_prepare_gate_resolver_tolerates_node_missing_id(self):
+        # Code-review fix: schema validation (which requires "id" on every node)
+        # hasn't run yet at this call site — a node dict missing "id" must not
+        # crash `sorted()` on a set containing None mixed with strings.
+        from types import SimpleNamespace
+
+        from pflow.cli.commands.run import _prepare_gate_resolver
+
+        fake_ctx = SimpleNamespace(obj={"auto_approve": ("bogus",), "only_node": None, "print_flag": False})
+        ir_data = {"nodes": [{"type": "shell", "params": {}}, {"id": "real-step", "type": "shell"}]}
+        _prepare_gate_resolver(fake_ctx, ir_data, None)  # must not raise
+
 
 class TestNonInteractive:
     def test_warns_at_start_then_fails_at_gate_exit_1(self, gated_workflow):

--- a/tests/test_cli/test_guide.py
+++ b/tests/test_cli/test_guide.py
@@ -551,6 +551,15 @@ def test_detect_batch() -> None:
     assert "llm" in topics
 
 
+def test_detect_approval_gate() -> None:
+    # Task 125: `approval: required` (top-level node field) surfaces the approval guide.
+    ir = {
+        "nodes": [{"id": "g", "type": "shell", "params": {}, "approval": "required"}],
+        "edges": [],
+    }
+    assert "approval" in detect_topics_from_ir(ir)
+
+
 def test_detect_error_handling_via_error_edge() -> None:
     # An `on-error:` edge routes to the error-handling topic, not branching.
     ir = {

--- a/tests/test_core/test_approval_field.py
+++ b/tests/test_core/test_approval_field.py
@@ -1,0 +1,158 @@
+"""Task 125 — the ``approval:`` field: parser hoist, IR schema, validation, compile.
+
+The field rides the exact ``prewarm``/``cache`` top-level path: hoisted out of
+params by the parser (so it never reaches node exec params or the cache hash),
+allowlisted in the IR schema (``additionalProperties: False`` on nodes), rejected
+on batch hosts by ONE shared rule at BOTH entry points (validator diagnostic +
+compiler ``CompilationError``), and landed on ``NodeConfig.approval``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pflow.core.exceptions import CompilationError
+from pflow.core.markdown_parser import parse_markdown
+from pflow.core.workflow.validator import WorkflowValidator
+from pflow.registry import Registry
+from pflow.runtime import compile_workflow
+
+GATED_MARKDOWN = """# Notify
+
+Send a message after approval.
+
+## Steps
+
+### notify
+
+Post the message.
+
+- type: shell
+- command: echo send-it
+- approval: required
+"""
+
+
+class TestParserHoist:
+    def test_markdown_parsed_gate_preview_has_no_bookkeeping_keys(self):
+        # Code-block params carry engine bookkeeping (`_python_source_line`); the
+        # approval preview is a display surface and must filter `_`-prefixed keys
+        # like every other one (node_output_formatter / trace_report convention).
+        from pflow.core.exceptions import GateNotInteractiveError
+        from pflow.runtime.engine import WorkflowEngine
+
+        md = (
+            "# Gate\n\nGated code step.\n\n## Steps\n\n### calc\n\nCompute a thing.\n\n"
+            "- type: code\n- approval: required\n\n```python\nresult: str = 'x'\n```\n"
+        )
+        compiled = compile_workflow(parse_markdown(md).ir, Registry())
+        assert "_python_source_line" in compiled.start_node.params  # the leak source exists
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            WorkflowEngine().run(compiled, {})
+        assert list(exc_info.value.request.preview) == ["python"]
+
+    def test_approval_is_hoisted_out_of_params(self):
+        ir = parse_markdown(GATED_MARKDOWN).ir
+        (node,) = ir["nodes"]
+        assert node["approval"] == "required"
+        assert "approval" not in node["params"]
+
+    def test_workflow_without_approval_has_no_field(self):
+        ir = parse_markdown(GATED_MARKDOWN.replace("- approval: required\n", "")).ir
+        (node,) = ir["nodes"]
+        assert "approval" not in node
+
+
+def _ir(node: dict[str, Any]) -> dict[str, Any]:
+    return {"ir_version": "0.1.0", "nodes": [node], "edges": []}
+
+
+def _shell(**extra: Any) -> dict[str, Any]:
+    return {"id": "n", "type": "shell", "params": {"command": "echo hi"}, **extra}
+
+
+class TestSchemaAndValidation:
+    def test_valid_gate_passes_validation_cleanly(self):
+        diagnostics = WorkflowValidator().validate(_ir(_shell(approval="required")))
+        assert diagnostics == []
+
+    def test_invalid_enum_value_fails_with_field_path(self):
+        diagnostics = WorkflowValidator().validate(_ir(_shell(approval="banana")))
+        assert any("approval" in str(d.context.get("path", "")) for d in diagnostics)
+
+    def test_bool_value_gets_the_required_suggestion(self):
+        # `- approval: true` is the likeliest agent mistake (YAML coerces to bool);
+        # the generic type-arm would steer toward the string "true", which then
+        # fails the enum. The approval arm short-circuits both shapes.
+        diagnostics = WorkflowValidator().validate(_ir(_shell(approval=True)))
+        assert any("approval: required" in s for d in diagnostics for s in (d.suggestions or []))
+
+    def test_batch_host_gate_rejected_by_validator(self):
+        node = _shell(approval="required", batch={"items": "${items}", "as": "item"})
+        node["params"]["command"] = "echo ${item}"
+        diagnostics = WorkflowValidator().validate(_ir(node))
+        messages = [d.message for d in diagnostics]
+        assert any("not supported on batch steps" in m for m in messages)
+        assert any("before or after the batch" in m for m in messages)
+
+    def test_gate_inside_subworkflow_validated_recursively(self, tmp_path):
+        # Task 136 recursive validation: a batch-host gate hidden in a CHILD
+        # workflow is caught when validating the parent.
+        child = tmp_path / "child.pflow.md"
+        child.write_text(
+            "# Child\n\nChild with an invalid batch gate.\n\n## Steps\n\n"
+            "### fan\n\nFan out.\n\n- type: shell\n- command: echo ${item}\n"
+            "- approval: required\n"
+            "- batch:\n    items: ${items}\n    as: item\n"
+        )
+        parent_ir = _ir({"id": "sub", "type": "workflow", "params": {"workflow": str(child)}})
+        diagnostics = WorkflowValidator().validate(parent_ir, workflow_file=tmp_path / "parent.pflow.md")
+        assert any("not supported on batch steps" in d.message for d in diagnostics)
+
+
+class TestCompiler:
+    def test_node_config_carries_approval(self):
+        compiled = compile_workflow(_ir(_shell(approval="required")), Registry())
+        assert compiled.node_configs["n"].approval is True
+
+    def test_node_config_defaults_to_false(self):
+        compiled = compile_workflow(_ir(_shell()), Registry())
+        assert compiled.node_configs["n"].approval is False
+
+    def test_non_required_value_is_a_compilation_error(self):
+        with pytest.raises(CompilationError, match="approval"):
+            compile_workflow(_ir(_shell(approval=True)), Registry())
+
+    def test_batch_host_gate_is_a_compilation_error(self):
+        node = _shell(approval="required", batch={"items": "${items}", "as": "item"})
+        node["params"]["command"] = "echo ${item}"
+        with pytest.raises(CompilationError) as exc_info:
+            compile_workflow(_ir(node), Registry())
+        rendered = "\n".join(d.message for d in exc_info.value.to_diagnostics())
+        assert "not supported on batch steps" in rendered
+
+    def test_workflow_type_node_may_be_gated(self, tmp_path):
+        child = tmp_path / "child.pflow.md"
+        child.write_text(
+            "# Child\n\nTrivial child.\n\n## Steps\n\n### s\n\nSay hi.\n\n- type: shell\n- command: echo hi\n"
+        )
+        ir = _ir({"id": "sub", "type": "workflow", "params": {"workflow": str(child)}, "approval": "required"})
+        compiled = compile_workflow(ir, Registry())
+        assert compiled.node_configs["sub"].approval is True
+
+    def test_approval_does_not_change_the_cache_config_hash(self):
+        # The gate is orthogonal to the node's output — adding it must not
+        # invalidate existing memo cache entries.
+        from pflow.runtime.engine.instrumentation import compute_config_hash, compute_node_config
+
+        def config_hash(compiled) -> str:
+            cfg = compiled.node_configs["n"]
+            static = cfg.template_config.static_params if cfg.template_config else compiled.start_node.params
+            templates = cfg.template_config.template_params if cfg.template_config else {}
+            return compute_config_hash(compute_node_config(cfg.node_type_name, static, templates, cfg.batch_config))
+
+        plain_hash = config_hash(compile_workflow(_ir(_shell()), Registry()))
+        gated_hash = config_hash(compile_workflow(_ir(_shell(approval="required")), Registry()))
+        assert plain_hash == gated_hash

--- a/tests/test_execution/formatters/test_success_formatter.py
+++ b/tests/test_execution/formatters/test_success_formatter.py
@@ -1500,3 +1500,20 @@ class TestFindAutoOutputNamespaceAware:
             "user",
             "wants",
         ]
+
+
+class TestDeniedStatusRendering:
+    """Defensive: denied results normally route through the error path (CLI
+    intercepts DENIED; MCP goes via success=False), but if a denied result ever
+    reaches the success text formatter it must never render the success ✓."""
+
+    def test_denied_status_never_renders_success_checkmark(self):
+        result_dict = {
+            "success": False,
+            "status": "denied",
+            "duration_ms": 120,
+            "execution": {"nodes_executed": 1, "steps": []},
+        }
+        text = format_success_as_text(result_dict)
+        assert "denied at an approval gate" in text
+        assert "✓ Workflow completed" not in text

--- a/tests/test_execution/test_gate_prompt.py
+++ b/tests/test_execution/test_gate_prompt.py
@@ -193,6 +193,21 @@ class TestPreviewRendering:
         assert "<REDACTED>" in rendered
         assert "application/json" in rendered  # non-secret nested value survives
 
+    def test_long_nonsecret_nested_value_survives_to_display_budget(self, monkeypatch, capsys):
+        # PR #554 review warning: routing preview values through
+        # sanitize_parameters cut long NON-secret nested strings to ~20 chars —
+        # blinding the approver. Masking must not truncate; only the renderer's
+        # 200-char display budget applies.
+        body = "b" * 150
+        rendered = self._rendered(
+            _approval(json={"body": body, "token": "sk-super-secret"}),
+            monkeypatch,
+            capsys,
+        )
+        assert body in rendered  # full 150-char value visible (under the 200 budget)
+        assert "<truncated>" not in rendered
+        assert "sk-super-secret" not in rendered  # nested secret still redacted
+
     def test_nested_secret_in_list_of_dicts_is_redacted(self, monkeypatch, capsys):
         rendered = self._rendered(
             _approval(inputs=[{"api_key": "sk-live-abc123"}, {"name": "safe"}]),

--- a/tests/test_execution/test_gate_prompt.py
+++ b/tests/test_execution/test_gate_prompt.py
@@ -1,0 +1,176 @@
+"""Unit tests for the TTY gate resolver (Task 125 Phase 3 — execution/gate_prompt.py).
+
+The resolver is the ONE builder every surface uses (CLI interactive, MCP non-TTY,
+parallel-batch worker via ``allow_prompt=False``). These tests pin its contract:
+auto-approve is approval-only and thread-config-independent; prompting requires
+stdin+stderr TTY (NOT stdout — Decision 14); every no-prompt path raises the
+payload-carrying ``GateNotInteractiveError``; Ctrl-C (click Abort) becomes
+``KeyboardInterrupt`` so the engine never archives it as a node failure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+import pytest
+
+from pflow.core.exceptions import GateNotInteractiveError
+from pflow.core.gate import GateRequest, GateResolution
+from pflow.execution.gate_prompt import build_gate_resolver, can_prompt
+
+
+class _FakeOC:
+    """Duck-typed OutputController: just the fields/seam the resolver reads."""
+
+    def __init__(
+        self, *, stdin_tty: bool = True, stdout_tty: bool = False, stderr_tty: bool = True, print_flag: bool = False
+    ):
+        self.stdin_tty = stdin_tty
+        self.stdout_tty = stdout_tty
+        self.stderr_tty = stderr_tty
+        self.print_flag = print_flag
+        self.prompt_preparations = 0
+
+    def prepare_for_prompt(self) -> None:
+        self.prompt_preparations += 1
+
+
+def _approval(node_id: str = "notify", **preview: Any) -> GateRequest:
+    return GateRequest(
+        node_id=node_id, node_type="ShellNode", kind="action_approval", preview=preview or {"command": "echo hi"}
+    )
+
+
+def _escalation(**kwargs: Any) -> GateRequest:
+    return GateRequest(node_id="agent-step", node_type="ClaudeCodeNode", kind="decision_escalation", **kwargs)
+
+
+class TestCanPrompt:
+    def test_requires_stdin_and_stderr_tty_but_not_stdout(self):
+        # Decision 14: `pflow wf | jq` (stdout piped) at a real terminal must still gate.
+        assert can_prompt(_FakeOC(stdin_tty=True, stderr_tty=True, stdout_tty=False)) is True
+
+    def test_false_without_controller_or_under_print_flag_or_non_tty(self):
+        assert can_prompt(None) is False
+        assert can_prompt(_FakeOC(print_flag=True)) is False
+        assert can_prompt(_FakeOC(stdin_tty=False)) is False
+        assert can_prompt(_FakeOC(stderr_tty=False)) is False
+
+
+class TestAutoApprove:
+    def test_flag_approves_named_approval_gate_without_prompting(self):
+        resolver = build_gate_resolver(frozenset({"notify"}), None)
+        resolution = resolver(_approval("notify"))
+        assert resolution == GateResolution(approved=True, resolved_via="flag")
+
+    def test_flag_works_with_prompting_disallowed(self):
+        # The parallel-batch worker path: allow_prompt=False must not disable the flag.
+        resolver = build_gate_resolver(frozenset({"notify"}), None)
+        resolution = resolver(_approval("notify"), allow_prompt=False)
+        assert resolution.approved is True and resolution.resolved_via == "flag"
+
+    def test_flag_never_resolves_an_escalation(self):
+        # You cannot pre-answer an unknown question.
+        resolver = build_gate_resolver(frozenset({"agent-step"}), None)
+        with pytest.raises(GateNotInteractiveError):
+            resolver(_escalation(question="which schema?"))
+
+    def test_unlisted_gate_without_tty_raises_with_payload(self):
+        resolver = build_gate_resolver(frozenset({"other"}), None)
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            resolver(_approval("notify"))
+        assert exc_info.value.request.node_id == "notify"
+        assert exc_info.value.parallel_batch is False
+
+    def test_allow_prompt_false_is_the_only_source_of_parallel_batch(self):
+        resolver = build_gate_resolver(frozenset(), _FakeOC())
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            resolver(_approval(), allow_prompt=False)
+        assert exc_info.value.parallel_batch is True
+
+
+class TestPromptFlows:
+    def test_approval_yes_and_no(self, monkeypatch):
+        oc = _FakeOC()
+        resolver = build_gate_resolver(frozenset(), oc)
+        for answer, approved in ((True, True), (False, False)):
+            monkeypatch.setattr(click, "confirm", lambda *a, _answer=answer, **k: _answer)
+            resolution = resolver(_approval())
+            assert resolution.approved is approved
+            assert resolution.resolved_via == "prompt"
+        assert oc.prompt_preparations == 2, "prompt must close the open progress partial line first"
+
+    def test_escalation_numbered_choice_maps_to_option_label(self, monkeypatch):
+        monkeypatch.setattr(click, "prompt", lambda *a, **k: "2")
+        resolver = build_gate_resolver(frozenset(), _FakeOC())
+        request = _escalation(
+            question="one config file or per-env?",
+            options=({"label": "merge", "description": "simpler"}, {"label": "per-env", "tradeoffs": "more files"}),
+            recommendation="per-env",
+        )
+        resolution = resolver(request)
+        assert resolution == GateResolution(approved=True, resolved_via="prompt", chosen="per-env")
+
+    def test_escalation_free_text_becomes_chosen(self, monkeypatch):
+        monkeypatch.setattr(click, "prompt", lambda *a, **k: "  keep both, gate on env var  ")
+        resolver = build_gate_resolver(frozenset(), _FakeOC())
+        resolution = resolver(_escalation(question="?", options=({"label": "a"},)))
+        assert resolution.chosen == "keep both, gate on env var"
+
+    def test_out_of_range_number_is_free_text_not_crash(self, monkeypatch):
+        monkeypatch.setattr(click, "prompt", lambda *a, **k: "9")
+        resolver = build_gate_resolver(frozenset(), _FakeOC())
+        resolution = resolver(_escalation(question="?", options=({"label": "a"},)))
+        assert resolution.chosen == "9"
+
+    def test_ctrl_c_abort_becomes_keyboard_interrupt(self, monkeypatch):
+        # click.Abort is an Exception subclass — if it escaped as-is, the engine's
+        # generic except arm would archive the gate as a node failure.
+        def _abort(*a: Any, **k: Any) -> bool:
+            raise click.exceptions.Abort()
+
+        monkeypatch.setattr(click, "confirm", _abort)
+        resolver = build_gate_resolver(frozenset(), _FakeOC())
+        with pytest.raises(KeyboardInterrupt):
+            resolver(_approval())
+
+
+class TestPreviewRendering:
+    def _rendered(self, request: GateRequest, monkeypatch, capsys) -> str:
+        monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+        build_gate_resolver(frozenset(), _FakeOC())(request)
+        return capsys.readouterr().err
+
+    def test_secret_values_masked_long_values_truncated_newlines_escaped(self, monkeypatch, capsys):
+        rendered = self._rendered(
+            _approval(api_key="sk-super-secret", body="line1\nline2", note="x" * 500),
+            monkeypatch,
+            capsys,
+        )
+        assert "sk-super-secret" not in rendered
+        assert "line1\\nline2" in rendered
+        assert "… (500 chars)" in rendered
+        assert "Approval required: notify (ShellNode)" in rendered
+
+    def test_non_string_values_render_as_compact_json(self, monkeypatch, capsys):
+        rendered = self._rendered(_approval(payload={"a": 1, "b": [True, None]}), monkeypatch, capsys)
+        assert '{"a": 1, "b": [true, null]}' in rendered
+
+    def test_escalation_renders_options_with_recommendation_marker(self, monkeypatch, capsys):
+        monkeypatch.setattr(click, "prompt", lambda *a, **k: "1")
+        build_gate_resolver(frozenset(), _FakeOC())(
+            _escalation(
+                question="merge configs?",
+                options=(
+                    {"label": "merge", "description": "simpler", "tradeoffs": "breaks overrides"},
+                    {"label": "split"},
+                ),
+                recommendation="split",
+            )
+        )
+        rendered = capsys.readouterr().err
+        assert "Escalation from agent-step" in rendered
+        assert "merge configs?" in rendered
+        assert "1. merge — simpler — breaks overrides" in rendered
+        assert "2. split (rec)" in rendered

--- a/tests/test_execution/test_gate_prompt.py
+++ b/tests/test_execution/test_gate_prompt.py
@@ -89,6 +89,29 @@ class TestAutoApprove:
             resolver(_approval(), allow_prompt=False)
         assert exc_info.value.parallel_batch is True
 
+    def test_flag_echo_suppressed_on_worker_thread_with_real_output_controller(self, capsys):
+        # Code-review fix: the auto-approve visibility echo must NOT touch a real
+        # (unbuffered) OutputController when called with allow_prompt=False — that
+        # combination means this call is running on a parallel-batch WORKER
+        # thread, where the per-worker progress buffer (not the real controller)
+        # is the only concurrency-safe channel. Previously this test gap existed
+        # because the only prior coverage used output_controller=None (the echo
+        # early-returns regardless) or a RecordingResolver test double (never
+        # touches build_gate_resolver's real echo at all).
+        oc = _FakeOC()
+        resolver = build_gate_resolver(frozenset({"notify"}), oc)
+        resolution = resolver(_approval("notify"), allow_prompt=False)
+        assert resolution == GateResolution(approved=True, resolved_via="flag")
+        assert oc.prompt_preparations == 0, "must not touch the real OutputController from a worker thread"
+        assert capsys.readouterr().err == ""
+
+    def test_flag_echo_still_fires_on_main_thread(self, capsys):
+        oc = _FakeOC()
+        resolver = build_gate_resolver(frozenset({"notify"}), oc)
+        resolver(_approval("notify"), allow_prompt=True)
+        assert oc.prompt_preparations == 1
+        assert "pre-approved via --auto-approve=notify" in capsys.readouterr().err
+
 
 class TestPromptFlows:
     def test_approval_yes_and_no(self, monkeypatch):
@@ -156,6 +179,28 @@ class TestPreviewRendering:
     def test_non_string_values_render_as_compact_json(self, monkeypatch, capsys):
         rendered = self._rendered(_approval(payload={"a": 1, "b": [True, None]}), monkeypatch, capsys)
         assert '{"a": 1, "b": [true, null]}' in rendered
+
+    def test_nested_secret_in_dict_value_is_redacted(self, monkeypatch, capsys):
+        # Code-review fix: mask_sensitive_value only checks the top-level key —
+        # a secret nested inside a dict/list value (headers on an http node,
+        # inputs on a sub-workflow) must not render verbatim.
+        rendered = self._rendered(
+            _approval(headers={"Authorization": "Bearer sk-super-secret", "Accept": "application/json"}),
+            monkeypatch,
+            capsys,
+        )
+        assert "sk-super-secret" not in rendered
+        assert "<REDACTED>" in rendered
+        assert "application/json" in rendered  # non-secret nested value survives
+
+    def test_nested_secret_in_list_of_dicts_is_redacted(self, monkeypatch, capsys):
+        rendered = self._rendered(
+            _approval(inputs=[{"api_key": "sk-live-abc123"}, {"name": "safe"}]),
+            monkeypatch,
+            capsys,
+        )
+        assert "sk-live-abc123" not in rendered
+        assert "safe" in rendered
 
     def test_escalation_renders_options_with_recommendation_marker(self, monkeypatch, capsys):
         monkeypatch.setattr(click, "prompt", lambda *a, **k: "1")

--- a/tests/test_execution/test_plan_drift.py
+++ b/tests/test_execution/test_plan_drift.py
@@ -2787,3 +2787,177 @@ def test_plan_downstream_batch_respects_depth_guard(tmp_path, monkeypatch) -> No
     fanout = next(e for e in plan.entries if e.node_id == "fanout")
     assert fanout.status != "opaque", "downstream batch at max depth must error, not emit clean opaque"
     assert any("Max sub-workflow depth" in d.message for d in plan.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Task 125: the approval-gate parity pin — "plan says would-pause ⟺ engine
+# pauses". Compared by node-id SET, not count (a gated loop node is ONE plan
+# entry but N pause events), across every gate shape the ledger allows: a
+# standard node, a gated workflow-type node, a gate INSIDE the child, and a
+# gated loop node. Mutation-verified at authoring time: stamping
+# `approval=False` in `_annotate_entry` fails the plan side; skipping
+# `run_approval_gate` fails the engine side.
+# ---------------------------------------------------------------------------
+
+
+def _gated_shapes_ir(tmp_path: Path) -> dict[str, Any]:
+    child_path = tmp_path / "gated-child.pflow.md"
+    write_workflow_file(
+        {
+            "nodes": [
+                {"id": "inner-gate", "type": "shell", "params": {"command": "printf inner"}, "approval": "required"},
+            ],
+            "edges": [],
+        },
+        child_path,
+    )
+    loop_code = "i: int\nresult: dict = {'done': i >= 2}"
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "plain", "type": "shell", "params": {"command": "printf plain"}},
+            {"id": "gated-shell", "type": "shell", "params": {"command": "printf gated"}, "approval": "required"},
+            {
+                "id": "gated-sub",
+                "type": "workflow",
+                "params": {"workflow": str(child_path)},
+                "approval": "required",
+            },
+            {
+                "id": "gated-loop",
+                "type": "code",
+                "params": {"code": loop_code, "inputs": {"i": "${__iteration__}"}},
+                "approval": "required",
+                "loop": {"until": "${gated-loop.result.done}", "max_iterations": 3},
+            },
+        ],
+        "edges": [
+            {"from": "plain", "to": "gated-shell"},
+            {"from": "gated-shell", "to": "gated-sub"},
+            {"from": "gated-sub", "to": "gated-loop"},
+        ],
+        "start_node": "plain",
+    }
+
+
+def _flatten_gated_ids(entries: list[Any]) -> set[str]:
+    gated: set[str] = set()
+    for entry in entries:
+        if entry.approval:
+            gated.add(entry.node_id)
+        if entry.sub_plan is not None:
+            gated |= _flatten_gated_ids(entry.sub_plan.entries)
+    return gated
+
+
+@pytest.mark.trace_files
+def test_plan_would_pause_matches_engine_gate_pauses(tmp_path, monkeypatch) -> None:
+    import json
+
+    from pflow.core.gate import GateResolution
+    from pflow.runtime.workflow_trace import WorkflowTraceCollector
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    ir = _gated_shapes_ir(tmp_path)
+    registry = Registry()
+    cache = MemoizationCache(read_enabled=True)
+
+    # Plan side: gated entries by node-id set, nested sub-plans included.
+    compiled = compile_workflow(ir, registry=registry)
+    plan = build_plan(compiled, {}, cache, registry, workflow_name="gated-shapes")
+    plan_gated = _flatten_gated_ids(plan.entries)
+
+    # Engine side: a REAL run (auto-approving resolver — the test never prompts),
+    # gate pause events read from the streamed trace (gate lines are disk-only).
+    collector = WorkflowTraceCollector(
+        "gated-shapes", workflow_path=str(tmp_path / "gated-shapes.pflow.md"), is_run_scoped=True, stream_to_disk=True
+    )
+    shared: dict[str, Any] = {
+        "__gate_resolver__": lambda request, *, allow_prompt=True: GateResolution(approved=True, resolved_via="flag")
+    }
+    engine = WorkflowEngine(trace_collector=collector)
+    try:
+        compiled_for_run = compile_workflow(ir, registry=Registry())
+        engine.run(compiled_for_run, shared)
+    finally:
+        collector.finalize()
+    pause_lines = [
+        json.loads(line)
+        for line in collector._stream_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and '"gate"' in line
+    ]
+    pauses = [ln for ln in pause_lines if ln.get("kind") == "gate" and ln.get("phase") == "pause"]
+    engine_gated = {ln["node_id"] for ln in pauses}
+
+    assert plan_gated == engine_gated == {"gated-shell", "gated-sub", "inner-gate", "gated-loop"}
+    # The SET comparison is load-bearing: the gated loop node pauses per
+    # iteration (2 real iterations) but is exactly one plan entry.
+    loop_pauses = [ln for ln in pauses if ln["node_id"] == "gated-loop"]
+    assert len(loop_pauses) == 2, f"expected one pause per loop iteration, got {len(loop_pauses)}"
+
+
+def test_dry_run_renders_approval_tag_and_footer(tmp_path) -> None:
+    ir = _gated_shapes_ir(tmp_path)
+    registry = Registry()
+    compiled = compile_workflow(ir, registry=registry)
+    plan = build_plan(compiled, {}, MemoizationCache(read_enabled=True), registry, workflow_name="gated-shapes")
+
+    text = format_plan_text(plan)
+    assert "gated-shell  [shell, approval]" in text
+    assert ", approval]" in text.split("gated-sub")[1].splitlines()[0]  # sub-workflow line carries the tag
+    assert "pause for approval at run time" in text
+    assert "--auto-approve=gated-shell" in text
+
+    from pflow.execution.formatters.plan_formatter import format_plan_json
+
+    document = format_plan_json(plan)
+    by_id = {e["node_id"]: e for e in document["plan"]}
+    assert by_id["gated-shell"].get("approval") is True
+    assert by_id["gated-sub"].get("approval") is True
+    assert "approval" not in by_id["plain"]
+
+
+def test_cached_gated_node_not_stamped_and_engine_skips_gate(tmp_path) -> None:
+    """A cache HIT never gates (the engine seam sits after the cache early-return),
+    so the plan must not stamp `approval` on a cached entry — else the ⏸ footer and
+    JSON `approval` field promise a pause the engine won't make (deep-review find:
+    the safe-direction half of the parity invariant, unpinned until now)."""
+    from pflow.core.gate import GateResolution
+
+    ir = {
+        "nodes": [
+            {
+                "id": "gated-cached",
+                "type": "shell",
+                "cache": True,
+                "params": {"command": "printf gated"},
+                "approval": "required",
+            },
+        ],
+        "edges": [],
+    }
+    compiled, registry = _compile(ir)
+    cache = MemoizationCache(db_path=tmp_path / "cache.db")
+
+    # Seed: real run through the gate (auto-approving resolver), which memo-caches.
+    prompts: list[str] = []
+
+    def approve(request, *, allow_prompt=True):
+        prompts.append(request.node_id)
+        return GateResolution(approved=True, resolved_via="flag")
+
+    shared: dict[str, Any] = {"__gate_resolver__": approve, "__memoization_cache__": cache}
+    WorkflowEngine().run(compiled, shared)
+    assert prompts == ["gated-cached"], "seed run must gate once"
+
+    # Plan side: the entry is cached → NOT stamped, absent from the footer/JSON.
+    plan = build_plan(compiled, {}, cache, registry, workflow_name="gated-cached")
+    (entry,) = plan.entries
+    assert entry.status == "cached"
+    assert entry.approval is False
+    assert "pause for approval" not in format_plan_text(plan)
+
+    # Engine side: the second run cache-hits and never invokes the resolver again.
+    shared2: dict[str, Any] = {"__gate_resolver__": approve, "__memoization_cache__": cache}
+    WorkflowEngine().run(compiled, shared2)
+    assert prompts == ["gated-cached"], "cache hit must not re-gate"

--- a/tests/test_execution/test_plan_drift.py
+++ b/tests/test_execution/test_plan_drift.py
@@ -414,6 +414,63 @@ def test_plan_batch_sub_workflow_partial_cache_matches_execution(tmp_path) -> No
     assert _log_lines(log_file) == ["a", "b", "c"]
 
 
+def test_plan_batch_sub_workflow_preserves_child_approval_flag(tmp_path) -> None:
+    """Code-review fix: a gated step inside a batched sub-workflow's child must
+    still show `approval: true` in the aggregated dry-run entry.
+
+    `_aggregate_batch_child_plans` builds a FRESH synthetic PlanEntry per
+    node-id (collapsing per-item entries into one view) — it must forward
+    `approval` from the per-item entries, or the dry-run footer/JSON silently
+    omits a gate the engine still pauses on (or fails loudly on, non-
+    interactively) at runtime — the resolver's namespace is flat across the
+    whole workflow tree, so the child gate fires regardless of batching.
+
+    Mutation: drop the `approval=...` kwarg from the synthetic PlanEntry in
+    `_aggregate_batch_child_plans` → this assertion fails (defaults to False).
+    """
+    child_path = tmp_path / "gated-child.pflow.md"
+    parent_path = tmp_path / "gated-parent.pflow.md"
+
+    write_workflow_file(
+        {
+            "inputs": {"value": {"type": "string"}},
+            "nodes": [
+                {
+                    "id": "gated-echo",
+                    "type": "shell",
+                    "params": {"command": "printf '${value}'"},
+                    "approval": "required",
+                }
+            ],
+            "edges": [],
+            "outputs": {"out": {"source": "${gated-echo.stdout}", "description": "Echoed value"}},
+        },
+        child_path,
+    )
+    write_workflow_file(
+        {
+            "inputs": {"items": {"type": "array"}},
+            "nodes": [
+                {
+                    "id": "fanout",
+                    "type": "workflow",
+                    "params": {"workflow": str(child_path), "inputs": {"value": "${item}"}},
+                    "batch": {"items": "${items}"},
+                }
+            ],
+            "edges": [],
+        },
+        parent_path,
+    )
+
+    plan = _runner_plan(parent_path, {"items": ["a", "b"]})
+    assert [entry.status for entry in plan.entries] == ["sub_workflow"]
+    fanout = plan.entries[0]
+    assert fanout.sub_plan is not None
+    child_entry = next(e for e in fanout.sub_plan.entries if e.node_id == "gated-echo")
+    assert child_entry.approval is True
+
+
 def test_plan_cache_false_always_executes(tmp_path) -> None:
     """Nodes with cache:false must re-execute regardless of previous runs."""
     log_file = tmp_path / "cache-false.log"

--- a/tests/test_integration/test_cli_mcp_parity.py
+++ b/tests/test_integration/test_cli_mcp_parity.py
@@ -229,3 +229,56 @@ def test_empty_input_batch_emits_non_degrading_info_advisory():
         if d.severity == Severity.INFO and d.node_id == "consume" and "0 items" in d.message
     ]
     assert len(advisories) == 1, [(d.severity, d.message) for d in result.diagnostics]
+
+
+# ---------------------------------------------------------------------------
+# Task 125: MCP is the production non-TTY gate surface (split-session braindump).
+# Parity contract: a gated workflow through ExecutionService fails loudly with the
+# SAME payload-carrying, ask-your-human text the CLI shows, and `auto_approve`
+# pre-approves per-node exactly like `--auto-approve` — including when the engine
+# runs off the main thread (asyncio.to_thread, the real MCP tool bridge), which
+# pins the no-thread-guard design (a main-thread check would break MCP here).
+# ---------------------------------------------------------------------------
+
+
+def _gated_ir() -> dict[str, Any]:
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "make-value",
+                "type": "shell",
+                "purpose": "Produce a value first.",
+                "params": {"command": "echo hello"},
+            },
+            {
+                "id": "guarded-step",
+                "type": "shell",
+                "purpose": "Side-effecting step behind an approval gate.",
+                "params": {"command": "echo posting-${make-value.stdout}"},
+                "approval": "required",
+            },
+        ],
+        "edges": [{"from": "make-value", "to": "guarded-step"}],
+        "start_node": "make-value",
+    }
+
+
+def test_mcp_gated_workflow_fails_loudly_with_remediation_ladder():
+    from pflow.mcp_server.services.execution_service import ExecutionService
+
+    with pytest.raises(RuntimeError) as exc_info:
+        ExecutionService.execute_workflow(_gated_ir(), {})
+    text = str(exc_info.value)
+    assert "requires a human approval decision" in text
+    assert "ask your human" in text
+    assert 'auto_approve=["guarded-step"]' in text
+
+
+def test_mcp_auto_approve_pre_approves_off_main_thread():
+    import asyncio
+
+    from pflow.mcp_server.services.execution_service import ExecutionService
+
+    text = asyncio.run(asyncio.to_thread(ExecutionService.execute_workflow, _gated_ir(), {}, ["guarded-step"]))
+    assert "posting-hello" in text

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -1,0 +1,474 @@
+"""Task 125 — approval gates + escalation: engine seam behavior.
+
+Covers the two ``_execute_node`` hook points (pre-exec approval, post-exec
+escalation), the gate-exception boundary exemptions (engine / WorkflowExecutor /
+batch retry), the parallel-batch prompt guard, and the cache interactions. The
+resolver here is always a test fake implementing the ``core/gate.py`` contract —
+the real TTY resolver is Phase 3 (CLI) work.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pflow.core.exceptions import GateDenied, GateNotInteractiveError, PflowError
+from pflow.core.gate import GateRequest, GateResolution
+from pflow.registry import Registry
+from pflow.runtime import compile_workflow
+from pflow.runtime.engine import WorkflowEngine
+from pflow.runtime.engine.gate import detect_escalation
+
+
+class RecordingResolver:
+    """Fake resolver: records every request, answers from a script."""
+
+    def __init__(
+        self,
+        *,
+        approved: bool = True,
+        chosen: str | None = None,
+        notes: str | None = None,
+        auto_approve: frozenset[str] = frozenset(),
+    ):
+        self.approved = approved
+        self.chosen = chosen
+        self.notes = notes
+        self.auto_approve = auto_approve
+        self.calls: list[tuple[GateRequest, bool]] = []
+
+    def __call__(self, request: GateRequest, *, allow_prompt: bool) -> GateResolution:
+        self.calls.append((request, allow_prompt))
+        if request.node_id in self.auto_approve:
+            return GateResolution(approved=True, resolved_via="flag")
+        if not allow_prompt:
+            raise GateNotInteractiveError(request, parallel_batch=True)
+        return GateResolution(approved=self.approved, resolved_via="prompt", chosen=self.chosen, notes=self.notes)
+
+
+def _shell_ir(*, approval_on_b: bool = True) -> dict[str, Any]:
+    nodes = [
+        {"id": "a", "type": "shell", "params": {"command": "echo hello"}},
+        {"id": "b", "type": "shell", "params": {"command": "echo from-${a.stdout}"}},
+    ]
+    if approval_on_b:
+        nodes[1]["approval"] = "required"
+    return {"ir_version": "0.1.0", "nodes": nodes, "edges": [{"from": "a", "to": "b"}]}
+
+
+def _run(ir: dict[str, Any], shared: dict[str, Any]) -> str:
+    compiled = compile_workflow(ir, Registry())
+    return WorkflowEngine().run(compiled, shared)
+
+
+class TestApprovalGate:
+    def test_approved_gate_continues_and_previews_resolved_params(self):
+        resolver = RecordingResolver(approved=True)
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        action = _run(_shell_ir(), shared)
+        assert action == "default"
+        assert "from-hello" in shared["b"]["stdout"]
+        ((request, allow_prompt),) = resolver.calls
+        assert request.kind == "action_approval"
+        assert request.node_id == "b"
+        assert allow_prompt is True
+        # The preview shows the RESOLVED template value, not `${a.stdout}`.
+        assert request.preview["command"] == "echo from-hello"
+
+    def test_denied_gate_stops_cleanly_before_exec(self, tmp_path):
+        marker = tmp_path / "ran.txt"
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo ok"}},
+                {"id": "b", "type": "shell", "params": {"command": f"touch {marker}"}, "approval": "required"},
+            ],
+            "edges": [{"from": "a", "to": "b"}],
+        }
+        shared: dict[str, Any] = {"__gate_resolver__": RecordingResolver(approved=False)}
+        with pytest.raises(GateDenied) as exc_info:
+            _run(ir, shared)
+        # The gated node NEVER ran: no side effect, no namespace, no failure record.
+        assert not marker.exists()
+        assert "b" not in shared
+        assert not shared.get("__failures__")
+        assert shared["__execution__"]["failed_node"] is None
+        assert exc_info.value.request.node_id == "b"
+        assert exc_info.value.retriable is False
+
+    def test_no_resolver_fails_loudly_with_payload(self):
+        shared: dict[str, Any] = {}
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            _run(_shell_ir(), shared)
+        diag = exc_info.value.to_diagnostics()[0]
+        # The agent-actionable contract: cause + payload + ask-your-human + scoped flag.
+        assert "non-interactive" in diag.message
+        assert diag.context["gate"]["node_id"] == "b"
+        assert diag.context["gate"]["preview"]["command"] == "echo from-hello"
+        assert any("ask your human" in s for s in diag.suggestions)
+        assert any("--auto-approve=b" in s for s in diag.suggestions)
+        assert not shared.get("__failures__")
+
+    def test_secretlike_preview_values_masked_in_diagnostic_only(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call",
+                    "type": "shell",
+                    "params": {"command": "echo x", "api_key": "sk-super-secret"},
+                    "approval": "required",
+                }
+            ],
+            "edges": [],
+        }
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            _run(ir, {})
+        diag = exc_info.value.to_diagnostics()[0]
+        assert diag.context["gate"]["preview"]["api_key"] == "<REDACTED>"
+        # The in-memory payload itself stays unmasked (trace-consistent).
+        assert exc_info.value.request.preview["api_key"] == "sk-super-secret"
+
+    def test_cached_node_never_gates(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        from pflow.runtime.cache import MemoizationCache
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "g",
+                    "type": "shell",
+                    "params": {"command": "echo gated"},
+                    "approval": "required",
+                    "cache": True,
+                }
+            ],
+            "edges": [],
+        }
+        resolver = RecordingResolver(approved=True)
+        shared1: dict[str, Any] = {"__gate_resolver__": resolver, "__memoization_cache__": MemoizationCache()}
+        _run(ir, shared1)
+        assert len(resolver.calls) == 1
+        # Second run hits the memo cache — nothing is about to happen, so no gate.
+        shared2: dict[str, Any] = {"__gate_resolver__": resolver, "__memoization_cache__": MemoizationCache()}
+        _run(ir, shared2)
+        assert shared2["__cache_hits__"] == ["g"]
+        assert len(resolver.calls) == 1
+
+    def test_gate_on_loop_node_prompts_every_iteration(self):
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "tick",
+                    "type": "code",
+                    "params": {
+                        "code": "i: int\nresult: dict = {'go': int(i) < 2}",
+                        "inputs": {"i": "${__iteration__}"},
+                    },
+                    "approval": "required",
+                    "loop": {"while": "${tick.result.go}", "max_iterations": 5},
+                }
+            ],
+            "edges": [],
+        }
+        resolver = RecordingResolver(approved=True)
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        _run(ir, shared)
+        # while goes falsy on iteration 2 → two executions → two prompts.
+        assert len(resolver.calls) == 2
+
+    def test_broken_resolver_return_type_is_loud(self):
+        shared: dict[str, Any] = {"__gate_resolver__": lambda request, *, allow_prompt: "yes"}
+        with pytest.raises(PflowError, match="broken resolver installation"):
+            _run(_shell_ir(), shared)
+
+
+ESCALATION_CODE = (
+    "result: dict = {'escalation': {'question': 'Merge configs?', "
+    "'options': [{'label': 'merge', 'description': 'one file'}, "
+    "{'label': 'split', 'description': 'per env'}], "
+    "'recommendation': 'split'}, 'work': 'partial'}"
+)
+
+
+def _code_ir(code: str, node_id: str = "agent", **extra: Any) -> dict[str, Any]:
+    node = {"id": node_id, "type": "code", "params": {"code": code}, **extra}
+    return {"ir_version": "0.1.0", "nodes": [node], "edges": []}
+
+
+class TestEscalation:
+    def test_dict_marker_pauses_and_decision_lands_in_marker(self):
+        resolver = RecordingResolver(chosen="split", notes="keep env overrides")
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        action = _run(_code_ir(ESCALATION_CODE), shared)
+        assert action == "default"
+        ((request, _),) = resolver.calls
+        assert request.kind == "decision_escalation"
+        assert request.question == "Merge configs?"
+        assert [o["label"] for o in request.options] == ["merge", "split"]
+        assert request.recommendation == "split"
+        assert shared["agent"]["result"]["escalation"]["decision"] == {
+            "chosen": "split",
+            "notes": "keep env overrides",
+        }
+        # The rest of the node's work product is untouched.
+        assert shared["agent"]["result"]["work"] == "partial"
+
+    def test_decided_marker_never_reprompts(self):
+        decided = "result: dict = {'escalation': {'question': 'q', 'decision': {'chosen': 'a', 'notes': None}}}"
+        resolver = RecordingResolver()
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        _run(_code_ir(decided), shared)
+        assert resolver.calls == []
+
+    def test_string_marker_pauses_with_string_as_question(self):
+        resolver = RecordingResolver(chosen="postgres")
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        _run(_code_ir("result: dict = {'escalation': 'which db?'}"), shared)
+        ((request, _),) = resolver.calls
+        assert request.question == "which db?"
+        assert shared["agent"]["result"]["escalation"] == {
+            "question": "which db?",
+            "decision": {"chosen": "postgres", "notes": None},
+        }
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "result: dict = {'escalation': {}}",  # empty dict — clearly intended, unusable
+            "result: dict = {'escalation': 42}",  # unusable shape
+            "result: dict = {'escalation': True}",  # unusable shape
+        ],
+    )
+    def test_malformed_marker_warns_and_does_not_pause(self, code):
+        resolver = RecordingResolver()
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        _run(_code_ir(code), shared)
+        assert resolver.calls == []
+        warning = shared["__warnings__"]["agent"]
+        assert "did NOT pause" in warning.message
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "result: dict = {'no_escalation': 1}",
+            "result: dict = {'escalation': None}",
+            "result: dict = {'escalation': False}",
+            "result: str = 'plain prose without the keyword'",
+        ],
+    )
+    def test_absent_or_falsy_marker_never_pauses_or_warns(self, code):
+        resolver = RecordingResolver()
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        _run(_code_ir(code), shared)
+        assert resolver.calls == []
+        assert "agent" not in shared.get("__warnings__", {})
+
+    def test_schema_softfail_string_result_mentioning_escalation_warns(self):
+        # detect_escalation unit path: a claude-code schema soft-failure leaves a
+        # raw string result + _schema_error in the namespace.
+        shared = {
+            "agent": {
+                "result": "I think we need an escalation here: the plan conflicts with the data model",
+                "_schema_error": "output did not match schema",
+            },
+            "__warnings__": {},
+        }
+        assert detect_escalation(shared, "agent") is None
+        assert "swallowed" in shared["__warnings__"]["agent"].message
+
+    def test_noninteractive_escalation_keeps_success_record(self):
+        shared: dict[str, Any] = {}
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            _run(_code_ir(ESCALATION_CODE), shared)
+        # The node genuinely succeeded — its record stands; nothing is archived.
+        assert shared["agent"]["result"]["work"] == "partial"
+        assert not shared.get("__failures__")
+        diag = exc_info.value.to_diagnostics()[0]
+        assert any("cannot be pre-approved" in s for s in diag.suggestions)
+
+    def test_escalating_result_is_never_cached(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        from pflow.runtime.cache import MemoizationCache
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        ir = _code_ir(ESCALATION_CODE, cache=True)
+        resolver = RecordingResolver(chosen="split")
+        shared1: dict[str, Any] = {"__gate_resolver__": resolver, "__memoization_cache__": MemoizationCache()}
+        _run(ir, shared1)
+        # Not in-process-completed, not memo-cached: a fresh run re-executes and re-escalates.
+        assert "agent" not in shared1["__execution__"]["completed_nodes"]
+        shared2: dict[str, Any] = {"__gate_resolver__": resolver, "__memoization_cache__": MemoizationCache()}
+        _run(ir, shared2)
+        assert shared2.get("__cache_hits__", []) == []
+        assert len(resolver.calls) == 2
+
+    def test_non_escalating_result_still_caches(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        from pflow.runtime.cache import MemoizationCache
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        ir = _code_ir("result: dict = {'work': 'done'}", cache=True)
+        shared1: dict[str, Any] = {"__memoization_cache__": MemoizationCache()}
+        _run(ir, shared1)
+        assert "agent" in shared1["__execution__"]["completed_nodes"]
+        shared2: dict[str, Any] = {"__memoization_cache__": MemoizationCache()}
+        _run(ir, shared2)
+        assert shared2["__cache_hits__"] == ["agent"]
+
+
+class TestBatchInteractions:
+    def _batch_escalation_ir(self, *, decided: bool = False) -> dict[str, Any]:
+        decision = ", 'decision': {'chosen': 'x'}" if decided else ""
+        code = f"item: str\nresult: dict = {{'escalation': {{'question': 'item asks: ' + str(item){decision}}}}}"
+        return {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "worker",
+                    "type": "code",
+                    "params": {"code": code, "inputs": {"item": "${item}"}},
+                    "batch": {"items": "${items}", "as": "item"},
+                }
+            ],
+            "edges": [],
+        }
+
+    def test_undecided_escalation_in_batch_item_fails_loudly_with_context(self):
+        shared: dict[str, Any] = {"items": ["alpha", "beta"], "__gate_resolver__": RecordingResolver()}
+        with pytest.raises(PflowError) as exc_info:
+            _run(self._batch_escalation_ir(), shared)
+        message = str(exc_info.value)
+        assert "batch item 1 of 2" in message
+        assert "item asks: alpha" in message
+        assert "outside the batch" in message
+
+    def test_decided_escalation_in_batch_item_is_skipped(self):
+        shared: dict[str, Any] = {"items": ["alpha"], "__gate_resolver__": RecordingResolver()}
+        action = _run(self._batch_escalation_ir(decided=True), shared)
+        assert action == "default"
+
+    def test_approval_gate_before_batch_previews_and_batch_runs(self):
+        # Decision 1's recommended shape: gate the step BEFORE the batch.
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {"id": "confirm", "type": "shell", "params": {"command": "echo go"}, "approval": "required"},
+                {
+                    "id": "fan",
+                    "type": "code",
+                    "params": {"code": "item: int\nresult: str = str(item)", "inputs": {"item": "${item}"}},
+                    "batch": {"items": "${items}", "as": "item"},
+                },
+            ],
+            "edges": [{"from": "confirm", "to": "fan"}],
+        }
+        resolver = RecordingResolver(approved=True)
+        shared: dict[str, Any] = {"items": [1, 2, 3], "__gate_resolver__": resolver}
+        _run(ir, shared)
+        assert len(resolver.calls) == 1
+        assert shared["fan"]["count"] == 3
+
+
+class TestSubWorkflowBoundary:
+    def _child_workflow(self, tmp_path, *, gated_command: str = "echo child-action") -> str:
+        child = tmp_path / "child.pflow.md"
+        child.write_text(
+            "# Child\n\nChild with a gated step.\n\n## Steps\n\n"
+            "### gated-step\n\nDo the child action.\n\n"
+            "- type: shell\n"
+            f"- command: {gated_command}\n"
+            "- approval: required\n"
+        )
+        return str(child)
+
+    def _parent_ir(self, child_path: str, **node_extra: Any) -> dict[str, Any]:
+        return {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "sub", "type": "workflow", "params": {"workflow": child_path}, **node_extra}],
+            "edges": [],
+        }
+
+    def test_gate_inside_subworkflow_prompts_via_propagated_resolver(self, tmp_path):
+        resolver = RecordingResolver(approved=True)
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        action = _run(self._parent_ir(self._child_workflow(tmp_path)), shared)
+        assert action == "default"
+        ((request, _),) = resolver.calls
+        assert request.node_id == "gated-step"
+
+    def test_denial_inside_subworkflow_crosses_boundary_unconverted(self, tmp_path):
+        shared: dict[str, Any] = {"__gate_resolver__": RecordingResolver(approved=False)}
+        with pytest.raises(GateDenied):
+            _run(self._parent_ir(self._child_workflow(tmp_path)), shared)
+        assert not shared.get("__failures__")
+
+    def test_denial_is_not_routable_via_error_action_continue(self, tmp_path):
+        # Decision 5/11: a workflow must not "handle" a human's no.
+        ir = self._parent_ir(self._child_workflow(tmp_path))
+        ir["nodes"][0]["params"]["error_action"] = "continue"
+        shared: dict[str, Any] = {"__gate_resolver__": RecordingResolver(approved=False)}
+        with pytest.raises(GateDenied):
+            _run(ir, shared)
+
+    def test_denial_in_sequential_batch_item_stops_run_without_retry_reprompt(self, tmp_path):
+        child_path = self._child_workflow(tmp_path)
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "sub",
+                    "type": "workflow",
+                    "params": {"workflow": child_path},
+                    "batch": {"items": "${items}", "as": "item", "max_retries": 3},
+                }
+            ],
+            "edges": [],
+        }
+        resolver = RecordingResolver(approved=False)
+        shared: dict[str, Any] = {"items": [1, 2, 3], "__gate_resolver__": resolver}
+        with pytest.raises(GateDenied):
+            _run(ir, shared)
+        # retriable=False: the batch retry loop must NOT re-prompt a human who said no,
+        # and later items must not prompt either.
+        assert len(resolver.calls) == 1
+
+    def test_parallel_batch_gate_cannot_prompt_but_flag_approval_works(self, tmp_path):
+        child_path = self._child_workflow(tmp_path)
+
+        def batch_ir() -> dict[str, Any]:
+            return {
+                "ir_version": "0.1.0",
+                "nodes": [
+                    {
+                        "id": "sub",
+                        "type": "workflow",
+                        "params": {"workflow": child_path},
+                        "batch": {"items": "${items}", "as": "item", "parallel": True, "error_handling": "continue"},
+                    }
+                ],
+                "edges": [],
+            }
+
+        # Without a pre-approval: the worker cannot prompt → loud, truthful error.
+        resolver = RecordingResolver(approved=True)
+        shared: dict[str, Any] = {"items": [1], "__gate_resolver__": resolver}
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            _run(batch_ir(), shared)
+        assert exc_info.value.parallel_batch is True
+        ((_request, allow_prompt),) = resolver.calls
+        assert allow_prompt is False
+
+        # With the gate pre-approved (flag lookup is thread-safe): the batch runs.
+        approver = RecordingResolver(auto_approve=frozenset({"gated-step"}))
+        shared2: dict[str, Any] = {"items": [1, 2], "__gate_resolver__": approver}
+        action = _run(batch_ir(), shared2)
+        assert action == "default"
+        assert shared2["sub"]["success_count"] == 2

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -374,13 +374,13 @@ class TestRunnerBoundary:
     """End-to-end through WorkflowRunner (tests/CLAUDE.md pitfall #20: engine-level
     tests can pass while the real pipeline breaks).
 
-    Pins TODAY's production behavior for a gated run with no resolver installed
-    (which is every CLI/MCP run until Phase 3): the run fails as a result (never a
-    propagated exception — the CLI's trace finalize depends on a non-None result),
-    the payload-carrying gate diagnostic survives runner conversion intact, and it
-    is JSON-serializable end to end (the MCP/JSON formatters serialize it verbatim).
-    Phase 3 will CHANGE the denied half of this boundary — these assertions are the
-    contract its edits must consciously update, not silently break.
+    Pins the production behavior for a gated run with no resolver installed
+    (any caller not passing ``gate_resolver`` — e.g. a bare library caller): the
+    run fails as a result (never a propagated exception — the CLI's trace finalize
+    depends on a non-None result), the payload-carrying gate diagnostic survives
+    runner conversion intact, and it is JSON-serializable end to end (the MCP/JSON
+    formatters serialize it verbatim). The denied half (Phase 3) maps GateDenied →
+    ``WorkflowStatus.DENIED``, pinned below.
     """
 
     def test_noninteractive_gate_through_runner_keeps_payload_diagnostics(self):
@@ -415,6 +415,68 @@ class TestRunnerBoundary:
         assert "hello" in result.shared_after["a"]["stdout"]
         assert "b" not in result.shared_after
         assert not result.shared_after.get("__failures__")
+
+    def test_denied_gate_through_runner_yields_denied_status_not_failed(self):
+        """Phase 3 (Decision 5): a human's "no" is WorkflowStatus.DENIED — a clean
+        stop the CLI maps to exit 3 — never FAILED, never a __failures__ entry."""
+        from pflow.core.gate import GateResolution
+        from pflow.core.workflow.status import WorkflowStatus
+        from pflow.execution import WorkflowRunner
+        from pflow.execution.result import RunnerConfig
+
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo hello"}},
+                {"id": "b", "type": "shell", "params": {"command": "echo boom"}, "approval": "required"},
+            ],
+            "edges": [{"from": "a", "to": "b"}],
+        }
+
+        def deny(request, *, allow_prompt=True):
+            return GateResolution(approved=False, resolved_via="prompt")
+
+        result = WorkflowRunner().run(ir, {}, config=RunnerConfig(trace_enabled=False), gate_resolver=deny)
+        assert result.success is False
+        assert result.status is WorkflowStatus.DENIED
+        # The gated node never ran, nothing broke, upstream survives.
+        assert "b" not in result.shared_after
+        assert not result.shared_after.get("__failures__")
+        assert "hello" in result.shared_after["a"]["stdout"]
+        # The denial diagnostic carries the gate payload for the JSON/MCP surfaces.
+        gate_diags = [d for d in result.diagnostics if (d.context or {}).get("category") == "gate"]
+        assert gate_diags and gate_diags[0].node_id == "b"
+
+    def test_approving_resolver_installed_via_runner_reaches_nested_engines(self, tmp_path):
+        """The gate_resolver kwarg mirrors progress_callback: __gate_resolver__ is
+        propagated into sub-workflow child engines, so a CHILD gate prompts/approves
+        through the SAME resolver with zero WorkflowExecutor plumbing."""
+        from pflow.core.gate import GateResolution
+        from pflow.execution import WorkflowRunner
+        from pflow.execution.result import RunnerConfig
+
+        child_path = tmp_path / "child.pflow.md"
+        child_path.write_text(
+            "# Child\n\nChild with a gated step.\n\n## Steps\n\n"
+            "### gated-child\n\nDo the child action.\n\n"
+            "- type: shell\n"
+            "- command: echo child-ran\n"
+            "- approval: required\n"
+        )
+        parent = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "sub", "type": "workflow", "params": {"workflow": str(child_path)}}],
+            "edges": [],
+        }
+        seen: list[str] = []
+
+        def approve(request, *, allow_prompt=True):
+            seen.append(request.node_id)
+            return GateResolution(approved=True, resolved_via="prompt")
+
+        result = WorkflowRunner().run(parent, {}, config=RunnerConfig(trace_enabled=False), gate_resolver=approve)
+        assert result.success, f"child-gated run failed: {[d.message for d in result.diagnostics]}"
+        assert seen == ["gated-child"]
 
 
 class TestBatchInteractions:

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import pytest
 
-from pflow.core.exceptions import GateDenied, GateNotInteractiveError, PflowError
+from pflow.core.exceptions import GateDenied, GateNotInteractiveError, GateResolverError, PflowError
 from pflow.core.gate import GateRequest, GateResolution
 from pflow.registry import Registry
 from pflow.runtime import compile_workflow
@@ -207,8 +207,38 @@ class TestApprovalGate:
 
     def test_broken_resolver_return_type_is_loud(self):
         shared: dict[str, Any] = {"__gate_resolver__": lambda request, *, allow_prompt: "yes"}
-        with pytest.raises(PflowError, match="broken resolver installation"):
+        with pytest.raises(GateResolverError, match="broken resolver installation"):
             _run(_shell_ir(), shared)
+
+
+class TestGateResolverFailure:
+    """A resolver bug is gate-scoped control flow, never a node failure.
+
+    Without the GateResolverError exemption, an unexpected resolver exception
+    falls to the engine's generic except arm — which at the POST-exec escalation
+    seam records a duplicate error event and archives the node's genuinely
+    successful output into __failures__.
+    """
+
+    @staticmethod
+    def _crashing_resolver(request: GateRequest, *, allow_prompt: bool) -> GateResolution:
+        raise RuntimeError("resolver bug")
+
+    def test_resolver_crash_at_approval_gate_is_gate_scoped(self):
+        shared: dict[str, Any] = {"__gate_resolver__": self._crashing_resolver}
+        with pytest.raises(GateResolverError, match="RuntimeError: resolver bug"):
+            _run(_shell_ir(), shared)
+        # The gated node never ran and was NOT archived as a node failure.
+        assert "b" not in shared
+        assert "b" not in shared.get("__failures__", {})
+
+    def test_resolver_crash_at_escalation_keeps_node_success_record(self):
+        shared: dict[str, Any] = {"__gate_resolver__": self._crashing_resolver}
+        with pytest.raises(GateResolverError, match="RuntimeError: resolver bug"):
+            _run(_code_ir(ESCALATION_CODE), shared)
+        # The node's honest success record stands: output in place, no failure archive.
+        assert shared["agent"]["result"]["work"] == "partial"
+        assert "agent" not in shared.get("__failures__", {})
 
 
 ESCALATION_CODE = (
@@ -527,6 +557,35 @@ class TestBatchInteractions:
         assert "batch item 1 of 2" in message
         assert "item asks: alpha" in message
         assert "outside the batch" in message
+
+    def test_batch_escalation_reports_original_item_index_when_earlier_item_failed(self):
+        # `results` holds successes only — with item 1 (alpha) failing, the
+        # escalating item 2 (beta) sits at results[0]. The error must still
+        # name it "batch item 2 of 2", not "1 of 2".
+        code = (
+            "item: str\n"
+            "if item == 'alpha':\n"
+            "    raise ValueError('boom')\n"
+            "result: dict = {'escalation': {'question': 'item asks: ' + str(item)}}"
+        )
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "worker",
+                    "type": "code",
+                    "params": {"code": code, "inputs": {"item": "${item}"}},
+                    "batch": {"items": "${items}", "as": "item", "error_handling": "continue"},
+                }
+            ],
+            "edges": [],
+        }
+        shared: dict[str, Any] = {"items": ["alpha", "beta"], "__gate_resolver__": RecordingResolver()}
+        with pytest.raises(PflowError) as exc_info:
+            _run(ir, shared)
+        message = str(exc_info.value)
+        assert "batch item 2 of 2" in message
+        assert "item asks: beta" in message
 
     def test_decided_escalation_in_batch_item_is_skipped(self):
         shared: dict[str, Any] = {"items": ["alpha"], "__gate_resolver__": RecordingResolver()}

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -324,6 +324,99 @@ class TestEscalation:
         assert shared2["__cache_hits__"] == ["agent"]
 
 
+class TestEscalationContinueSemantics:
+    """The escalation CONTINUE mechanism — the reason escalation exists.
+
+    Pins the two timing claims the whole design rests on: the human's decision is
+    written to the store BEFORE the walk's loop-re-entry check evaluates `while:`,
+    and BEFORE iteration 2's carry resolution reads it. If either ordering broke,
+    escalation would pause correctly but the answer would never reach the work.
+    """
+
+    def test_escalation_decision_feeds_loop_carry_reentry(self):
+        code = (
+            "answer: str\n"
+            "needs_human = answer == 'none'\n"
+            "result: dict = (\n"
+            "    {'escalation': {'question': 'which layout?'}, 'go': True}\n"
+            "    if needs_human\n"
+            "    else {'go': False, 'used': answer}\n"
+            ")\n"
+        )
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "agent",
+                    "type": "code",
+                    "params": {"code": code, "inputs": {"answer": "none"}},
+                    "loop": {
+                        "while": "${agent.result.go}",
+                        "max_iterations": 5,
+                        "carry": {"answer": "${agent.result.escalation.decision.chosen}"},
+                    },
+                }
+            ],
+            "edges": [],
+        }
+        resolver = RecordingResolver(chosen="split")
+        shared: dict[str, Any] = {"__gate_resolver__": resolver}
+        action = _run(ir, shared)
+        assert action == "default"
+        # Iteration 1 escalated exactly once; iteration 2 got the human's answer via
+        # carry and finished the work with it.
+        assert len(resolver.calls) == 1
+        assert shared["agent"]["result"] == {"go": False, "used": "split"}
+        assert shared["__execution__"]["node_visit_counts"]["agent"] == 2
+
+
+class TestRunnerBoundary:
+    """End-to-end through WorkflowRunner (tests/CLAUDE.md pitfall #20: engine-level
+    tests can pass while the real pipeline breaks).
+
+    Pins TODAY's production behavior for a gated run with no resolver installed
+    (which is every CLI/MCP run until Phase 3): the run fails as a result (never a
+    propagated exception — the CLI's trace finalize depends on a non-None result),
+    the payload-carrying gate diagnostic survives runner conversion intact, and it
+    is JSON-serializable end to end (the MCP/JSON formatters serialize it verbatim).
+    Phase 3 will CHANGE the denied half of this boundary — these assertions are the
+    contract its edits must consciously update, not silently break.
+    """
+
+    def test_noninteractive_gate_through_runner_keeps_payload_diagnostics(self):
+        import json as _json
+
+        from pflow.execution import WorkflowRunner
+        from pflow.execution.result import RunnerConfig
+
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {"id": "a", "type": "shell", "params": {"command": "echo hello"}},
+                {
+                    "id": "b",
+                    "type": "shell",
+                    "params": {"command": "echo from-${a.stdout}"},
+                    "approval": "required",
+                },
+            ],
+            "edges": [{"from": "a", "to": "b"}],
+        }
+        result = WorkflowRunner().run(ir, {}, config=RunnerConfig(trace_enabled=False))
+        assert result.success is False
+        gate_diags = [d for d in result.diagnostics if (d.context or {}).get("category") == "gate"]
+        assert gate_diags, f"gate diagnostic lost in runner conversion: {result.diagnostics}"
+        diag = gate_diags[0]
+        # The operating agent must see WHAT was about to happen — resolved, not raw.
+        assert diag.context["gate"]["preview"]["command"] == "echo from-hello"
+        assert any("ask your human" in s for s in (diag.suggestions or []))
+        _json.dumps(diag.to_dict())  # must survive the JSON/MCP serialization path
+        # Upstream work is preserved and the gated node never ran / never "failed".
+        assert "hello" in result.shared_after["a"]["stdout"]
+        assert "b" not in result.shared_after
+        assert not result.shared_after.get("__failures__")
+
+
 class TestBatchInteractions:
     def _batch_escalation_ir(self, *, decided: bool = False) -> dict[str, Any]:
         decision = ", 'decision': {'chosen': 'x'}" if decided else ""

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -130,6 +130,29 @@ class TestApprovalGate:
         # The in-memory payload itself stays unmasked (trace-consistent).
         assert exc_info.value.request.preview["api_key"] == "sk-super-secret"
 
+    def test_secret_nested_in_dict_value_masked_in_diagnostic(self):
+        # Code-review fix: mask_sensitive_value only checks the TOP-LEVEL key —
+        # a secret nested inside a dict value (e.g. `headers:` on an http node)
+        # must not reach the MCP/JSON-visible diagnostic unmasked.
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call",
+                    "type": "shell",
+                    "params": {"command": "echo x", "headers": {"Authorization": "Bearer sk-super-secret"}},
+                    "approval": "required",
+                }
+            ],
+            "edges": [],
+        }
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            _run(ir, {})
+        diag = exc_info.value.to_diagnostics()[0]
+        assert diag.context["gate"]["preview"]["headers"]["Authorization"] == "<REDACTED>"
+        # The in-memory payload itself stays unmasked (trace-consistent).
+        assert exc_info.value.request.preview["headers"]["Authorization"] == "Bearer sk-super-secret"
+
     def test_cached_node_never_gates(self, tmp_path, monkeypatch):
         from pathlib import Path
 

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -153,6 +153,30 @@ class TestApprovalGate:
         # The in-memory payload itself stays unmasked (trace-consistent).
         assert exc_info.value.request.preview["headers"]["Authorization"] == "Bearer sk-super-secret"
 
+    def test_long_nonsecret_nested_value_intact_in_diagnostic(self):
+        # PR #554 review warning: sanitize_parameters cut long non-secret nested
+        # values to ~20 chars in the MCP/JSON-visible diagnostic — the agent must
+        # be able to show its human the FULL action (approving blind defeats the
+        # gate). Masking is mask-only; the diagnostic never truncates.
+        body = "b" * 150
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "call",
+                    "type": "shell",
+                    "params": {"command": "echo x", "json": {"body": body, "token": "sk-super-secret"}},
+                    "approval": "required",
+                }
+            ],
+            "edges": [],
+        }
+        with pytest.raises(GateNotInteractiveError) as exc_info:
+            _run(ir, {})
+        preview = exc_info.value.to_diagnostics()[0].context["gate"]["preview"]
+        assert preview["json"]["body"] == body  # full value, no "...<truncated>" cut
+        assert "sk-super-secret" not in str(preview)  # nested secret still redacted
+
     def test_cached_node_never_gates(self, tmp_path, monkeypatch):
         from pathlib import Path
 

--- a/tests/test_runtime/test_gate_trace.py
+++ b/tests/test_runtime/test_gate_trace.py
@@ -142,6 +142,30 @@ class TestGateTraceEvents:
         )
         assert resolution["resolution"] == "non_interactive"
 
+    def test_resolver_crash_emits_error_resolution_and_trailer_says_failed(self, tmp_path, monkeypatch):
+        """A resolver bug still leaves an honest trace: a resolution line
+        (``"error"``) is emitted before the exception escapes, and the trailer
+        reads ``failed`` via the gate_outcome channel — never ``success``."""
+        from pflow.core.exceptions import GateResolverError
+
+        def crasher(request, *, allow_prompt):
+            raise RuntimeError("resolver bug")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector = WorkflowTraceCollector(
+            "gated", workflow_path=str(tmp_path / "gated.pflow.md"), is_run_scoped=True, stream_to_disk=True
+        )
+        compiled = compile_workflow(_gated_ir(), Registry())
+        with pytest.raises(GateResolverError):
+            WorkflowEngine(trace_collector=collector).run(compiled, {"__gate_resolver__": crasher})
+        collector.finalize()
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "failed"
+        resolution = next(
+            ln for ln in _read_lines(collector._stream_path) if ln["kind"] == "gate" and ln["phase"] == "resolution"
+        )
+        assert resolution["resolution"] == "error"
+
     def _nested_gate_after_sibling_ir(self, tmp_path: Path, name: str) -> dict[str, Any]:
         """A sub-workflow with an EARLIER sibling step (records an event under the
         host) followed by a LATER gated step — the shape that orphans a trace event

--- a/tests/test_runtime/test_gate_trace.py
+++ b/tests/test_runtime/test_gate_trace.py
@@ -1,0 +1,174 @@
+"""Task 125 — the ``gate`` trace event: disk-only sideband, reader tolerance, trailer channel.
+
+The load-bearing invariants (each shipped as a review-confirmed fix):
+- gate lines are DISK-ONLY (never in ``collector.events``) so they can't become a
+  node's "final event" and break ``--only`` snapshot seeding;
+- the reconstruct reader treats ``gate`` as known-but-ignored, so a gated run's
+  trace stays fully readable (``pflow report`` / ``--only`` / analyze-cache);
+- the pause event round-trips the exact ``GateRequest`` payload (Task 171's
+  serialization test);
+- a gate-stopped run's trailer is honest via the collector's ``gate_outcome``
+  channel (without it, a denied run's own trace would read "success").
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pflow.core.exceptions import GateDenied
+from pflow.core.gate import GateResolution
+from pflow.core.trace_io import load_trace_file
+from pflow.registry import Registry
+from pflow.runtime import compile_workflow
+from pflow.runtime.engine import WorkflowEngine
+from pflow.runtime.workflow_trace import WorkflowTraceCollector, load_full_run_events
+
+
+def _gated_ir() -> dict[str, Any]:
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {"id": "a", "type": "shell", "params": {"command": "echo hello"}},
+            {"id": "b", "type": "shell", "params": {"command": "echo from-${a.stdout}"}, "approval": "required"},
+        ],
+        "edges": [{"from": "a", "to": "b"}],
+    }
+
+
+def _approver(request, *, allow_prompt):
+    return GateResolution(approved=True, resolved_via="prompt")
+
+
+def _denier(request, *, allow_prompt):
+    return GateResolution(approved=False, resolved_via="prompt")
+
+
+def _run_streamed(ir: dict[str, Any], resolver, tmp_path: Path) -> tuple[WorkflowTraceCollector, dict[str, Any]]:
+    collector = WorkflowTraceCollector(
+        "gated", workflow_path=str(tmp_path / "gated.pflow.md"), is_run_scoped=True, stream_to_disk=True
+    )
+    compiled = compile_workflow(ir, Registry())
+    shared: dict[str, Any] = {"__gate_resolver__": resolver}
+    engine = WorkflowEngine(trace_collector=collector)
+    try:
+        engine.run(compiled, shared)
+    finally:
+        collector.finalize()
+    return collector, shared
+
+
+def _read_lines(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.mark.trace_files
+class TestGateTraceEvents:
+    def test_approved_run_emits_pause_and_resolution_and_stays_readable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector, _ = _run_streamed(_gated_ir(), _approver, tmp_path)
+        lines = _read_lines(collector._stream_path)
+
+        gate_lines = [ln for ln in lines if ln["kind"] == "gate"]
+        assert [ln["phase"] for ln in gate_lines] == ["pause", "resolution"]
+        pause, resolution = gate_lines
+        # The pause line IS the serialization test for the payload (Task 171).
+        assert pause["request"]["node_id"] == "b"
+        assert pause["request"]["kind"] == "action_approval"
+        assert pause["request"]["preview"] == {"command": "echo from-hello"}
+        assert resolution["resolution"] == "approved"
+        assert resolution["resolved_via"] == "prompt"
+
+        # DISK-ONLY: gate lines never enter the in-memory event list.
+        assert all("gate" not in (e.get("kind") or "") for e in collector.events)
+        assert len(collector.events) == 2  # the two node completions only
+
+        # The reconstruct reader ignores the kind — the trace is NOT corrupt.
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "success"
+        assert {e["node_id"] for e in trace["nodes"]} == {"a", "b"}
+
+    def test_gated_approved_run_is_a_valid_only_snapshot_source(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector, _ = _run_streamed(_gated_ir(), _approver, tmp_path)
+        collector.save_to_file()
+        events, status = load_full_run_events(collector.workflow_path)
+        assert status == "success"
+        assert [e["node_id"] for e in events] == ["a", "b"]
+
+    def test_denied_run_trailer_says_denied_and_node_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector = WorkflowTraceCollector(
+            "gated", workflow_path=str(tmp_path / "gated.pflow.md"), is_run_scoped=True, stream_to_disk=True
+        )
+        compiled = compile_workflow(_gated_ir(), Registry())
+        shared: dict[str, Any] = {"__gate_resolver__": _denier}
+        with pytest.raises(GateDenied):
+            WorkflowEngine(trace_collector=collector).run(compiled, shared)
+        collector.finalize()
+
+        lines = _read_lines(collector._stream_path)
+        resolution = next(ln for ln in lines if ln["kind"] == "gate" and ln["phase"] == "resolution")
+        assert resolution["resolution"] == "denied"
+        # The denied node has NO node.start marker and NO completion event.
+        assert not any(ln.get("node_id") == "b" for ln in lines if ln["kind"] in ("node.start", "event"))
+
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "denied"
+        # A denied trace is deliberately NOT a --only snapshot source (loader allowlist).
+        collector.save_to_file()
+        assert load_full_run_events(collector.workflow_path) is None
+
+    def test_noninteractive_gate_trailer_says_failed_not_success(self, tmp_path, monkeypatch):
+        from pflow.core.exceptions import GateNotInteractiveError
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector = WorkflowTraceCollector(
+            "gated", workflow_path=str(tmp_path / "gated.pflow.md"), is_run_scoped=True, stream_to_disk=True
+        )
+        compiled = compile_workflow(_gated_ir(), Registry())
+        with pytest.raises(GateNotInteractiveError):
+            WorkflowEngine(trace_collector=collector).run(compiled, {})
+        collector.finalize()
+        trace = load_trace_file(collector._stream_path)
+        # Node "a" succeeded and no node failed — without the gate_outcome channel
+        # this trailer would read "success" for a run that died at a gate.
+        assert trace["final_status"] == "failed"
+        resolution = next(
+            ln for ln in _read_lines(collector._stream_path) if ln["kind"] == "gate" and ln["phase"] == "resolution"
+        )
+        assert resolution["resolution"] == "non_interactive"
+
+    def test_escalation_gate_lines_carry_decision(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "agent",
+                    "type": "code",
+                    "params": {"code": "result: dict = {'escalation': {'question': 'q?'}}"},
+                }
+            ],
+            "edges": [],
+        }
+
+        def chooser(request, *, allow_prompt):
+            return GateResolution(approved=True, resolved_via="prompt", chosen="a", notes="n")
+
+        collector, shared = _run_streamed(ir, chooser, tmp_path)
+        lines = _read_lines(collector._stream_path)
+        gate_lines = [ln for ln in lines if ln["kind"] == "gate"]
+        assert [ln["phase"] for ln in gate_lines] == ["pause", "resolution"]
+        assert gate_lines[0]["gate_kind"] == "decision_escalation"
+        assert gate_lines[1]["resolution"] == "choice"
+        assert gate_lines[1]["decision"] == {"chosen": "a", "notes": "n"}
+        # Ordering: the node's own completion event precedes the gate pause —
+        # its honest success record stands untouched.
+        kinds_for_agent = [ln["kind"] for ln in lines if ln.get("node_id") == "agent"]
+        assert kinds_for_agent.index("event") < kinds_for_agent.index("gate")
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "success"

--- a/tests/test_runtime/test_gate_trace.py
+++ b/tests/test_runtime/test_gate_trace.py
@@ -142,6 +142,76 @@ class TestGateTraceEvents:
         )
         assert resolution["resolution"] == "non_interactive"
 
+    def _nested_gate_after_sibling_ir(self, tmp_path: Path, name: str) -> dict[str, Any]:
+        """A sub-workflow with an EARLIER sibling step (records an event under the
+        host) followed by a LATER gated step — the shape that orphans a trace event
+        if the host's own completion event is never recorded on a gate stop."""
+        child = tmp_path / f"{name}.pflow.md"
+        child.write_text(
+            "# Child\n\nSibling then a gated step.\n\n## Steps\n\n"
+            "### sibling\n\nRuns first, recording an event under the host.\n\n"
+            "- type: shell\n- command: echo sibling\n\n"
+            "### gated-step\n\nThe gate stops here.\n\n"
+            "- type: shell\n- command: echo gated\n- approval: required\n"
+        )
+        return {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "sub", "type": "workflow", "params": {"workflow": str(child)}}],
+            "edges": [],
+        }
+
+    def test_denied_nested_gate_after_sibling_event_does_not_orphan_trace(self, tmp_path, monkeypatch):
+        """Code-review fix: a sub-workflow HOST's own trace event must be recorded
+        even when a gate stops mid-way through it. Before the fix, ``finalize()``
+        itself raised in memory (an orphaned sibling event — parent_id pointing at
+        the host's reserved-but-never-written seq), silently swallowed by the
+        runner's ``contextlib.suppress``, leaving NO ``run.complete`` trailer — the
+        trace read back as ``final_status="incomplete"`` instead of "denied", and
+        any direct caller of ``tree()``/``collect_llm_calls()`` would crash outright.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector = WorkflowTraceCollector(
+            "nested-denied",
+            workflow_path=str(tmp_path / "nested-denied.pflow.md"),
+            is_run_scoped=True,
+            stream_to_disk=True,
+        )
+        compiled = compile_workflow(self._nested_gate_after_sibling_ir(tmp_path, "child-denied"), Registry())
+        with pytest.raises(GateDenied):
+            WorkflowEngine(trace_collector=collector).run(compiled, {"__gate_resolver__": _denier})
+        collector.finalize()  # must not raise
+
+        lines = _read_lines(collector._stream_path)
+        assert any(ln["kind"] == "run.complete" for ln in lines), "finalize() must reach the trailer write"
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "denied"
+        # tree() rebuilt successfully (load_trace_file calls it) — the sibling's
+        # event is not an orphan; the whole point of the fix.
+        assert collector.tree()
+
+    def test_noninteractive_nested_gate_after_sibling_event_does_not_orphan_trace(self, tmp_path, monkeypatch):
+        """Same orphan risk via the non-interactive-fail variant of the same
+        gate-exception exemption arm."""
+        from pflow.core.exceptions import GateNotInteractiveError
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        collector = WorkflowTraceCollector(
+            "nested-noninteractive",
+            workflow_path=str(tmp_path / "nested-noninteractive.pflow.md"),
+            is_run_scoped=True,
+            stream_to_disk=True,
+        )
+        compiled = compile_workflow(self._nested_gate_after_sibling_ir(tmp_path, "child-noninteractive"), Registry())
+        with pytest.raises(GateNotInteractiveError):
+            WorkflowEngine(trace_collector=collector).run(compiled, {})
+        collector.finalize()  # must not raise
+
+        lines = _read_lines(collector._stream_path)
+        assert any(ln["kind"] == "run.complete" for ln in lines)
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "failed"
+        assert collector.tree()
+
     def test_nested_child_gate_events_land_in_run_stream(self, tmp_path, monkeypatch):
         """A gate inside a sub-workflow (the harness's primary shape) with a REAL
         run-scoped collector: NEW-path children share the run collector, so the

--- a/tests/test_runtime/test_gate_trace.py
+++ b/tests/test_runtime/test_gate_trace.py
@@ -142,6 +142,72 @@ class TestGateTraceEvents:
         )
         assert resolution["resolution"] == "non_interactive"
 
+    def test_nested_child_gate_events_land_in_run_stream(self, tmp_path, monkeypatch):
+        """A gate inside a sub-workflow (the harness's primary shape) with a REAL
+        run-scoped collector: NEW-path children share the run collector, so the
+        child gate's pause/resolution lines must appear in the streamed trace —
+        and the trace must stay fully readable."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        child = tmp_path / "child.pflow.md"
+        child.write_text(
+            "# Child\n\nChild with a gated step.\n\n## Steps\n\n### gated-step\n\n"
+            "Do the child action.\n\n- type: shell\n- command: echo child-action\n- approval: required\n"
+        )
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [{"id": "sub", "type": "workflow", "params": {"workflow": str(child)}}],
+            "edges": [],
+        }
+        collector, _ = _run_streamed(ir, _approver, tmp_path)
+        gate_lines = [ln for ln in _read_lines(collector._stream_path) if ln["kind"] == "gate"]
+        assert [(ln["phase"], ln["node_id"]) for ln in gate_lines] == [
+            ("pause", "gated-step"),
+            ("resolution", "gated-step"),
+        ]
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "success"
+
+    def test_parallel_batch_child_gate_with_live_collector_never_crashes(self, tmp_path, monkeypatch):
+        """Worker-thread safety with a REAL streaming collector: batch-item children
+        get buffer collectors (owner=None), so a worker-thread record_gate must be a
+        silent no-op — NOT an owner-thread assertion crash. Pins the production
+        combination (CLI streaming + parallel batch + pre-approved child gate) that
+        the traceless engine tests cannot see."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        child = tmp_path / "child.pflow.md"
+        child.write_text(
+            "# Child\n\nChild with a gated step.\n\n## Steps\n\n### gated-step\n\n"
+            "Do the child action.\n\n- type: shell\n- command: echo child-action\n- approval: required\n"
+        )
+        ir = {
+            "ir_version": "0.1.0",
+            "nodes": [
+                {
+                    "id": "fan",
+                    "type": "workflow",
+                    "params": {"workflow": str(child)},
+                    "batch": {"items": "${items}", "as": "item", "parallel": True},
+                }
+            ],
+            "edges": [],
+        }
+
+        def flag_approver(request, *, allow_prompt):
+            if request.node_id == "gated-step":
+                return GateResolution(approved=True, resolved_via="flag")
+            raise AssertionError(f"unexpected gate: {request.node_id}")
+
+        collector = WorkflowTraceCollector(
+            "batched", workflow_path=str(tmp_path / "batched.pflow.md"), is_run_scoped=True, stream_to_disk=True
+        )
+        compiled = compile_workflow(ir, Registry())
+        shared: dict[str, Any] = {"items": [1, 2, 3], "__gate_resolver__": flag_approver}
+        WorkflowEngine(trace_collector=collector).run(compiled, shared)
+        collector.finalize()
+        assert shared["fan"]["success_count"] == 3
+        trace = load_trace_file(collector._stream_path)
+        assert trace["final_status"] == "success"
+
     def test_escalation_gate_lines_carry_decision(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         ir = {

--- a/web/src/components/RunProgress.test.tsx
+++ b/web/src/components/RunProgress.test.tsx
@@ -126,6 +126,19 @@ describe("RunProgress", () => {
     expect(badge()?.className).toContain("status-stopped");
   });
 
+  it("renders a DENIED run amber — never the green success fallthrough (Task 125)", () => {
+    // A human's "no" at an approval gate: the badge is the amber stopped shape, the
+    // outcome row carries run-denied, and the text says the word.
+    render(
+      <RunProgress steps={[step("a", { status: "success" })]} banner={{ final_status: "denied", nodes_executed: 1 }} />,
+    );
+    const badge = document.querySelector(".run-progress-outcome .status-badge");
+    expect(badge?.className).toContain("status-stopped");
+    expect(badge?.className).not.toContain("status-success");
+    const outcome = screen.getByText(/Run denied · 1 nodes/).closest(".run-progress-outcome");
+    expect(outcome?.className).toContain("run-denied");
+  });
+
   it("resolves a no-banner terminal run via `outcome` instead of spinning a fake 'Running…'", () => {
     // The callout is a second consumer of run-lifecycle state. stopped (process killed) and not-found
     // (stale ?run=) never set a banner, so without `outcome` the outcome line spun "Running…" forever

--- a/web/src/components/RunProgress.tsx
+++ b/web/src/components/RunProgress.tsx
@@ -19,11 +19,16 @@ export type RunOutcome = "stopped" | "not-found" | null;
 // The overall-run status badge (the SAME round node badge used at a node's top-right): a spinner while
 // running, ✓ on success, ! on failure. A completed run reads its banner; otherwise a terminal `outcome`
 // (stopped/not-found) wins over the live spinner. final_status has no NodeStatus for "degraded"
-// (succeeded-with-warnings) — the closest badge is the amber "stopped"; the outcome TEXT carries the word.
+// (succeeded-with-warnings) or "denied" (human's no at a gate, Task 125) — the closest badge for both
+// is the amber "stopped"; the outcome TEXT carries the exact word.
 function runBadgeStatus(banner: RunComplete | null, outcome: RunOutcome): NodeStatus {
   if (banner) {
     if (banner.final_status === "failed") return "failed";
     if (banner.final_status === "degraded") return "stopped";
+    // Task 125: a human denied an approval gate — clean stop, not a failure. Amber like
+    // degraded/stopped (the outcome text carries the word "denied"); the success ✓
+    // fallthrough below must never render a human's "no" as green.
+    if (banner.final_status === "denied") return "stopped";
     return "success";
   }
   if (outcome === "stopped") return "stopped";

--- a/web/src/components/RunSelector.tsx
+++ b/web/src/components/RunSelector.tsx
@@ -27,6 +27,9 @@ export function runMark(run: RunInfo): { glyph: string; cls: string; label: stri
   if (run.final_status === "success") return { glyph: "✓", cls: "run-success", label: "success" };
   if (run.final_status === "degraded") return { glyph: "⊘", cls: "run-degraded", label: "degraded" };
   if (run.final_status === "failed") return { glyph: "✗", cls: "run-failed", label: "failed" };
+  // Task 125: a human denied an approval gate — clean stop, amber like degraded (never the
+  // grey stale fallthrough, which reads as "interrupted/unknown").
+  if (run.final_status === "denied") return { glyph: "⊘", cls: "run-denied", label: "denied" };
   return { glyph: "·", cls: "run-stale", label: run.final_status ?? "done" };
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -733,6 +733,10 @@ button.active {
 .run-banner.run-stale {
   border-color: #d29922;
 }
+/* Denied at an approval gate (Task 125) — a human's "no", clean stop: amber, never red/green. */
+.run-banner.run-denied {
+  border-color: #d29922;
+}
 
 /* Catalog "● running" badge (Task 173 D6) — a pulsing dot + label on a workflow with a live run. */
 .catalog-item-running {
@@ -861,6 +865,10 @@ button.active {
   color: #8b949e;
 }
 .run-mark.run-stopped {
+  color: #d29922;
+}
+/* Denied at an approval gate (Task 125) — amber, matching the banner/outcome treatment. */
+.run-mark.run-denied {
   color: #d29922;
 }
 
@@ -2437,6 +2445,10 @@ textarea.run-field-input {
 }
 /* A killed run (no banner) — amber, mirroring the canvas .run-banner.run-stopped + degraded. */
 .run-progress-outcome.run-stopped {
+  color: var(--status-stopped);
+}
+/* Denied at an approval gate (Task 125) — amber, mirroring the canvas .run-banner.run-denied. */
+.run-progress-outcome.run-denied {
   color: var(--status-stopped);
 }
 

--- a/web/src/views/GraphView.tsx
+++ b/web/src/views/GraphView.tsx
@@ -909,7 +909,7 @@ function GraphCanvas({ workflow, onBack }: GraphViewProps): JSX.Element {
             </div>
           )}
           {runBanner && (
-            // Task 173: the run outcome banner (final_status: success | degraded | failed). The live
+            // Task 173: the run outcome banner (final_status: success | degraded | failed | denied). The live
             // per-node state shows on the nodes themselves; this is the run-level summary.
             <div className={`run-banner run-${runBanner.final_status ?? "running"}`} role="status">
               Run {runBanner.final_status ?? "running"}


### PR DESCRIPTION
## Summary

Adds blocking human-in-the-loop gates to pflow workflows: an author-declared
`approval: required` on any step pauses the run for a yes/no before that step
fires, and a `claude-code` agent step can raise a decision **escalation**
mid-run (question + options + recommendation) for a human to answer. Both are
one primitive — a `GateRequest` payload — with two triggers.

## Task

125

## Changes

- **Engine substrate** (`runtime/engine/engine.py`): a pre-exec approval gate
  seam (before the `node.start` trace marker — a denied node never appears in
  the trace) and a post-exec escalation seam (after the node's own completion
  trace, before loop re-entry — so `loop:` + `carry:` can fold the human's
  decision into a re-forked agent).
- **`GateRequest`/`GateResolution`** (`core/gate.py`): the payload IS the seam
  (ADR-0009) — the same JSON-native object feeds the TTY prompt, the `gate`
  trace event, and the non-interactive error diagnostic.
- **Resolver** (`execution/gate_prompt.py`): one builder for every surface —
  CLI interactive (stdin+stderr TTY, not stdout — `pflow wf | jq` still
  gates), MCP (auto-approve only), parallel-batch worker (stub). Ctrl-C at a
  prompt exits 130 like any interrupt, never a node failure.
- **Denial as a clean stop, not a failure**: `WorkflowStatus.DENIED`, CLI exit
  code 3 (vs 1 for failures), its own text/JSON rendering, amber (never
  green) in the web UI badge/banner/run-selector.
- **`--auto-approve=<node-id>`** (repeatable, per-node only — no blanket
  flag, by design) + MCP `workflow_execute(auto_approve=[...])`.
- **Dry-run parity**: gated steps render `[type, approval]` + a footer line
  and `"approval": true` in JSON dry-run — an agent's gate-discovery surface
  before any side effect fires. A cache hit never gates, so cached entries
  are correctly never stamped.
- **`gate` trace events** (pause + resolution, disk-only like `node.start`)
  for audit — `resolved_via: prompt|flag` shows which gates a human answered
  live vs. pre-approved.
- Validation rejects `approval:` on batch-host steps (the preview couldn't
  show resolved `${item}` values); escalation from inside a batch item fails
  loudly rather than silently skipping.
- Guide (`pflow guide approval`) + Mintlify docs
  (`docs/how-it-works/approval-gates.mdx`) covering both gate kinds, the
  agent-operator playbook (discover via dry-run, ask your human, scoped
  `--auto-approve`), and the escalation continue-via-loop recipe.

## Explanation

pflow workflows previously ran start-to-finish with no checkpoint — any
step that posts to Slack, deploys, or otherwise acts on the user's behalf
fired without review. This closes that gap for the **blocking** case (human
present at a terminal during the run); durable, answer-later gates are a
separate follow-up (Task 171) that rides the same `GateRequest` payload
unchanged.

Design highlights carried through review: denial is modeled as a human
verdict (not a node failure) end-to-end — no `error`-successor routing, a
distinct exit code, and an explicit non-success-but-not-failure status
threaded through every consumer (CLI text/JSON, trace trailer, web badge,
run-selector). The escalation trigger is a reserved `result.escalation` key
(works for any node type, not just `claude-code`) rather than a new node
type, keeping the node count and IR surface unchanged. Auto-approve is
deliberately scoped per-node with no blanket form — an agent that always
passes an approve-all flag would defeat the gate's purpose; the friction of
naming each gate is the point.

A 6-agent deep-review pass (silent-failures, impact-completeness,
feature-interactions, agent-ux, test-fidelity, simplicity) found 6 confirmed
issues, all fixed: the denied JSON document now matches the unified failure
shape (`errors`/`diagnostics` arrays, not just a bespoke `gate` key); the
unmatched-`--auto-approve`-id warning no longer misreads a legitimate
nested-workflow gate as a typo; cached-but-gated plan entries are no longer
stamped `approval: true` (a cache hit never gates); the web `RunSelector`
picked up the same amber-denied treatment as the canvas banner and run
callout; the non-interactive pre-flight warning no longer fires for gates
`--only` can't reach; and one v1 limitation (gate events inside a batch
item's sub-workflow don't reach the trace — the item runs on a buffered
collector) is now documented rather than silently dropped.

## Created Docs

- `.taskmaster/tasks/task_125/task-125.md`
- `.taskmaster/tasks/task_125/implementation/implementation-plan.md`
- `.taskmaster/tasks/task_125/implementation/progress-log.md`
- `docs/how-it-works/approval-gates.mdx` (new, plus nav entry in `docs/docs.json`)
- `src/pflow/guide/features/approval.md` (new agent-facing guide topic)

## Testing

- `test_approval_gate.py` (37) — approve/deny/non-interactive, masked
  diagnostics, cache-never-gates, per-iteration loop prompts, escalation
  shape ladder, batch guards, sub-workflow boundary, denied-status contract,
  nested-resolver propagation
- `test_gate_trace.py` (9) — pause/resolution lines, payload round-trip,
  disk-only invariant, denied/failed trailers, child-gate stream
- `test_gate_prompt.py` (15, new) — resolver contract for every surface,
  Decision-14 TTY rule, secret masking/truncation, Ctrl-C to KeyboardInterrupt
- `test_approval_gate_cli.py` (9, new) — exit 3 plus JSON denied document,
  `--auto-approve`, nested-gate-aware warnings, non-interactive fail+warn,
  `-p` suppression, `--only` scoping
- `test_plan_drift.py` (+3) — mutation-verified (both sides) drift pin
  "plan says would-pause equals engine pauses", including the cached-gated
  corner and a gated sub-workflow/loop node
- `test_cli_mcp_parity.py` (+2) — MCP loud-fail with remediation ladder,
  `auto_approve` off-main-thread via `asyncio.to_thread`
- `RunProgress.test.tsx` (+1) — denied renders amber, never the green
  success fallthrough
- Manual: real pty verification of the TTY approve/deny/escalation prompts;
  `pflow ui` screenshot of a replayed denied run (amber banner and badge)
- `make test` 8367 passed, `make test-e2e` 43 passed, `make check` green,
  web `tsc --noEmit` clean, 694 vitest passed