### PR TITLE
Fix cross-platform Windows test workflow

### DIFF
--- a/.agents/skills/pflow-sandbox-testing/SKILL.md
+++ b/.agents/skills/pflow-sandbox-testing/SKILL.md
@@ -1,94 +1,149 @@
 ---
 name: pflow-sandbox-testing
-description: Run pflow's pytest suite efficiently from Codex sandbox mode. Use when validating this repository and running into problems with `uv run` or `make test` panics, tests try to write `~/.pflow`, or subprocess CLI tests fail because they invoke Homebrew `uv`.
+description: Run focused pflow tests and CLI checks safely inside Codex sandbox mode on Windows, macOS, or Linux. Use when `make test`, `make check`, or `uv run` fails because of sandboxed caches or home-directory writes; Windows Git Bash or subprocess tests fail; or validation must be split between local focused checks and GitHub Actions.
 ---
 
 # Pflow Sandbox Testing
 
-## Commands
+## Operating Rules
 
-Use the existing virtualenv directly. In this sandbox, `uv run ...` can panic before Python starts:
+1. Detect the host platform and invoke the existing virtualenv directly. Do not use `uv run` merely to launch Python or pytest inside the sandbox.
+2. Run the smallest test path that proves the change. Expand scope only when the preceding layer passes.
+3. On Windows, bound every unfamiliar batch to 30 seconds. If it reaches the limit, terminate it and its exact child process tree; do not retry a broader command.
+4. Do not run pflow's full Windows suite in the Codex sandbox. Use GitHub Actions for authoritative Windows shell, subprocess, e2e, and full-suite validation.
+5. Treat sandbox-specific failures as environment evidence, not product regressions, until a focused reproduction succeeds outside the restricted boundary or fails in CI.
 
-```bash
-HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest <paths-or-options>
+## Direct Virtualenv Commands
+
+Set `PYTHONWARNDEFAULTENCODING=1` in the environment so pytest-xdist workers inherit the encoding-warning guard. Do not replace it with `python -X warn_default_encoding` in parallel runs; interpreter flags do not propagate to xdist worker interpreters.
+
+### Windows PowerShell
+
+```powershell
+$env:PYTHONWARNDEFAULTENCODING = "1"
+.\.venv\Scripts\python.exe -m pytest tests\test_core\test_duration_format.py -q
 ```
 
-Use `/private/tmp`, not `/tmp`, because macOS may report physical paths as `/private/tmp`; some shell cwd tests compare against `os.path.expanduser("~")`.
+If tests use `Path.home()` or write pflow state, redirect both Windows home variables to writable temp space:
 
-Focused example:
-
-```bash
-HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest tests/test_core/test_duration_format.py -q
+```powershell
+$testHome = Join-Path $env:TEMP "pflow-test-home"
+New-Item -ItemType Directory -Force $testHome | Out-Null
+$env:HOME = $testHome
+$env:USERPROFILE = $testHome
 ```
 
-Near-full sandbox baseline:
+### macOS
 
 ```bash
-HOME=/private/tmp/pflow-test-home .venv/bin/python -m pytest -n 4 --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py -k 'not test_dry_run_json_mode_emits_no_stderr and not test_litellm_not_imported_by_cli_main and not test_progress_streams_before_downstream_nodes_complete'
+HOME=/private/tmp/pflow-test-home \
+PYTHONWARNDEFAULTENCODING=1 \
+.venv/bin/python -m pytest tests/test_core/test_duration_format.py -q
 ```
 
-Known baseline at creation time: `5372 passed, 18 skipped` (might have changed since then).
+Use `/private/tmp` because physical-path comparisons may resolve `/tmp` to `/private/tmp`.
 
-## Manual pflow Verification
+### Linux
 
-The pflow CLI works in this sandbox, but prefer the project virtualenv directly:
+```bash
+HOME="${TMPDIR:-/tmp}/pflow-test-home" \
+PYTHONWARNDEFAULTENCODING=1 \
+.venv/bin/python -m pytest tests/test_core/test_duration_format.py -q
+```
+
+## Validation Ladder
+
+Use these layers in order:
+
+1. **Collection diagnosis:** `python -m pytest --collect-only -qq <scope>`
+2. **Focused behavior:** one test, class, or file
+3. **Related regression surface:** a small explicit list of files
+4. **Directory batch:** only when its expected runtime is known and bounded
+5. **Broader POSIX run:** only when proportional to the task
+6. **Full Windows or broad e2e run:** GitHub Actions
+
+Example broader non-e2e macOS run:
+
+```bash
+HOME=/private/tmp/pflow-test-home \
+PYTHONWARNDEFAULTENCODING=1 \
+.venv/bin/python -m pytest -n 4 --dist=worksteal --doctest-modules \
+  --ignore=tests/test_nodes/test_llm/test_llm_integration.py -m "not e2e"
+```
+
+Do not hard-code historical pass counts in validation reports. Report the command, platform, exit status, and current result.
+
+## Windows Sandbox Failure Signatures
+
+### uv cache access
+
+`uv`, `make test`, or `make check` may try to access `%LOCALAPPDATA%\uv\cache` and fail with `Access is denied`. Use `.venv\Scripts\python.exe` or the relevant `.venv\Scripts\*.exe` tool directly. Do not relocate or rebuild the environment as a workaround.
+
+### Git Bash process creation
+
+Shell-dependent tests may fail with:
+
+```text
+bash.exe: *** fatal error - couldn't create signal pipe, Win32 error 5
+```
+
+This is a sandbox process-permission failure. Stop the affected batch; repeated shell launches create a large failure storm and can make pytest spend excessive time formatting and transporting failures. Validate non-shell behavior locally and defer Git Bash behavior to Windows CI.
+
+### Buffered or silent long runs
+
+No output does not prove a run is healthy. If a bounded command yields a running process, enforce the original deadline. Terminating the parent tool call may leave `make`, `python`, or `bash` children alive on Windows, so record the run's start time or PIDs and verify that only processes created by that run are stopped. Never kill unrelated user processes by name alone.
+
+## Other Sandbox Failure Signatures
+
+- `Attempted to create a NULL object` or `Tokio executor failed` before Python starts: bypass `uv` and use the virtualenv executable directly.
+- Writes under `~/.pflow` or the real user home fail: redirect home to a writable temp root.
+- Network, remote MCP, LiteLLM, or external API checks fail: treat restricted network or credentials as the leading cause; do not weaken tests to make them pass.
+- A required validation genuinely needs downloads, credentials, network, or writes outside workspace/temp: request the appropriate permission instead of constructing a brittle workaround.
+
+## Quality Checks Without `make check`
+
+Run only the tools relevant to the change through `.venv` when `uv lock` or tool caches are blocked. Examples on Windows:
+
+```powershell
+.\.venv\Scripts\ruff.exe check <paths>
+.\.venv\Scripts\ruff.exe format --check <paths>
+.\.venv\Scripts\python.exe -m mypy <paths>
+```
+
+Do not claim that `make check` passed when only selected tools ran. Lock consistency, pre-commit, and the complete quality gate remain separate checks for an unrestricted environment or CI.
+
+## Manual pflow Checks
+
+Prefer the virtualenv CLI directly:
+
+```powershell
+.\.venv\Scripts\pflow.exe --help
+.\.venv\Scripts\pflow.exe guide core
+```
+
+On macOS:
 
 ```bash
 HOME=/private/tmp/pflow-test-home .venv/bin/pflow --help
 HOME=/private/tmp/pflow-test-home .venv/bin/pflow guide core
 ```
 
-Bare `pflow` may not be on `PATH`. If you need commands or subprocesses to resolve `pflow` by name, prepend the virtualenv:
+On Linux:
 
 ```bash
-HOME=/private/tmp/pflow-test-home PATH="$PWD/.venv/bin:$PATH" pflow --help
+HOME="${TMPDIR:-/tmp}/pflow-test-home" .venv/bin/pflow --help
+HOME="${TMPDIR:-/tmp}/pflow-test-home" .venv/bin/pflow guide core
 ```
 
-Use `HOME=/private/tmp/pflow-test-home` for manual workflow runs too. This keeps pflow traces and caches under `/private/tmp/pflow-test-home/.pflow` instead of trying to write to the real home directory.
+Good sandbox checks include `--validate-only`, `--dry-run`, `--print`, JSON output, and code or local-file workflows confined to workspace/temp. On Windows, do not use shell-node workflows to certify behavior after the Git Bash signal-pipe failure appears.
 
-Manual scratch workflow pattern:
+## CI Handoff
 
-```bash
-HOME=/private/tmp/pflow-test-home .venv/bin/pflow scratchpads/example/workflow.pflow.md --validate-only
-HOME=/private/tmp/pflow-test-home .venv/bin/pflow scratchpads/example/workflow.pflow.md key=value --print
-```
+Use the latest Windows GitHub Actions job to distinguish a sandbox limitation from a repository regression. CI is authoritative for:
 
-Good manual regression checks in this sandbox:
+- the full Windows suite;
+- Git Bash and real subprocess behavior;
+- e2e tests and subprocess CLI entry points;
+- global `uv`/Make integration outside sandbox filesystem restrictions.
 
-- `shell`, `code`, and local `file` workflows that read/write inside the repository or `/private/tmp`
-- CLI help and guide commands
-- `--validate-only`, `--dry-run`, `--print`, and `--output-format json` behavior
-
-Sandbox limits to keep in mind:
-
-- Network is restricted, so `http`, remote MCP, LiteLLM, and external API workflows may fail for environment reasons.
-- Filesystem writes are limited to the workspace and writable temp roots; workflows writing elsewhere may hit permission errors.
-- Read-only inspection of accessible local folders can work, but do not assume arbitrary user-home writes are allowed.
-
-## Sandbox Permissions
-
-If an important command fails because of sandbox permissions, shared metadata outside the workspace, restricted network access, blocked credentials, GUI access, or non-interactive approval limits, stop and ask the user to run `/permissions` and choose **"approve for me"**. Do this before trying connector workarounds, hand-assembling commits through APIs, or building brittle alternatives around the sandbox.
-
-Common symptoms:
-
-- `git add` or `git commit` cannot create `.git/.../index.lock`
-- `git push` cannot reach the remote because network is restricted
-- `gh pr create`, `gh auth status`, or other `gh` commands fail because the CLI cannot access credentials or network
-- dependency managers, package downloads, external CLIs, browser/GUI tools, or subprocesses fail only because they need access outside the sandbox
-
-## Known Failures
-
-Do not trust `make test` or `uv run ...` inside this sandbox. `uv` may fail with:
-
-```text
-Attempted to create a NULL object.
-Tokio executor failed
-```
-
-The three excluded tests spawn `/opt/homebrew/bin/uv` directly, so they fail for sandbox/tooling reasons:
-
-- `tests/test_cli/test_dry_run_subprocess.py::test_dry_run_json_mode_emits_no_stderr`
-- `tests/test_cli/test_lazy_imports.py::test_litellm_not_imported_by_cli_main`
-- `tests/test_cli/test_progress_streaming_subprocess.py::TestRealSubprocessProgressRendering::test_progress_streams_before_downstream_nodes_complete`
-
-If tests write to `/Users/<username>/.pflow`, set `HOME=/private/tmp/pflow-test-home`. `ExecutionCache` uses `Path.home() / ".pflow"` and otherwise hits sandbox permission errors.
+When handing off, state which focused checks passed, which checks were skipped because of sandbox boundaries, and which CI job must provide the remaining proof.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,10 +79,10 @@ jobs:
   # Summary job for branch protection — matrix jobs report as
   # "tests-and-type-check (3.10)" etc., so the bare name never resolves.
   # Point the required status check at this job; it also gates the Windows
-  # suite and the macOS Make compatibility smoke test.
+  # suite, Windows MCP smoke, and macOS Make compatibility smoke test.
   tests-and-type-check-done:
     if: always()
-    needs: [tests-and-type-check, tests-windows, tests-macos-make]
+    needs: [tests-and-type-check, tests-windows, tests-windows-mcp-smoke, tests-macos-make]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -90,6 +90,9 @@ jobs:
             exit 1
           fi
           if [[ "${{ needs.tests-windows.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.tests-windows-mcp-smoke.result }}" != "success" ]]; then
             exit 1
           fi
           if [[ "${{ needs.tests-macos-make.result }}" != "success" ]]; then
@@ -121,7 +124,7 @@ jobs:
   tests-windows:
     runs-on: windows-latest
     # ~8k tests at ~2x runner slowness should land well under this; the cap
-    # exists so a hung test/npx spawn can't burn a runner for the 6h default.
+    # exists so a hung test or subprocess can't burn a runner for the 6h default.
     timeout-minutes: 60
     defaults:
       run:
@@ -157,7 +160,10 @@ jobs:
         # incompatibilities. This reproduces the contributor path that caught
         # the original regression.
         shell: pwsh
-        run: make SHELL=cmd.exe .SHELLFLAGS=/C test-all-local PYTEST_WORKERS=2
+        env:
+          # Keep timing evidence in the job log while benchmarking four workers.
+          PYTEST_ADDOPTS: --durations=25
+        run: make SHELL=cmd.exe .SHELLFLAGS=/C test-all-local PYTEST_WORKERS=4
 
       # LOAD-BEARING, not incidental: ubuntu mypy treats `sys.platform ==
       # "win32"` branch bodies as statically unreachable and never
@@ -169,14 +175,28 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv run mypy
 
+  # Keep the network-dependent MCP spawn proof off the Windows test critical
+  # path. The summary job still gates it, but it runs in parallel with pytest.
+  tests-windows-mcp-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "3.13"
+
       # Closes the one MCP assumption CI can close (task-116.md "Assumed
       # correct" item): the mcp SDK resolving `npx` through its Windows
-      # `.cmd` shim when spawning a stdio server. Lockfile evidence says the
-      # SDK ships a win32 path (pywin32 dep); this proves spawning works.
-      # A CI step, not an e2e test, so local `make test-e2e` never grows a
-      # node/npx + network dependency. `pflow mcp sync` exits 1 on failure.
+      # `.cmd` shim when spawning a stdio server. A CI step, not an e2e test,
+      # so local `make test-e2e` never grows a node/npx + network dependency.
       - name: 'MCP smoke: npx stdio server spawns on Windows'
-        if: ${{ !cancelled() }}
         timeout-minutes: 10
         run: |
           npx --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      # Makes EncodingWarning fire (opt-in at the interpreter level) so the
-      # pytest filterwarnings=["error::EncodingWarning"] rule actually guards
-      # something — see pyproject.toml [tool.pytest.ini_options].
-      PYTHONWARNDEFAULTENCODING: "1"
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -74,19 +69,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        # Use -n 2 for CI (conservative for 2-core GitHub runners)
-        run: uv run python -m pytest -n 2 --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py
+        # Exercise the same entry point contributors use. The Make target
+        # owns the EncodingWarning environment inherited by xdist workers.
+        run: make test-all-local PYTEST_WORKERS=2
 
       - name: Check typing
         run: uv run mypy
 
   # Summary job for branch protection — matrix jobs report as
   # "tests-and-type-check (3.10)" etc., so the bare name never resolves.
-  # Point the required status check at this job; it also gates the single
-  # Windows job now that Task 116 is green.
+  # Point the required status check at this job; it also gates the Windows
+  # suite and the macOS Make compatibility smoke test.
   tests-and-type-check-done:
     if: always()
-    needs: [tests-and-type-check, tests-windows]
+    needs: [tests-and-type-check, tests-windows, tests-macos-make]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -96,6 +92,28 @@ jobs:
           if [[ "${{ needs.tests-windows.result }}" != "success" ]]; then
             exit 1
           fi
+          if [[ "${{ needs.tests-macos-make.result }}" != "success" ]]; then
+            exit 1
+          fi
+
+  # macOS ships an older GNU Make than Linux and Windows. Keep a focused
+  # smoke test on the built-in Make so target-specific export syntax remains
+  # compatible while the Linux matrix owns broad version coverage.
+  tests-macos-make:
+    runs-on: macos-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "3.13"
+
+      - name: Run encoding canary through built-in Make
+        run: |
+          /usr/bin/make --version
+          /usr/bin/make test PYTEST_WORKERS=2 'PYTEST=uv run python -m pytest tests/test_encoding_warning_net.py'
 
   # Task 116 Windows gate. Single Python version (not a matrix) —
   # version-specific bugs are rarely Windows-specific, and this job is
@@ -109,7 +127,10 @@ jobs:
       run:
         shell: bash
     env:
-      PYTHONWARNDEFAULTENCODING: "1"
+      # Exercise the shell implementation contributors actually install.
+      # windows-latest also exposes Cygwin Bash, so relying on PATH would
+      # silently test different path and HOME semantics from Git for Windows.
+      PFLOW_BASH: C:\Program Files\Git\bin\bash.exe
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -119,16 +140,24 @@ jobs:
         with:
           python-version: "3.13"
 
-      # Cheap insurance for an unverified assumption (Task 116 braindump):
-      # "Git Bash is on the windows-latest runner PATH" is training
-      # knowledge, not something verified this session. If this ever prints
-      # WSL bash or nothing, ADR-0013's bash-on-windows premise needs
-      # rework before Chunk B (shell node / stdin) lands.
-      - name: 'Debug: bash resolution'
-        run: which bash && bash --version
+      - name: Install GNU Make
+        shell: pwsh
+        run: choco install make --version=4.4.1 --yes --no-progress
 
-      - name: Run tests
-        run: uv run python -m pytest -n 2 --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py
+      - name: Verify Git Bash used by pflow
+        shell: pwsh
+        run: |
+          if (-not (Test-Path -LiteralPath $env:PFLOW_BASH -PathType Leaf)) {
+            throw "Git Bash was not found at PFLOW_BASH=$env:PFLOW_BASH"
+          }
+          & $env:PFLOW_BASH --version
+
+      - name: Run tests through native Windows Make
+        # Force cmd.exe so Git Bash on the runner cannot hide Windows recipe
+        # incompatibilities. This reproduces the contributor path that caught
+        # the original regression.
+        shell: pwsh
+        run: make SHELL=cmd.exe .SHELLFLAGS=/C test-all-local PYTEST_WORKERS=2
 
       # LOAD-BEARING, not incidental: ubuntu mypy treats `sys.platform ==
       # "win32"` branch bodies as statically unreachable and never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ pflow's node system is built on `BaseNode` and `Node` (~90 lines in `src/pflow/c
 
 ```bash
 make install                    # Install dependencies and pre-commit hooks
-make test                      # Run all tests with pytest
-make test-e2e                  # Run e2e tests with pytest
+make test                       # Run non-e2e tests, excluding paid LLM tests
+make test-e2e                   # Run e2e tests, excluding paid LLM tests
+make test-all-local             # Run the full non-paid suite, including e2e
 make check                     # Run all quality checks (lint, type check, etc.)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,16 @@ So you want to contribute — cool. Here's what you need to know to get going wi
 
 ## Setting up
 
-You'll need Python 3.10+ and [uv](https://docs.astral.sh/uv/) (we use uv instead of pip for everything).
+You'll need Python 3.10+, [uv](https://docs.astral.sh/uv/), and [GNU Make](https://www.gnu.org/software/make/) available on `PATH`. We use uv instead of pip for everything.
+
+On Windows, also install [Git for Windows](https://gitforwindows.org/) for pflow's shell-node tests. GNU Make can be installed with `winget install --id ezwinports.make --exact`. Restart your terminal after installing command-line tools so it receives the updated `PATH`.
+
+Verify the prerequisites before cloning:
+
+```bash
+uv --version
+make --version
+```
 
 ```bash
 git clone https://github.com/spinje/pflow.git
@@ -12,16 +21,18 @@ cd pflow
 make install
 ```
 
-That installs dependencies and sets up pre-commit hooks. If `make install` works and you can run `make test` without everything catching fire, you're good.
+That installs dependencies and sets up pre-commit hooks. If `make install` works and you can run `make test`, you're good.
 
 ## Running things
 
 ```bash
-make test    # runs the full test suite with pytest
-make check   # linting, type checking, the whole quality gauntlet
+make test            # fast default: excludes e2e and paid LLM tests
+make test-e2e        # subprocess, shell, and pipe boundary tests
+make test-all-local  # all non-paid tests, including e2e
+make check           # linting, formatting, pre-commit, mypy, and deptry
 ```
 
-Run both before you open a PR. CI will catch it anyway, but it's faster to catch it locally than to wait for GitHub Actions to tell you what you already could've known.
+Run `make test-all-local` and `make check` before you open a PR. CI will catch it anyway, but it's faster to catch it locally than to wait for GitHub Actions to tell you what you already could've known.
 
 ## Making changes
 
@@ -30,7 +41,7 @@ The usual fork-and-PR flow:
 1. Fork the repo
 2. Create a branch off `main` (call it whatever makes sense, I don't care about branch naming conventions)
 3. Make your changes
-4. Run `make test` and `make check`
+4. Run `make test-all-local` and `make check`
 5. Open a PR against `main`
 
 That's basically it.

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-all-local: ## Run all non-LLM tests, including e2e, in parallel
 .PHONY: test-with-skipped
 test-with-skipped: ## Run non-paid tests showing skip reasons (useful for debugging)
 	@echo [test] Running all tests without paid API calls and showing skip reasons
-	@$(PYTEST) --doctest-modules --ignore=$(LLM_INTEGRATION_TEST) -v -rs
+	@$(PYTEST) $(PYTEST_NON_LLM) -v -rs
 
 .PHONY: ui-build
 ui-build: ## Build the web UI bundle into src/pflow/ui/static (requires Node).

--- a/Makefile
+++ b/Makefile
@@ -1,83 +1,111 @@
+UV ?= uv
+PYTHON = $(UV) run python
+PYTEST = $(PYTHON) -m pytest
+PYTEST_WORKERS ?= 4
+LLM_INTEGRATION_TEST := tests/test_nodes/test_llm/test_llm_integration.py
+PYTEST_NON_LLM := --doctest-modules --ignore=$(LLM_INTEGRATION_TEST)
+TEST_TARGETS := test test-e2e test-debug test-llm test-all test-all-local test-with-skipped
+
+# Target-specific exports are handled by GNU Make itself, so they work with
+# POSIX shells and native Windows cmd.exe. The environment variable (rather
+# than Python's -X flag) is required so pytest-xdist workers inherit it.
+$(TEST_TARGETS): export PYTHONWARNDEFAULTENCODING := 1
+test-llm test-all: export RUN_LLM_TESTS := 1
+# This diagnostic target must never make paid API calls because a developer
+# happens to have RUN_LLM_TESTS set in their shell.
+test-with-skipped: export RUN_LLM_TESTS :=
+
+.PHONY: verify-encoding-warning
+verify-encoding-warning:
+	@$(PYTHON) -c "import sys; sys.flags.warn_default_encoding or sys.exit('PYTHONWARNDEFAULTENCODING was not inherited by Python')"
+
+.PHONY: verify-openai-key
+verify-openai-key:
+	@$(PYTHON) -c "import os, sys; os.environ.get('RUN_LLM_TESTS') == '1' or sys.exit('RUN_LLM_TESTS=1 was not inherited by Python'); os.environ.get('OPENAI_API_KEY') or sys.exit('OPENAI_API_KEY must be exported to run paid LLM tests')"
+
+$(TEST_TARGETS): verify-encoding-warning
+test-llm test-all: verify-openai-key
+
 .PHONY: install
 install: ## Install the virtual environment and install the pre-commit hooks
-	@echo "🚀 Creating virtual environment using uv"
-	@uv sync
-	@uv run pre-commit install
+	@echo [setup] Creating virtual environment using uv
+	@$(UV) sync
+	@$(UV) run pre-commit install
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Checking lock file consistency with 'pyproject.toml'"
-	@uv lock --locked
-	@echo "🚀 Checking Claude/Codex reusable assets are synchronized"
-	@uv run python scripts/sync_claude_assets.py --check
-	@echo "🚀 Linting ALL files (git-agnostic, catches untracked): ruff"
-	@uv run ruff check .
-	@uv run ruff format --check .
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
-	@echo "🚀 Static type checking: Running mypy"
-	@uv run mypy
-	@echo "🚀 Checking for obsolete dependencies: Running deptry"
-	@uv run deptry src
+	@echo [check] Checking lock file consistency with pyproject.toml
+	@$(UV) lock --locked
+	@echo [check] Checking Claude and Codex reusable assets are synchronized
+	@$(UV) run python scripts/sync_claude_assets.py --check
+	@echo [check] Linting all files with ruff
+	@$(UV) run ruff check .
+	@$(UV) run ruff format --check .
+	@echo [check] Running pre-commit
+	@$(UV) run pre-commit run -a
+	@echo [check] Running mypy
+	@$(UV) run mypy
+	@echo [check] Checking for obsolete dependencies with deptry
+	@$(UV) run deptry src
 
 .PHONY: sync-claude-assets
 sync-claude-assets: ## Regenerate Codex assets derived from Claude sources.
-	@uv run python scripts/sync_claude_assets.py --write
+	@$(UV) run python scripts/sync_claude_assets.py --write
 
 .PHONY: test
 test: ## Test the code with pytest in parallel (excludes LLM tests that require API keys)
-	@echo "🚀 Testing code: Running non-e2e pytest in parallel with 4 workers (excluding LLM tests)"
-	@PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest -n 4 --dist=worksteal --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py -m "not e2e"
+	@echo [test] Running non-e2e tests with $(PYTEST_WORKERS) workers, excluding paid LLM tests
+	@$(PYTEST) -n $(PYTEST_WORKERS) --dist=worksteal $(PYTEST_NON_LLM) -m "not e2e"
 
 .PHONY: test-e2e
 test-e2e: ## Run real subprocess / shell / pipe boundary tests in parallel
-	@echo "🚀 Testing e2e code: Running pytest in parallel with 4 workers (excluding LLM tests)"
-	@PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest -n 4 --dist=worksteal --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py -m e2e
+	@echo [test] Running e2e tests with $(PYTEST_WORKERS) workers, excluding paid LLM tests
+	@$(PYTEST) -n $(PYTEST_WORKERS) --dist=worksteal $(PYTEST_NON_LLM) -m e2e
 
 .PHONY: test-debug
 test-debug: ## Test the code with pytest sequentially for debugging
-	@echo "🚀 Testing code: Running pytest sequentially (for debugging)"
-	@PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest -n 0 -vv --tb=short --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py
+	@echo [test] Running all non-LLM tests sequentially for debugging, including e2e
+	@$(PYTEST) -n 0 -vv --tb=short $(PYTEST_NON_LLM)
 
 .PHONY: test-llm
 test-llm: ## Run LLM integration tests with real API calls (requires API keys)
-	@echo "🚀 Testing LLM with real API calls"
-	@echo "📝 Note: Requires OPENAI_API_KEY in the environment (or ~/.pflow/settings.json env section)"
-	@RUN_LLM_TESTS=1 PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest tests/test_nodes/test_llm/test_llm_integration.py -v
+	@echo [test] Running paid LLM integration tests
+	@echo [test] OPENAI_API_KEY must be exported in the environment
+	@$(PYTEST) $(LLM_INTEGRATION_TEST) -v
 
 .PHONY: test-all
 test-all: ## Run all tests including LLM integration tests in parallel
-	@echo "🚀 Testing code: Running all tests including LLM integration (4 workers)"
-	@RUN_LLM_TESTS=1 PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest -n 4 --doctest-modules
+	@echo [test] Running all tests, including paid LLM tests, with $(PYTEST_WORKERS) workers
+	@$(PYTEST) -n $(PYTEST_WORKERS) --doctest-modules
 
 .PHONY: test-all-local
 test-all-local: ## Run all non-LLM tests, including e2e, in parallel
-	@echo "🚀 Testing code: Running all non-LLM pytest tests in parallel with 4 workers"
-	@PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest -n 4 --dist=worksteal --doctest-modules --ignore=tests/test_nodes/test_llm/test_llm_integration.py
+	@echo [test] Running all non-LLM tests, including e2e, with $(PYTEST_WORKERS) workers
+	@$(PYTEST) -n $(PYTEST_WORKERS) --dist=worksteal $(PYTEST_NON_LLM)
 
 .PHONY: test-with-skipped
-test-with-skipped: ## Run tests showing all skipped tests (useful for debugging)
-	@echo "🚀 Testing code: Running all tests (showing skipped)"
-	@PYTHONWARNDEFAULTENCODING=1 uv run python -m pytest --doctest-modules -v | grep -E "PASSED|FAILED|SKIPPED|ERROR"
+test-with-skipped: ## Run non-paid tests showing skip reasons (useful for debugging)
+	@echo [test] Running all tests without paid API calls and showing skip reasons
+	@$(PYTEST) --doctest-modules --ignore=$(LLM_INTEGRATION_TEST) -v -rs
 
 .PHONY: ui-build
 ui-build: ## Build the web UI bundle into src/pflow/ui/static (requires Node).
-	@echo "🚀 Building pflow UI frontend bundle"
+	@echo [build] Building pflow UI frontend bundle
 	@cd web && npm ci && npm run build
 
 .PHONY: build
 build: clean-build ui-build ## Build wheel file (includes the UI bundle)
-	@echo "🚀 Creating wheel file"
+	@echo [build] Creating wheel file
 	@uvx --from build pyproject-build --installer uv
 
 .PHONY: clean-build
 clean-build: ## Clean build artifacts
-	@echo "🚀 Removing build artifacts"
-	@uv run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
+	@echo [build] Removing build artifacts
+	@$(UV) run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
 
 .PHONY: publish
 publish: ## Publish a release to PyPI.
-	@echo "🚀 Publishing."
+	@echo [publish] Uploading release to PyPI
 	@uvx twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 .PHONY: build-and-publish
@@ -85,7 +113,20 @@ build-and-publish: build publish ## Build and publish.
 
 .PHONY: help
 help:
-	@uv run python -c "import re; \
-	[[print(f'\033[36m{m[0]:<20}\033[0m {m[1]}') for m in re.findall(r'^([a-zA-Z_-]+):.*?## (.*)$$', open(makefile).read(), re.M)] for makefile in ('$(MAKEFILE_LIST)').strip().split()]"
+	@echo Available targets:
+	@echo   install            Install dependencies and pre-commit hooks
+	@echo   check              Run linting, formatting, pre-commit, mypy, and deptry
+	@echo   test               Run non-e2e tests, excluding paid LLM tests
+	@echo   test-e2e           Run subprocess and shell boundary tests
+	@echo   test-debug         Run all non-LLM tests sequentially, including e2e
+	@echo   test-all-local     Run all non-LLM tests in parallel, including e2e
+	@echo   test-with-skipped  Run safely without paid calls and show skip reasons
+	@echo   test-llm           Run paid LLM integration tests
+	@echo   test-all           Run every test, including paid LLM tests
+	@echo   ui-build           Build the web UI bundle
+	@echo   clean-build        Remove Python build artifacts
+	@echo   build              Build the Python wheel
+	@echo   build-and-publish  Build and upload a release to PyPI
+	@echo   publish            Upload a release to PyPI
 
 .DEFAULT_GOAL := help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,10 @@ markers = [
 # do with pflow, and would also swallow the tmp_path blind spot above across
 # the whole test suite rather than catching it where it matters — a
 # regression inside pflow's own source. Only fires when the interpreter runs
-# with PYTHONWARNDEFAULTENCODING=1 (set in Makefile test targets + CI job
-# envs) or -X warn_default_encoding — the filter alone is inert without it.
+# with PYTHONWARNDEFAULTENCODING=1 (exported by Makefile test targets and tox)
+# or -X warn_default_encoding — the filter alone is inert without it. The
+# environment variable is required for parallel runs so xdist workers inherit
+# the setting.
 filterwarnings = ["error::EncodingWarning:pflow.*"]
 
 [tool.ruff]

--- a/scripts/sync_claude_assets.py
+++ b/scripts/sync_claude_assets.py
@@ -42,7 +42,7 @@ def metadata_value(metadata: str, key: str, source: Path) -> str:
 
 
 def render_skill(source: Path, name: str | None = None) -> str:
-    metadata, body = split_frontmatter(source.read_text(), source)
+    metadata, body = split_frontmatter(source.read_text(encoding="utf-8"), source)
     skill_name = name or metadata_value(metadata, "name", source)
     description = metadata_value(metadata, "description", source)
     return f"---\nname: {json.dumps(skill_name)}\ndescription: {json.dumps(description)}\n---\n{body}"
@@ -50,7 +50,7 @@ def render_skill(source: Path, name: str | None = None) -> str:
 
 def render_command_skill(source: Path) -> str:
     """Render a Claude command as a Codex skill without changing its source."""
-    metadata, body = split_frontmatter(source.read_text(), source)
+    metadata, body = split_frontmatter(source.read_text(encoding="utf-8"), source)
     body = translate_command_arguments(body)
     body = body.replace("{{task_id}}", "<task_id>")
     body = CLAUDE_COMMAND_AGENT.sub(r"\1", body)
@@ -77,7 +77,7 @@ def translate_command_arguments(body: str) -> str:
 
 
 def render_agent(source: Path) -> str:
-    metadata, body = split_frontmatter(source.read_text(), source)
+    metadata, body = split_frontmatter(source.read_text(encoding="utf-8"), source)
     if TRIPLE_LITERAL_QUOTE in body:
         raise ValueError(f"{source}: instructions contain {TRIPLE_LITERAL_QUOTE!r}")
     name = metadata_value(metadata, "name", source)
@@ -91,13 +91,13 @@ def render_agent(source: Path) -> str:
 
 
 def ensure_content(target: Path, expected: str, write: bool, result: SyncResult) -> None:
-    if target.is_file() and target.read_text() == expected:
+    if target.is_file() and target.read_text(encoding="utf-8") == expected:
         return
     if not write:
         result.errors.append(f"Generated asset is stale: {target}")
         return
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(expected)
+    target.write_text(expected, encoding="utf-8")
     result.changed.append(target)
 
 
@@ -109,7 +109,7 @@ def synchronize_skill(source_dir: Path, target_dir: Path, write: bool, result: S
     for relative_path in source_files:
         source = source_dir / relative_path
         target = target_dir / relative_path
-        expected = render_skill(source) if relative_path == Path("SKILL.md") else source.read_text()
+        expected = render_skill(source) if relative_path == Path("SKILL.md") else source.read_text(encoding="utf-8")
         ensure_content(target, expected, write, result)
 
     if not target_dir.exists():
@@ -148,7 +148,12 @@ def synchronize(root: Path, write: bool) -> SyncResult:
 
     agents_source = root / ".claude/agents"
     protocol_source = agents_source / "REVIEW-PROTOCOL.md"
-    ensure_content(root / ".codex/agents/REVIEW-PROTOCOL.md", protocol_source.read_text(), write, result)
+    ensure_content(
+        root / ".codex/agents/REVIEW-PROTOCOL.md",
+        protocol_source.read_text(encoding="utf-8"),
+        write,
+        result,
+    )
     for source in sorted(agents_source.glob("*.md")):
         if source == protocol_source:
             continue

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -178,7 +178,7 @@ Other markers used across the suite:
 | `make test-all-local` | `-n 4 --dist=worksteal` | `test_llm_integration.py` only |
 | `make test-llm` | sequential | Only runs LLM-specific tests |
 | `make test-all` | `-n 4` | Nothing — runs everything |
-| `make test-with-skipped` | sequential | Nothing — shows skip reasons |
+| `make test-with-skipped` | sequential | LLM integration — shows non-paid skip reasons |
 
 All commands include `--doctest-modules`, but `pyproject.toml` sets `testpaths = ["tests"]`, so collection only ever reaches `tests/` — **`src/pflow/` doctests are NOT collected by any `make` target**. They run only when pytest is pointed directly at a source path, e.g. `pytest --doctest-modules src/pflow/runtime/template_validation/type_checker.py`. Keep src doctests runnable anyway: if `testpaths` ever gains `src`, a stale example becomes a build failure.
 
@@ -198,6 +198,8 @@ def test_cli_subprocess(tmp_path, uv_exe, prepared_subprocess_env):
 **Rule: ONE subprocess test per bug/feature is usually enough.** Use unit tests for edge cases (1000x faster).
 
 **Marker rule**: real subprocess / pipe / shell-boundary CLI tests must be marked `e2e` so they do not run in default `make test`. Use in-process `CliRunner` or `WorkflowRunner` tests for the broad matrix, and keep subprocess tests as narrow contract pins.
+
+**External-tool rule**: the default suite may exercise the shell node, but it must not require incidental runner tools such as `jq` or a `python3` alias. Use the active Python environment for generic JSON/stdin assertions. If an external executable is itself the integration boundary under test, mark that narrow test `e2e` and skip with an explicit availability check when the tool is absent.
 
 **Trace rule**: do not rely on trace files unless the test is marked `trace_files`. If the test only needs runtime trace events, assert on `result.trace.events`; if it needs serialized JSON, add `@pytest.mark.trace_files`.
 

--- a/tests/shared/shell_command_utils.py
+++ b/tests/shared/shell_command_utils.py
@@ -1,0 +1,28 @@
+"""Portable command helpers for shell-node tests."""
+
+import shlex
+import sys
+
+
+def python_command(script: str) -> str:
+    """Run *script* with the interpreter executing pytest.
+
+    On Windows the shell node uses Git Bash, which needs the native executable
+    path translated before it can be invoked reliably. This avoids depending
+    on an activated virtualenv or on ``python``/``python3`` PATH aliases.
+    """
+    executable = shlex.quote(sys.executable)
+    if sys.platform == "win32":
+        executable = f'"$(cygpath -u {executable})"'
+
+    return f"{executable} -c {shlex.quote(script)}"
+
+
+def python_json_command(expression: str) -> str:
+    """Evaluate *expression* with JSON stdin available as ``data``.
+
+    Shell tests run under a POSIX-compatible shell on every platform. The
+    expression is shell-quoted as part of the complete Python snippet.
+    """
+    script = f"import json,sys; data=json.load(sys.stdin); print({expression})"
+    return python_command(script)

--- a/tests/test_cli/test_dual_mode_stdin.py
+++ b/tests/test_cli/test_dual_mode_stdin.py
@@ -15,6 +15,7 @@ LESSONS LEARNED:
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -522,6 +523,7 @@ class TestWorkflowChaining:
     """
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
+    @pytest.mark.skipif(shutil.which("jq") is None, reason="requires jq for the workflow-chain integration boundary")
     def test_workflow_chaining_producer_to_consumer(self, tmp_path, uv_exe, prepared_subprocess_env):
         """Test that two workflows can be chained via Unix pipe.
 
@@ -588,6 +590,7 @@ class TestWorkflowChaining:
         assert result.stdout.strip() == "3", f"Expected '3' but got '{result.stdout.strip()}'"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
+    @pytest.mark.skipif(shutil.which("jq") is None, reason="requires jq for the workflow-chain integration boundary")
     def test_three_stage_pipeline(self, tmp_path, uv_exe, prepared_subprocess_env):
         """Test three workflows chained via pipes: producer | transform | consumer."""
         # Producer: generates [1,2,3,4,5]

--- a/tests/test_cli/test_dual_mode_stdin.py
+++ b/tests/test_cli/test_dual_mode_stdin.py
@@ -15,7 +15,6 @@ LESSONS LEARNED:
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -27,6 +26,7 @@ from click.testing import CliRunner
 from pflow.cli.main import main
 from tests.conftest import set_isolated_home
 from tests.shared.markdown_utils import ir_to_markdown
+from tests.shared.shell_command_utils import python_json_command
 
 
 def _skip_uv_sandbox_panic(result):
@@ -523,7 +523,6 @@ class TestWorkflowChaining:
     """
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
-    @pytest.mark.skipif(shutil.which("jq") is None, reason="requires jq for the workflow-chain integration boundary")
     def test_workflow_chaining_producer_to_consumer(self, tmp_path, uv_exe, prepared_subprocess_env):
         """Test that two workflows can be chained via Unix pipe.
 
@@ -557,7 +556,7 @@ class TestWorkflowChaining:
                 {
                     "id": "count",
                     "type": "shell",
-                    "params": {"stdin": "${data}", "command": "jq length"},
+                    "params": {"stdin": "${data}", "command": python_json_command("len(data)")},
                 }
             ],
             "edges": [],
@@ -590,7 +589,6 @@ class TestWorkflowChaining:
         assert result.stdout.strip() == "3", f"Expected '3' but got '{result.stdout.strip()}'"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix pipe test")
-    @pytest.mark.skipif(shutil.which("jq") is None, reason="requires jq for the workflow-chain integration boundary")
     def test_three_stage_pipeline(self, tmp_path, uv_exe, prepared_subprocess_env):
         """Test three workflows chained via pipes: producer | transform | consumer."""
         # Producer: generates [1,2,3,4,5]
@@ -606,7 +604,16 @@ class TestWorkflowChaining:
         transform = {
             "ir_version": "0.1.0",
             "inputs": {"data": {"type": "string", "required": True, "stdin": True}},
-            "nodes": [{"id": "double", "type": "shell", "params": {"stdin": "${data}", "command": "jq '[.[] * 2]'"}}],
+            "nodes": [
+                {
+                    "id": "double",
+                    "type": "shell",
+                    "params": {
+                        "stdin": "${data}",
+                        "command": python_json_command("[item * 2 for item in data]"),
+                    },
+                }
+            ],
             "edges": [],
             "start_node": "double",
             "outputs": {"result": {"source": "${double.stdout}"}},
@@ -616,7 +623,13 @@ class TestWorkflowChaining:
         consumer = {
             "ir_version": "0.1.0",
             "inputs": {"data": {"type": "string", "required": True, "stdin": True}},
-            "nodes": [{"id": "sum", "type": "shell", "params": {"stdin": "${data}", "command": "jq 'add'"}}],
+            "nodes": [
+                {
+                    "id": "sum",
+                    "type": "shell",
+                    "params": {"stdin": "${data}", "command": python_json_command("sum(data)")},
+                }
+            ],
             "edges": [],
             "start_node": "sum",
             "outputs": {"result": {"source": "${sum.stdout}"}},

--- a/tests/test_encoding_warning_net.py
+++ b/tests/test_encoding_warning_net.py
@@ -5,12 +5,13 @@ The net is a chain with an inert-by-default failure mode: the pyproject
 encoding-less IO in pflow's own source to test failures, but Python only
 EMITS EncodingWarning when the interpreter starts with
 PYTHONWARNDEFAULTENCODING=1 / -X warn_default_encoding (PEP 597). Delete the
-env var from the Makefile or CI, or "simplify" the filter line, and the net
+env var from the Makefile or tox, or "simplify" the filter line, and the net
 dies silently while everything stays green. These tests make that death loud.
 
-Skip behavior is part of the design: on a bare `pytest` run (no env var) the
-canary SKIPS visibly instead of pretending the net is up — `make test` and
-both CI jobs set the env var, so there it must pass.
+Skip behavior is part of the design: on a bare local `pytest` run (no env
+var) the canary SKIPS visibly instead of pretending the net is up. Make
+targets fail earlier in their explicit preflight, tox sets the variable, and
+CI fails closed below if the setting is ever lost.
 
 Why exec with a faked __name__: warning attribution follows the __name__ of
 the frame that calls open() (verified in the Task 116 progress log, Bug 4),
@@ -19,15 +20,25 @@ impersonate pflow source without planting a deliberate encoding bug in
 src/pflow (which ruff PLW1514 would rightly reject).
 """
 
+import os
 import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
+encoding_warning_inactive = pytest.mark.skipif(
     not sys.flags.warn_default_encoding,
     reason="EncodingWarning net inactive in this run: PYTHONWARNDEFAULTENCODING=1 not set "
-    "(make test and CI set it; the canary only certifies runs that claim the net)",
+    "(Make targets and tox set it; the canary only certifies runs that claim the net)",
 )
+
+
+def test_encoding_warning_net_is_active_in_ci():
+    """Fail closed in CI while allowing an explicit skip for bare local pytest."""
+    if sys.flags.warn_default_encoding:
+        return
+    if os.getenv("CI"):
+        pytest.fail("EncodingWarning net is inactive in CI: PYTHONWARNDEFAULTENCODING=1 was not inherited")
+    pytest.skip("EncodingWarning net is only required through Make, tox, or CI")
 
 
 def _open_without_encoding_as(module_name: str, path: object) -> None:
@@ -36,6 +47,7 @@ def _open_without_encoding_as(module_name: str, path: object) -> None:
     exec(code, {"__name__": module_name, "path": str(path)})  # noqa: S102
 
 
+@encoding_warning_inactive
 def test_encoding_regression_in_pflow_source_fails_loudly(tmp_path):
     """An encoding-less open() attributed to a pflow.* module must be a hard
     error, not a warning. Red here means the net is dead: the env var was
@@ -47,6 +59,7 @@ def test_encoding_regression_in_pflow_source_fails_loudly(tmp_path):
         _open_without_encoding_as("pflow._encoding_net_canary", target)
 
 
+@encoding_warning_inactive
 def test_net_stays_scoped_to_pflow_modules(tmp_path):
     """The same call attributed to a non-pflow module must stay an ordinary
     warning. Red here means the filter was widened back to a blanket

--- a/tests/test_integration/test_inline_object_json_parsing_e2e.py
+++ b/tests/test_integration/test_inline_object_json_parsing_e2e.py
@@ -9,6 +9,7 @@ import pytest
 from pflow.runtime import compile_workflow
 from pflow.runtime.engine import WorkflowEngine
 from tests.shared.registry_utils import ensure_test_registry
+from tests.shared.shell_command_utils import python_json_command
 
 
 @pytest.fixture
@@ -35,7 +36,7 @@ class TestInlineObjectParsingE2E:
                     "type": "shell",
                     "params": {
                         "stdin": {"data": "${get-data.stdout}"},
-                        "command": "jq '.data.count'",
+                        "command": python_json_command('data["data"]["count"]'),
                     },
                 },
             ],
@@ -47,7 +48,7 @@ class TestInlineObjectParsingE2E:
         engine = WorkflowEngine()
         engine.run(workflow, shared)
 
-        # jq should have been able to access .data.count
+        # The downstream command can access the parsed object, not a JSON string.
         assert "3" in shared["process"]["stdout"]
 
     def test_multiple_sources_combined(self, registry):
@@ -73,7 +74,7 @@ class TestInlineObjectParsingE2E:
                             "first": "${source-a.stdout}",
                             "second": "${source-b.stdout}",
                         },
-                        "command": "jq '.first.a + .second.b'",
+                        "command": python_json_command('data["first"]["a"] + data["second"]["b"]'),
                     },
                 },
             ],
@@ -107,7 +108,7 @@ class TestInlineObjectParsingE2E:
                     "type": "shell",
                     "params": {
                         "stdin": {"items": "${get-items.stdout}"},
-                        "command": "jq '.items | length'",
+                        "command": python_json_command('len(data["items"])'),
                     },
                 },
             ],
@@ -168,7 +169,7 @@ class TestInlineObjectParsingE2E:
                     "type": "shell",
                     "params": {
                         "stdin": {"outer": {"inner": {"config": "${get-config.stdout}"}}},
-                        "command": "jq '.outer.inner.config.debug'",
+                        "command": python_json_command('json.dumps(data["outer"]["inner"]["config"]["debug"])'),
                     },
                 },
             ],
@@ -202,7 +203,7 @@ class TestInlineObjectParsingE2E:
                             "static": {"fixed": "value"},
                             "number": 42,
                         },
-                        "command": "jq '.dynamic.items[0] + .number'",
+                        "command": python_json_command('data["dynamic"]["items"][0] + data["number"]'),
                     },
                 },
             ],

--- a/tests/test_integration/test_mcp_shell_integration.py
+++ b/tests/test_integration/test_mcp_shell_integration.py
@@ -1,4 +1,4 @@
-"""Integration test for MCP → Shell → jq workflow.
+"""Integration tests for passing MCP-shaped data through shell stdin.
 
 This tests the complete fix for the shell stdin template variable issue,
 simulating the exact user scenario that was failing.
@@ -11,20 +11,21 @@ JSON/strings when passed as stdin to shell commands.
 from pflow.registry import Registry
 from pflow.runtime import compile_workflow
 from pflow.runtime.engine import WorkflowEngine
+from tests.shared.shell_command_utils import python_json_command
 
 
 class TestMCPShellIntegration:
-    """Test MCP dict output → shell stdin → jq processing."""
+    """Test MCP dict output → shell stdin → JSON processing."""
 
-    def test_mcp_dict_to_shell_with_jq(self):
-        """Test that MCP dict can be piped to jq via shell stdin.
+    def test_mcp_dict_to_shell_json_processing(self):
+        """Test that an MCP dict can be processed via shell stdin.
 
         This was the original failing scenario:
         - Upstream node stores dict in shared store
         - Template ${mock-mcp.result} resolves to dict
         - Shell node receives dict in stdin param
         - Type adaptation converts dict → JSON string
-        - jq processes the JSON from stdin
+        - A command processes the JSON from stdin
         """
         # Pre-seed mock MCP data into shared store, then use shell to extract
         mcp_data = {
@@ -49,7 +50,7 @@ class TestMCPShellIntegration:
                     "type": "shell",
                     "params": {
                         "stdin": "${mock_mcp_data}",  # This is a dict!
-                        "command": "jq -r '.data.valueRanges[0].values | map(.[0]) | .[-1]'",
+                        "command": python_json_command('data["data"]["valueRanges"][0]["values"][-1][0]'),
                     },
                 },
             ],
@@ -67,17 +68,20 @@ class TestMCPShellIntegration:
         # Verify success
         assert action == "default"
 
-        # Verify jq extracted the last URL
+        # Verify the command extracted the last URL.
         assert "https://open.spotify.com/track/xyz" in shared["extract-url"]["stdout"]
 
     def test_mcp_nested_dict_extraction(self):
-        """Test extracting nested data from MCP dict via jq."""
+        """Test extracting nested data from an MCP dict as JSON."""
         workflow_ir = {
             "nodes": [
                 {
                     "id": "extract-email",
                     "type": "shell",
-                    "params": {"stdin": "${mock_mcp_data}", "command": "jq -r '.user.profile.email'"},
+                    "params": {
+                        "stdin": "${mock_mcp_data}",
+                        "command": python_json_command('data["user"]["profile"]["email"]'),
+                    },
                 },
             ],
             "edges": [],
@@ -100,7 +104,10 @@ class TestMCPShellIntegration:
                 {
                     "id": "extract-second",
                     "type": "shell",
-                    "params": {"stdin": "${mock_mcp_data}", "command": "jq -r '.[1].name'"},
+                    "params": {
+                        "stdin": "${mock_mcp_data}",
+                        "command": python_json_command('data[1]["name"]'),
+                    },
                 },
             ],
             "edges": [],
@@ -171,8 +178,11 @@ class TestMCPShellIntegration:
                     "type": "shell",
                     "params": {
                         "stdin": "${sheets_data}",
-                        # Simplified command that just extracts the last URL using jq
-                        "command": "jq -r '.data.valueRanges[0].values | map(.[0]) | map(select(contains(\"spotify.com\"))) | .[-1]'",
+                        # Extract the last value containing a Spotify URL.
+                        "command": python_json_command(
+                            '[value[0] for value in data["data"]["valueRanges"][0]["values"] '
+                            'if "spotify.com" in value[0]][-1]'
+                        ),
                     },
                 },
             ],

--- a/tests/test_integration/test_shell_stdin_type_preservation.py
+++ b/tests/test_integration/test_shell_stdin_type_preservation.py
@@ -143,7 +143,7 @@ class TestShellStdinTypePreservation:
                     "params": {
                         "stdin": {"user": "${user}", "settings": "${settings}"},
                         "command": python_json_command(
-                            'json.dumps(data["user"] | data["settings"], separators=(",", ":"))'
+                            'json.dumps({**data["user"], **data["settings"]}, separators=(",", ":"))'
                         ),
                     },
                 }

--- a/tests/test_integration/test_shell_stdin_type_preservation.py
+++ b/tests/test_integration/test_shell_stdin_type_preservation.py
@@ -20,6 +20,7 @@ from typing import Any
 from pflow.registry.registry import Registry
 from pflow.runtime import compile_workflow
 from pflow.runtime.engine import WorkflowEngine
+from tests.shared.shell_command_utils import python_json_command
 
 
 def _compile_and_run(workflow_ir: dict[str, Any], initial_params: dict[str, Any]) -> dict[str, Any]:
@@ -41,7 +42,7 @@ class TestShellStdinTypePreservation:
         """THE USE CASE: Multiple data sources combined in stdin.
 
         This is the exact scenario from Task 103 that motivated the fix.
-        Users want to pass multiple upstream results to jq/python for processing.
+        Users want to pass multiple upstream results to CLI tools for processing.
         """
         workflow_ir = {
             "inputs": {
@@ -128,8 +129,8 @@ class TestShellStdinTypePreservation:
         assert parsed["flag"] is True
         assert parsed["items"] == ["a", "b", "c"]
 
-    def test_shell_stdin_with_jq_processing(self):
-        """Real-world: Use jq to process combined data sources."""
+    def test_shell_stdin_with_json_processing(self):
+        """Real-world: process combined JSON data sources."""
         workflow_ir = {
             "inputs": {
                 "user": {"type": "object", "required": True},
@@ -141,8 +142,9 @@ class TestShellStdinTypePreservation:
                     "type": "shell",
                     "params": {
                         "stdin": {"user": "${user}", "settings": "${settings}"},
-                        # jq merges user and settings objects
-                        "command": "jq -c '.user + .settings'",
+                        "command": python_json_command(
+                            'json.dumps(data["user"] | data["settings"], separators=(",", ":"))'
+                        ),
                     },
                 }
             ],
@@ -158,7 +160,7 @@ class TestShellStdinTypePreservation:
             },
         )
 
-        # jq should successfully merge the objects
+        # The command should successfully merge the objects.
         result = json.loads(shared["merge"]["stdout"])
 
         assert result["name"] == "Alice"

--- a/tests/test_nodes/test_shell/test_improved_behavior.py
+++ b/tests/test_nodes/test_shell/test_improved_behavior.py
@@ -1,18 +1,12 @@
 """Improved tests that verify actual behavior, not just superficial checks."""
 
 import os
-import re
 import sys
 import tempfile
 import time
 
 from pflow.nodes.shell.shell import ShellNode
-
-
-def _shell_path(path: str) -> str:
-    normalized = path.replace("\\", "/").rstrip("/")
-    normalized = re.sub(r"(?<![A-Za-z0-9_/-])([A-Za-z]):/", lambda m: f"/{m.group(1).lower()}/", normalized)
-    return normalized
+from tests.shared.shell_command_utils import python_command
 
 
 def run_shell_node(shared, **params):
@@ -271,11 +265,14 @@ class TestShellSpecificBehaviors:
         """Test that ~ is expanded in shell commands."""
         shared = {}
 
-        run_shell_node(shared, command="echo ~")
+        # Git Bash mounts the native Windows temp directory at /tmp, so compare
+        # native paths rather than treating /tmp and C:\...\Temp as different.
+        command = "cygpath -w ~" if sys.platform == "win32" else "echo ~"
+        run_shell_node(shared, command=command)
 
         output = shared["stdout"].strip()
         expected_home = os.environ.get("HOME") or os.path.expanduser("~")
-        assert _shell_path(output) == _shell_path(expected_home)
+        assert os.path.normcase(os.path.realpath(output)) == os.path.normcase(os.path.realpath(expected_home))
         assert output != "~"  # Should be expanded
 
     def test_shell_builtin_commands(self):
@@ -312,8 +309,10 @@ class TestRealWorldUseCases:
         """Test using Python one-liner for JSON processing."""
         shared = {}
 
-        # Create JSON and process with Python
-        command = '''echo '{"name": "test", "value": 42}' | python3 -c "import sys, json; d=json.load(sys.stdin); print(d['value'])"'''
+        # Use the interpreter running pytest; clean Windows environments do not
+        # necessarily provide a separate ``python3`` executable.
+        process_json = python_command("import sys,json; data=json.load(sys.stdin); print(data['value'])")
+        command = f"""echo '{{"name": "test", "value": 42}}' | {process_json}"""
         run_shell_node(shared, command=command)
 
         assert "42" in shared["stdout"]

--- a/tests/test_nodes/test_shell/test_shell.py
+++ b/tests/test_nodes/test_shell/test_shell.py
@@ -134,12 +134,15 @@ class TestShellNodeShellFeatures:
         # node = ShellNode()
         shared = {}
 
-        # HOME should be set in any Unix environment
-        run_shell_node(shared, command="echo $HOME")
+        # Git Bash mounts the native Windows temp directory at /tmp, so compare
+        # native paths rather than treating /tmp and C:\...\Temp as different.
+        command = 'cygpath -w "$HOME"' if sys.platform == "win32" else "echo $HOME"
+        run_shell_node(shared, command=command)
 
         output = shared["stdout"].strip()
         assert output != "$HOME"  # Should be expanded
-        assert _shell_path(output) == _shell_path(os.environ.get("HOME", ""))
+        expected_home = os.environ.get("HOME", "")
+        assert os.path.normcase(os.path.realpath(output)) == os.path.normcase(os.path.realpath(expected_home))
         assert shared["exit_code"] == 0
 
     def test_shell_for_loop(self):

--- a/tests/test_nodes/test_shell/test_shell_stdin.py
+++ b/tests/test_nodes/test_shell/test_shell_stdin.py
@@ -5,6 +5,7 @@ including template-resolved values (set directly as resolved params).
 """
 
 from pflow.nodes.shell.shell import ShellNode
+from tests.shared.shell_command_utils import python_json_command
 
 
 class TestShellStdinParameterFallback:
@@ -68,7 +69,7 @@ class TestShellStdinParameterFallback:
 
         json_data = '{"key": "value with \'quotes\' and special $chars"}'
 
-        node.set_params({"command": "jq -r '.key'", "stdin": json_data})
+        node.set_params({"command": python_json_command('data["key"]'), "stdin": json_data})
 
         shared = {}
 
@@ -116,7 +117,10 @@ class TestShellStdinWithComplexData:
         # Simulated MCP response (JSON string with nested data)
         mcp_result = '{"successful":true,"data":{"url":"https://open.spotify.com/track/xyz"}}'
 
-        node.set_params({"stdin": mcp_result, "command": "jq -r '.data.url'"})
+        node.set_params({
+            "stdin": mcp_result,
+            "command": python_json_command('data["data"]["url"]'),
+        })
 
         shared = {}
 

--- a/tests/test_nodes/test_shell/test_stdin_type_adaptation.py
+++ b/tests/test_nodes/test_shell/test_stdin_type_adaptation.py
@@ -5,6 +5,7 @@ since subprocess.run() requires string or None for input.
 """
 
 from pflow.nodes.shell.shell import ShellNode
+from tests.shared.shell_command_utils import python_json_command
 
 
 class TestDictListToJSON:
@@ -13,7 +14,7 @@ class TestDictListToJSON:
     def test_dict_stdin_serialized_to_json(self):
         """Dict in stdin should be JSON serialized."""
         node = ShellNode()
-        node.set_params({"command": "jq -r '.key'", "stdin": {"key": "value"}})
+        node.set_params({"command": python_json_command('data["key"]'), "stdin": {"key": "value"}})
         shared = {}
 
         action = node.run(shared)
@@ -24,7 +25,7 @@ class TestDictListToJSON:
     def test_list_stdin_serialized_to_json(self):
         """List in stdin should be JSON serialized."""
         node = ShellNode()
-        node.set_params({"command": "jq -r '.[0]'", "stdin": [1, 2, 3]})
+        node.set_params({"command": python_json_command("data[0]"), "stdin": [1, 2, 3]})
         shared = {}
 
         action = node.run(shared)
@@ -36,7 +37,7 @@ class TestDictListToJSON:
         """Complex nested structures should serialize correctly."""
         data = {"user": {"name": "John", "age": 30}, "items": [{"id": 1}, {"id": 2}]}
         node = ShellNode()
-        node.set_params({"command": "jq -r '.user.name'", "stdin": data})
+        node.set_params({"command": python_json_command('data["user"]["name"]'), "stdin": data})
         shared = {}
 
         action = node.run(shared)
@@ -67,7 +68,7 @@ class TestDictListToJSON:
         """Dict with quotes and special chars should serialize correctly."""
         data = {"text": "He said \"hello\" and 'goodbye'"}
         node = ShellNode()
-        node.set_params({"command": "jq -r '.text'", "stdin": data})
+        node.set_params({"command": python_json_command('data["text"]'), "stdin": data})
         shared = {}
 
         action = node.run(shared)
@@ -196,7 +197,7 @@ class TestTemplateIntegration:
         """Dict value (as resolved from template variable) should be JSON serialized for stdin."""
         node = ShellNode()
         node.set_params({
-            "command": "jq -r '.data.url'",
+            "command": python_json_command('data["data"]["url"]'),
             "stdin": {"data": {"url": "https://example.com"}},
         })
         shared = {}
@@ -208,7 +209,10 @@ class TestTemplateIntegration:
     def test_list_stdin_from_resolved_template(self):
         """List value (as resolved from template variable) should be JSON serialized for stdin."""
         node = ShellNode()
-        node.set_params({"command": "jq -r '.[1]'", "stdin": ["first", "second", "third"]})
+        node.set_params({
+            "command": python_json_command("data[1]"),
+            "stdin": ["first", "second", "third"],
+        })
         shared = {}
 
         action = node.run(shared)
@@ -226,7 +230,7 @@ class TestTemplateIntegration:
         assert shared["stdout"] == "42"
 
     def test_mcp_json_response(self):
-        """Simulates real MCP response (dict) being piped to jq."""
+        """Simulates a real MCP response (dict) being processed as JSON."""
         node = ShellNode()
 
         # Simulated MCP response structure
@@ -237,7 +241,7 @@ class TestTemplateIntegration:
 
         node.set_params({
             "stdin": mcp_result,
-            "command": "jq -r '.data.valueRanges[0].values[0][0]'",
+            "command": python_json_command('data["data"]["valueRanges"][0]["values"][0][0]'),
         })
         shared = {}
 
@@ -270,7 +274,7 @@ class TestEdgeCases:
         """Dict with None values should serialize correctly."""
         data = {"key": None, "other": "value"}
         node = ShellNode()
-        node.set_params({"command": "jq -r '.other'", "stdin": data})
+        node.set_params({"command": python_json_command('data["other"]'), "stdin": data})
         shared = {}
 
         action = node.run(shared)
@@ -281,7 +285,7 @@ class TestEdgeCases:
         """Nested lists of dicts should serialize correctly."""
         data = [{"id": 1, "name": "first"}, {"id": 2, "name": "second"}]
         node = ShellNode()
-        node.set_params({"command": "jq -r '.[1].name'", "stdin": data})
+        node.set_params({"command": python_json_command('data[1]["name"]'), "stdin": data})
         shared = {}
 
         action = node.run(shared)

--- a/tests/test_nodes/test_shell/test_windows_bash.py
+++ b/tests/test_nodes/test_shell/test_windows_bash.py
@@ -414,20 +414,34 @@ class TestMissingBashRaisesFromPrep:
         assert result.shared_after.get("exit_code") != 0
 
 
-# Resolved at import, BEFORE any test patches sys.platform: shutil.which has
-# its own `sys.platform == "win32"` branch (PATHEXT probing) that would return
+# This class is a POSIX-host probe: it forces pflow down the win32 branch while
+# still launching the host's native bash.  Do not resolve or run it on actual
+# Windows.  There, ``shutil.which("bash")`` may select the WSL launcher or a
+# Cygwin shell and would bypass the production resolver's Git Bash safeguards;
+# the ordinary Windows shell suite already exercises the real win32 path.
+#
+# Resolve at import, BEFORE any test patches sys.platform: shutil.which has its
+# own ``sys.platform == "win32"`` branch (PATHEXT probing) that would return
 # None for extensionless /usr/bin/bash once the fake platform is in place.
-_REAL_BASH = shutil.which("bash")
+_HOST_IS_WINDOWS = sys.platform == "win32"
+_REAL_BASH = None if _HOST_IS_WINDOWS else shutil.which("bash")
 
 
-@pytest.mark.skipif(_REAL_BASH is None, reason="needs a real bash to exercise the win32 exec branch")
+@pytest.mark.skipif(
+    _REAL_BASH is None,
+    reason=(
+        "POSIX-host-only probe; native Windows uses the production Git Bash resolver tests"
+        if _HOST_IS_WINDOWS
+        else "needs a real bash to exercise the win32 exec branch"
+    ),
+)
 class TestWindowsExecRealBash:
-    """Run the win32 exec branch against a REAL bash (available on Linux/macOS).
+    """Run the win32 exec branch against a real bash on Linux/macOS hosts.
 
     The argv-shape test above mocks subprocess.run, so it can't catch a broken
-    kwarg in the win32 call (e.g. dropped stdin piping or capture). On Windows
-    CI the whole shell suite exercises this branch; these two tests give the
-    same signal on every Linux run, before any push.
+    kwarg in the win32 call (e.g. dropped stdin piping or capture). The native
+    Windows suite exercises the production resolver and execution path; these
+    tests provide equivalent subprocess coverage on POSIX hosts before a push.
     """
 
     @pytest.fixture(autouse=True)

--- a/tests/test_runtime/test_template_resolver_inline_object_parsing.py
+++ b/tests/test_runtime/test_template_resolver_inline_object_parsing.py
@@ -7,6 +7,7 @@ Escape hatch: Use complex templates ("prefix ${var}") to keep raw strings.
 """
 
 from pflow.runtime.template_resolver import TemplateResolver
+from tests.shared.shell_command_utils import python_json_command
 
 
 class TestInlineObjectJsonParsing:
@@ -163,10 +164,10 @@ class TestNoDoubleParsing:
 
 
 class TestRealWorldScenarios:
-    """Integration-style tests with realistic shell → jq patterns."""
+    """Integration-style tests with realistic shell JSON patterns."""
 
     def test_curl_response_in_stdin(self):
-        """Typical pattern: curl output → process with jq."""
+        """Typical pattern: curl output → process structured JSON."""
         context = {"api-call": {"stdout": '{"status": "ok", "data": {"users": [{"id": 1}, {"id": 2}]}}\n'}}
         result = TemplateResolver.resolve_nested({"stdin": {"response": "${api-call.stdout}"}}, context)
         assert result["stdin"]["response"]["status"] == "ok"
@@ -290,7 +291,7 @@ class TestValidationRuntimeConsistency:
                     "params": {
                         # This is the inline object pattern we're testing
                         "stdin": {"data": "${get-json.stdout}"},
-                        "command": "jq '.data.items | length'",
+                        "command": python_json_command('len(data["data"]["items"])'),
                     },
                 },
             ],
@@ -305,7 +306,7 @@ class TestValidationRuntimeConsistency:
         engine = WorkflowEngine()
         engine.run(workflow, shared)
 
-        # jq could access .data.items, proving JSON was parsed
+        # The command accessed .data.items, proving JSON was parsed.
         assert "3" in shared["use-json"]["stdout"]
 
     def test_resolver_and_variable_exists_agree(self):

--- a/tests/test_scripts/test_sync_claude_assets.py
+++ b/tests/test_scripts/test_sync_claude_assets.py
@@ -17,13 +17,21 @@ def write_file(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def read_file(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 def make_root(tmp_path: Path) -> Path:
-    skill = "---\nname: demo-skill\ndescription: Demo skill\nargument-hint: ignored\n---\n\n# Demo\n"
-    agent = "---\nname: demo-agent\ndescription: Demo agent\nmodel: ignored\n---\n\nDo the work.\n"
-    command = "---\ndescription: Demo command\nargument-hint: ignored\n---\n\nDo the command.\n"
+    skill = (
+        "---\nname: demo-skill\ndescription: Demo skill\nargument-hint: ignored\n---\n\n# Demo\n\n● TIGHT dependency.\n"
+    )
+    agent = "---\nname: demo-agent\ndescription: Demo agent\nmodel: ignored\n---\n\nDo the work. 🔍\n"
+    command = (
+        "---\ndescription: Demo command\nargument-hint: ignored\n---\n\nDo the command.\n\nPreserve “smart quotes”.\n"
+    )
 
     write_file(tmp_path / ".claude/skills/demo-skill/SKILL.md", skill)
-    write_file(tmp_path / ".claude/skills/demo-skill/reference.md", "Reference.\n")
+    write_file(tmp_path / ".claude/skills/demo-skill/reference.md", "Reference with café text.\n")
     write_file(tmp_path / ".claude/agents/REVIEW-PROTOCOL.md", "Protocol.\n")
     write_file(tmp_path / ".claude/agents/demo-agent.md", agent)
     write_file(tmp_path / ".claude/commands/demo-command.md", command)
@@ -36,21 +44,20 @@ def test_write_generates_codex_assets(tmp_path: Path) -> None:
     result = sync_claude_assets.synchronize(root, write=True)
 
     assert result.errors == []
-    assert (root / ".agents/skills/demo-skill/reference.md").read_text() == "Reference.\n"
-    assert (
-        (root / ".agents/skills/demo-skill/SKILL.md")
-        .read_text()
-        .startswith('---\nname: "demo-skill"\ndescription: "Demo skill"\n---\n')
+    assert read_file(root / ".agents/skills/demo-skill/reference.md") == "Reference with café text.\n"
+    assert read_file(root / ".agents/skills/demo-skill/SKILL.md").startswith(
+        '---\nname: "demo-skill"\ndescription: "Demo skill"\n---\n'
     )
-    assert (
-        (root / ".agents/skills/demo-command/SKILL.md")
-        .read_text()
-        .startswith('---\nname: "demo-command"\ndescription: "Demo command"\n---\n')
+    assert read_file(root / ".agents/skills/demo-command/SKILL.md").startswith(
+        '---\nname: "demo-command"\ndescription: "Demo command"\n---\n'
     )
-    agent = (root / ".codex/agents/demo-agent.toml").read_text()
+    agent = read_file(root / ".codex/agents/demo-agent.toml")
     assert 'description = "Demo agent"' in agent
     assert "developer_instructions = '''" in agent
     assert 'name = "demo-agent"' in agent
+    assert "Do the work. 🔍" in agent
+    assert "● TIGHT dependency." in read_file(root / ".agents/skills/demo-skill/SKILL.md")
+    assert "Preserve “smart quotes”." in read_file(root / ".agents/skills/demo-command/SKILL.md")
 
 
 def test_check_reports_generated_asset_drift(tmp_path: Path) -> None:
@@ -68,16 +75,17 @@ def test_write_translates_claude_only_command_syntax(tmp_path: Path) -> None:
     root = make_root(tmp_path)
     command = root / ".claude/commands/demo-command.md"
     command.write_text(
-        command.read_text().replace(
+        read_file(command).replace(
             "Do the command.",
             "Inputs: $ARGUMENTS\ntask_description='$ARGUMENTS'\n!`git branch --show-current`\n@agent-demo\n{{task_id}}",
-        )
+        ),
+        encoding="utf-8",
     )
 
     result = sync_claude_assets.synchronize(root, write=True)
 
     assert result.errors == []
-    rendered = (root / ".agents/skills/demo-command/SKILL.md").read_text()
+    rendered = read_file(root / ".agents/skills/demo-command/SKILL.md")
     assert "$ARGUMENTS" not in rendered
     assert "@agent-demo" not in rendered
     assert "{{task_id}}" not in rendered

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ python =
 
 [testenv]
 passenv = PYTHON_VERSION
+setenv =
+    PYTHONWARNDEFAULTENCODING = 1
 allowlist_externals = uv
 commands =
     uv sync --python {envpython}


### PR DESCRIPTION
## Summary

- make the developer test and check targets portable across native Windows Make and POSIX environments
- remove incidental `jq` and `python3` dependencies from default shell tests by invoking the active Python interpreter
- normalize Git Bash/Cygwin HOME paths and prevent a POSIX-host probe from selecting WSL/Cygwin on native Windows
- align Windows CI, contributor guidance, and the sandbox-testing skill with the supported Git-for-Windows workflow

## Root cause

The GitHub-hosted Windows image supplied `jq`, a real `python3.exe`, and Cygwin Bash, so CI masked assumptions that failed on a normal Windows contributor machine. Native Windows Make also executes recipes through `cmd.exe`, where POSIX-style environment prefixes are not valid.

## Impact

`make test` and `make check` now use shell-neutral Make behavior, default tests no longer require unrelated runner tools, and Windows CI explicitly exercises Git for Windows Bash rather than whichever Bash appears first on PATH.

## Validation

- Ruff lint and formatting passed for all changed Python test files
- 204 affected tests collected successfully
- workflow YAML parsed successfully
- `git diff --check` passed
- `make -n check` passed after rebasing onto current `main`

The full Git Bash shell suite was not executed inside the restricted Codex sandbox; the Windows GitHub Actions job is the authoritative execution check.
