### PR TITLE
Speed up Windows test feedback

### DIFF
--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: "create-task"
+description: "Create task file from discussion context"
+---
+
+# Create Task
+
+Capture the current discussion into a task file that will guide implementation.
+
+## Input
+
+Task ID: **the user's request**
+
+If this is a number (e.g., "107"), create a task file for **what was just discussed** in this conversation, using that number as the task ID.
+
+If empty, ask the user for a task ID.
+
+**Output**: `.taskmaster/tasks/task_<id>/task-<id>.md`
+
+## What You're Creating
+
+A task file is a handoff document. A future agent (or you in a new session) will read this to understand:
+- What we decided to build
+- Why it matters
+- Key design decisions made
+- How to verify it works
+
+**Source**: Your context window. Everything discussed about this task is your primary input.
+
+## When to Stop and Ask
+
+If you lack clarity on ANY of these, ask before writing:
+- What the task accomplishes (the goal)
+- Why it's needed (the problem it solves)
+- Key technical approach (how it should be built)
+
+Don't guess at fundamentals. It's better to ask than to document assumptions.
+
+## Template
+
+```markdown
+# Task <id>: <title>
+
+## Description
+
+<2-3 sentences: what this does and why it matters>
+
+## Status
+
+<not started | in progress | done | blocked>
+
+## Priority
+
+<high | medium | low>
+
+## Problem
+
+What's wrong today? Why do we need this?
+
+## Solution
+
+What are we building? High-level approach.
+
+## Design Decisions
+
+Key choices made during discussion:
+- Decision 1: We chose X because Y
+- Decision 2: We'll do A, not B, because C
+
+## Dependencies
+
+What must exist first?
+- Task N: <title> — <why it's needed>
+
+Or "None" if no dependencies.
+
+## Requirements
+
+Specific, testable things the implementation must satisfy. Group by area when there are many.
+Not "what we're building" (that's Solution) or "how we'll test it" (that's Verification) —
+this is "what properties must hold."
+
+## Implementation Notes
+
+Technical details, integration points, edge cases discussed.
+
+## Verification
+
+How do we know it works?
+- Key test scenarios
+- Acceptance criteria
+
+## References
+
+Files, docs, prior tasks, or external resources relevant to implementation.
+Omit if nothing was referenced.
+```
+
+## Section Guidance
+
+**Solution vs. Requirements vs. Verification — what goes where:**
+- **Solution**: The approach. *What* we're building and *how* at a high level. ("Markdown format with YAML frontmatter, `## heading` for nodes, code blocks for prompts/scripts.")
+- **Requirements**: Properties the implementation must satisfy. Specific, testable, grouped by area. ("Parser must handle nested YAML frontmatter." "Invalid enum values produce blocking error with available choices listed.")
+- **Verification**: How we confirm it works. Test scenarios, acceptance criteria, edge cases to exercise. ("Existing workflows converted to markdown produce equivalent IR.")
+
+If something is both a requirement and a test scenario, put it in Requirements. Verification can reference requirements ("All requirements from Parser section verified").
+
+## Guidelines
+
+1. **Write for a fresh reader** — They weren't in this conversation
+2. **Capture decisions, not just facts** — "We chose X because Y" is more valuable than "We'll use X"
+3. **Be specific about scope** — What's in vs. out?
+4. **Link to context** — Reference files, examples, or prior tasks discussed
+5. **Omit the obvious** — Don't pad with boilerplate
+6. **Include references** — Link to files, docs, prior tasks, or existing patterns that the implementer will need
+7. **Status defaults to "not started"** — Unless discussed otherwise
+8. **Priority defaults to "medium"** — Unless explicitly discussed
+
+## Example
+
+```markdown
+# Task 107: Implement Markdown Workflow Format
+
+## Description
+
+A new workflow authoring format using markdown that compiles to IR. Optimizes for LLM authoring with literate programming, lintable code blocks, and token efficiency.
+
+## Status
+
+not started
+
+## Priority
+
+medium
+
+## Problem
+
+JSON workflows have significant friction:
+- Prompts require `\n` escaping on single lines
+- Shell/jq commands need quote escaping
+- No linting — errors only at runtime
+- Documentation separate from workflow
+- ~20-40% more tokens than necessary
+
+## Solution
+
+Markdown format with:
+- YAML frontmatter for metadata (inputs, outputs, edges)
+- `## heading` for node IDs
+- Simple `key: value` for node parameters
+- Language-tagged code blocks:
+  - ` ```prompt ` — LLM prompts
+  - ` ```shell ` — Shell commands (lintable with shellcheck)
+  - ` ```python ` — Python code (lintable with ruff/mypy)
+- Prose documentation inline between nodes
+
+## Design Decisions
+
+- **Markdown → IR, not → JSON**: Compile to internal representation, not JSON files
+- **Python over jq**: Task 104's Python node replaces most shell transforms
+- **Edges explicit**: Declared in frontmatter, not inferred from references
+- **Literate workflows**: Documentation IS the workflow file
+
+## Dependencies
+
+- Task 104: Python Script Node — Enables lintable data transformations in markdown
+- Task 49: PyPI Release — Complete first to not delay v0.6.0
+
+## Requirements
+
+### Parser
+- Parse YAML frontmatter into metadata dict (inputs, outputs, edges)
+- Split document into nodes at `## heading` boundaries
+- Extract `key: value` pairs as node parameters (string, int, float, bool, list)
+- Extract language-tagged code blocks (`prompt`, `shell`, `python`)
+- Preserve prose between nodes as documentation (accessible at runtime, not executed)
+
+### Compilation
+- Markdown → IR produces identical IR structure as existing JSON → IR
+- All existing node types must be expressible in markdown format
+- Edges declared in frontmatter YAML, not inferred from references
+- Variable references in code blocks (`{{input.name}}`) validated against declared inputs
+
+### Error Handling
+- Syntax errors report file path + line number + human-readable message
+- Missing required fields (no `## heading`, no frontmatter) produce specific error types
+- Duplicate node IDs (duplicate `## heading`) produce blocking error
+- Unknown `key:` parameters produce warning, not error (forward compatibility)
+
+### Linting Integration
+- Shell code blocks extractable to temp files for `shellcheck` validation
+- Python code blocks extractable to temp files for `ruff`/`mypy` validation
+- Lint errors map back to original markdown line numbers
+
+### Constraints
+- No new runtime dependencies beyond one markdown parsing library
+- UTF-8 only (no encoding detection)
+
+## Implementation Notes
+
+Parser approach:
+1. Use existing markdown library (mistune, markdown-it-py)
+2. Extract YAML frontmatter
+3. Identify nodes by `## heading`
+4. Parse inline `key: value` parameters
+5. Extract code blocks by language tag
+6. Compile to existing IR structure
+
+Error messages should be semantic with line numbers since markdown always parses successfully.
+
+## Verification
+
+- Parser correctly extracts frontmatter, nodes, code blocks
+- Round-trip: markdown → IR → execution works
+- Linting tools (shellcheck, ruff) work on extracted code blocks
+- Existing workflows converted to markdown produce equivalent IR
+- Token count comparison shows expected reduction
+
+## References
+
+- Existing JSON workflow parser: `src/parsers/json_workflow.py`
+- IR data structures: `src/core/ir.py`
+- Task 104 progress log: `.taskmaster/tasks/task_104/implementation/progress-log.md`
+```
+
+## MVP Context
+
+We're building an MVP with zero users:
+- No backwards compatibility concerns
+- No migration code needed
+- Breaking changes are fine
+- Favor simple, direct solutions
+
+Don't over-engineer. Describe what was discussed, not an idealized version. 
+And remember this task spec is the what and why. The how and implementation details lives in the implementation plan.

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -231,5 +231,5 @@ We're building an MVP with zero users:
 - Breaking changes are fine
 - Favor simple, direct solutions
 
-Don't over-engineer. Describe what was discussed, not an idealized version. 
+Don't over-engineer. Describe what was discussed, not an idealized version.
 And remember this task spec is the what and why. The how and implementation details lives in the implementation plan.

--- a/.claude/commands/create-task.md
+++ b/.claude/commands/create-task.md
@@ -231,5 +231,5 @@ We're building an MVP with zero users:
 - Breaking changes are fine
 - Favor simple, direct solutions
 
-Don't over-engineer. Describe what was discussed, not an idealized version. 
+Don't over-engineer. Describe what was discussed, not an idealized version.
 And remember this task spec is the what and why. The how and implementation details lives in the implementation plan.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,10 +76,10 @@ jobs:
       - name: Check typing
         run: uv run mypy
 
-  # Summary job for branch protection — matrix jobs report as
-  # "tests-and-type-check (3.10)" etc., so the bare name never resolves.
-  # Point the required status check at this job; it also gates the Windows
-  # suite, Windows MCP smoke, and macOS Make compatibility smoke test.
+  # Summary job for branch protection — Linux-version and Windows-shard matrix
+  # jobs have suffixed display names, so their bare names never resolve as
+  # stable required checks. Point branch protection at this job; it gates both
+  # matrices, Windows MCP smoke, and the macOS Make compatibility smoke test.
   tests-and-type-check-done:
     if: always()
     needs: [tests-and-type-check, tests-windows, tests-windows-mcp-smoke, tests-macos-make]
@@ -118,11 +118,25 @@ jobs:
           /usr/bin/make --version
           /usr/bin/make test PYTEST_WORKERS=2 'PYTEST=uv run python -m pytest tests/test_encoding_warning_net.py'
 
-  # Task 116 Windows gate. Single Python version (not a matrix) —
-  # version-specific bugs are rarely Windows-specific, and this job is
-  # already the expensive one (Windows runners run ~2x slower).
+  # Task 116 Windows gate. Keep a single Python version because version-specific
+  # bugs are rarely Windows-specific, but split the suite across two runners to
+  # offset Windows process/filesystem overhead. The shards are exhaustive and
+  # disjoint by construction: one owns core+CLI, the other owns tests/ minus
+  # those two directories, so newly added test areas cannot fall through a
+  # hand-maintained manifest.
   tests-windows:
+    name: tests-windows (${{ matrix.shard }})
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: core-cli
+            pytest-targets: tests/test_core tests/test_cli
+            run-mypy: false
+          - shard: rest
+            pytest-targets: tests --ignore=tests/test_core --ignore=tests/test_cli
+            run-mypy: true
     # ~8k tests at ~2x runner slowness should land well under this; the cap
     # exists so a hung test or subprocess can't burn a runner for the 6h default.
     timeout-minutes: 60
@@ -163,7 +177,9 @@ jobs:
         env:
           # Keep timing evidence in the job log while benchmarking four workers.
           PYTEST_ADDOPTS: --durations=25
-        run: make SHELL=cmd.exe .SHELLFLAGS=/C test-all-local PYTEST_WORKERS=4
+        run: >-
+          make SHELL=cmd.exe .SHELLFLAGS=/C test-all-local PYTEST_WORKERS=4
+          "PYTEST=uv run python -m pytest ${{ matrix.pytest-targets }}"
 
       # LOAD-BEARING, not incidental: ubuntu mypy treats `sys.platform ==
       # "win32"` branch bodies as statically unreachable and never
@@ -172,7 +188,7 @@ jobs:
       # detection, server creationflags) ever gets. `!cancelled()` so a red
       # test step doesn't mask this signal during green-up iteration.
       - name: Check typing
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.run-mypy }}
         run: uv run mypy
 
   # Keep the network-dependent MCP spawn proof off the Windows test critical

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,10 +133,10 @@ jobs:
         include:
           - shard: core-cli-nodes
             pytest-targets: tests/test_core tests/test_cli tests/test_nodes
-            run-mypy: false
+            run-mypy: true
           - shard: rest
             pytest-targets: tests --ignore=tests/test_core --ignore=tests/test_cli --ignore=tests/test_nodes
-            run-mypy: true
+            run-mypy: false
     # ~8k tests at ~2x runner slowness should land well under this; the cap
     # exists so a hung test or subprocess can't burn a runner for the 6h default.
     timeout-minutes: 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,9 +121,9 @@ jobs:
   # Task 116 Windows gate. Keep a single Python version because version-specific
   # bugs are rarely Windows-specific, but split the suite across two runners to
   # offset Windows process/filesystem overhead. The shards are exhaustive and
-  # disjoint by construction: one owns core+CLI, the other owns tests/ minus
-  # those two directories, so newly added test areas cannot fall through a
-  # hand-maintained manifest.
+  # disjoint by construction: one owns core+CLI+nodes, the other owns tests/
+  # minus those three directories, so newly added test areas cannot fall
+  # through a hand-maintained manifest.
   tests-windows:
     name: tests-windows (${{ matrix.shard }})
     runs-on: windows-latest
@@ -131,11 +131,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: core-cli
-            pytest-targets: tests/test_core tests/test_cli
+          - shard: core-cli-nodes
+            pytest-targets: tests/test_core tests/test_cli tests/test_nodes
             run-mypy: false
           - shard: rest
-            pytest-targets: tests --ignore=tests/test_core --ignore=tests/test_cli
+            pytest-targets: tests --ignore=tests/test_core --ignore=tests/test_cli --ignore=tests/test_nodes
             run-mypy: true
     # ~8k tests at ~2x runner slowness should land well under this; the cap
     # exists so a hung test or subprocess can't burn a runner for the 6h default.

--- a/tests/test_cli/test_approval_gate_cli.py
+++ b/tests/test_cli/test_approval_gate_cli.py
@@ -26,6 +26,8 @@ def gated_workflow(tmp_path):
     """Two-step workflow: plain step, then a gated step with a side-effect proof file."""
     proof = tmp_path / "proof.txt"
     path = tmp_path / "gated.pflow.md"
+    # Keep the guarded step as shell: denial rendering intentionally asserts
+    # the resolved `gate.preview.command` that only a shell action provides.
     path.write_text(
         "# Gated Demo\n\nDemo.\n\n## Steps\n\n"
         "### make-value\n\nProduce a value.\n\n"

--- a/tests/test_cli/test_approval_gate_cli.py
+++ b/tests/test_cli/test_approval_gate_cli.py
@@ -29,12 +29,15 @@ def gated_workflow(tmp_path):
     path.write_text(
         "# Gated Demo\n\nDemo.\n\n## Steps\n\n"
         "### make-value\n\nProduce a value.\n\n"
-        "- type: shell\n"
-        "- command: echo hello\n\n"
+        "- type: code\n\n"
+        "```python code\n"
+        'result: str = "hello"\n'
+        "```\n\n"
         "### guarded-step\n\nPost the value.\n\n"
         "- type: shell\n"
-        f"- command: echo posting-${{make-value.stdout}} > {proof}; printf done\n"
-        "- approval: required\n"
+        f"- command: echo posting-${{make-value.result}} > {proof}; printf done\n"
+        "- approval: required\n",
+        encoding="utf-8",
     )
     return path, proof
 

--- a/tests/test_cli/test_cli_error_boundary.py
+++ b/tests/test_cli/test_cli_error_boundary.py
@@ -85,10 +85,10 @@ def _save_broken_workflow(home_dir, name: str) -> None:
     (workflow_dir / f"{name}.pflow.md").write_text(PARSE_ERROR_WORKFLOW, encoding="utf-8")
 
 
-@pytest.mark.e2e
 class TestDescribeParseError:
     """Primary guards for GH #292 — pflow describe must not crash with a traceback."""
 
+    @pytest.mark.e2e
     def test_describe_parse_error_renders_via_diagnostic_pipeline(self, tmp_path, prepared_subprocess_env):
         """pflow describe <workflow-with-parse-error> renders a structured diagnostic, not a traceback."""
         env = dict(prepared_subprocess_env)
@@ -109,6 +109,7 @@ class TestDescribeParseError:
         # Suggestion block surfaced (from MarkdownParseError.suggestion)
         assert "Add a text paragraph" in result.stderr, f"missing suggestion block:\n{result.stderr}"
 
+    @pytest.mark.e2e
     def test_history_also_uses_boundary_for_parse_errors(self, tmp_path, prepared_subprocess_env):
         """Architectural check: boundary is not describe-specific.
 

--- a/tests/test_cli/test_cli_error_boundary.py
+++ b/tests/test_cli/test_cli_error_boundary.py
@@ -70,11 +70,19 @@ def _run_pflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProc
     )
 
 
+def _run_pflow_in_process(args: list[str], env: dict[str, str]):
+    """Invoke the real Click group without paying for another Python startup."""
+    from pflow.cli.main import cli
+
+    clean_env: dict[str, str | None] = {**env, "PYTEST_CURRENT_TEST": None}
+    return CliRunner().invoke(cli, args, env=clean_env)
+
+
 def _save_broken_workflow(home_dir, name: str) -> None:
     """Write PARSE_ERROR_WORKFLOW as a saved workflow under HOME/.pflow/workflows/."""
     workflow_dir = home_dir / ".pflow" / "workflows" / name
     workflow_dir.mkdir(parents=True, exist_ok=True)
-    (workflow_dir / f"{name}.pflow.md").write_text(PARSE_ERROR_WORKFLOW)
+    (workflow_dir / f"{name}.pflow.md").write_text(PARSE_ERROR_WORKFLOW, encoding="utf-8")
 
 
 @pytest.mark.e2e
@@ -143,15 +151,16 @@ class TestDescribeParseError:
 
         # Also write a copy as a standalone file for the --validate-only path
         standalone = tmp_path / "standalone.pflow.md"
-        standalone.write_text(PARSE_ERROR_WORKFLOW)
+        standalone.write_text(PARSE_ERROR_WORKFLOW, encoding="utf-8")
 
-        describe_result = _run_pflow(["describe", "__boundary_symmetry"], env)
-        validate_result = _run_pflow([str(standalone), "--validate-only"], env)
-        _skip_uv_sandbox_panic(describe_result)
-        _skip_uv_sandbox_panic(validate_result)
+        # Real-process rendering is already pinned by the neighboring describe
+        # and history tests. This symmetry assertion only needs the shared Click
+        # boundary, so avoid two more cold Python processes.
+        describe_result = _run_pflow_in_process(["describe", "__boundary_symmetry"], env)
+        validate_result = _run_pflow_in_process([str(standalone), "--validate-only"], env)
 
-        assert describe_result.returncode == 1
-        assert validate_result.returncode == 1
+        assert describe_result.exit_code == 1
+        assert validate_result.exit_code == 1
 
         # The rendered diagnostic body must match. Both paths use the same
         # MarkdownParseError.to_diagnostics() → format_diagnostic() pipeline.
@@ -161,8 +170,8 @@ class TestDescribeParseError:
             "At: line 23",
             "Add a text paragraph between the heading and the parameters",
         ):
-            assert marker in describe_result.stderr, f"describe missing '{marker}':\n{describe_result.stderr}"
-            assert marker in validate_result.stderr, f"validate missing '{marker}':\n{validate_result.stderr}"
+            assert marker in describe_result.output, f"describe missing '{marker}':\n{describe_result.output}"
+            assert marker in validate_result.output, f"validate missing '{marker}':\n{validate_result.output}"
 
 
 class TestBoundaryNarrowCatch:

--- a/tests/test_cli/test_litellm_pricing_map_offline.py
+++ b/tests/test_cli/test_litellm_pricing_map_offline.py
@@ -22,6 +22,7 @@ test fails — exactly the regression to catch.
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -71,12 +72,11 @@ The LLM response.
 
 def test_analyze_cache_does_not_attempt_remote_model_cost_map(
     tmp_path: Path,
-    uv_exe: str,
     prepared_subprocess_env: dict[str, str],
 ) -> None:
     """``pflow analyze-cache`` must not log LiteLLM's remote-fetch warning."""
     workflow = tmp_path / "workflow.pflow.md"
-    workflow.write_text(_WORKFLOW_BODY)
+    workflow.write_text(_WORKFLOW_BODY, encoding="utf-8")
 
     env = dict(prepared_subprocess_env)
     # Point LiteLLM's model-cost URL at a guaranteed-unreachable host.
@@ -89,9 +89,9 @@ def test_analyze_cache_does_not_attempt_remote_model_cost_map(
 
     result = subprocess.run(  # noqa: S603 — fixture-controlled args; mirrors other subprocess CLI tests
         [
-            uv_exe,
-            "run",
-            "pflow",
+            sys.executable,
+            "-m",
+            "pflow.cli",
             "analyze-cache",
             str(workflow),
             "--no-trace-autoload",

--- a/tests/test_cli/test_workflow_save.py
+++ b/tests/test_cli/test_workflow_save.py
@@ -12,7 +12,7 @@ from tests.conftest import set_isolated_home
 from tests.shared.markdown_utils import write_workflow_file
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def prepared_subprocess_env(tmp_path_factory):
     """Provide an isolated home for the one fresh-process CLI assertion."""
     home = tmp_path_factory.mktemp("home_workflow_save")

--- a/tests/test_cli/test_workflow_save.py
+++ b/tests/test_cli/test_workflow_save.py
@@ -13,22 +13,13 @@ from tests.shared.markdown_utils import write_workflow_file
 
 
 @pytest.fixture(scope="module")
-def prepared_subprocess_env(tmp_path_factory, uv_exe):
-    """Module-scoped env to avoid repeated registry init overhead per test."""
+def prepared_subprocess_env(tmp_path_factory):
+    """Provide an isolated home for the one fresh-process CLI assertion."""
     home = tmp_path_factory.mktemp("home_workflow_save")
     (home / ".pflow").mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
     set_isolated_home(env, home)
-
-    subprocess.run(  # noqa: S603
-        [uv_exe, "run", "pflow", "registry", "list", "--json"],
-        capture_output=True,
-        text=True,
-        shell=False,
-        env=env,
-    )
-
     return env
 
 
@@ -125,22 +116,25 @@ class TestWorkflowSaveCLI:
         assert "non-existent-node" in result.output or "Unknown node type" in result.output
 
     @pytest.mark.e2e
-    def test_no_prompt_when_stdout_is_piped(self, sample_workflow, tmp_path, uv_exe, prepared_subprocess_env):
+    def test_no_prompt_when_stdout_is_piped(self, tmp_path, prepared_subprocess_env):
         """Test that save prompt is not shown when stdout is piped."""
         # Create a workflow file with simpler workflow
         simple_workflow = {
             "ir_version": "0.1.0",
-            "nodes": [{"id": "echo1", "type": "shell", "params": {"command": "echo test"}}],
+            "nodes": [
+                {
+                    "id": "value",
+                    "type": "code",
+                    "params": {"code": 'result: str = "test"'},
+                }
+            ],
             "edges": [],
-            "start_node": "echo1",
+            "start_node": "value",
         }
         workflow_file = tmp_path / "workflow.pflow.md"
         write_workflow_file(simple_workflow, workflow_file)
 
-        # Find uv executable
-        _ = uv_exe  # Ensure fixture is requested for skip behavior without using it
-
-        # Run with stdout piped - using a simple echo workflow
+        # Run with stdout piped using an in-process workflow node.
         try:
             # Use prepared env with isolated HOME and initialized registry
             env = prepared_subprocess_env
@@ -149,6 +143,7 @@ class TestWorkflowSaveCLI:
                 [sys.executable, "-m", "pflow.cli", "--output-format", "json", str(workflow_file)],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
                 shell=False,
                 cwd=str(tmp_path),  # Use tmp_path as working directory

--- a/tests/test_core/test_yaml_shielding_hygiene.py
+++ b/tests/test_core/test_yaml_shielding_hygiene.py
@@ -24,9 +24,8 @@ _RAW_LOADERS = frozenset({"safe_load", "load", "full_load"})
 _ALLOWED_ARGS = frozenset({"fm_text"})
 
 
-def _raw_yaml_load_calls(py_file: Path, rel: str) -> list[str]:
+def _raw_yaml_load_calls(tree: ast.AST, rel: str) -> list[str]:
     """Return ``rel:lineno`` for each non-exempt ``yaml.<loader>(...)`` call in the file."""
-    tree = ast.parse(py_file.read_text(encoding="utf-8"))
     hits: list[str] = []
     for node in ast.walk(tree):
         func = getattr(node, "func", None)
@@ -44,31 +43,8 @@ def _raw_yaml_load_calls(py_file: Path, rel: str) -> list[str]:
     return hits
 
 
-def test_author_content_yaml_uses_shielding_helper() -> None:
-    src_root = Path(__file__).resolve().parents[2] / "src" / "pflow"
-    repo_root = src_root.parents[1]
-    assert src_root.is_dir(), f"expected src/pflow/ at {src_root}"
-
-    violations: list[str] = []
-    for py_file in sorted(src_root.rglob("*.py")):
-        rel = py_file.relative_to(repo_root).as_posix()
-        if rel in _ALLOWED_FILES:
-            continue
-        violations.extend(_raw_yaml_load_calls(py_file, rel))
-
-    if violations:
-        pytest.fail(
-            "Raw yaml.safe_load/yaml.load on (possibly) author content found. Author "
-            "content can carry ${...} templates that PyYAML mis-parses (issue #482).\n"
-            "Use pflow.core.yaml_utils.safe_load_preserving_templates instead — or, if "
-            "this parses system metadata only (e.g. frontmatter), add its argument to "
-            "_ALLOWED_ARGS with a reason.\n\n" + "\n".join(violations)
-        )
-
-
-def _aliased_or_from_yaml_imports(py_file: Path, rel: str) -> list[str]:
+def _aliased_or_from_yaml_imports(tree: ast.AST, rel: str) -> list[str]:
     """Return ``rel:lineno`` for yaml imports the call-based guard above can't see."""
-    tree = ast.parse(py_file.read_text(encoding="utf-8"))
     hits: list[str] = []
     for node in ast.walk(tree):
         # `from yaml import safe_load` / `load` / `full_load`
@@ -86,26 +62,41 @@ def _aliased_or_from_yaml_imports(py_file: Path, rel: str) -> list[str]:
     return hits
 
 
-def test_no_aliased_or_from_yaml_imports() -> None:
-    """The call-based guard keys on ``yaml.<loader>(...)`` attribute calls.
+def test_yaml_shielding_hygiene() -> None:
+    """Scan each source AST once for raw loaders and imports that bypass the guard.
 
-    ``from yaml import safe_load`` or ``import yaml as y`` would bypass it — exactly
-    the regression it exists to prevent — so forbid those import forms entirely.
-    Author-content callers must use the shielding helper; the few frontmatter
-    callers use plain ``import yaml``.
+    The checks used to walk and parse the entire source tree independently. Keeping
+    both policies in one test preserves their distinct diagnostics while avoiding a
+    second Windows filesystem scan and AST parse.
     """
     src_root = Path(__file__).resolve().parents[2] / "src" / "pflow"
     repo_root = src_root.parents[1]
+    assert src_root.is_dir(), f"expected src/pflow/ at {src_root}"
 
-    violations: list[str] = []
+    raw_loader_violations: list[str] = []
+    import_violations: list[str] = []
     for py_file in sorted(src_root.rglob("*.py")):
         rel = py_file.relative_to(repo_root).as_posix()
-        violations.extend(_aliased_or_from_yaml_imports(py_file, rel))
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        if rel not in _ALLOWED_FILES:
+            raw_loader_violations.extend(_raw_yaml_load_calls(tree, rel))
+        import_violations.extend(_aliased_or_from_yaml_imports(tree, rel))
 
-    if violations:
-        pytest.fail(
+    messages: list[str] = []
+    if raw_loader_violations:
+        messages.append(
+            "Raw yaml.safe_load/yaml.load on (possibly) author content found. Author "
+            "content can carry ${...} templates that PyYAML mis-parses (issue #482).\n"
+            "Use pflow.core.yaml_utils.safe_load_preserving_templates instead — or, if "
+            "this parses system metadata only (e.g. frontmatter), add its argument to "
+            "_ALLOWED_ARGS with a reason.\n\n" + "\n".join(raw_loader_violations)
+        )
+    if import_violations:
+        messages.append(
             "Aliased or from-imports of yaml found. These bypass the call-based "
             "yaml-shielding guard (which keys on `yaml.<loader>(...)`). Use plain "
             "`import yaml` (frontmatter) or pflow.core.yaml_utils."
-            "safe_load_preserving_templates.\n\n" + "\n".join(violations)
+            "safe_load_preserving_templates.\n\n" + "\n".join(import_violations)
         )
+    if messages:
+        pytest.fail("\n\n".join(messages))

--- a/tests/test_execution/test_plan_drift.py
+++ b/tests/test_execution/test_plan_drift.py
@@ -45,11 +45,13 @@ def _recording_code_params(
     log_expression: str | None = None,
     inputs: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Build an in-process node that records execution without launching Bash."""
+    """Record node-agnostic planner behavior in-process without launching Bash."""
     resolved_inputs = inputs or {}
     declarations = "".join(f"{name}: str\n" for name in resolved_inputs)
-    result_expression = result_expression or repr(label)
-    log_expression = log_expression or repr(f"{label}\n")
+    if result_expression is None:
+        result_expression = repr(label)
+    if log_expression is None:
+        log_expression = repr(f"{label}\n")
     params: dict[str, Any] = {
         "code": f"""from pathlib import Path
 {declarations}with Path({str(log_file)!r}).open("a", encoding="utf-8") as log:

--- a/tests/test_execution/test_plan_drift.py
+++ b/tests/test_execution/test_plan_drift.py
@@ -37,6 +37,31 @@ def _log_lines(path: Path) -> list[str]:
     return path.read_text(encoding="utf-8").splitlines()
 
 
+def _recording_code_params(
+    log_file: Path,
+    label: str,
+    *,
+    result_expression: str | None = None,
+    log_expression: str | None = None,
+    inputs: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build an in-process node that records execution without launching Bash."""
+    resolved_inputs = inputs or {}
+    declarations = "".join(f"{name}: str\n" for name in resolved_inputs)
+    result_expression = result_expression or repr(label)
+    log_expression = log_expression or repr(f"{label}\n")
+    params: dict[str, Any] = {
+        "code": f"""from pathlib import Path
+{declarations}with Path({str(log_file)!r}).open("a", encoding="utf-8") as log:
+    log.write({log_expression})
+result: str = {result_expression}
+"""
+    }
+    if resolved_inputs:
+        params["inputs"] = resolved_inputs
+    return params
+
+
 def _runner_plan(path: Path, params: dict | None = None):
     return WorkflowRunner().plan(str(path), params or {}, RunnerConfig())
 
@@ -75,8 +100,8 @@ def test_plan_matches_execution_for_fresh_workflow(tmp_path) -> None:
     log_file = tmp_path / "exec.log"
     ir = {
         "nodes": [
-            {"id": "a", "type": "shell", "cache": True, "params": {"command": f"echo a >> {log_file}; printf a"}},
-            {"id": "b", "type": "shell", "cache": True, "params": {"command": f"echo b >> {log_file}; printf b"}},
+            {"id": "a", "type": "code", "cache": True, "params": _recording_code_params(log_file, "a")},
+            {"id": "b", "type": "code", "cache": True, "params": _recording_code_params(log_file, "b")},
         ],
         "edges": [{"from": "a", "to": "b"}],
     }
@@ -95,8 +120,8 @@ def test_plan_matches_execution_after_first_run(tmp_path) -> None:
     log_file = tmp_path / "exec.log"
     ir = {
         "nodes": [
-            {"id": "a", "type": "shell", "cache": True, "params": {"command": f"echo a >> {log_file}; printf a"}},
-            {"id": "b", "type": "shell", "cache": True, "params": {"command": f"echo b >> {log_file}; printf b"}},
+            {"id": "a", "type": "code", "cache": True, "params": _recording_code_params(log_file, "a")},
+            {"id": "b", "type": "code", "cache": True, "params": _recording_code_params(log_file, "b")},
         ],
         "edges": [{"from": "a", "to": "b"}],
     }
@@ -116,8 +141,18 @@ def test_plan_cross_node_template_resolution(tmp_path) -> None:
     """Cached upstream outputs must be visible so downstream cache keys match."""
     ir = {
         "nodes": [
-            {"id": "a", "type": "shell", "cache": True, "params": {"command": "printf cached-value"}},
-            {"id": "b", "type": "shell", "cache": True, "params": {"command": "printf ${a.stdout}"}},
+            {
+                "id": "a",
+                "type": "code",
+                "cache": True,
+                "params": {"code": 'result: str = "cached-value"'},
+            },
+            {
+                "id": "b",
+                "type": "code",
+                "cache": True,
+                "params": {"code": "value: str\nresult: str = value", "inputs": {"value": "${a.result}"}},
+            },
         ],
         "edges": [{"from": "a", "to": "b"}],
     }
@@ -135,36 +170,56 @@ def test_plan_matches_execution_after_config_edit(tmp_path) -> None:
     log_file = tmp_path / "edit.log"
     old_ir = {
         "nodes": [
-            {"id": "a", "type": "shell", "cache": True, "params": {"command": f"echo a >> {log_file}; printf a"}},
+            {"id": "a", "type": "code", "cache": True, "params": _recording_code_params(log_file, "a")},
             {
                 "id": "b",
-                "type": "shell",
+                "type": "code",
                 "cache": True,
-                "params": {"command": f"echo b >> {log_file}; printf '${{a.stdout}}-b'"},
+                "params": _recording_code_params(
+                    log_file,
+                    "b",
+                    result_expression='a + "-b"',
+                    inputs={"a": "${a.result}"},
+                ),
             },
             {
                 "id": "c",
-                "type": "shell",
+                "type": "code",
                 "cache": True,
-                "params": {"command": f"echo c >> {log_file}; printf '${{b.stdout}}-c'"},
+                "params": _recording_code_params(
+                    log_file,
+                    "c",
+                    result_expression='b + "-c"',
+                    inputs={"b": "${b.result}"},
+                ),
             },
         ],
         "edges": [{"from": "a", "to": "b"}, {"from": "b", "to": "c"}],
     }
     new_ir = {
         "nodes": [
-            {"id": "a", "type": "shell", "cache": True, "params": {"command": f"echo a >> {log_file}; printf a"}},
+            {"id": "a", "type": "code", "cache": True, "params": _recording_code_params(log_file, "a")},
             {
                 "id": "b",
-                "type": "shell",
+                "type": "code",
                 "cache": True,
-                "params": {"command": f"echo b2 >> {log_file}; printf '${{a.stdout}}-b2'"},
+                "params": _recording_code_params(
+                    log_file,
+                    "b2",
+                    result_expression='a + "-b2"',
+                    inputs={"a": "${a.result}"},
+                ),
             },
             {
                 "id": "c",
-                "type": "shell",
+                "type": "code",
                 "cache": True,
-                "params": {"command": f"echo c >> {log_file}; printf '${{b.stdout}}-c'"},
+                "params": _recording_code_params(
+                    log_file,
+                    "c",
+                    result_expression='b + "-c"',
+                    inputs={"b": "${b.result}"},
+                ),
             },
         ],
         "edges": [{"from": "a", "to": "b"}, {"from": "b", "to": "c"}],
@@ -234,19 +289,24 @@ def test_plan_sub_workflow_partial_cache_matches(tmp_path) -> None:
             "nodes": [
                 {
                     "id": "child-a",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo child-a >> {log_file}; printf child-a"},
+                    "params": _recording_code_params(log_file, "child-a"),
                 },
                 {
                     "id": "child-b",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo child-b >> {log_file}; printf '${{child-a.stdout}}-child-b'"},
+                    "params": _recording_code_params(
+                        log_file,
+                        "child-b",
+                        result_expression='child_a + "-child-b"',
+                        inputs={"child_a": "${child-a.result}"},
+                    ),
                 },
             ],
             "edges": [{"from": "child-a", "to": "child-b"}],
-            "outputs": {"out": {"source": "${child-b.stdout}", "description": "child output"}},
+            "outputs": {"out": {"source": "${child-b.result}", "description": "child output"}},
         },
         child_path,
     )
@@ -255,9 +315,9 @@ def test_plan_sub_workflow_partial_cache_matches(tmp_path) -> None:
             "nodes": [
                 {
                     "id": "pre",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo pre >> {log_file}; printf pre"},
+                    "params": _recording_code_params(log_file, "pre"),
                 },
                 {
                     "id": "call-child",
@@ -266,9 +326,14 @@ def test_plan_sub_workflow_partial_cache_matches(tmp_path) -> None:
                 },
                 {
                     "id": "post",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo post >> {log_file}; printf '${{call-child.out}}-post'"},
+                    "params": _recording_code_params(
+                        log_file,
+                        "post",
+                        result_expression='child_out + "-post"',
+                        inputs={"child_out": "${call-child.out}"},
+                    ),
                 },
             ],
             "edges": [{"from": "pre", "to": "call-child"}, {"from": "call-child", "to": "post"}],
@@ -284,19 +349,24 @@ def test_plan_sub_workflow_partial_cache_matches(tmp_path) -> None:
             "nodes": [
                 {
                     "id": "child-a",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo child-a >> {log_file}; printf child-a"},
+                    "params": _recording_code_params(log_file, "child-a"),
                 },
                 {
                     "id": "child-b",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo child-b2 >> {log_file}; printf '${{child-a.stdout}}-child-b2'"},
+                    "params": _recording_code_params(
+                        log_file,
+                        "child-b2",
+                        result_expression='child_a + "-child-b2"',
+                        inputs={"child_a": "${child-a.result}"},
+                    ),
                 },
             ],
             "edges": [{"from": "child-a", "to": "child-b"}],
-            "outputs": {"out": {"source": "${child-b.stdout}", "description": "child output"}},
+            "outputs": {"out": {"source": "${child-b.result}", "description": "child output"}},
         },
         child_path,
     )
@@ -325,9 +395,15 @@ def test_plan_batch_items_cache_matches(tmp_path) -> None:
             },
             {
                 "id": "batch",
-                "type": "shell",
+                "type": "code",
                 "cache": True,
-                "params": {"command": f"echo ${{item}} >> {log_file}; printf '${{item}}'"},
+                "params": _recording_code_params(
+                    log_file,
+                    "",
+                    result_expression="item",
+                    log_expression='item + "\\n"',
+                    inputs={"item": "${item}"},
+                ),
                 "batch": {"items": "${source.result}"},
             },
         ],
@@ -367,13 +443,19 @@ def test_plan_batch_sub_workflow_partial_cache_matches_execution(tmp_path) -> No
             "nodes": [
                 {
                     "id": "echo",
-                    "type": "shell",
+                    "type": "code",
                     "cache": True,
-                    "params": {"command": f"echo ${{value}} >> {log_file}; printf '${{value}}'"},
+                    "params": _recording_code_params(
+                        log_file,
+                        "",
+                        result_expression="value",
+                        log_expression='value + "\\n"',
+                        inputs={"value": "${value}"},
+                    ),
                 }
             ],
             "edges": [],
-            "outputs": {"out": {"source": "${echo.stdout}", "description": "Echoed value"}},
+            "outputs": {"out": {"source": "${echo.result}", "description": "Echoed value"}},
         },
         child_path,
     )
@@ -478,9 +560,9 @@ def test_plan_cache_false_always_executes(tmp_path) -> None:
         "nodes": [
             {
                 "id": "uncached",
-                "type": "shell",
+                "type": "code",
                 "cache": False,
-                "params": {"command": f"echo uncached >> {log_file}; printf uncached"},
+                "params": _recording_code_params(log_file, "uncached"),
             },
         ],
         "edges": [],

--- a/tests/test_runtime/test_cache.py
+++ b/tests/test_runtime/test_cache.py
@@ -516,10 +516,14 @@ def test_concurrent_access(tmp_path):
     cache = MemoizationCache(db_path=db_path)
     errors: list[Exception] = []
     num_threads = 8
-    ops_per_thread = 20
+    # Synchronize the first operation so this remains a genuine contention
+    # test without paying for hundreds of redundant SQLite round-trips.
+    start = threading.Barrier(num_threads)
+    ops_per_thread = 8
 
     def worker(thread_id: int) -> None:
         try:
+            start.wait()
             for i in range(ops_per_thread):
                 key = f"t{thread_id}-{i}"
                 cache.put(key, f"node-{thread_id}", "/wf.pflow.md", "default", {"tid": thread_id, "i": i})

--- a/tests/test_runtime/test_only_snapshot.py
+++ b/tests/test_runtime/test_only_snapshot.py
@@ -126,7 +126,7 @@ def _write_interned_trace(
 
 @pytest.mark.trace_files
 def test_only_does_not_refire_side_effecting_upstream(tmp_path: Path) -> None:
-    """Full run fires a shell side effect once; --only must NOT re-fire it.
+    """Full run fires a side effect once; --only must NOT re-fire it.
 
     End-to-end through WorkflowRunner (per tests/CLAUDE.md #20): the sentinel
     file count is the proof the upstream node didn't execute, and the execution
@@ -137,13 +137,22 @@ def test_only_does_not_refire_side_effecting_upstream(tmp_path: Path) -> None:
         "nodes": [
             {
                 "id": "fetch",
-                "type": "shell",
-                "params": {"command": f"echo fired >> {sentinel}; printf data"},
+                "type": "code",
+                "params": {
+                    "code": f"""from pathlib import Path
+with Path({str(sentinel)!r}).open("a", encoding="utf-8") as log:
+    log.write("fired\\n")
+result: str = "data"
+"""
+                },
             },
             {
                 "id": "summarize",
-                "type": "shell",
-                "params": {"command": "printf 'summary of ${fetch.stdout}'"},
+                "type": "code",
+                "params": {
+                    "code": 'fetch_result: str\nresult: str = f"summary of {fetch_result}"',
+                    "inputs": {"fetch_result": "${fetch.result}"},
+                },
             },
         ],
         "edges": [{"from": "fetch", "to": "summarize"}],
@@ -155,13 +164,13 @@ def test_only_does_not_refire_side_effecting_upstream(tmp_path: Path) -> None:
     full = WorkflowRunner().run(str(wf), {}, RunnerConfig())
     assert full.success, [d.message for d in full.diagnostics]
     full.trace.save_to_file()
-    assert sentinel.read_text().count("fired") == 1
+    assert sentinel.read_text(encoding="utf-8").count("fired") == 1
 
     # --only summarize: fetch is restored, never re-run.
     result = WorkflowRunner().run(str(wf), {}, RunnerConfig(only_node="summarize"))
     assert result.success, [d.message for d in result.diagnostics]
-    assert sentinel.read_text().count("fired") == 1, "side-effecting upstream re-fired under --only"
-    assert result.shared_after["summarize"]["stdout"] == "summary of data"
+    assert sentinel.read_text(encoding="utf-8").count("fired") == 1, "side-effecting upstream re-fired under --only"
+    assert result.shared_after["summarize"]["result"] == "summary of data"
 
     steps = build_execution_steps({"nodes": [{"id": "fetch"}, {"id": "summarize"}]}, result.shared_after, None)
     by_id = {s["node_id"]: s["status"] for s in steps}
@@ -178,9 +187,16 @@ def test_only_does_not_seed_downstream_nodes(tmp_path: Path) -> None:
     """
     ir = {
         "nodes": [
-            {"id": "first", "type": "shell", "params": {"command": "printf first-v1"}},
-            {"id": "middle", "type": "shell", "params": {"command": "printf 'mid ${first.stdout}'"}},
-            {"id": "last", "type": "shell", "params": {"command": "printf last-v1"}},
+            {"id": "first", "type": "code", "params": {"code": 'result: str = "first-v1"'}},
+            {
+                "id": "middle",
+                "type": "code",
+                "params": {
+                    "code": 'first_result: str\nresult: str = f"mid {first_result}"',
+                    "inputs": {"first_result": "${first.result}"},
+                },
+            },
+            {"id": "last", "type": "code", "params": {"code": 'result: str = "last-v1"'}},
         ],
         "edges": [{"from": "first", "to": "middle"}, {"from": "middle", "to": "last"}],
     }
@@ -193,7 +209,7 @@ def test_only_does_not_seed_downstream_nodes(tmp_path: Path) -> None:
 
     result = WorkflowRunner().run(str(wf), {}, RunnerConfig(only_node="middle"))
     assert result.success, [d.message for d in result.diagnostics]
-    assert result.shared_after["middle"]["stdout"] == "mid first-v1"  # target resolved vs restored upstream
+    assert result.shared_after["middle"]["result"] == "mid first-v1"  # target resolved vs restored upstream
     assert "first" in result.shared_after  # upstream restored
     assert "last" not in result.shared_after, "downstream 'last' must not be restored under --only middle"
     assert result.shared_after["__execution__"]["restored_nodes"] == ["first"]


### PR DESCRIPTION
## What changed

- split the Windows test gate into two exhaustive, disjoint matrix shards
- rebalance the shards from measured Windows runtime by moving process-heavy node tests onto the light shard
- place win32 mypy on the shard whose pytest workload is shorter, so it still runs once without extending the critical path unnecessarily
- remove incidental Git Bash launches from planner, snapshot, approval-gate, and workflow-save tests
- reduce redundant SQLite contention operations while starting all cache workers simultaneously
- parse the source tree once for both YAML shielding policies
- retain real subprocess coverage where startup, piping, encoding, or import-time behavior is the contract

## Why

The latest successful `main` baseline spent 167 seconds in Windows pytest and approximately 3m56 in the Windows job, making Windows the CI critical path. Windows process creation and filesystem scanning are substantially slower than on Linux, and several tests were paying those costs without testing process or shell behavior.

The final split is intentionally runtime-weighted rather than count-balanced. In the latest completed ready-for-review run:

- `core-cli-nodes`: 5,304 collected tests; 77.71s pytest + 18s mypy
- `rest`: 3,491 collected tests; 88.37s pytest

Post-setup work is therefore balanced within roughly seven seconds. The jobs completed in 2m12 and 2m28; the remaining difference came from checkout/setup variance. The slower Windows job is approximately 1m28 faster than the merged-main baseline and no longer exceeds the slowest Linux matrix job.

## Validation

- both Windows shard commands collect successfully and together cover all 8,795 collected entries
- exact shard comparison found no missing tests or cross-shard overlap
- repeated sharded Windows CI runs passed both shards and win32 mypy
- focused planner, snapshot, cache, CLI, and YAML tests pass through the existing virtual environment
- the final review-polish regression set passed 10 focused tests locally
- Ruff lint and format checks pass for every changed Python file
- workflow YAML parses successfully and both native Make command overrides were dry-run under PowerShell
- two independent adversarial reviews and all Claude PR reviews found no blocking issues

The full Windows shell and subprocess suite is intentionally left to GitHub Actions, which is authoritative outside the restricted local sandbox.

## Follow-up

- #574 profiles and safely reduces universal pytest isolation-fixture overhead, with measurement and isolation proofs required before structural changes.
