### PR TITLE
test: zero-warning suite — explicit encoding everywhere + blanket EncodingWarning net

### DIFF
--- a/.taskmaster/tasks/task_116/task-review.md
+++ b/.taskmaster/tasks/task_116/task-review.md
@@ -63,6 +63,10 @@ switch to `cmd.exe` or PowerShell.
 7. **The `EncodingWarning` net is scoped to `pflow.*`.** A blanket
    `error::EncodingWarning` detonates on test fixtures and third-party libraries; the goal is to
    catch pflow source regressions, especially `os.fdopen`, which `PLW1514` misses.
+   > **Superseded 2026-07-11:** the net was widened to a blanket `error::EncodingWarning` (plus a
+   > narrow `ignore::EncodingWarning:litellm.*`) after every test call site — the "detonation"
+   > residue this item describes — was given an explicit `encoding="utf-8"`. Do not narrow it back;
+   > the canary in `tests/test_encoding_warning_net.py` now asserts blanket coverage.
 8. **`PLW1514` only works because ruff preview mode is explicit.** Keep
    `preview = true` and `explicit-preview-rules = true`; otherwise the selected rule has no effect.
 9. **Do not certify skill symlinks on Windows.** The service is scheduled for rebuild without
@@ -234,7 +238,8 @@ switch to `cmd.exe` or PowerShell.
 - `tests/test_core/test_settings.py::test_validate_permissions_noop_on_windows` - mutation-proven
   guard against false Windows chmod warnings.
 - `tests/test_encoding_warning_net.py` - warning filter is live for pflow source and scoped away
-  from non-pflow modules.
+  from non-pflow modules. (Superseded 2026-07-11: the canary now asserts blanket coverage of test
+  code too, with only `litellm.*` ignored — see invariant 7 above.)
 - `tests/conftest.py` helper consumers - any new subprocess env builder should route through
   `set_isolated_home`.
 

--- a/examples/real-workflows/generate-changelog/workflow.pflow.md
+++ b/examples/real-workflows/generate-changelog/workflow.pflow.md
@@ -705,7 +705,7 @@ path = Path(mintlify_file) if mintlify_file else None
 if not path or not path.is_file():
     examples_text = ''
 else:
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     updates = re.findall(r'<Update.*?</Update>', content, re.DOTALL)
     labeled = [f'Example {i}:\n{u}' for i, u in enumerate(updates[:4], 1)]
     examples_text = '\n\n'.join(labeled)
@@ -877,7 +877,7 @@ if unmatched_reviews:
         unmatched_reviews,
     ])
 
-outfile.write_text('\n'.join(parts))
+outfile.write_text('\n'.join(parts), encoding="utf-8")
 result: str = str(outfile)
 ```
 
@@ -904,7 +904,7 @@ from pathlib import Path
 
 path = Path(changelog_file)
 if path.exists():
-    existing = path.read_text()
+    existing = path.read_text(encoding="utf-8")
     lines = existing.split('\n', 1)
     if lines[0].startswith('# '):
         rest = lines[1] if len(lines) > 1 else ''
@@ -914,7 +914,7 @@ if path.exists():
 else:
     content = '# Changelog\n\n' + new_section + '\n'
 
-path.write_text(content)
+path.write_text(content, encoding="utf-8")
 result: str = changelog_file
 ```
 
@@ -943,7 +943,7 @@ if not mintlify_file:
 else:
     path = Path(mintlify_file)
     if path.exists():
-        existing = path.read_text()
+        existing = path.read_text(encoding="utf-8")
         lines = existing.split('\n')
         fence_count = 0
         insert_after = -1
@@ -966,7 +966,7 @@ else:
             'icon: "clock"\nrss: true\n---\n\n' + new_section + '\n'
         )
 
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
     msg = mintlify_file
 
 result: str = msg

--- a/examples/real-workflows/screenshot-pflow-web-ui/live-reload.pflow.md
+++ b/examples/real-workflows/screenshot-pflow-web-ui/live-reload.pflow.md
@@ -76,7 +76,7 @@ distinct purpose ("Finalize…") so the remap check can tell which node is focus
     python3 - "${wf_file}" <<'PY'
     import sys
     content = "# Live Reload Probe\n\nThrowaway workflow for the live-reload skill check.\n\n## Steps\n\n### greet\n\nGreet the world to begin the run.\n\n- type: shell\n- command: echo hello\n\n### done\n\nFinalize and report completion of the run.\n\n- type: shell\n- command: echo done\n"
-    open(sys.argv[1], "w").write(content)
+    open(sys.argv[1], "w", encoding="utf-8").write(content)
     PY
 
 ### opened
@@ -120,7 +120,7 @@ Append a node at the end (does NOT renumber existing nodes) — the in-place + v
     python3 - "${wf_file}" <<'PY'
     import sys
     block = "\n### tail\n\nAppended tail step for the in-place check.\n\n- type: shell\n- command: echo tail\n"
-    open(sys.argv[1], "a").write(block)
+    open(sys.argv[1], "a", encoding="utf-8").write(block)
     PY
 
 ### wait_append
@@ -160,10 +160,10 @@ in its description — the remap + source-pane-refresh check.
     python3 - "${wf_file}" <<'PY'
     import sys
     p = sys.argv[1]
-    s = open(p).read()
+    s = open(p, encoding="utf-8").read()
     block = "### middle\n\nRELOADMARKER inserted-before step for the remap check.\n\n- type: shell\n- command: echo middle\n\n"
     s = s.replace("### done", block + "### done", 1)
-    open(p, "w").write(s)
+    open(p, "w", encoding="utf-8").write(s)
     PY
 
 ### wait_insert
@@ -203,7 +203,7 @@ Overwrite the source with an INVALID workflow (unknown node type → 422).
     python3 - "${wf_file}" <<'PY'
     import sys
     content = "# Broken\n\n## Steps\n\n### x\n\nA step with an unknown type.\n\n- type: nonexistent_type_zzz\n"
-    open(sys.argv[1], "w").write(content)
+    open(sys.argv[1], "w", encoding="utf-8").write(content)
     PY
 
 ### wait_corrupt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,28 +144,20 @@ markers = [
 ]
 # Note: We don't set addopts with -n here to allow flexibility
 # Use 'make test' for parallel or 'make test-debug' for sequential
-# Task 116 (Windows compat): ruff PLW1514 catches unspecified-encoding at
-# open()/read_text()/write_text() call sites when the receiver's Path type is
-# statically inferable, but it has two real blind spots this filter covers:
-# (1) os.fdopen, which PLW1514 never flags at all; (2) any call on a variable
-# derived from an untyped parameter (e.g. `tmp_path / "x"` inside a pytest
-# fixture with no `-> Path` annotation) — ruff can't prove the receiver is a
-# Path, so it silently skips hundreds of call sites of exactly this shape
-# across the test suite (verified: ruff flags `path: Path` but not a bare
-# `tmp_path` fixture param). Scoped to `pflow.*` — not a blanket
-# `error::EncodingWarning` — because Python's warning attribution follows the
-# DEFINING module of the frame that calls open()/write_text()/fdopen(), not
-# the caller: an unscoped filter promotes every third-party library's own
-# missing-encoding warnings (verified: litellm's own
-# containers/endpoint_factory.py) into hard test failures having nothing to
-# do with pflow, and would also swallow the tmp_path blind spot above across
-# the whole test suite rather than catching it where it matters — a
-# regression inside pflow's own source. Only fires when the interpreter runs
-# with PYTHONWARNDEFAULTENCODING=1 (exported by Makefile test targets and tox)
-# or -X warn_default_encoding — the filter alone is inert without it. The
-# environment variable is required for parallel runs so xdist workers inherit
-# the setting.
-filterwarnings = ["error::EncodingWarning:pflow.*"]
+# PEP 597 net (Task 116): any text-mode open()/read_text()/write_text()/fdopen
+# without encoding= is a hard error — in src, tests, and code-node snippets
+# alike. ruff PLW1514 catches most sites statically but has blind spots
+# (os.fdopen, paths derived from untyped fixture params like a bare tmp_path);
+# this filter is the runtime backstop. It only fires when the interpreter runs
+# with PYTHONWARNDEFAULTENCODING=1, exported by the Makefile test targets as an
+# env var so pytest-xdist workers inherit it. litellm ships its own
+# encoding-less opens (warning attribution follows the DEFINING module of the
+# frame that calls open(), so they're cleanly separable) — ignored below.
+# Canary: tests/test_encoding_warning_net.py fails loudly if the net dies.
+filterwarnings = [
+    "error::EncodingWarning",
+    "ignore::EncodingWarning:litellm.*",
+]
 
 [tool.ruff]
 # target-version is inferred from requires-python (>=3.10) — do not pin it separately.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -191,7 +191,7 @@ Use shared fixtures from `tests/conftest.py` for real CLI subprocess tests:
 ```python
 def test_cli_subprocess(tmp_path, uv_exe, prepared_subprocess_env):
     env = prepared_subprocess_env
-    completed = subprocess.run([uv_exe, "run", "pflow", "--help"], capture_output=True, text=True, env=env)
+    completed = subprocess.run([uv_exe, "run", "pflow", "--help"], capture_output=True, text=True, encoding="utf-8", env=env)
     assert completed.returncode == 0
 ```
 
@@ -202,6 +202,8 @@ def test_cli_subprocess(tmp_path, uv_exe, prepared_subprocess_env):
 **External-tool rule**: the default suite may exercise the shell node, but it must not require incidental runner tools such as `jq` or a `python3` alias. Use the active Python environment for generic JSON/stdin assertions. If an external executable is itself the integration boundary under test, mark that narrow test `e2e` and skip with an explicit availability check when the tool is absent.
 
 **Trace rule**: do not rely on trace files unless the test is marked `trace_files`. If the test only needs runtime trace events, assert on `result.trace.events`; if it needs serialized JSON, add `@pytest.mark.trace_files`.
+
+**Encoding rule** (suite-wide, not just subprocess tests): all text-mode file and subprocess I/O must pass `encoding="utf-8"` — `write_text`/`read_text`/`open`/`fdopen`, `subprocess.run(text=True, ...)`, and python-code snippets embedded in workflow strings alike. The suite runs under PEP 597 (`PYTHONWARNDEFAULTENCODING=1`) with a blanket `error::EncodingWarning` filter, so a bare call is a hard test failure, and on Windows it would silently write cp1252. Binary-mode (`"rb"`/`"wb"`) and deliberate byte-semantics tests are exempt.
 
 For timeout-sensitive tests (e.g., hang detection), you can use minimal inline setup to avoid fixture overhead:
 ```python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,7 +516,7 @@ def prepared_subprocess_env(tmp_path_factory, precomputed_core_registry_nodes):
         "last_core_scan": datetime.now().isoformat(),
         "nodes": precomputed_core_registry_nodes,
     }
-    registry_path.write_text(_json.dumps(registry_data, indent=2))
+    registry_path.write_text(_json.dumps(registry_data, indent=2), encoding="utf-8")
 
     env = os.environ.copy()
     set_isolated_home(env, home)

--- a/tests/test_cli/test_approval_gate_cli.py
+++ b/tests/test_cli/test_approval_gate_cli.py
@@ -84,7 +84,7 @@ class TestDeniedExit:
         _allow_prompting(monkeypatch, answer=True)
         result = invoke_cli(["--no-trace", str(path)])
         assert result.exit_code == 0
-        assert proof.read_text().strip() == "posting-hello"
+        assert proof.read_text(encoding="utf-8").strip() == "posting-hello"
 
 
 class TestAutoApprove:

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -80,7 +80,8 @@ def test_report_command_generates_from_trace(tmp_path: Path, monkeypatch):
     # Run a workflow first to generate a trace
     workflow = tmp_path / "test.pflow.md"
     workflow.write_text(
-        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n"
+        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n",
+        encoding="utf-8",
     )
     monkeypatch.setenv("HOME", str(tmp_path))
     runner = click.testing.CliRunner()
@@ -101,7 +102,8 @@ def test_report_flag_generates_report(tmp_path: Path, monkeypatch):
     # Create a minimal workflow
     workflow = tmp_path / "test.pflow.md"
     workflow.write_text(
-        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n"
+        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n",
+        encoding="utf-8",
     )
     report_dir = tmp_path / "report"
 
@@ -123,7 +125,8 @@ def test_report_flag_overrides_no_trace(tmp_path: Path, monkeypatch):
     """Test that --report overrides --no-trace (report requires trace data)."""
     workflow = tmp_path / "test.pflow.md"
     workflow.write_text(
-        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n"
+        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n",
+        encoding="utf-8",
     )
     report_dir = tmp_path / "report"
 
@@ -144,14 +147,14 @@ def test_report_command_refuses_non_empty_unmarked_output_dir(tmp_path: Path, mo
     report_dir = tmp_path / "report"
     report_dir.mkdir()
     existing = report_dir / "notes.md"
-    existing.write_text("keep")
+    existing.write_text("keep", encoding="utf-8")
 
     runner = click.testing.CliRunner()
     result = runner.invoke(main, ["report", str(trace_file), "-o", str(report_dir)])
 
     assert result.exit_code == 1
     assert "without .pflow-report.json" in result.output
-    assert existing.read_text() == "keep"
+    assert existing.read_text(encoding="utf-8") == "keep"
     assert not (report_dir / "summary.md").exists()
 
 
@@ -167,11 +170,12 @@ def test_report_dir_preflight_refuses_before_workflow_execution(tmp_path: Path, 
         "Say hello.\n\n"
         "- type: shell\n"
         "- cache: false\n"
-        f"- command: echo ran > {side_effect}\n"
+        f"- command: echo ran > {side_effect}\n",
+        encoding="utf-8",
     )
     report_dir = tmp_path / "report"
     report_dir.mkdir()
-    (report_dir / "notes.md").write_text("keep")
+    (report_dir / "notes.md").write_text("keep", encoding="utf-8")
 
     monkeypatch.setenv("HOME", str(tmp_path))
     runner = click.testing.CliRunner()
@@ -198,7 +202,8 @@ def test_auto_report_rerun_with_only_removes_downstream_pages(tmp_path: Path, mo
         "Second step.\n\n"
         "- type: shell\n"
         "- cache: false\n"
-        "- command: echo second\n"
+        "- command: echo second\n",
+        encoding="utf-8",
     )
     report_dir = tmp_path / ".pflow" / "reports" / "test"
 
@@ -215,7 +220,7 @@ def test_auto_report_rerun_with_only_removes_downstream_pages(tmp_path: Path, mo
     assert (report_dir / "01-first.md").exists()
     assert not (report_dir / "02-second.md").exists()
     assert (report_dir / ".pflow-report.json").exists()
-    assert "Nodes: 1/2 (--only 'first', 1 skipped)" in (report_dir / "summary.md").read_text()
+    assert "Nodes: 1/2 (--only 'first', 1 skipped)" in (report_dir / "summary.md").read_text(encoding="utf-8")
 
 
 def test_report_command_echoes_summary_to_stderr(tmp_path: Path, monkeypatch):
@@ -372,7 +377,8 @@ def test_run_report_flag_echoes_summary_to_stderr(tmp_path: Path, monkeypatch):
     """`pflow <workflow> --report` mirrors the inline stderr echo."""
     workflow = tmp_path / "test.pflow.md"
     workflow.write_text(
-        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n"
+        "# Test\n\n## Steps\n\n### hello\n\nSay hello.\n\n- type: shell\n- cache: false\n- command: echo hi\n",
+        encoding="utf-8",
     )
     report_dir = tmp_path / "report"
 

--- a/tests/test_cli/test_cli_error_boundary.py
+++ b/tests/test_cli/test_cli_error_boundary.py
@@ -65,6 +65,7 @@ def _run_pflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProc
         [sys.executable, "-m", "pflow.cli", *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=clean_env,
         timeout=60,
     )

--- a/tests/test_cli/test_dry_run_subprocess.py
+++ b/tests/test_cli/test_dry_run_subprocess.py
@@ -78,6 +78,7 @@ Echoes.
         [uv_exe, "run", "pflow", "--dry-run", "--output-format", "json", str(wf)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         shell=False,
         env=subprocess_env,
         cwd=str(tmp_path),

--- a/tests/test_cli/test_dual_mode_stdin.py
+++ b/tests/test_cli/test_dual_mode_stdin.py
@@ -48,6 +48,7 @@ def prepared_subprocess_env(tmp_path_factory, uv_exe):
         [uv_exe, "run", "pflow", "registry", "list", "--json"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         shell=False,
         env=env,
     )
@@ -82,7 +83,7 @@ class TestDualModeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         # Use file path directly (new interface - no --file flag)
@@ -179,7 +180,7 @@ class TestDualModeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         result = runner.invoke(main, [str(workflow_file)], input="piped data")
@@ -208,7 +209,7 @@ class TestDualModeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         result = runner.invoke(main, [str(workflow_file)])
@@ -242,7 +243,7 @@ class TestDualModeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         # Pipe "piped_value" but also provide CLI param - CLI should win
@@ -251,7 +252,7 @@ class TestDualModeStdinBehavior:
         assert result.exit_code == 0
         # Verify the CLI value was used, not the piped value
         assert output_file.exists()
-        written_content = output_file.read_text()
+        written_content = output_file.read_text(encoding="utf-8")
         assert written_content == "cli_value", f"Expected 'cli_value' but got '{written_content}'"
 
     def test_empty_stdin_treated_as_no_input(self, tmp_path):
@@ -277,7 +278,7 @@ class TestDualModeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         # Pipe empty string - treated as no input
@@ -321,7 +322,7 @@ class TestRealShellIntegration:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Test real shell pipe
         env = prepared_subprocess_env
@@ -331,6 +332,7 @@ class TestRealShellIntegration:
             input="Test data from pipe",
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=env,
         )
@@ -393,6 +395,7 @@ class TestRealShellIntegration:
             input=json_data,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=env,
         )
@@ -431,7 +434,7 @@ class TestBinaryAndLargeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Create a temporary binary file to simulate binary stdin
         binary_data = b"Binary\x00Data\xff"
@@ -457,6 +460,7 @@ class TestBinaryAndLargeStdinBehavior:
                     stdin=binary_stdin,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
                     shell=False,
                     env=env,
                 )
@@ -494,7 +498,7 @@ class TestBinaryAndLargeStdinBehavior:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Create large data (1MB)
         large_data = "x" * (1024 * 1024)
@@ -507,7 +511,7 @@ class TestBinaryAndLargeStdinBehavior:
         assert result.exit_code == 0, f"Expected success but got: {result.output}"
         # Verify the data was actually written correctly
         assert output_file.exists(), "Output file should have been created"
-        assert output_file.read_text() == large_data, "Large data should be written correctly"
+        assert output_file.read_text(encoding="utf-8") == large_data, "Large data should be written correctly"
 
 
 @pytest.mark.e2e
@@ -566,8 +570,8 @@ class TestWorkflowChaining:
 
         producer_file = tmp_path / "producer.pflow.md"
         consumer_file = tmp_path / "consumer.pflow.md"
-        producer_file.write_text(ir_to_markdown(producer))
-        consumer_file.write_text(ir_to_markdown(consumer))
+        producer_file.write_text(ir_to_markdown(producer), encoding="utf-8")
+        consumer_file.write_text(ir_to_markdown(consumer), encoding="utf-8")
 
         env = prepared_subprocess_env
 
@@ -578,6 +582,7 @@ class TestWorkflowChaining:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=True,
             env=env,
             timeout=30,
@@ -638,9 +643,9 @@ class TestWorkflowChaining:
         producer_file = tmp_path / "producer.pflow.md"
         transform_file = tmp_path / "transform.pflow.md"
         consumer_file = tmp_path / "consumer.pflow.md"
-        producer_file.write_text(ir_to_markdown(producer))
-        transform_file.write_text(ir_to_markdown(transform))
-        consumer_file.write_text(ir_to_markdown(consumer))
+        producer_file.write_text(ir_to_markdown(producer), encoding="utf-8")
+        transform_file.write_text(ir_to_markdown(transform), encoding="utf-8")
+        consumer_file.write_text(ir_to_markdown(consumer), encoding="utf-8")
 
         env = prepared_subprocess_env
 
@@ -650,6 +655,7 @@ class TestWorkflowChaining:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=True,
             env=env,
             timeout=30,
@@ -686,7 +692,7 @@ class TestWorkflowChaining:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         env = prepared_subprocess_env
 
@@ -696,6 +702,7 @@ class TestWorkflowChaining:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=True,
             env=env,
             timeout=30,
@@ -726,7 +733,7 @@ class TestWorkflowChaining:
         }
 
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         env = prepared_subprocess_env
 
@@ -736,6 +743,7 @@ class TestWorkflowChaining:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=True,
             env=env,
             timeout=30,
@@ -744,7 +752,7 @@ class TestWorkflowChaining:
         _skip_uv_sandbox_panic(result)
         assert result.returncode == 0, f"Failed: stdout={result.stdout}, stderr={result.stderr}"
         assert output_file.exists(), "Output file should exist"
-        content = output_file.read_text()
+        content = output_file.read_text(encoding="utf-8")
         assert content == "got:[]", f"Expected 'got:[]' but got '{content}'"
 
 
@@ -763,7 +771,7 @@ class TestJSONOutputFormat:
             "start_node": "echo1",
         }
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # mix_stderr=False: see note on test_multiple_stdin_error_json_output.
         runner = CliRunner(mix_stderr=False)
@@ -791,7 +799,7 @@ class TestJSONOutputFormat:
             "start_node": "echo1",
         }
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         result = runner.invoke(main, [str(workflow_file)], input="piped data")
@@ -818,7 +826,7 @@ class TestJSONOutputFormat:
             "start_node": "echo1",
         }
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # mix_stderr=False: under click 8.1 (transitive pin from litellm 1.83.x),
         # CliRunner defaults to mix_stderr=True which merges stderr into stdout
@@ -860,7 +868,7 @@ class TestJSONOutputFormat:
             "start_node": "echo1",
         }
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         runner = CliRunner()
         result = runner.invoke(main, [str(workflow_file)], input="piped data")

--- a/tests/test_cli/test_dual_mode_stdout.py
+++ b/tests/test_cli/test_dual_mode_stdout.py
@@ -45,6 +45,7 @@ def _run_pflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProc
         [sys.executable, "-m", "pflow.cli", *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=clean_env,
         timeout=60,
     )
@@ -72,7 +73,7 @@ class TestStdoutRedirectLabel:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow([str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -114,7 +115,7 @@ class TestStdoutRedirectLabel:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow([str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -145,7 +146,7 @@ class TestMultiOutputAmbiguity:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow([str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -176,7 +177,7 @@ class TestMultiOutputAmbiguity:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(["-p", str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -203,7 +204,7 @@ class TestMultiOutputAmbiguity:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(["--output-format", "json", str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -228,7 +229,7 @@ class TestMultiOutputAmbiguity:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(["-o", "alpha", str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -257,7 +258,7 @@ class TestMultiOutputAmbiguity:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(["-o", "beta", str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)
@@ -296,7 +297,7 @@ class TestStdoutValidator:
             ],
         }
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(["--validate-only", str(workflow_file)], prepared_subprocess_env)
         _skip_uv_sandbox_panic(result)

--- a/tests/test_cli/test_guide.py
+++ b/tests/test_cli/test_guide.py
@@ -347,7 +347,8 @@ def test_mcp_topic_has_no_dynamic_interface() -> None:
 def test_compose_from_workflow_file(tmp_path: Path) -> None:
     wf = tmp_path / "test.pflow.md"
     wf.write_text(
-        "# Test\n\nA test.\n\n## Steps\n\n### fetch\n\nFetch data.\n\n- type: http\n- url: https://example.com\n"
+        "# Test\n\nA test.\n\n## Steps\n\n### fetch\n\nFetch data.\n\n- type: http\n- url: https://example.com\n",
+        encoding="utf-8",
     )
     result = compose_guide([str(wf)])
     assert "HTTP" in result
@@ -359,7 +360,8 @@ def test_compose_from_workflow_detects_multiple_types(tmp_path: Path) -> None:
         "# Multi\n\nA multi-node workflow.\n\n## Steps\n\n"
         "### fetch\n\nFetch.\n\n- type: http\n- url: https://example.com\n\n"
         "### process\n\nProcess.\n\n- type: code\n- inputs:\n    data: ${fetch.response}\n\n"
-        "```python code\ndata: dict\nresult: dict = data\n```\n"
+        "```python code\ndata: dict\nresult: dict = data\n```\n",
+        encoding="utf-8",
     )
     result = compose_guide([str(wf)])
     assert "HTTP" in result
@@ -373,7 +375,8 @@ def test_compose_from_workflow_detects_claude_code(tmp_path: Path) -> None:
         "### fix\n\nFix code.\n\n"
         "- type: claude-code\n"
         "- max_turns: 2\n\n"
-        "```prompt\nFix the failing test.\n```\n"
+        "```prompt\nFix the failing test.\n```\n",
+        encoding="utf-8",
     )
     result = compose_guide([str(wf)])
     assert "# Claude Code Node" in result
@@ -451,7 +454,8 @@ Log the error.
 ```shell command
 echo "failed" >&2
 ```
-"""
+""",
+        encoding="utf-8",
     )
     result = compose_guide([str(wf)])
 
@@ -469,7 +473,8 @@ echo "failed" >&2
 def test_compose_workflow_ref_plus_explicit_topic(tmp_path: Path) -> None:
     wf = tmp_path / "simple.pflow.md"
     wf.write_text(
-        "# Simple\n\nSimple.\n\n## Steps\n\n### fetch\n\nFetch.\n\n- type: http\n- url: https://example.com\n"
+        "# Simple\n\nSimple.\n\n## Steps\n\n### fetch\n\nFetch.\n\n- type: http\n- url: https://example.com\n",
+        encoding="utf-8",
     )
     result = compose_guide([str(wf), "batch"])
     assert "HTTP" in result
@@ -478,7 +483,10 @@ def test_compose_workflow_ref_plus_explicit_topic(tmp_path: Path) -> None:
 
 def test_compose_workflow_ref_deduplicates_with_explicit(tmp_path: Path) -> None:
     wf = tmp_path / "http-wf.pflow.md"
-    wf.write_text("# HTTP WF\n\nHTTP.\n\n## Steps\n\n### fetch\n\nFetch.\n\n- type: http\n- url: https://example.com\n")
+    wf.write_text(
+        "# HTTP WF\n\nHTTP.\n\n## Steps\n\n### fetch\n\nFetch.\n\n- type: http\n- url: https://example.com\n",
+        encoding="utf-8",
+    )
     result = compose_guide(["http", str(wf)])
     # http should only appear once (explicit + auto-detected deduplicated)
     assert result.count("# HTTP Node") == 1
@@ -491,7 +499,7 @@ def test_compose_nonexistent_workflow_raises(tmp_path: Path) -> None:
 
 def test_compose_unparseable_workflow_raises(tmp_path: Path) -> None:
     wf = tmp_path / "broken.pflow.md"
-    wf.write_text("not a valid workflow at all")
+    wf.write_text("not a valid workflow at all", encoding="utf-8")
     with pytest.raises(GuideError, match=r"Failed to parse|No guide topics"):
         compose_guide([str(wf)])
 
@@ -501,7 +509,7 @@ def test_compose_broken_saved_workflow_shows_load_error(tmp_path: Path, isolate_
     not 'Unknown topic'."""
     wf_dir = Path(isolate_pflow_config["workflows_path"]) / "broken-wf"
     wf_dir.mkdir(parents=True)
-    (wf_dir / "broken-wf.pflow.md").write_text("---\nname: broken-wf\n---\nnot valid")
+    (wf_dir / "broken-wf.pflow.md").write_text("---\nname: broken-wf\n---\nnot valid", encoding="utf-8")
 
     with pytest.raises(GuideError, match="failed to load"):
         compose_guide(["broken-wf"])

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -524,7 +524,7 @@ def test_home_directory_expansion(monkeypatch, tmp_path: Path):
             "nodes": [{"id": "echo1", "type": "shell", "params": {"command": "echo 'home test'"}}],
             "edges": [],
         }
-        test_file.write_text(ir_to_markdown(workflow))
+        test_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Run with ~ path
         result = runner.invoke(main, ["~/.test_workflow_temp.pflow.md"])

--- a/tests/test_cli/test_mcp_auto_discovery.py
+++ b/tests/test_cli/test_mcp_auto_discovery.py
@@ -526,7 +526,7 @@ class TestAutoDiscoveryIntegration:
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             # Create a valid JSON config file
-            mock_manager.config_path.write_text('{"mcpServers": {}}')
+            mock_manager.config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
 
             # Set up registry metadata to force sync
             registry.set_metadata("mcp_last_sync_time", 0)

--- a/tests/test_cli/test_mermaid.py
+++ b/tests/test_cli/test_mermaid.py
@@ -186,7 +186,7 @@ class TestMermaidOutputFlag:
 
         assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}\noutput: {result.output}"
         assert output_path.exists()
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert "graph LR" in content
         assert "step1" in content
         # Mermaid should NOT be on stdout (it went to file)
@@ -218,7 +218,7 @@ class TestMermaidNestedWorkflowExpansion:
             f"- type: workflow\n"
             f"- workflow: {child_path}\n"
         )
-        parent_path.write_text(parent_md)
+        parent_path.write_text(parent_md, encoding="utf-8")
 
         result = _invoke([str(parent_path)])
 
@@ -235,14 +235,15 @@ class TestMermaidMarkdownOutput:
         workflow_path = tmp_path / "wf.pflow.md"
         workflow_path.write_text(
             "# My Cool Workflow\n\nThis workflow does amazing things.\n\n"
-            "## Steps\n\n### step1\n\nDoes a thing nicely.\n\n- type: shell\n- command: echo hi\n"
+            "## Steps\n\n### step1\n\nDoes a thing nicely.\n\n- type: shell\n- command: echo hi\n",
+            encoding="utf-8",
         )
         output_path = tmp_path / "diagram.md"
 
         result = _invoke([str(workflow_path), "-o", str(output_path)])
 
         assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}\noutput: {result.output}"
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert content.startswith("# My Cool Workflow\n")
         assert "This workflow does amazing things." in content
         assert "```mermaid\n" in content
@@ -264,7 +265,7 @@ class TestMermaidMarkdownOutput:
         result = _invoke([str(workflow_path), "-o", str(output_path)])
 
         assert result.exit_code == 0
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert content.startswith("graph LR\n")
         assert "```mermaid" not in content
 
@@ -284,7 +285,7 @@ class TestMermaidDescriptionsFlag:
             "- type: shell\n"
             "- command: echo hello\n"
         )
-        workflow_path.write_text(workflow_md)
+        workflow_path.write_text(workflow_md, encoding="utf-8")
 
         result = _invoke(["--descriptions", str(workflow_path)])
 

--- a/tests/test_cli/test_nested_workflow_cli.py
+++ b/tests/test_cli/test_nested_workflow_cli.py
@@ -132,10 +132,10 @@ class TestNestedWorkflowCLI:
     def test_nested_workflow_e2e(self, tmp_path: Path) -> None:
         """Nested workflow executes child and surfaces its output to parent."""
         child_file = tmp_path / "to-uppercase.pflow.md"
-        child_file.write_text(CHILD_WORKFLOW)
+        child_file.write_text(CHILD_WORKFLOW, encoding="utf-8")
 
         parent_file = tmp_path / "parent.pflow.md"
-        parent_file.write_text(_make_parent_workflow(str(child_file)))
+        parent_file.write_text(_make_parent_workflow(str(child_file)), encoding="utf-8")
 
         result = invoke_cli([str(parent_file), "title=hello"])
 
@@ -172,7 +172,7 @@ class TestNestedWorkflowCLI:
         # workflows/{name}/{name}.pflow.md, so siblings must be in that folder.
         saved_dir = workflows_dir / "test-saved-nested"
         child_file = saved_dir / "child-upper.pflow.md"
-        child_file.write_text(CHILD_WORKFLOW)
+        child_file.write_text(CHILD_WORKFLOW, encoding="utf-8")
 
         # Patch WorkflowManager at all import sites to use our tmp workflows dir
         with (
@@ -194,10 +194,10 @@ class TestNestedWorkflowCLI:
     def test_nested_workflow_validate_only(self, tmp_path: Path) -> None:
         """--validate-only accepts a valid nested workflow without executing it."""
         child_file = tmp_path / "to-uppercase.pflow.md"
-        child_file.write_text(CHILD_WORKFLOW)
+        child_file.write_text(CHILD_WORKFLOW, encoding="utf-8")
 
         parent_file = tmp_path / "parent.pflow.md"
-        parent_file.write_text(_make_parent_workflow(str(child_file)))
+        parent_file.write_text(_make_parent_workflow(str(child_file)), encoding="utf-8")
 
         result = invoke_cli(["--validate-only", str(parent_file)])
 
@@ -210,11 +210,11 @@ class TestNestedWorkflowCLI:
     def test_nested_workflow_missing_input_error(self, tmp_path: Path) -> None:
         """Nested workflow reports error when child is missing required inputs."""
         child_file = tmp_path / "to-uppercase.pflow.md"
-        child_file.write_text(CHILD_WORKFLOW)
+        child_file.write_text(CHILD_WORKFLOW, encoding="utf-8")
 
         # Parent does NOT pass the required 'text' input to child
         parent_file = tmp_path / "parent.pflow.md"
-        parent_file.write_text(_make_parent_workflow(str(child_file), pass_text=False))
+        parent_file.write_text(_make_parent_workflow(str(child_file), pass_text=False), encoding="utf-8")
 
         result = invoke_cli([str(parent_file), "title=hello"])
 
@@ -238,12 +238,14 @@ class TestNestedWorkflowCLI:
         # Broken child: missing step description (parse error)
         broken_child = tmp_path / "broken-child.pflow.md"
         broken_child.write_text(
-            "# Broken\n\nA broken workflow.\n\n## Steps\n\n### process\n- type: llm\n- prompt: hello\n"
+            "# Broken\n\nA broken workflow.\n\n## Steps\n\n### process\n- type: llm\n- prompt: hello\n",
+            encoding="utf-8",
         )
 
         # Parent: upstream LLM node → broken sub-workflow
         parent_file = tmp_path / "parent.pflow.md"
-        parent_file.write_text(f"""\
+        parent_file.write_text(
+            f"""\
 # Parent
 
 A parent workflow with an expensive upstream step.
@@ -273,7 +275,9 @@ Call the broken sub-workflow.
 - workflow: {broken_child}
 - inputs:
     text: ${{expensive-llm.response}}
-""")
+""",
+            encoding="utf-8",
+        )
 
         result = invoke_cli([str(parent_file), "query=test"])
 
@@ -309,11 +313,12 @@ Call the broken sub-workflow.
 
         # Grandchild: the leaf workflow that does actual work
         grandchild = inner_dir / "grandchild.pflow.md"
-        grandchild.write_text(CHILD_WORKFLOW)  # reuse: uppercases ${text}
+        grandchild.write_text(CHILD_WORKFLOW, encoding="utf-8")  # reuse: uppercases ${text}
 
         # Child (middle): calls grandchild with relative path
         child = middle_dir / "child.pflow.md"
-        child.write_text("""\
+        child.write_text(
+            """\
 # Middle Workflow
 
 Passes text through to grandchild.
@@ -344,11 +349,14 @@ Call the grandchild workflow.
 - workflow: ./inner/grandchild.pflow.md
 - inputs:
     text: ${text}
-""")
+""",
+            encoding="utf-8",
+        )
 
         # Parent: calls child with relative path
         parent = root / "parent.pflow.md"
-        parent.write_text("""\
+        parent.write_text(
+            """\
 # Top-Level Workflow
 
 Three-level nesting test.
@@ -378,7 +386,9 @@ Display the result.
 
 - type: shell
 - command: echo ${process.result}
-""")
+""",
+            encoding="utf-8",
+        )
 
         result = invoke_cli([str(parent), "title=deep nesting works"])
 
@@ -400,11 +410,11 @@ Display the result.
         children_dir.mkdir(parents=True)
 
         child_file = children_dir / "child.pflow.md"
-        child_file.write_text(CHILD_WORKFLOW)
+        child_file.write_text(CHILD_WORKFLOW, encoding="utf-8")
 
         # Parent uses relative path to child
         parent_file = parent_dir / "parent.pflow.md"
-        parent_file.write_text(_make_parent_workflow("./children/child.pflow.md"))
+        parent_file.write_text(_make_parent_workflow("./children/child.pflow.md"), encoding="utf-8")
 
         result = invoke_cli([str(parent_file), "title=hello"])
 

--- a/tests/test_cli/test_parse_error_handling.py
+++ b/tests/test_cli/test_parse_error_handling.py
@@ -156,7 +156,7 @@ A test node.
     def test_permission_error_shows_helpful_message(self, tmp_path):
         """Test permission error shows helpful message."""
         wf = tmp_path / "wf.pflow.md"
-        wf.write_text("# Test\n\n## Steps\n\n### a\n\nDesc.\n\n- type: shell\n- command: echo test\n")
+        wf.write_text("# Test\n\n## Steps\n\n### a\n\nDesc.\n\n- type: shell\n- command: echo test\n", encoding="utf-8")
 
         from unittest.mock import patch
 
@@ -173,7 +173,7 @@ A test node.
     def test_unicode_decode_error_shows_helpful_message(self, tmp_path):
         """Test unicode decode error shows helpful message."""
         wf = tmp_path / "wf.pflow.md"
-        wf.write_text("placeholder")
+        wf.write_text("placeholder", encoding="utf-8")
 
         from unittest.mock import patch
 

--- a/tests/test_cli/test_probe.py
+++ b/tests/test_cli/test_probe.py
@@ -59,7 +59,7 @@ def test_probe_help_mentions_metadata_contract(runner: click.testing.CliRunner) 
 
 def test_probe_basic_node_execution_with_temp_file(runner: click.testing.CliRunner, tmp_path: Path) -> None:
     test_file = tmp_path / "test.txt"
-    test_file.write_text("Hello, world!")
+    test_file.write_text("Hello, world!", encoding="utf-8")
 
     from pflow.nodes.file.read_file import ReadFileNode
 
@@ -77,7 +77,7 @@ def test_probe_basic_node_execution_with_temp_file(runner: click.testing.CliRunn
 
 def test_probe_json_output_produces_valid_json(runner: click.testing.CliRunner, tmp_path: Path) -> None:
     test_file = tmp_path / "test.txt"
-    test_file.write_text("test content")
+    test_file.write_text("test content", encoding="utf-8")
 
     from pflow.nodes.file.read_file import ReadFileNode
 

--- a/tests/test_cli/test_progress_streaming_subprocess.py
+++ b/tests/test_cli/test_progress_streaming_subprocess.py
@@ -80,6 +80,7 @@ def subprocess_env(tmp_path_factory, uv_exe):
         [uv_exe, "run", "pflow", "registry", "list", "--json"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         shell=False,
         env=env,
     )
@@ -93,6 +94,7 @@ def _run_pflow(uv_exe: str, env: dict, workflow_path) -> subprocess.CompletedPro
         [uv_exe, "run", "pflow", str(workflow_path)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         shell=False,
         env=env,
     )
@@ -177,7 +179,7 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_file = tmp_path / "fail.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(uv_exe, subprocess_env, workflow_file)
         _skip_if_uv_sandbox_panics(result)
@@ -234,7 +236,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         outer_path = tmp_path / "outer.pflow.md"
@@ -261,7 +264,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         result = _run_pflow(uv_exe, subprocess_env, outer_path)
@@ -350,7 +354,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         # Parent workflow: parallel batch over 4 items, each runs the inner workflow
@@ -372,7 +377,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         result = _run_pflow(uv_exe, subprocess_env, outer_path)
@@ -448,12 +454,13 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "verbose.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", "-v", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -516,7 +523,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         # Middle workflow: parallel batch over the innermost workflow
@@ -538,7 +546,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         # Outer workflow: parallel batch over the middle workflow
@@ -560,7 +569,8 @@ class TestRealSubprocessProgressRendering:
                     },
                 ],
                 "edges": [],
-            })
+            }),
+            encoding="utf-8",
         )
 
         result = _run_pflow(uv_exe, subprocess_env, outer_path)
@@ -629,13 +639,14 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "only_zero_skip.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Snapshot --only needs a prior full run to restore upstream from.
         seed = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -646,6 +657,7 @@ class TestRealSubprocessProgressRendering:
             [uv_exe, "run", "pflow", str(workflow_path), "--only", "only_step"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -704,13 +716,14 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "print_only.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Snapshot --only needs a prior full run to restore upstream from.
         seed = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -721,6 +734,7 @@ class TestRealSubprocessProgressRendering:
             [uv_exe, "run", "pflow", "-p", str(workflow_path), "--only", "step_b"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -767,12 +781,13 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "print_plain.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", "-p", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -844,13 +859,14 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "barrier.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         proc = subprocess.Popen(  # noqa: S603
             [uv_exe, "run", "pflow", str(workflow_path)],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
             bufsize=1,  # line-buffered reads so readline returns as data arrives
             env=subprocess_env,
             shell=False,
@@ -913,12 +929,13 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "json_mode.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", "--output-format", "json", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -976,12 +993,13 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "json_print_mode.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", "--output-format", "json", "-p", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -1030,12 +1048,13 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "json_fail.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = subprocess.run(  # noqa: S603
             [uv_exe, "run", "pflow", "--output-format", "json", str(workflow_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             shell=False,
             env=subprocess_env,
         )
@@ -1091,7 +1110,7 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "timeout.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(uv_exe, subprocess_env, workflow_path)
         _skip_if_uv_sandbox_panics(result)
@@ -1177,7 +1196,7 @@ class TestRealSubprocessProgressRendering:
             "edges": [],
         }
         workflow_path = tmp_path / "gh194_routing.pflow.md"
-        workflow_path.write_text(ir_to_markdown(workflow))
+        workflow_path.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         result = _run_pflow(uv_exe, subprocess_env, workflow_path)
         _skip_if_uv_sandbox_panics(result)

--- a/tests/test_cli/test_resume_list_cli.py
+++ b/tests/test_cli/test_resume_list_cli.py
@@ -81,7 +81,7 @@ def home(tmp_path, monkeypatch):
 @pytest.fixture
 def gate_wf(tmp_path):
     path = tmp_path / "list_demo.pflow.md"
-    path.write_text(_GATE_WF)
+    path.write_text(_GATE_WF, encoding="utf-8")
     return path
 
 
@@ -177,7 +177,7 @@ def test_json_shape_and_empty_state(home, gate_wf):
 
 def test_failed_run_is_not_listed(home, tmp_path):
     wf = tmp_path / "fail_demo.pflow.md"
-    wf.write_text(_FAIL_WF)
+    wf.write_text(_FAIL_WF, encoding="utf-8")
     failed = _runner().invoke(cli, [str(wf)])
     assert failed.exit_code == 1
     result = _runner().invoke(cli, ["resume", "list"])

--- a/tests/test_cli/test_resume_no_hang_subprocess.py
+++ b/tests/test_cli/test_resume_no_hang_subprocess.py
@@ -77,13 +77,14 @@ def test_side_effecting_resume_non_tty_refuses_without_hanging(tmp_path, uv_exe,
     env = dict(prepared_subprocess_env)
     env.pop("PYTEST_CURRENT_TEST", None)  # production-like logging (pitfall in subprocess_env docs)
     wf = tmp_path / "wf.pflow.md"
-    wf.write_text(_WF)
+    wf.write_text(_WF, encoding="utf-8")
 
     # 1) Real failed run streams a trace and prints the resume target.
     fail = subprocess.run(  # noqa: S603
         [uv_exe, "run", "pflow", str(wf), "mode=bad"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=env,
         timeout=120,
     )
@@ -103,6 +104,7 @@ def test_side_effecting_resume_non_tty_refuses_without_hanging(tmp_path, uv_exe,
             stdin=read_fd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             env=env,
             timeout=45,
         )

--- a/tests/test_cli/test_run_node.py
+++ b/tests/test_cli/test_run_node.py
@@ -627,7 +627,7 @@ class TestRunInputsEndpoint:
     def test_happy_path_returns_tokens_without_secrets(self, tmp_path, monkeypatch) -> None:
         debug = _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         resolved = str(wf_file.resolve())
         _write_io_trace(debug, resolved, "20260101-000000-000020", inputs={"name": "World", "api_key": "sk-secret"})
         r = _local(create_app()).get("/api/run-inputs", params={"workflow": str(wf_file), "run": "run-1"})
@@ -637,7 +637,7 @@ class TestRunInputsEndpoint:
     def test_unknown_run_is_404(self, tmp_path, monkeypatch) -> None:
         debug = _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         resolved = str(wf_file.resolve())
         _write_io_trace(debug, resolved, "20260101-000000-000020", inputs={"name": "World"})
         r = _local(create_app()).get("/api/run-inputs", params={"workflow": str(wf_file), "run": "ghost"})
@@ -655,14 +655,14 @@ class TestRunNodeEndpoint:
     def test_missing_ref_is_400(self, tmp_path, monkeypatch) -> None:
         _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         r = _local(create_app()).get("/api/run-node", params={"workflow": str(wf_file)})
         assert r.status_code == 400
 
     def test_malformed_ref_is_400(self, tmp_path, monkeypatch) -> None:
         _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         r = _local(create_app()).get("/api/run-node", params={"workflow": str(wf_file), "ref": "not-json"})
         assert r.status_code == 400
 
@@ -673,7 +673,7 @@ class TestRunNodeEndpoint:
     def test_happy_path_returns_detail(self, tmp_path, monkeypatch) -> None:
         debug = _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         resolved = str(wf_file.resolve())
         _write_trace(debug, resolved, "20260101-000000-000001", [_event("greet", node_output={"stdout": "hi"})])
         ref = json.dumps({"node_id": "greet", "ancestor_path": [], "port": None})
@@ -685,7 +685,7 @@ class TestRunNodeEndpoint:
         """An empty ``&run=`` means "not pinned" (follow the newest run), not "match the run with id ''"."""
         debug = _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         resolved = str(wf_file.resolve())
         _write_trace(debug, resolved, "20260101-000000-000001", [_event("greet", node_output={"stdout": "hi"})])
         ref = json.dumps({"node_id": "greet", "ancestor_path": [], "port": None})
@@ -695,7 +695,7 @@ class TestRunNodeEndpoint:
     def test_no_matching_event_is_404(self, tmp_path, monkeypatch) -> None:
         debug = _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         resolved = str(wf_file.resolve())
         _write_trace(debug, resolved, "20260101-000000-000001", [_event("greet")])
         ref = json.dumps({"node_id": "absent", "ancestor_path": [], "port": None})
@@ -706,7 +706,7 @@ class TestRunNodeEndpoint:
         # End-to-end through the handler: an IO ref (port "in") projects meta.inputs, no event needed.
         debug = _debug(tmp_path, monkeypatch)
         wf_file = tmp_path / "wf.pflow.md"
-        wf_file.write_text("# x")
+        wf_file.write_text("# x", encoding="utf-8")
         resolved = str(wf_file.resolve())
         _write_io_trace(debug, resolved, "20260101-000000-000010", inputs={"name": "World"})
         ref = json.dumps({"node_id": "name", "ancestor_path": [], "port": "in"})

--- a/tests/test_cli/test_ui.py
+++ b/tests/test_cli/test_ui.py
@@ -494,8 +494,8 @@ class TestFrontendFallback:
         """With a bundle present, ``/`` serves index.html, assets resolve, and the
         API routes still win (they are registered before the static mount)."""
         (tmp_path / "assets").mkdir()
-        (tmp_path / "index.html").write_text("<!doctype html><div id=root></div>")
-        (tmp_path / "assets" / "app.js").write_text("console.log('hi')")
+        (tmp_path / "index.html").write_text("<!doctype html><div id=root></div>", encoding="utf-8")
+        (tmp_path / "assets" / "app.js").write_text("console.log('hi')", encoding="utf-8")
 
         with patch("pflow.ui.server._STATIC_DIR", tmp_path):
             client = _local(create_app())
@@ -518,8 +518,8 @@ class TestFrontendFallback:
         rebuild (the recurring stale-canvas debugging trap).
         """
         (tmp_path / "assets").mkdir()
-        (tmp_path / "index.html").write_text("<!doctype html><div id=root></div>")
-        (tmp_path / "assets" / "app-CAFE1234.js").write_text("console.log('hi')")
+        (tmp_path / "index.html").write_text("<!doctype html><div id=root></div>", encoding="utf-8")
+        (tmp_path / "assets" / "app-CAFE1234.js").write_text("console.log('hi')", encoding="utf-8")
 
         with patch("pflow.ui.server._STATIC_DIR", tmp_path):
             client = _local(create_app())

--- a/tests/test_cli/test_unified_error_output.py
+++ b/tests/test_cli/test_unified_error_output.py
@@ -134,7 +134,7 @@ class TestUnifiedErrorJsonShape:
     def test_parse_error(self, tmp_path: Path) -> None:
         """A malformed .pflow.md file (no ## Steps) produces parse_error category."""
         bad_file = tmp_path / "bad.pflow.md"
-        bad_file.write_text("# My Workflow\n\nSome description but no steps section.\n")
+        bad_file.write_text("# My Workflow\n\nSome description but no steps section.\n", encoding="utf-8")
 
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, ["--output-format", "json", str(bad_file)])

--- a/tests/test_cli/test_validate_only.py
+++ b/tests/test_cli/test_validate_only.py
@@ -239,7 +239,7 @@ class TestValidateOnlyEdgeCases:
         """Should show helpful error for invalid markdown workflow."""
         workflow_path = tmp_path / "bad.pflow.md"
         # Missing ## Steps section — invalid markdown workflow
-        workflow_path.write_text("# Bad Workflow\n\nJust some text, no steps.\n")
+        workflow_path.write_text("# Bad Workflow\n\nJust some text, no steps.\n", encoding="utf-8")
 
         result = invoke_cli(["--validate-only", str(workflow_path)])
 
@@ -250,7 +250,7 @@ class TestValidateOnlyEdgeCases:
     def test_validate_only_rejects_json_files(self, tmp_path: Path) -> None:
         """Should show helpful error when a .json file is passed."""
         workflow_path = tmp_path / "old.json"
-        workflow_path.write_text('{"nodes": []}')
+        workflow_path.write_text('{"nodes": []}', encoding="utf-8")
 
         result = invoke_cli(["--validate-only", str(workflow_path)])
 
@@ -586,7 +586,7 @@ class TestValidationErrorDiagnosticShape:
             "- command: echo hello\n"
         )
         workflow_path = tmp_path / "typo.pflow.md"
-        workflow_path.write_text(workflow_md)
+        workflow_path.write_text(workflow_md, encoding="utf-8")
 
         result = invoke_cli(["--validate-only", str(workflow_path)])
 
@@ -612,7 +612,7 @@ class TestValidationErrorDiagnosticShape:
             "- command: echo hello\n"
         )
         workflow_path = tmp_path / "typo.pflow.md"
-        workflow_path.write_text(workflow_md)
+        workflow_path.write_text(workflow_md, encoding="utf-8")
 
         result = invoke_cli(["--validate-only", "--output-format", "json", str(workflow_path)])
 
@@ -641,7 +641,7 @@ class TestValidationErrorDiagnosticShape:
             "- command: echo hello\n"
         )
         workflow_path = tmp_path / "typo.pflow.md"
-        workflow_path.write_text(workflow_md)
+        workflow_path.write_text(workflow_md, encoding="utf-8")
 
         result = invoke_cli([str(workflow_path)])
 

--- a/tests/test_cli/test_validation_before_execution.py
+++ b/tests/test_cli/test_validation_before_execution.py
@@ -264,7 +264,7 @@ class TestValidationBeforeExecution:
 
         # File should be created (execution happened)
         assert output_file.exists(), "Workflow should have executed and created the file"
-        assert output_file.read_text() == "validation passed"
+        assert output_file.read_text(encoding="utf-8") == "validation passed"
 
 
 class TestValidationConsistency:

--- a/tests/test_cli/test_workflow_output_handling.py
+++ b/tests/test_cli/test_workflow_output_handling.py
@@ -503,7 +503,7 @@ class TestWorkflowOutputHandling:
             "edges": [],
         }
         workflow_file = tmp_path / "only-output-contract.pflow.md"
-        workflow_file.write_text(ir_to_markdown(workflow))
+        workflow_file.write_text(ir_to_markdown(workflow), encoding="utf-8")
 
         # Snapshot --only needs a prior full run to restore upstream from. Trace
         # filenames are microsecond-granular (issue #443), so these rapid full +

--- a/tests/test_cli/test_workflow_resolution.py
+++ b/tests/test_cli/test_workflow_resolution.py
@@ -556,7 +556,7 @@ class TestEdgeCases:
         runner = click.testing.CliRunner()
 
         wf = tmp_path / "wf.pflow.md"
-        wf.write_text("placeholder")
+        wf.write_text("placeholder", encoding="utf-8")
 
         def raise_decode(*args, **kwargs):
             raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")

--- a/tests/test_cli/test_workflow_save_cli.py
+++ b/tests/test_cli/test_workflow_save_cli.py
@@ -53,7 +53,7 @@ class TestWorkflowSaveCLI:
         saved_file = home_pflow / "my-workflow" / "my-workflow.pflow.md"
         assert saved_file.exists(), "Workflow file should be created"
 
-        content = saved_file.read_text()
+        content = saved_file.read_text(encoding="utf-8")
         # Saved file should have YAML frontmatter
         assert content.startswith("---\n")
         # Should contain the workflow content
@@ -90,7 +90,9 @@ class TestWorkflowSaveCLI:
 
         # Write a markdown file that parses but produces invalid IR (missing type on node)
         draft = tmp_path / "bad.pflow.md"
-        draft.write_text("# Bad\n\nBad workflow.\n\n## Steps\n\n### node1\n\nA node.\n\n- id: node1\n")
+        draft.write_text(
+            "# Bad\n\nBad workflow.\n\n## Steps\n\n### node1\n\nA node.\n\n- id: node1\n", encoding="utf-8"
+        )
 
         result = runner.invoke(
             save_cmd,
@@ -284,7 +286,7 @@ class TestWorkflowSaveCLI:
 
         # Verify overwrite happened — saved file should contain new node
         existing = home_pflow / "my-workflow" / "my-workflow.pflow.md"
-        content = existing.read_text()
+        content = existing.read_text(encoding="utf-8")
         assert "### new" in content
 
     def test_force_save_invalid_content_preserves_existing(
@@ -307,7 +309,7 @@ class TestWorkflowSaveCLI:
 
         existing = home_pflow / "my-workflow" / "my-workflow.pflow.md"
         assert existing.exists()
-        original_content = existing.read_text()
+        original_content = existing.read_text(encoding="utf-8")
 
         # Try to force-save invalid content over it
         broken_ir = {
@@ -328,7 +330,7 @@ class TestWorkflowSaveCLI:
 
         # The existing valid workflow must survive
         assert existing.exists(), "Valid workflow was deleted before validation caught the error"
-        assert existing.read_text() == original_content, "Valid workflow content was modified"
+        assert existing.read_text(encoding="utf-8") == original_content, "Valid workflow content was modified"
 
     def test_workflow_save_rejects_overwrite_without_force(
         self, runner: click.testing.CliRunner, tmp_path: Any, sample_workflow_ir: dict[str, Any]

--- a/tests/test_cli/test_workflow_save_integration.py
+++ b/tests/test_cli/test_workflow_save_integration.py
@@ -68,7 +68,7 @@ class TestWorkflowSaveIntegration:
         assert workflow_file.exists()
 
         # Verify file content structure — should have YAML frontmatter
-        content = workflow_file.read_text()
+        content = workflow_file.read_text(encoding="utf-8")
         assert content.startswith("---\n")
 
         # Parse frontmatter
@@ -143,7 +143,7 @@ class TestWorkflowSaveIntegration:
         assert result.exit_code == 0
         assert "Workflow completed" in result.output
         assert output_file.exists()
-        assert output_file.read_text() == "Integration test output"
+        assert output_file.read_text(encoding="utf-8") == "Integration test output"
 
         # Then, test the save functionality separately (still integration testing)
         workflows_dir = tmp_path / "workflows"

--- a/tests/test_core/test_approval_field.py
+++ b/tests/test_core/test_approval_field.py
@@ -105,7 +105,8 @@ class TestSchemaAndValidation:
             "# Child\n\nChild with an invalid batch gate.\n\n## Steps\n\n"
             "### fan\n\nFan out.\n\n- type: shell\n- command: echo ${item}\n"
             "- approval: required\n"
-            "- batch:\n    items: ${items}\n    as: item\n"
+            "- batch:\n    items: ${items}\n    as: item\n",
+            encoding="utf-8",
         )
         parent_ir = _ir({"id": "sub", "type": "workflow", "params": {"workflow": str(child)}})
         diagnostics = WorkflowValidator().validate(parent_ir, workflow_file=tmp_path / "parent.pflow.md")
@@ -136,7 +137,8 @@ class TestCompiler:
     def test_workflow_type_node_may_be_gated(self, tmp_path):
         child = tmp_path / "child.pflow.md"
         child.write_text(
-            "# Child\n\nTrivial child.\n\n## Steps\n\n### s\n\nSay hi.\n\n- type: shell\n- command: echo hi\n"
+            "# Child\n\nTrivial child.\n\n## Steps\n\n### s\n\nSay hi.\n\n- type: shell\n- command: echo hi\n",
+            encoding="utf-8",
         )
         ir = _ir({"id": "sub", "type": "workflow", "params": {"workflow": str(child)}, "approval": "required"})
         compiled = compile_workflow(ir, Registry())

--- a/tests/test_core/test_dependency_discovery.py
+++ b/tests/test_core/test_dependency_discovery.py
@@ -116,7 +116,7 @@ class TestFileRefInParams:
         """A prompt param pointing to a file is discovered."""
         prompt_dir = tmp_path / "prompts"
         prompt_dir.mkdir()
-        (prompt_dir / "foo.md").write_text("You are a helpful assistant")
+        (prompt_dir / "foo.md").write_text("You are a helpful assistant", encoding="utf-8")
 
         ir = _make_ir([
             {"id": "ask", "type": "llm", "params": {"prompt": "./prompts/foo.md"}},
@@ -135,7 +135,7 @@ class TestFileRefInParams:
         """A command param pointing to a script is discovered."""
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "run.sh").write_text("#!/bin/bash\necho hi")
+        (scripts_dir / "run.sh").write_text("#!/bin/bash\necho hi", encoding="utf-8")
 
         ir = _make_ir([
             {"id": "run", "type": "shell", "params": {"command": "./scripts/run.sh"}},
@@ -153,7 +153,7 @@ class TestFileRefInParams:
         """A code param pointing to a .py file is discovered."""
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "process.py").write_text("result = 42")
+        (scripts_dir / "process.py").write_text("result = 42", encoding="utf-8")
 
         ir = _make_ir([
             {"id": "compute", "type": "python", "params": {"code": "./scripts/process.py"}},
@@ -169,7 +169,7 @@ class TestFileRefInParams:
 
     def test_source_param(self, tmp_path: Path) -> None:
         """A source param is also in FILE_RESOLVABLE_PARAMS."""
-        (tmp_path / "template.md").write_text("template content")
+        (tmp_path / "template.md").write_text("template content", encoding="utf-8")
 
         ir = _make_ir([
             {"id": "out", "type": "llm", "params": {"source": "./template.md"}},
@@ -212,7 +212,7 @@ class TestSubWorkflowFileRef:
             "edges": [],
         }
         sub_path = tmp_path / "sub.pflow.md"
-        sub_path.write_text(ir_to_markdown(sub_ir))
+        sub_path.write_text(ir_to_markdown(sub_ir), encoding="utf-8")
 
         ir = _make_ir([
             {"id": "outer", "type": "workflow", "params": {"workflow": "./sub.pflow.md"}},
@@ -258,7 +258,7 @@ class TestRecursiveSubWorkflowDeps:
         # Create the file that sub-workflow references
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "inner.md").write_text("inner prompt content")
+        (prompts_dir / "inner.md").write_text("inner prompt content", encoding="utf-8")
 
         # Create sub-workflow that references a prompt file
         sub_ir = {
@@ -268,7 +268,7 @@ class TestRecursiveSubWorkflowDeps:
             "edges": [],
         }
         sub_path = tmp_path / "sub.pflow.md"
-        sub_path.write_text(ir_to_markdown(sub_ir))
+        sub_path.write_text(ir_to_markdown(sub_ir), encoding="utf-8")
 
         # Create parent workflow that references the sub-workflow
         ir = _make_ir([
@@ -291,7 +291,7 @@ class TestRecursiveSubWorkflowDeps:
     def test_deeply_nested_sub_workflows(self, tmp_path: Path) -> None:
         """Three levels of nesting: parent -> child -> grandchild, all deps collected."""
         # Create grandchild prompt
-        (tmp_path / "deep.md").write_text("deep content")
+        (tmp_path / "deep.md").write_text("deep content", encoding="utf-8")
 
         # Create grandchild workflow referencing deep.md
         grandchild_ir = {
@@ -299,7 +299,7 @@ class TestRecursiveSubWorkflowDeps:
             "edges": [],
         }
         grandchild_path = tmp_path / "grandchild.pflow.md"
-        grandchild_path.write_text(ir_to_markdown(grandchild_ir))
+        grandchild_path.write_text(ir_to_markdown(grandchild_ir), encoding="utf-8")
 
         # Create child workflow referencing grandchild
         child_ir = {
@@ -307,7 +307,7 @@ class TestRecursiveSubWorkflowDeps:
             "edges": [],
         }
         child_path = tmp_path / "child.pflow.md"
-        child_path.write_text(ir_to_markdown(child_ir))
+        child_path.write_text(ir_to_markdown(child_ir), encoding="utf-8")
 
         # Create parent workflow referencing child
         parent_ir = _make_ir([
@@ -340,7 +340,7 @@ class TestBatchConfigFile:
     def test_batch_config_discovered(self, tmp_path: Path) -> None:
         """A batch param with a file reference is discovered."""
         batch_content = "items:\n  - focus: ai\n    prompt: inline prompt\n"
-        (tmp_path / "reviews.yaml").write_text(batch_content)
+        (tmp_path / "reviews.yaml").write_text(batch_content, encoding="utf-8")
 
         ir = _make_ir([
             {"id": "review", "type": "llm", "batch": "./reviews.yaml", "params": {"prompt": "${item.prompt}"}},
@@ -359,11 +359,11 @@ class TestBatchConfigFile:
         """Batch YAML file that itself contains file references in items."""
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "review.md").write_text("review prompt content")
+        (prompts_dir / "review.md").write_text("review prompt content", encoding="utf-8")
 
         # The batch YAML file contains file references in items
         batch_content = "items:\n  - prompt: ./prompts/review.md\n    focus: quality\n"
-        (tmp_path / "batch.yaml").write_text(batch_content)
+        (tmp_path / "batch.yaml").write_text(batch_content, encoding="utf-8")
 
         ir = _make_ir([
             {"id": "review", "type": "llm", "batch": "./batch.yaml", "params": {"prompt": "${item.prompt}"}},
@@ -392,8 +392,8 @@ class TestBatchItemFileRefs:
         """File refs in inline batch items (dict, not string) are discovered."""
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "ai.md").write_text("check for AI tells")
-        (prompts_dir / "cliche.md").write_text("check for cliches")
+        (prompts_dir / "ai.md").write_text("check for AI tells", encoding="utf-8")
+        (prompts_dir / "cliche.md").write_text("check for cliches", encoding="utf-8")
 
         ir = _make_ir([
             {
@@ -438,7 +438,7 @@ class TestBatchItemFileRefs:
 
     def test_non_resolvable_batch_item_keys_ignored(self, tmp_path: Path) -> None:
         """Keys not in FILE_RESOLVABLE_PARAMS are ignored even if value looks like a path."""
-        (tmp_path / "data.txt").write_text("data")
+        (tmp_path / "data.txt").write_text("data", encoding="utf-8")
         ir = _make_ir([
             {
                 "id": "step",
@@ -469,7 +469,7 @@ class TestCycleDetection:
             "edges": [],
         }
         self_path = tmp_path / "self.pflow.md"
-        self_path.write_text(ir_to_markdown(self_ir))
+        self_path.write_text(ir_to_markdown(self_ir), encoding="utf-8")
 
         # The parent IR also references self.pflow.md
         ir = _make_ir([
@@ -492,7 +492,7 @@ class TestCycleDetection:
             "edges": [],
         }
         a_path = tmp_path / "a.pflow.md"
-        a_path.write_text(ir_to_markdown(a_ir))
+        a_path.write_text(ir_to_markdown(a_ir), encoding="utf-8")
 
         # Workflow B references A
         b_ir = {
@@ -500,7 +500,7 @@ class TestCycleDetection:
             "edges": [],
         }
         b_path = tmp_path / "b.pflow.md"
-        b_path.write_text(ir_to_markdown(b_ir))
+        b_path.write_text(ir_to_markdown(b_ir), encoding="utf-8")
 
         # Start from A
         ir = _make_ir([
@@ -526,7 +526,7 @@ class TestCycleDetection:
             "edges": [],
         }
         self_path = tmp_path / "self.pflow.md"
-        self_path.write_text(ir_to_markdown(self_ir))
+        self_path.write_text(ir_to_markdown(self_ir), encoding="utf-8")
 
         ir = _make_ir([
             {"id": "outer", "type": "workflow", "params": {"workflow": "./self.pflow.md"}},
@@ -636,21 +636,21 @@ class TestMixedDependencies:
             "edges": [],
         }
         sub_path = tmp_path / "sub.pflow.md"
-        sub_path.write_text(ir_to_markdown(sub_ir))
+        sub_path.write_text(ir_to_markdown(sub_ir), encoding="utf-8")
 
         # Create prompt file
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "system.md").write_text("system prompt")
+        (prompts_dir / "system.md").write_text("system prompt", encoding="utf-8")
 
         # Create script file
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "process.sh").write_text("#!/bin/bash\necho done")
+        (scripts_dir / "process.sh").write_text("#!/bin/bash\necho done", encoding="utf-8")
 
         # Create batch config
         batch_content = "items:\n  - focus: quality\n    prompt: inline\n"
-        (tmp_path / "batch.yaml").write_text(batch_content)
+        (tmp_path / "batch.yaml").write_text(batch_content, encoding="utf-8")
 
         ir = _make_ir([
             {"id": "orchestrate", "type": "workflow", "params": {"workflow": "./sub.pflow.md"}},
@@ -743,7 +743,7 @@ class TestEdgeCases:
         prompts_dir = tmp_path / "prompts"
         workflows_dir.mkdir()
         prompts_dir.mkdir()
-        (prompts_dir / "shared.md").write_text("shared prompt")
+        (prompts_dir / "shared.md").write_text("shared prompt", encoding="utf-8")
 
         ir = _make_ir([
             {"id": "ask", "type": "llm", "params": {"prompt": "../prompts/shared.md"}},
@@ -756,8 +756,8 @@ class TestEdgeCases:
 
     def test_multiple_file_refs_in_same_node(self, tmp_path: Path) -> None:
         """A node with multiple file-referenced params has all discovered."""
-        (tmp_path / "prompt.md").write_text("prompt content")
-        (tmp_path / "stdin.txt").write_text("stdin content")
+        (tmp_path / "prompt.md").write_text("prompt content", encoding="utf-8")
+        (tmp_path / "stdin.txt").write_text("stdin content", encoding="utf-8")
 
         ir = _make_ir([
             {
@@ -784,7 +784,7 @@ class TestEdgeCases:
             "edges": [],
         }
         sub_path = tmp_path / "shared.pflow.md"
-        sub_path.write_text(ir_to_markdown(sub_ir))
+        sub_path.write_text(ir_to_markdown(sub_ir), encoding="utf-8")
 
         ir = _make_ir([
             {"id": "a", "type": "workflow", "params": {"workflow": "./shared.pflow.md"}},

--- a/tests/test_core/test_file_resolver.py
+++ b/tests/test_core/test_file_resolver.py
@@ -126,7 +126,7 @@ class TestResolveFileReferences:
         """Text file content substituted into prompt param."""
         prompt_dir = tmp_path / "prompts"
         prompt_dir.mkdir()
-        (prompt_dir / "system.md").write_text("You are helpful\n${concept.title}")
+        (prompt_dir / "system.md").write_text("You are helpful\n${concept.title}", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "params": {"prompt": "./prompts/system.md"}}])
         resolve_file_references(ir, tmp_path)
@@ -136,7 +136,7 @@ class TestResolveFileReferences:
 
     def test_yaml_param_resolution(self, tmp_path: Path) -> None:
         """YAML file content parsed into dict for output_schema param."""
-        (tmp_path / "schema.yaml").write_text("type: object\nproperties:\n  name:\n    type: string")
+        (tmp_path / "schema.yaml").write_text("type: object\nproperties:\n  name:\n    type: string", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "params": {"output_schema": "./schema.yaml"}}])
         resolve_file_references(ir, tmp_path)
@@ -148,7 +148,9 @@ class TestResolveFileReferences:
 
     def test_batch_string_resolution(self, tmp_path: Path) -> None:
         """Entire batch config loaded from external YAML file."""
-        (tmp_path / "batch.yaml").write_text("items:\n  - focus: ai\n    prompt: hello\nparallel: true")
+        (tmp_path / "batch.yaml").write_text(
+            "items:\n  - focus: ai\n    prompt: hello\nparallel: true", encoding="utf-8"
+        )
 
         ir = _make_ir([{"id": "n1", "type": "llm", "batch": "./batch.yaml", "params": {}}])
         resolve_file_references(ir, tmp_path)
@@ -165,7 +167,7 @@ class TestResolveFileReferences:
         Previously raised a YAML error because the `{` in `${candidate}` was read as a
         nested flow mapping — the same bug as inline params, now fixed at this surface too.
         """
-        (tmp_path / "batch.yaml").write_text("items:\n  - { contender: ${candidate} }\n")
+        (tmp_path / "batch.yaml").write_text("items:\n  - { contender: ${candidate} }\n", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "batch": "./batch.yaml", "params": {}}])
         resolve_file_references(ir, tmp_path)
@@ -176,8 +178,8 @@ class TestResolveFileReferences:
         """File references inside inline batch items resolved."""
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "ai.md").write_text("Check for AI tells")
-        (prompts_dir / "cliche.md").write_text("Check for cliches")
+        (prompts_dir / "ai.md").write_text("Check for AI tells", encoding="utf-8")
+        (prompts_dir / "cliche.md").write_text("Check for cliches", encoding="utf-8")
 
         ir = _make_ir([
             {
@@ -203,8 +205,8 @@ class TestResolveFileReferences:
 
     def test_multiple_nodes_resolved(self, tmp_path: Path) -> None:
         """File references in different nodes resolved independently."""
-        (tmp_path / "prompt.md").write_text("prompt content")
-        (tmp_path / "code.py").write_text("result: str = 'hello'")
+        (tmp_path / "prompt.md").write_text("prompt content", encoding="utf-8")
+        (tmp_path / "code.py").write_text("result: str = 'hello'", encoding="utf-8")
 
         ir = _make_ir([
             {"id": "n1", "type": "llm", "params": {"prompt": "./prompt.md"}},
@@ -253,7 +255,7 @@ class TestResolveFileReferences:
 
     def test_yaml_parse_error(self, tmp_path: Path) -> None:
         """Invalid YAML in batch file raises error."""
-        (tmp_path / "bad.yaml").write_text("items:\n  - [broken")
+        (tmp_path / "bad.yaml").write_text("items:\n  - [broken", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "batch": "./bad.yaml", "params": {}}])
 
@@ -264,7 +266,7 @@ class TestResolveFileReferences:
         """Paths resolve relative to base_dir, not CWD."""
         sub = tmp_path / "sub" / "prompts"
         sub.mkdir(parents=True)
-        (sub / "foo.md").write_text("from sub")
+        (sub / "foo.md").write_text("from sub", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "params": {"prompt": "./prompts/foo.md"}}])
         resolve_file_references(ir, tmp_path / "sub")
@@ -273,7 +275,7 @@ class TestResolveFileReferences:
 
     def test_provenance_tracking(self, tmp_path: Path) -> None:
         """_source_files records the original relative path."""
-        (tmp_path / "p.md").write_text("content")
+        (tmp_path / "p.md").write_text("content", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "params": {"prompt": "./p.md"}}])
         resolve_file_references(ir, tmp_path)
@@ -282,7 +284,7 @@ class TestResolveFileReferences:
 
     def test_idempotent(self, tmp_path: Path) -> None:
         """Running resolution twice doesn't break anything or corrupt provenance."""
-        (tmp_path / "p.md").write_text("content")
+        (tmp_path / "p.md").write_text("content", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "params": {"prompt": "./p.md"}}])
         resolve_file_references(ir, tmp_path)
@@ -303,7 +305,7 @@ class TestResolveFileReferences:
         prompts_dir = tmp_path / "prompts"
         workflows_dir.mkdir()
         prompts_dir.mkdir()
-        (prompts_dir / "shared.md").write_text("shared prompt content")
+        (prompts_dir / "shared.md").write_text("shared prompt content", encoding="utf-8")
 
         ir = _make_ir([{"id": "n1", "type": "llm", "params": {"prompt": "../prompts/shared.md"}}])
         resolve_file_references(ir, workflows_dir)
@@ -338,7 +340,7 @@ class TestResolveFileReferences:
 
     def test_mixed_file_and_inline_params(self, tmp_path: Path) -> None:
         """Some params are file refs, others are inline — both handled correctly."""
-        (tmp_path / "system.md").write_text("Be helpful")
+        (tmp_path / "system.md").write_text("Be helpful", encoding="utf-8")
 
         ir = _make_ir([
             {
@@ -359,7 +361,7 @@ class TestResolveFileReferences:
 
     def test_batch_items_mixed(self, tmp_path: Path) -> None:
         """Only file-reference values in batch items are resolved."""
-        (tmp_path / "p.md").write_text("file content")
+        (tmp_path / "p.md").write_text("file content", encoding="utf-8")
 
         ir = _make_ir([
             {
@@ -380,7 +382,7 @@ class TestResolveFileReferences:
 
     def test_batch_items_non_resolvable_param_untouched(self, tmp_path: Path) -> None:
         """Non-resolvable params in batch items are not resolved even if they look like paths."""
-        (tmp_path / "data.md").write_text("should not be inlined")
+        (tmp_path / "data.md").write_text("should not be inlined", encoding="utf-8")
 
         ir = _make_ir([
             {
@@ -400,7 +402,7 @@ class TestResolveFileReferences:
 
     def test_non_resolvable_param_untouched(self, tmp_path: Path) -> None:
         """Params not in FILE_RESOLVABLE_PARAMS are never resolved."""
-        (tmp_path / "target.md").write_text("should not be inlined")
+        (tmp_path / "target.md").write_text("should not be inlined", encoding="utf-8")
 
         ir = _make_ir([
             {

--- a/tests/test_core/test_file_resolver_integration.py
+++ b/tests/test_core/test_file_resolver_integration.py
@@ -22,7 +22,7 @@ class TestFileResolverWithParser:
         # Create external prompt file
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "system.md").write_text("You are a helpful assistant.\n\nAnalyze: ${input}")
+        (prompts_dir / "system.md").write_text("You are a helpful assistant.\n\nAnalyze: ${input}", encoding="utf-8")
 
         # Create workflow markdown
         workflow_md = """\
@@ -46,7 +46,7 @@ Analyze the input with LLM.
 - type: llm
 - prompt: ./prompts/system.md
 """
-        (tmp_path / "workflow.pflow.md").write_text(workflow_md)
+        (tmp_path / "workflow.pflow.md").write_text(workflow_md, encoding="utf-8")
 
         # Parse and resolve
         result = parse_markdown(workflow_md)
@@ -65,7 +65,7 @@ Analyze the input with LLM.
         """Parse a workflow with code file ref and resolve it."""
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "transform.py").write_text('result: str = "hello world"')
+        (scripts_dir / "transform.py").write_text('result: str = "hello world"', encoding="utf-8")
 
         workflow_md = """\
 # Test
@@ -87,7 +87,7 @@ Transform data.
 
     def test_parsed_workflow_with_command_file(self, tmp_path: Path) -> None:
         """Parse a workflow with command file ref and resolve it."""
-        (tmp_path / "run.sh").write_text("echo hello world")
+        (tmp_path / "run.sh").write_text("echo hello world", encoding="utf-8")
 
         workflow_md = """\
 # Test
@@ -109,7 +109,7 @@ Run a script.
 
     def test_ir_schema_validates_source_files(self, tmp_path: Path) -> None:
         """_source_files field passes IR schema validation."""
-        (tmp_path / "p.md").write_text("content")
+        (tmp_path / "p.md").write_text("content", encoding="utf-8")
 
         workflow_md = """\
 # Test
@@ -156,7 +156,7 @@ This is inline prompt content.
 
     def test_template_in_file_survives_resolution(self, tmp_path: Path) -> None:
         """Template variables in external files are preserved for later resolution."""
-        (tmp_path / "p.md").write_text("Hello ${upstream.response}, analyze ${concept.title}")
+        (tmp_path / "p.md").write_text("Hello ${upstream.response}, analyze ${concept.title}", encoding="utf-8")
 
         ir: dict[str, Any] = {
             "nodes": [{"id": "n1", "type": "llm", "params": {"prompt": "./p.md"}}],
@@ -172,8 +172,8 @@ This is inline prompt content.
         """External batch YAML file, then resolve file refs inside its items."""
         prompts = tmp_path / "prompts"
         prompts.mkdir()
-        (prompts / "reviewer-a.md").write_text("Review for quality A")
-        (prompts / "reviewer-b.md").write_text("Review for quality B")
+        (prompts / "reviewer-a.md").write_text("Review for quality A", encoding="utf-8")
+        (prompts / "reviewer-b.md").write_text("Review for quality B", encoding="utf-8")
 
         batch_yaml = """\
 items:
@@ -183,7 +183,7 @@ items:
     prompt: ./prompts/reviewer-b.md
 parallel: true
 """
-        (tmp_path / "reviews.yaml").write_text(batch_yaml)
+        (tmp_path / "reviews.yaml").write_text(batch_yaml, encoding="utf-8")
 
         ir: dict[str, Any] = {
             "nodes": [
@@ -220,7 +220,7 @@ parallel: true
         # Create external script that uses a template variable
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "run.sh").write_text('echo "hello from file"')
+        (scripts_dir / "run.sh").write_text('echo "hello from file"', encoding="utf-8")
 
         workflow_md = """\
 # Execution Path Test
@@ -235,7 +235,7 @@ Run external script.
 - command: ./scripts/run.sh
 """
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(workflow_md)
+        workflow_file.write_text(workflow_md, encoding="utf-8")
 
         # Compile through the same path the CLI uses
         from pflow.core.file_resolver import get_base_dir, resolve_file_references
@@ -267,7 +267,7 @@ Run external script.
         # External command file with template variable referencing an upstream node
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "process.sh").write_text('echo "Processing: ${fetch.stdout}"')
+        (scripts_dir / "process.sh").write_text('echo "Processing: ${fetch.stdout}"', encoding="utf-8")
 
         workflow_md = """\
 # Template Detection Test
@@ -292,7 +292,7 @@ Process the fetched data using an external command file.
 - command: ./scripts/process.sh
 """
         workflow_file = tmp_path / "workflow.pflow.md"
-        workflow_file.write_text(workflow_md)
+        workflow_file.write_text(workflow_md, encoding="utf-8")
 
         result = parse_markdown(workflow_md)
         ir = result.ir
@@ -322,7 +322,7 @@ Process the fetched data using an external command file.
         child_dir = tmp_path / "child"
         child_scripts = child_dir / "scripts"
         child_scripts.mkdir(parents=True)
-        (child_scripts / "greet.sh").write_text('echo "Hello ${name}"')
+        (child_scripts / "greet.sh").write_text('echo "Hello ${name}"', encoding="utf-8")
 
         child_md = """\
 # Child Workflow
@@ -346,7 +346,7 @@ Greet by name using external command.
 - command: ./scripts/greet.sh
 """
         child_file = child_dir / "child.pflow.md"
-        child_file.write_text(child_md)
+        child_file.write_text(child_md, encoding="utf-8")
 
         # Compile the child with _pflow_workflow_file set to its own location
         # (simulating what workflow_executor.py does)
@@ -406,7 +406,7 @@ class TestTemplateErrorSourceFileProvenance:
         # Create external prompt with a reference to a nonexistent node
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "bad.md").write_text("Hello ${nonexistent_node.output}")
+        (prompts_dir / "bad.md").write_text("Hello ${nonexistent_node.output}", encoding="utf-8")
 
         workflow_md = """\
 # Test

--- a/tests/test_core/test_prompt_cache_validation.py
+++ b/tests/test_core/test_prompt_cache_validation.py
@@ -513,10 +513,11 @@ def test_parser_to_validator_pipeline_emits_order_mismatch(tmp_path) -> None:
         "- type: llm\n"
         "- prompt_cache: [concept_brief, concept]\n"
         "- model: anthropic/claude-sonnet-4-5\n\n"
-        "```prompt\nPrompt body referencing ${concept} and ${concept_brief}.\n```\n"
+        "```prompt\nPrompt body referencing ${concept} and ${concept_brief}.\n```\n",
+        encoding="utf-8",
     )
 
-    ir = parse_markdown(workflow_path.read_text()).ir
+    ir = parse_markdown(workflow_path.read_text(encoding="utf-8")).ir
     ir.setdefault("ir_version", "0.1.0")
     diagnostics = WorkflowValidator.validate(ir, workflow_file=workflow_path)
 
@@ -562,7 +563,8 @@ def test_v6_subworkflow_invalid_on_non_llm_via_real_validator(tmp_path) -> None:
         "- type: shell\n"
         "- prompt_cache: [topic]\n"
         "- prewarm: true\n\n"
-        '```shell command\necho "${topic}"\n```\n'
+        '```shell command\necho "${topic}"\n```\n',
+        encoding="utf-8",
     )
     parent_path = tmp_path / "parent.pflow.md"
     parent_path.write_text(
@@ -575,11 +577,12 @@ def test_v6_subworkflow_invalid_on_non_llm_via_real_validator(tmp_path) -> None:
         "- type: workflow\n"
         f"- workflow: ./{child_path.name}\n"
         "- inputs:\n"
-        "    topic: ${topic}\n"
+        "    topic: ${topic}\n",
+        encoding="utf-8",
     )
 
     # Drive the standard WorkflowValidator path (mirrors `pflow validate-only`).
-    parent_ir = parse_markdown(parent_path.read_text()).ir
+    parent_ir = parse_markdown(parent_path.read_text(encoding="utf-8")).ir
     parent_ir.setdefault("ir_version", "0.1.0")
     diagnostics = WorkflowValidator.validate(parent_ir, workflow_file=parent_path)
 
@@ -841,7 +844,7 @@ def test_external_prompt_file_resolved_at_save_then_overlap_detected(tmp_path) -
     from pflow.core.workflow.save_service import save_workflow_with_options
 
     prompt_file = tmp_path / "creative-direction.prompt.md"
-    prompt_file.write_text("Use the concept ${concept} to draft a song.")
+    prompt_file.write_text("Use the concept ${concept} to draft a song.", encoding="utf-8")
 
     workflow_file = tmp_path / "song-creator.pflow.md"
     workflow_file.write_text(
@@ -855,13 +858,14 @@ def test_external_prompt_file_resolved_at_save_then_overlap_detected(tmp_path) -
         "- type: llm\n"
         "- prompt: ./creative-direction.prompt.md\n"
         "- prompt_cache: [concept]\n"
-        "- model: anthropic/claude-sonnet-4-5\n"
+        "- model: anthropic/claude-sonnet-4-5\n",
+        encoding="utf-8",
     )
 
     with pytest.raises(WorkflowValidationError) as excinfo:
         save_workflow_with_options(
             "song-creator-overlap-test",
-            workflow_file.read_text(),
+            workflow_file.read_text(encoding="utf-8"),
             source_path=workflow_file,
         )
     diagnostic_ids = {d.id for d in (excinfo.value.validation_errors or [])}
@@ -889,7 +893,7 @@ def test_cli_save_subprocess_with_overlap_exits_nonzero(tmp_path, uv_exe, prepar
     import subprocess
 
     prompt_file = tmp_path / "creative-direction.prompt.md"
-    prompt_file.write_text("Use the concept ${concept} to draft a song.")
+    prompt_file.write_text("Use the concept ${concept} to draft a song.", encoding="utf-8")
 
     workflow_file = tmp_path / "song-creator.pflow.md"
     workflow_file.write_text(
@@ -903,7 +907,8 @@ def test_cli_save_subprocess_with_overlap_exits_nonzero(tmp_path, uv_exe, prepar
         "- type: llm\n"
         "- prompt: ./creative-direction.prompt.md\n"
         "- prompt_cache: [concept]\n"
-        "- model: anthropic/claude-sonnet-4-5\n"
+        "- model: anthropic/claude-sonnet-4-5\n",
+        encoding="utf-8",
     )
 
     completed = subprocess.run(  # noqa: S603 — fixture-controlled args, mirrors the established subprocess CLI test pattern
@@ -919,6 +924,7 @@ def test_cli_save_subprocess_with_overlap_exits_nonzero(tmp_path, uv_exe, prepar
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=prepared_subprocess_env,
         timeout=60,
     )
@@ -1293,7 +1299,8 @@ def test_thinking_temperature_mismatch_pflow_save_subprocess_exits_nonzero(
         "- model: anthropic/claude-haiku-4-5\n"
         "- reasoning_effort: low\n"
         "- temperature: 0.3\n"
-        "- prompt: ${question}\n"
+        "- prompt: ${question}\n",
+        encoding="utf-8",
     )
 
     completed = subprocess.run(  # noqa: S603 — fixture-controlled args, mirrors the established subprocess CLI test pattern
@@ -1309,6 +1316,7 @@ def test_thinking_temperature_mismatch_pflow_save_subprocess_exits_nonzero(
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=prepared_subprocess_env,
         timeout=60,
     )

--- a/tests/test_core/test_react_flow_contract_fixtures.py
+++ b/tests/test_core/test_react_flow_contract_fixtures.py
@@ -25,7 +25,7 @@ _REGEN = "uv run python -m tests.fixtures.react_flow_contracts._generate"
 def test_committed_contract_fixture_matches_live_renderer(name: str) -> None:
     path = CONTRACT_DIR / f"{name}.json"
     assert path.exists(), f"missing committed fixture {path} — regenerate: {_REGEN}"
-    committed = json.loads(path.read_text())
+    committed = json.loads(path.read_text(encoding="utf-8"))
     live = render_contract(name)
     assert committed == live, (
         f"web/src/test/fixtures/contracts/{name}.json no longer matches the live renderer "

--- a/tests/test_core/test_skill_service.py
+++ b/tests/test_core/test_skill_service.py
@@ -660,13 +660,13 @@ class TestFindPflowSkills:
         non_pflow_dir = project_dir / ".claude" / "skills" / "other-skill"
         non_pflow_dir.mkdir(parents=True)
         non_pflow_file = tmp_path / "other.md"
-        non_pflow_file.write_text("# Other Skill")
+        non_pflow_file.write_text("# Other Skill", encoding="utf-8")
         (non_pflow_dir / "SKILL.md").symlink_to(non_pflow_file)
 
         # Create regular file (not symlink)
         regular_dir = project_dir / ".claude" / "skills" / "regular"
         regular_dir.mkdir(parents=True)
-        (regular_dir / "SKILL.md").write_text("# Regular Skill")
+        (regular_dir / "SKILL.md").write_text("# Regular Skill", encoding="utf-8")
 
         # Find skills
         skills = find_pflow_skills(

--- a/tests/test_core/test_stdin_no_hang.py
+++ b/tests/test_core/test_stdin_no_hang.py
@@ -193,7 +193,7 @@ def test_stdin_no_hang_integration(tmp_path, uv_exe):
     pflow_dir = tmp_path / ".pflow"
     pflow_dir.mkdir(exist_ok=True)
     registry_data = {"nodes": {"shell": {"module": "pflow.nodes.shell.shell", "class_name": "ShellNode"}}}
-    (pflow_dir / "registry.json").write_text(json.dumps(registry_data))
+    (pflow_dir / "registry.json").write_text(json.dumps(registry_data), encoding="utf-8")
 
     try:
         result = subprocess.run(
@@ -202,6 +202,7 @@ def test_stdin_no_hang_integration(tmp_path, uv_exe):
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,  # No stdin data — the scenario that triggered the original hang
             text=True,
+            encoding="utf-8",
             env=env,
             timeout=5,
         )

--- a/tests/test_core/test_trace_io.py
+++ b/tests/test_core/test_trace_io.py
@@ -259,7 +259,7 @@ def test_inputs_routes_to_meta_line_not_trailer() -> None:
 def test_load_trace_file_round_trips_jsonl_from_disk(tmp_path: Path) -> None:
     trace = _nested_trace_with_all_shapes(_large_text())
     path = tmp_path / "workflow-trace-x.json"
-    path.write_text("\n".join(json.dumps(line) for line in flatten_trace_to_lines(trace)) + "\n")
+    path.write_text("\n".join(json.dumps(line) for line in flatten_trace_to_lines(trace)) + "\n", encoding="utf-8")
     assert load_trace_file(path) == trace
 
 
@@ -309,7 +309,7 @@ def test_load_trace_file_rejects_legacy_single_object_format(tmp_path: Path) -> 
     # silently load. (The other two reader paths are covered by the report/explicit skip tests.)
     old = {"format_version": "2.5.0", "workflow_name": "old", "nodes": [{"node_id": "a", "node_output": {"r": "x"}}]}
     path = tmp_path / "workflow-trace-old.json"
-    path.write_text(json.dumps(old, indent=2))
+    path.write_text(json.dumps(old, indent=2), encoding="utf-8")
     with pytest.raises(json.JSONDecodeError):
         load_trace_file(path)
 
@@ -332,7 +332,7 @@ def test_load_trace_file_raises_jsondecodeerror_on_corrupt_jsonl(tmp_path: Path)
     meta = json.dumps({"kind": "meta", "pflow_trace": TRACE_JSONL_MARKER, "execution_id": "r"})
     good = json.dumps({"kind": "run.complete", "final_status": "success"})
     path = tmp_path / "workflow-trace-corrupt.json"
-    path.write_text(f"{meta}\n{{ not valid json\n{good}\n")
+    path.write_text(f"{meta}\n{{ not valid json\n{good}\n", encoding="utf-8")
     with pytest.raises(json.JSONDecodeError):
         load_trace_file(path)
 
@@ -445,7 +445,7 @@ def test_load_trace_file_tolerates_truncated_final_line(tmp_path: Path) -> None:
     good = json.dumps(_event_line("a", eid=0, parent_id=None))
     truncated = '{"kind": "event", "id": 1, "seq": 1, "parent_id": null, "node_i'  # half-written, no newline
     path = tmp_path / "workflow-trace-truncated.json"
-    path.write_text(f"{meta}\n{good}\n{truncated}")
+    path.write_text(f"{meta}\n{good}\n{truncated}", encoding="utf-8")
     trace = load_trace_file(path)
     assert trace["final_status"] == "incomplete"
     assert [n["node_id"] for n in trace["nodes"]] == ["a"], "the well-formed prefix is recovered"
@@ -475,6 +475,6 @@ def test_load_trace_file_rejects_malformed_line_after_run_complete(tmp_path: Pat
     complete = json.dumps({"kind": "run.complete", "final_status": "success"})
     garbage = '{"kind": "event", "id": 1, "seq": 1, "parent_i'  # truncated final line
     path = tmp_path / "workflow-trace-after-complete.json"
-    path.write_text(f"{meta}\n{complete}\n{garbage}")
+    path.write_text(f"{meta}\n{complete}\n{garbage}", encoding="utf-8")
     with pytest.raises(json.JSONDecodeError):
         load_trace_file(path)

--- a/tests/test_core/test_trace_report.py
+++ b/tests/test_core/test_trace_report.py
@@ -110,7 +110,7 @@ class TestGenerateReport:
         # return None — degrade, never crash. This is the generate_report reader-path proof; it is a
         # DISTINCT path from the format_version rejection above (that one loads, then rejects by version).
         legacy = tmp_path / "legacy-single-object.json"
-        legacy.write_text(json.dumps(_make_trace(nodes=[_make_event()])))
+        legacy.write_text(json.dumps(_make_trace(nodes=[_make_event()])), encoding="utf-8")
         assert generate_report(legacy, str(tmp_path / "report")) is None
 
     def test_creates_report_directory(self, tmp_path: Path) -> None:
@@ -123,7 +123,7 @@ class TestGenerateReport:
         assert report_dir is not None
         assert report_dir.is_dir()
         assert (report_dir / "summary.md").exists()
-        marker = json.loads((report_dir / ".pflow-report.json").read_text())
+        marker = json.loads((report_dir / ".pflow-report.json").read_text(encoding="utf-8"))
         assert marker["format"] == "pflow.report"
         assert marker["format_version"] == 1
         assert marker["workflow_name"] == "test-workflow"
@@ -202,7 +202,7 @@ class TestGenerateReport:
         report_dir = generate_report(trace_file, str(tmp_path / "report"))
 
         assert report_dir is not None
-        markdown = (report_dir / "01-fail-batch.md").read_text()
+        markdown = (report_dir / "01-fail-batch.md").read_text(encoding="utf-8")
         assert "## Batch Errors" in markdown
         assert "[0] RuntimeError: forced batch failure for oversized-item" in markdown
         assert "label='oversized-item'; payload=<str" in markdown
@@ -246,7 +246,7 @@ class TestGenerateReport:
         report_dir = generate_report(trace_file, str(tmp_path / "report"))
 
         assert report_dir is not None
-        markdown = (report_dir / "01-ok-batch.md").read_text()
+        markdown = (report_dir / "01-ok-batch.md").read_text(encoding="utf-8")
         assert "## Batch Errors" not in markdown
         assert "## Output" in markdown
         # The regression catcher: this key is suppressed if `and errors` is removed.
@@ -464,29 +464,29 @@ class TestGenerateReport:
         report_path = tmp_path / "report"
         report_path.mkdir()
         existing = report_path / "notes.md"
-        existing.write_text("do not replace")
+        existing.write_text("do not replace", encoding="utf-8")
         trace_file = tmp_path / "trace.json"
         write_trace_jsonl(trace_file, _make_trace(nodes=[_make_event()]))
 
         with pytest.raises(ReportGenerationError, match="without \\.pflow-report\\.json"):
             generate_report(trace_file, str(report_path))
 
-        assert existing.read_text() == "do not replace"
+        assert existing.read_text(encoding="utf-8") == "do not replace"
         assert not (report_path / "summary.md").exists()
 
     def test_explicit_invalid_marker_is_refused(self, tmp_path: Path) -> None:
         report_path = tmp_path / "report"
         report_path.mkdir()
-        (report_path / ".pflow-report.json").write_text("{not-json")
+        (report_path / ".pflow-report.json").write_text("{not-json", encoding="utf-8")
         existing = report_path / "old.md"
-        existing.write_text("old")
+        existing.write_text("old", encoding="utf-8")
         trace_file = tmp_path / "trace.json"
         write_trace_jsonl(trace_file, _make_trace(nodes=[_make_event()]))
 
         with pytest.raises(ReportGenerationError, match="invalid \\.pflow-report\\.json"):
             generate_report(trace_file, str(report_path))
 
-        assert existing.read_text() == "old"
+        assert existing.read_text(encoding="utf-8") == "old"
         assert not (report_path / "summary.md").exists()
 
     def test_auto_unmarked_existing_directory_is_replaced_for_migration(
@@ -497,7 +497,7 @@ class TestGenerateReport:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         report_path = tmp_path / ".pflow" / "reports" / "test-workflow"
         report_path.mkdir(parents=True)
-        (report_path / "stale.md").write_text("stale")
+        (report_path / "stale.md").write_text("stale", encoding="utf-8")
         trace_file = tmp_path / "trace.json"
         write_trace_jsonl(trace_file, _make_trace(nodes=[_make_event(node_id="fresh")]))
 
@@ -510,7 +510,7 @@ class TestGenerateReport:
 
     def test_existing_target_file_is_refused(self, tmp_path: Path) -> None:
         report_path = tmp_path / "report"
-        report_path.write_text("not a directory")
+        report_path.write_text("not a directory", encoding="utf-8")
 
         with pytest.raises(ReportGenerationError, match="not a directory"):
             validate_report_output_dir(report_path, allow_unmarked_existing=False)
@@ -542,7 +542,7 @@ class TestGenerateReport:
         write_trace_jsonl(second_trace_file, _make_trace(nodes=[_make_event(node_id="new")]))
 
         generate_report(first_trace_file, str(report_path))
-        old_summary = (report_path / "summary.md").read_text()
+        old_summary = (report_path / "summary.md").read_text(encoding="utf-8")
 
         def fail_write_node_files(
             _events: list[dict[str, Any]],
@@ -557,7 +557,7 @@ class TestGenerateReport:
         with pytest.raises(RuntimeError, match="render exploded"):
             generate_report(second_trace_file, str(report_path))
 
-        assert (report_path / "summary.md").read_text() == old_summary
+        assert (report_path / "summary.md").read_text(encoding="utf-8") == old_summary
         assert (report_path / "01-old.md").exists()
         assert not (report_path / "01-new.md").exists()
         assert not list(tmp_path.glob(".report.tmp-*"))
@@ -570,10 +570,10 @@ class TestGenerateReport:
         report_path = tmp_path / "report"
         report_path.mkdir()
         old_file = report_path / "old.md"
-        old_file.write_text("old")
+        old_file.write_text("old", encoding="utf-8")
         temp_path = tmp_path / ".report.tmp-test"
         temp_path.mkdir()
-        (temp_path / "new.md").write_text("new")
+        (temp_path / "new.md").write_text("new", encoding="utf-8")
 
         original_rename = Path.rename
 
@@ -588,7 +588,7 @@ class TestGenerateReport:
             _replace_report_dir(report_path, temp_path)
 
         assert report_path.is_dir()
-        assert (report_path / "old.md").read_text() == "old"
+        assert (report_path / "old.md").read_text(encoding="utf-8") == "old"
         assert not (report_path / "new.md").exists()
         assert temp_path.exists()
 

--- a/tests/test_core/test_workflow_manager.py
+++ b/tests/test_core/test_workflow_manager.py
@@ -295,7 +295,7 @@ class TestWorkflowManager:
         # Directory with wrong filename
         bad_dir = workflow_manager.workflows_dir / "wrong-name"
         bad_dir.mkdir()
-        (bad_dir / "other.pflow.md").write_text("# Wrong")
+        (bad_dir / "other.pflow.md").write_text("# Wrong", encoding="utf-8")
 
         names = workflow_manager.list_names()
 
@@ -305,7 +305,7 @@ class TestWorkflowManager:
         """Test list_names includes workflows that have entry points but fail to parse."""
         corrupt_dir = workflow_manager.workflows_dir / "corrupt"
         corrupt_dir.mkdir()
-        (corrupt_dir / "corrupt.pflow.md").write_text("not valid")
+        (corrupt_dir / "corrupt.pflow.md").write_text("not valid", encoding="utf-8")
 
         names = workflow_manager.list_names()
 
@@ -481,7 +481,9 @@ class TestWorkflowManager:
         corrupted_dir = workflow_manager.workflows_dir / "corrupted"
         corrupted_dir.mkdir()
         corrupted_file = corrupted_dir / "corrupted.pflow.md"
-        corrupted_file.write_text("# Corrupted\n\n## Steps\n\n### node1\n\nthis is not valid markdown workflow")
+        corrupted_file.write_text(
+            "# Corrupted\n\n## Steps\n\n### node1\n\nthis is not valid markdown workflow", encoding="utf-8"
+        )
 
         # list_all should skip it silently (logged at INFO)
         with caplog.at_level(logging.INFO, logger="pflow.core.workflow.manager"):

--- a/tests/test_core/test_workflow_validator.py
+++ b/tests/test_core/test_workflow_validator.py
@@ -319,7 +319,7 @@ Do something.
 - command: echo hello
 """
         child_file = tmp_path / "child.pflow.md"
-        child_file.write_text(child_content)
+        child_file.write_text(child_content, encoding="utf-8")
 
         # Parent workflow references child and uses its output
         workflow_ir = {

--- a/tests/test_core/test_workflow_validator_llm_model.py
+++ b/tests/test_core/test_workflow_validator_llm_model.py
@@ -420,7 +420,8 @@ def test_sub_workflow_bad_model_surfaces_via_child_provenance(tmp_path: Path, mo
         "Calls llm.\n\n"
         "- type: llm\n"
         "- model: openai/gpt-4o\n"
-        "- prompt: hello\n"
+        "- prompt: hello\n",
+        encoding="utf-8",
     )
 
     parent_ir = {

--- a/tests/test_docs/test_agent_references.py
+++ b/tests/test_docs/test_agent_references.py
@@ -78,13 +78,13 @@ def _source_corpus() -> str:
     """All Python source under src/ and tests/, concatenated for substring checks."""
     parts = []
     for root in (REPO_ROOT / "src", REPO_ROOT / "tests"):
-        parts.extend(p.read_text(errors="ignore") for p in root.rglob("*.py"))
+        parts.extend(p.read_text(encoding="utf-8", errors="ignore") for p in root.rglob("*.py"))
     return "\n".join(parts)
 
 
 def _iter_tokens(pattern: re.Pattern[str]):
     for agent_file in sorted(AGENTS_DIR.glob("*.md")):
-        for token in sorted(set(pattern.findall(agent_file.read_text()))):
+        for token in sorted(set(pattern.findall(agent_file.read_text(encoding="utf-8")))):
             yield agent_file.name, token
 
 

--- a/tests/test_encoding_warning_net.py
+++ b/tests/test_encoding_warning_net.py
@@ -1,8 +1,8 @@
 """Canary for the EncodingWarning regression net (Task 116).
 
 The net is a chain with an inert-by-default failure mode: the pyproject
-`filterwarnings = ["error::EncodingWarning:pflow.*"]` entry promotes
-encoding-less IO in pflow's own source to test failures, but Python only
+`filterwarnings = ["error::EncodingWarning", ...]` entry promotes
+encoding-less IO anywhere in the repo to test failures, but Python only
 EMITS EncodingWarning when the interpreter starts with
 PYTHONWARNDEFAULTENCODING=1 / -X warn_default_encoding (PEP 597). Delete the
 env var from the Makefile or tox, or "simplify" the filter line, and the net
@@ -60,14 +60,28 @@ def test_encoding_regression_in_pflow_source_fails_loudly(tmp_path):
 
 
 @encoding_warning_inactive
-def test_net_stays_scoped_to_pflow_modules(tmp_path):
-    """The same call attributed to a non-pflow module must stay an ordinary
-    warning. Red here means the filter was widened back to a blanket
-    `error::EncodingWarning` — the exact regression documented as Bug 4 in the
-    Task 116 progress log (third-party and tmp_path-fixture warnings become
-    hundreds of unrelated hard failures)."""
+def test_net_covers_test_code_too(tmp_path):
+    """An encoding-less open() attributed to a test module must also be a hard
+    error. The net was widened from `pflow.*` to a blanket filter once every
+    test call site carried an explicit encoding — red here means the filter
+    was narrowed back and the test suite can silently regrow encoding-less IO
+    that ruff PLW1514 cannot see (fdopen, untyped fixture-derived paths)."""
     target = tmp_path / "data.txt"
     target.write_text("x", encoding="utf-8")
 
-    # Must not raise; the emitted warning lands in the pytest summary residue.
-    _open_without_encoding_as("tests._encoding_net_canary", target)
+    with pytest.raises(EncodingWarning):
+        _open_without_encoding_as("tests._encoding_net_canary", target)
+
+
+@encoding_warning_inactive
+def test_third_party_litellm_stays_ignored(tmp_path):
+    """litellm's own encoding-less opens are not pflow's bug to fail on.
+    Red here means the `ignore::EncodingWarning:litellm.*` entry was dropped —
+    the blanket error filter would then detonate on litellm import-time IO
+    (json_loader.py, endpoint_factory.py) in tests that touch LLM paths."""
+    target = tmp_path / "data.txt"
+    target.write_text("x", encoding="utf-8")
+
+    # Must not raise and must not surface as a warning — the ignore filter
+    # swallows it entirely.
+    _open_without_encoding_as("litellm._encoding_net_canary", target)

--- a/tests/test_execution/test_executor_service.py
+++ b/tests/test_execution/test_executor_service.py
@@ -15,7 +15,7 @@ from tests.shared.markdown_utils import ir_to_markdown
 
 def _read_frontmatter(workflow_file):
     """Read and parse YAML frontmatter from a .pflow.md file."""
-    content = workflow_file.read_text()
+    content = workflow_file.read_text(encoding="utf-8")
     parts = content.split("---", 2)
     assert len(parts) >= 3, f"Expected frontmatter in {workflow_file}"
     return yaml.safe_load(parts[1])

--- a/tests/test_execution/test_runner.py
+++ b/tests/test_execution/test_runner.py
@@ -1412,7 +1412,7 @@ LLM node using a routed-Anthropic model identifier.
 - prompt: "respond ok ${q}"
 """
         workflow_file = tmp_path / "test.pflow.md"
-        workflow_file.write_text(workflow_md)
+        workflow_file.write_text(workflow_md, encoding="utf-8")
 
         runner = WorkflowRunner()
         with patch("pflow.nodes.llm.llm._count_text_tokens", return_value=10_000):

--- a/tests/test_execution/test_workflow_resolver_contract.py
+++ b/tests/test_execution/test_workflow_resolver_contract.py
@@ -60,7 +60,7 @@ def test_resolve_workflow_returns_fully_file_resolved_ir(tmp_path: Path) -> None
     # Build a minimal workflow with an external prompt file reference.
     prompt_file = tmp_path / "creative.prompt.md"
     prompt_content = "Write a creative response to: ${user_input}\n\nBe specific."
-    prompt_file.write_text(prompt_content)
+    prompt_file.write_text(prompt_content, encoding="utf-8")
 
     workflow_path = tmp_path / "test.pflow.md"
     workflow_path.write_text(
@@ -85,7 +85,8 @@ Call the LLM with the external prompt file.
 
 - type: llm
 - prompt: ./creative.prompt.md
-"""
+""",
+        encoding="utf-8",
     )
 
     resolved = resolve_workflow(str(workflow_path))
@@ -182,7 +183,8 @@ Calls an LLM with a prompt file that doesn't exist on disk.
 
 - type: llm
 - prompt: ./missing.prompt.md
-"""
+""",
+        encoding="utf-8",
     )
 
     with pytest.raises(CompilationError, match=r"file_resolution|missing"):

--- a/tests/test_integration/test_cache_opt_out_e2e.py
+++ b/tests/test_integration/test_cache_opt_out_e2e.py
@@ -33,7 +33,8 @@ Read external state that changes between runs.
 ```shell command
 echo current-state
 ```
-"""
+""",
+            encoding="utf-8",
         )
 
         runner = WorkflowRunner()

--- a/tests/test_integration/test_e2e_workflow.py
+++ b/tests/test_integration/test_e2e_workflow.py
@@ -445,5 +445,5 @@ def test_tilde_path_with_directory_creation(tmp_path, monkeypatch):
         assert stories_dir.is_dir(), f"Directory not created at {stories_dir}"
 
         # Verify content
-        content = expected_path.read_text()
+        content = expected_path.read_text(encoding="utf-8")
         assert content == "Once upon a time, there was a clever cat..."

--- a/tests/test_integration/test_failed_node_invariant.py
+++ b/tests/test_integration/test_failed_node_invariant.py
@@ -1850,7 +1850,7 @@ def test_subworkflow_failure_trace_json_has_no_diagnostic_repr(tmp_path):
     assert result.trace is not None
     with patch("pathlib.Path.home", return_value=tmp_path):
         trace_path = result.trace.save_to_file()
-    raw = trace_path.read_text()
+    raw = trace_path.read_text(encoding="utf-8")
     assert "_pflow_child_failure" in raw, "structured child failure must reach the saved trace"
     assert "Diagnostic(" not in raw, "no Diagnostic object may be stringified into the trace"
 

--- a/tests/test_integration/test_loop_config.py
+++ b/tests/test_integration/test_loop_config.py
@@ -1442,7 +1442,7 @@ Run the inner take-step until the queue drains.
     assert r.shared_after["loop-take"]["remaining"] == 0
     assert r.shared_after["loop-take"]["loop_stopped"] == "condition"
     # Queue fully drained — proves `read` re-executed each iteration.
-    assert [ln for ln in state.read_text().splitlines() if ln.strip()] == []
+    assert [ln for ln in state.read_text(encoding="utf-8").splitlines() if ln.strip()] == []
     assert "__loop_active__" not in r.shared_after  # guard cleared after loop
 
 
@@ -1509,9 +1509,9 @@ Remove one line from the outer queue file; report the remaining count.
 import pathlib
 queue_file: str
 _p = pathlib.Path(queue_file)
-_lines = [ln for ln in _p.read_text().splitlines() if ln.strip()]
+_lines = [ln for ln in _p.read_text(encoding="utf-8").splitlines() if ln.strip()]
 _rest = _lines[1:]
-_p.write_text("\\n".join(_rest) + ("\\n" if _rest else ""))
+_p.write_text("\\n".join(_rest) + ("\\n" if _rest else ""), encoding="utf-8")
 result: dict = {"remaining": len(_rest)}
 ```
 """,
@@ -1550,7 +1550,7 @@ until the outer queue drains.
     assert sa["run-inner"]["loop_stopped"] == "condition"
     # All three queue lines removed → the outer actually looped (not single-passed)
     # and the inner re-ran each outer iteration.
-    assert [ln for ln in state.read_text().splitlines() if ln.strip()] == []
+    assert [ln for ln in state.read_text(encoding="utf-8").splitlines() if ln.strip()] == []
     # Neither loop marker leaks past the depth-2 nest.
     assert "__iteration__" not in sa
     assert "__loop_active__" not in sa

--- a/tests/test_integration/test_metrics_integration.py
+++ b/tests/test_integration/test_metrics_integration.py
@@ -100,7 +100,7 @@ def temp_registry(temp_home):
         },
     }
 
-    registry_path.write_text(json.dumps(registry_data, indent=2))
+    registry_path.write_text(json.dumps(registry_data, indent=2), encoding="utf-8")
 
     # Return the registry path
     yield registry_path

--- a/tests/test_integration/test_plan_to_code_harness.py
+++ b/tests/test_integration/test_plan_to_code_harness.py
@@ -91,7 +91,7 @@ Stand-in for the git branch-setup shell node.
 
 ```python code
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write("branch-setup\\n")
 result: str = "ok"
 ```
@@ -107,7 +107,7 @@ Stand-in for the plan-hardening agent (read-only here).
 
 ```python code
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write("plan-review-fix\\n")
 result: str = "ok"
 ```
@@ -131,7 +131,7 @@ elif scenario == "cap":
     segments = [{"phases": ["P0"], "sim": "ok"}]
 else:
     segments = [{"phases": ["P0", "P1"], "sim": "ok"}, {"phases": ["P2"], "sim": "ok"}]
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write(f"breakdown:{len(segments)}segments\\n")
 result: dict = {"segments": segments}
 ```
@@ -171,7 +171,7 @@ index: int
 sim: str
 log: str
 commits = 0 if sim == "fail" else 2
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write(f"implement:seg{index}:commits{commits}\\n")
 result: int = commits
 ```
@@ -194,7 +194,7 @@ index: int
 scenario: str
 log: str
 ok = not (scenario == "seg-gate-fail" and index == 0)
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write(f"seg-gate:seg{index}:ok{ok}\\n")
 result: dict = {"ok": ok}
 ```
@@ -254,7 +254,7 @@ is the 1-based round number; the backward edge lives in the loop block, not the 
 round: int
 scenario: str
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write(f"review:round{round}\\n")
 keep = scenario == "cap"
 result: dict = {"round": round, "continue": keep}
@@ -271,7 +271,7 @@ Stand-in simplicity pass (fix-capable; runs after review, before verify).
 
 ```python code
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write("simplify\\n")
 result: str = "ok"
 ```
@@ -287,7 +287,7 @@ Stand-in adversarial verify (last code-touching stage).
 
 ```python code
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write("verify\\n")
 result: str = "ok"
 ```
@@ -307,7 +307,7 @@ whole result after verify. `ok` is false only in the `final-gate-fail` scenario.
 scenario: str
 log: str
 ok = scenario != "final-gate-fail"
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write(f"final-gate:ok{ok}\\n")
 result: dict = {"ok": ok}
 ```
@@ -344,7 +344,7 @@ Stand-in deterministic push (shell node in the real harness; immune to claude-co
 
 ```python code
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write("push\\n")
 result: str = "ok"
 ```
@@ -359,7 +359,7 @@ Stand-in ship.
 
 ```python code
 log: str
-with open(log, "a") as f:
+with open(log, "a", encoding="utf-8") as f:
     f.write("ship\\n")
 result: str = "shipped"
 ```

--- a/tests/test_integration/test_settings_filtering.py
+++ b/tests/test_integration/test_settings_filtering.py
@@ -62,7 +62,7 @@ def test_denied_nodes_not_in_llm_context(tmp_path):
             },
         },
     }
-    registry_path.write_text(json.dumps(registry_data))
+    registry_path.write_text(json.dumps(registry_data), encoding="utf-8")
 
     # Create settings that deny http
     settings_path = tmp_path / "settings.json"
@@ -70,7 +70,7 @@ def test_denied_nodes_not_in_llm_context(tmp_path):
         "version": "1.0.0",
         "registry": {"nodes": {"allow": ["*"], "deny": ["http", "pflow.nodes.http.*"]}},
     }
-    settings_path.write_text(json.dumps(settings_data))
+    settings_path.write_text(json.dumps(settings_data), encoding="utf-8")
 
     # Wire up registry with custom settings
     sm = SettingsManager(settings_path=settings_path)
@@ -114,7 +114,7 @@ def test_deny_rules_filter_nodes_from_registry(tmp_path):
             "read-file": {"module": "pflow.nodes.file.read_file", "class_name": "ReadFileNode", "type": "core"},
         },
     }
-    registry_path.write_text(json.dumps(registry_data))
+    registry_path.write_text(json.dumps(registry_data), encoding="utf-8")
 
     # Test 1: With restrictive deny rules, nodes are filtered out
     restrictive_settings = {
@@ -124,7 +124,7 @@ def test_deny_rules_filter_nodes_from_registry(tmp_path):
         },
     }
     restrictive_settings_path = tmp_path / "restrictive_settings.json"
-    restrictive_settings_path.write_text(json.dumps(restrictive_settings))
+    restrictive_settings_path.write_text(json.dumps(restrictive_settings), encoding="utf-8")
 
     sm_restrictive = SettingsManager(restrictive_settings_path)
     registry = Registry(registry_path=registry_path)
@@ -144,7 +144,7 @@ def test_deny_rules_filter_nodes_from_registry(tmp_path):
         },
     }
     permissive_settings_path = tmp_path / "permissive_settings.json"
-    permissive_settings_path.write_text(json.dumps(permissive_settings))
+    permissive_settings_path.write_text(json.dumps(permissive_settings), encoding="utf-8")
 
     sm_permissive = SettingsManager(permissive_settings_path)
     registry2 = Registry(registry_path=registry_path)

--- a/tests/test_integration/test_task153_extras_stderr_agent_ux.py
+++ b/tests/test_integration/test_task153_extras_stderr_agent_ux.py
@@ -110,14 +110,15 @@ class TestExtrasDiagnosticStderrAgentUX:
         Mutation-verify: if any of the four stderr markers drops out, this
         test fails and the agent-UX regression is caught in CI.
         """
-        (tmp_path / "child.pflow.md").write_text(CHILD_PFLOW_MD)
+        (tmp_path / "child.pflow.md").write_text(CHILD_PFLOW_MD, encoding="utf-8")
         parent = tmp_path / "parent.pflow.md"
-        parent.write_text(PARENT_WITH_TYPO)
+        parent.write_text(PARENT_WITH_TYPO, encoding="utf-8")
 
         completed = subprocess.run(  # noqa: S603
             [sys.executable, "-m", "pflow.cli", str(parent)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=15,
             shell=False,
             cwd=str(tmp_path),

--- a/tests/test_integration/test_unused_inputs.py
+++ b/tests/test_integration/test_unused_inputs.py
@@ -250,8 +250,8 @@ def test_no_false_positive_for_input_used_in_batch_prompt_files(tmp_path: Path) 
     validation, making template variables inside prompt files invisible.
     """
     # 1. Create external prompt files that reference the sub-workflow input
-    (tmp_path / "prompt-a.prompt.md").write_text("Analyze emotionally:\n\n${content}")
-    (tmp_path / "prompt-b.prompt.md").write_text("Analyze factually:\n\n${content}")
+    (tmp_path / "prompt-a.prompt.md").write_text("Analyze emotionally:\n\n${content}", encoding="utf-8")
+    (tmp_path / "prompt-b.prompt.md").write_text("Analyze factually:\n\n${content}", encoding="utf-8")
 
     # 2. Sub-workflow: declares 'content' input, uses it via batch prompt files
     sub_workflow_ir = {
@@ -306,7 +306,7 @@ def test_no_false_positive_for_input_used_in_batch_prompt_files(tmp_path: Path) 
     # 4. Validate the parent workflow (same pipeline as production — registry included
     #    so Step 7 enforcement runs, matching the production CLI/MCP paths).
     parent_path = tmp_path / "parent-workflow.pflow.md"
-    content = parent_path.read_text()
+    content = parent_path.read_text(encoding="utf-8")
     result = parse_markdown(content)
     ir = result.ir
     normalize_ir(ir)
@@ -337,7 +337,7 @@ def test_genuinely_unused_input_still_caught_alongside_prompt_file_inputs(tmp_pa
     for sub-workflows with file references.
     """
     # Prompt file uses ${content} but NOT ${debug_mode}
-    (tmp_path / "prompt.prompt.md").write_text("Analyze:\n\n${content}")
+    (tmp_path / "prompt.prompt.md").write_text("Analyze:\n\n${content}", encoding="utf-8")
 
     sub_workflow_ir = {
         "inputs": {
@@ -389,7 +389,7 @@ def test_genuinely_unused_input_still_caught_alongside_prompt_file_inputs(tmp_pa
     write_workflow_file(parent_workflow_ir, tmp_path / "parent.pflow.md", title="Parent Workflow")
 
     parent_path = tmp_path / "parent.pflow.md"
-    result = parse_markdown(parent_path.read_text())
+    result = parse_markdown(parent_path.read_text(encoding="utf-8"))
     ir = result.ir
     normalize_ir(ir)
     resolve_file_references(ir, tmp_path)
@@ -471,7 +471,7 @@ def test_missing_prompt_file_in_sub_workflow_reports_validation_error(tmp_path: 
 
     # 3. Validate the parent workflow
     parent_path = tmp_path / "parent-workflow.pflow.md"
-    content = parent_path.read_text()
+    content = parent_path.read_text(encoding="utf-8")
     result = parse_markdown(content)
     ir = result.ir
     normalize_ir(ir)

--- a/tests/test_integration/test_user_nodes.py
+++ b/tests/test_integration/test_user_nodes.py
@@ -67,7 +67,8 @@ class TestUserNodes:
 
             # Create a test user node with proper Interface format
             node_path = node_dir / "test_calculator.py"
-            node_path.write_text('''
+            node_path.write_text(
+                '''
 """Test calculator node for integration testing."""
 
 import json
@@ -129,7 +130,9 @@ class TestCalculatorNode(Node):
 
         shared["result"] = exec_res["result"]
         return "default"
-''')
+''',
+                encoding="utf-8",
+            )
 
             yield node_dir
 
@@ -346,7 +349,8 @@ class TestCalculatorNode(Node):
 
             # Create a node with syntax error
             broken_node = node_dir / "broken_syntax.py"
-            broken_node.write_text('''
+            broken_node.write_text(
+                '''
 """Broken node with syntax error."""
 
 from pflow.core.node import Node
@@ -362,7 +366,9 @@ class BrokenNode(Node):
         # Syntax error: missing closing parenthesis
         print("This is broken"
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Scanner should handle this gracefully
             results = scan_for_nodes([node_dir])
@@ -387,7 +393,8 @@ class BrokenNode(Node):
 
             # Create a node that will fail to import at runtime
             import_error_node = node_dir / "import_error.py"
-            import_error_node.write_text('''
+            import_error_node.write_text(
+                '''
 """Node with import that fails at runtime."""
 
 from pflow.core.node import Node
@@ -408,7 +415,9 @@ class ImportErrorNode(Node):
     def exec(self, shared, **kwargs):
         # This won't even be reached
         shared["result"] = nonexistent_module_xyz123.process(shared["data"])
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Scanner might skip this due to import error
             results = scan_for_nodes([node_dir])
@@ -446,7 +455,8 @@ class ImportErrorNode(Node):
 
             # Create node with Interface in wrong place (module docstring)
             wrong_location = node_dir / "wrong_interface.py"
-            wrong_location.write_text('''
+            wrong_location.write_text(
+                '''
 """Module with Interface in wrong location.
 
 Interface:
@@ -462,11 +472,14 @@ class WrongLocationNode(Node):
 
     def exec(self, shared, **kwargs):
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Create node with malformed Interface syntax
             malformed = node_dir / "malformed_interface.py"
-            malformed.write_text('''
+            malformed.write_text(
+                '''
 from pflow.core.node import Node
 
 class MalformedNode(Node):
@@ -482,7 +495,9 @@ class MalformedNode(Node):
 
     def exec(self, shared, **kwargs):
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Scan for nodes
             results = scan_for_nodes([node_dir])
@@ -510,7 +525,8 @@ class MalformedNode(Node):
 
             # Create two files with circular imports
             node_a = node_dir / "node_a.py"
-            node_a.write_text('''
+            node_a.write_text(
+                '''
 from pflow.core.node import Node
 from node_b import NodeB  # Circular import!
 
@@ -526,10 +542,13 @@ class NodeA(Node):
     def exec(self, shared, **kwargs):
         shared["a"] = "from A"
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             node_b = node_dir / "node_b.py"
-            node_b.write_text('''
+            node_b.write_text(
+                '''
 from pflow.core.node import Node
 from node_a import NodeA  # Circular import!
 
@@ -545,7 +564,9 @@ class NodeB(Node):
     def exec(self, shared, **kwargs):
         shared["b"] = "from B"
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Scanner should handle circular imports gracefully
             # (likely by failing to import both)
@@ -563,7 +584,8 @@ class NodeB(Node):
 
             # Create two nodes with the SAME name
             node1 = node_dir / "calc_v1.py"
-            node1.write_text('''
+            node1.write_text(
+                '''
 from pflow.core.node import Node
 
 class CalcV1(Node):
@@ -578,10 +600,13 @@ class CalcV1(Node):
     def exec(self, shared, **kwargs):
         shared["version"] = "v1"
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             node2 = node_dir / "calc_v2.py"
-            node2.write_text('''
+            node2.write_text(
+                '''
 from pflow.core.node import Node
 
 class CalcV2(Node):
@@ -596,7 +621,9 @@ class CalcV2(Node):
     def exec(self, shared, **kwargs):
         shared["version"] = "v2"
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Scan should find both
             results = scan_for_nodes([node_dir])
@@ -636,7 +663,8 @@ class CalcV2(Node):
 
             # Create a user node trying to override a core node
             override_attempt = node_dir / "fake_core.py"
-            override_attempt.write_text('''
+            override_attempt.write_text(
+                '''
 from pflow.core.node import Node
 
 class FakeReadFileNode(Node):
@@ -651,7 +679,9 @@ class FakeReadFileNode(Node):
     def exec(self, shared, **kwargs):
         shared["content"] = "MALICIOUS OVERRIDE!"
         return {}
-''')
+''',
+                encoding="utf-8",
+            )
 
             registry_path = Path(tmpdir) / "registry.json"
             registry = Registry(registry_path)
@@ -686,7 +716,8 @@ class FakeReadFileNode(Node):
 
             # Create a node that tries to access parent directories
             traversal_node = node_dir / "traversal.py"
-            traversal_node.write_text('''
+            traversal_node.write_text(
+                '''
 from pflow.core.node import Node
 import os
 
@@ -708,7 +739,7 @@ class TraversalNode(Node):
         # Attempt to read sensitive files
         target = prep_res["target"]
         try:
-            with open(target, 'r') as f:
+            with open(target, 'r', encoding="utf-8") as f:
                 data = f.read()
         except:
             data = "Access denied"
@@ -718,7 +749,9 @@ class TraversalNode(Node):
         # Store result in shared
         shared["data"] = exec_res["data"]
         return "default"
-''')
+''',
+                encoding="utf-8",
+            )
 
             # This node should be scannable (code is valid)
             results = scan_for_nodes([node_dir])
@@ -752,7 +785,8 @@ class TraversalNode(Node):
 
             # Create file with multiple classes, only one is a Node
             mixed_file = node_dir / "mixed_classes.py"
-            mixed_file.write_text('''
+            mixed_file.write_text(
+                '''
 from pflow.core.node import Node
 
 class NotANode:
@@ -782,7 +816,9 @@ class ActualNode(Node):
 def not_a_class():
     """Function, not a class."""
     pass
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Scan should only find the actual Node subclass
             results = scan_for_nodes([node_dir])

--- a/tests/test_integration/test_workflow_bundling.py
+++ b/tests/test_integration/test_workflow_bundling.py
@@ -71,7 +71,7 @@ class TestSaveBundlesFileReferences:
         # Arrange: create prompt file on disk
         prompts_dir = project_dir / "prompts"
         prompts_dir.mkdir()
-        (prompts_dir / "foo.md").write_text("You are a helpful assistant")
+        (prompts_dir / "foo.md").write_text("You are a helpful assistant", encoding="utf-8")
 
         ir = {
             "nodes": [
@@ -94,7 +94,7 @@ class TestSaveBundlesFileReferences:
 
         # Assert: dependency file is bundled preserving relative path
         assert (bundle_dir / "prompts" / "foo.md").exists()
-        assert (bundle_dir / "prompts" / "foo.md").read_text() == "You are a helpful assistant"
+        assert (bundle_dir / "prompts" / "foo.md").read_text(encoding="utf-8") == "You are a helpful assistant"
 
 
 class TestSaveBundlesSubWorkflows:
@@ -114,7 +114,7 @@ class TestSaveBundlesSubWorkflows:
             "edges": [],
         }
         sub_path = project_dir / "sub.pflow.md"
-        sub_path.write_text(ir_to_markdown(sub_ir, title="Sub Workflow"))
+        sub_path.write_text(ir_to_markdown(sub_ir, title="Sub Workflow"), encoding="utf-8")
 
         parent_ir = {
             "nodes": [
@@ -136,7 +136,7 @@ class TestSaveBundlesSubWorkflows:
         assert (bundle_dir / "parent-wf.pflow.md").exists()
         assert (bundle_dir / "sub.pflow.md").exists()
         # Verify the sub-workflow content is intact
-        sub_content = (bundle_dir / "sub.pflow.md").read_text()
+        sub_content = (bundle_dir / "sub.pflow.md").read_text(encoding="utf-8")
         assert "step1" in sub_content
 
 
@@ -147,10 +147,10 @@ class TestSavePreservesRelativeStructure:
         """Files in different subdirs keep their relative paths in the bundle."""
         # Arrange: create files in two different subdirectories
         (project_dir / "prompts").mkdir()
-        (project_dir / "prompts" / "system.md").write_text("System prompt content")
+        (project_dir / "prompts" / "system.md").write_text("System prompt content", encoding="utf-8")
 
         (project_dir / "scripts").mkdir()
-        (project_dir / "scripts" / "helper.py").write_text("print('hello')")
+        (project_dir / "scripts" / "helper.py").write_text("print('hello')", encoding="utf-8")
 
         ir = {
             "nodes": [
@@ -181,8 +181,8 @@ class TestSavePreservesRelativeStructure:
         assert (bundle_dir / "scripts" / "helper.py").exists()
 
         # Verify file contents
-        assert (bundle_dir / "prompts" / "system.md").read_text() == "System prompt content"
-        assert (bundle_dir / "scripts" / "helper.py").read_text() == "print('hello')"
+        assert (bundle_dir / "prompts" / "system.md").read_text(encoding="utf-8") == "System prompt content"
+        assert (bundle_dir / "scripts" / "helper.py").read_text(encoding="utf-8") == "print('hello')"
 
 
 class TestSavedWorkflowLoadsCorrectly:
@@ -192,7 +192,7 @@ class TestSavedWorkflowLoadsCorrectly:
         """After saving with deps, load() returns the full metadata with valid IR."""
         # Arrange
         (project_dir / "prompts").mkdir()
-        (project_dir / "prompts" / "sys.md").write_text("Be concise.")
+        (project_dir / "prompts" / "sys.md").write_text("Be concise.", encoding="utf-8")
 
         ir = {
             "nodes": [
@@ -234,7 +234,7 @@ class TestForceSaveReplacesEntireBundle:
 
         # --- Save v1 with dep A ---
         (project_dir / "prompts").mkdir(exist_ok=True)
-        (project_dir / "prompts" / "v1-prompt.md").write_text("Version 1 prompt")
+        (project_dir / "prompts" / "v1-prompt.md").write_text("Version 1 prompt", encoding="utf-8")
 
         ir_v1 = {
             "nodes": [
@@ -257,7 +257,7 @@ class TestForceSaveReplacesEntireBundle:
 
         # --- Force-save v2 with dep B (no dep A) ---
         (project_dir / "scripts").mkdir(exist_ok=True)
-        (project_dir / "scripts" / "v2-code.py").write_text("print('v2')")
+        (project_dir / "scripts" / "v2-code.py").write_text("print('v2')", encoding="utf-8")
 
         ir_v2 = {
             "nodes": [
@@ -280,10 +280,10 @@ class TestForceSaveReplacesEntireBundle:
 
         # Assert: new dep B exists
         assert (bundle_dir / "scripts" / "v2-code.py").exists()
-        assert (bundle_dir / "scripts" / "v2-code.py").read_text() == "print('v2')"
+        assert (bundle_dir / "scripts" / "v2-code.py").read_text(encoding="utf-8") == "print('v2')"
 
         # Assert: entry point updated
-        entry = (bundle_dir / "force-test.pflow.md").read_text()
+        entry = (bundle_dir / "force-test.pflow.md").read_text(encoding="utf-8")
         assert "run" in entry  # v2 node id
 
 
@@ -407,7 +407,7 @@ class TestFileReferencesResolveFromBundle:
 
         # Arrange: create a project with a prompt file
         (project_dir / "prompts").mkdir()
-        (project_dir / "prompts" / "system.md").write_text("You are a test assistant")
+        (project_dir / "prompts" / "system.md").write_text("You are a test assistant", encoding="utf-8")
 
         ir: dict[str, Any] = {
             "nodes": [
@@ -671,7 +671,8 @@ class TestSubWorkflowParseErrorPropagation:
         sub_path.write_text(
             ir_to_markdown(
                 {"nodes": [{"id": "s", "type": "shell", "params": {"command": "echo"}}], "edges": []},
-            )
+            ),
+            encoding="utf-8",
         )
 
         parent_ir: dict[str, Any] = {

--- a/tests/test_integration/test_workflow_manager_integration.py
+++ b/tests/test_integration/test_workflow_manager_integration.py
@@ -645,4 +645,4 @@ def test_nested_workflow_with_real_nodes(tmp_path):
 
         # Verify the file was actually written
         assert (tmp_path / "output.txt").exists()
-        assert (tmp_path / "output.txt").read_text() == "Hello from nested workflow!"
+        assert (tmp_path / "output.txt").read_text(encoding="utf-8") == "Hello from nested workflow!"

--- a/tests/test_mcp/test_config_management.py
+++ b/tests/test_mcp/test_config_management.py
@@ -33,7 +33,7 @@ class TestAtomicWriteProtection:
             manager.add_server("github", "stdio", "npx", ["@modelcontextprotocol/server-github"])
 
             # Read the original content
-            original_content = config_path.read_text()
+            original_content = config_path.read_text(encoding="utf-8")
             original_data = json.loads(original_content)
 
             # Simulate atomic rename failure (the critical moment)
@@ -45,10 +45,10 @@ class TestAtomicWriteProtection:
 
             # CRITICAL: Original file must be untouched
             assert config_path.exists()
-            assert config_path.read_text() == original_content
+            assert config_path.read_text(encoding="utf-8") == original_content
 
             # Verify content is still valid
-            current_data = json.loads(config_path.read_text())
+            current_data = json.loads(config_path.read_text(encoding="utf-8"))
             assert current_data == original_data
             assert "github" in current_data["mcpServers"]
             assert "slack" not in current_data["mcpServers"]
@@ -311,7 +311,7 @@ class TestSecurityValidation:
             # The patterns should be stored as literal strings
             # If they were executed, we'd see different content
             # For example, ${VAR`whoami`} would become the actual username
-            raw_content = config_path.read_text()
+            raw_content = config_path.read_text(encoding="utf-8")
 
             # These dangerous patterns should exist as literal strings
             assert "${VAR && echo hacked}" in raw_content  # Not executed

--- a/tests/test_mcp/test_mcp_node_behavior.py
+++ b/tests/test_mcp/test_mcp_node_behavior.py
@@ -364,7 +364,7 @@ class TestMCPNodeErrorHandling:
                 "github": {"command": "npx", "args": ["@modelcontextprotocol/server-github"]},
             }
         }
-        config_file.write_text(json.dumps(config_data))
+        config_file.write_text(json.dumps(config_data), encoding="utf-8")
 
         node = MCPNode()
 

--- a/tests/test_mcp/test_standard_config_parser.py
+++ b/tests/test_mcp/test_standard_config_parser.py
@@ -25,7 +25,8 @@ class TestStandardConfigParser:
                         "env": {"GITHUB_TOKEN": "test-token"},
                     }
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -41,7 +42,9 @@ class TestStandardConfigParser:
     def test_parse_stdio_without_type_field(self, tmp_path):
         """Test that missing 'type' field defaults to stdio."""
         config_file = tmp_path / "test.mcp.json"
-        config_file.write_text(json.dumps({"mcpServers": {"test-server": {"command": "node", "args": ["server.js"]}}}))
+        config_file.write_text(
+            json.dumps({"mcpServers": {"test-server": {"command": "node", "args": ["server.js"]}}}), encoding="utf-8"
+        )
 
         manager = MCPServerManager()
         servers = manager.parse_standard_mcp_config(config_file)
@@ -62,7 +65,8 @@ class TestStandardConfigParser:
                         "headers": {"Authorization": "Bearer token123"},
                     }
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -77,7 +81,8 @@ class TestStandardConfigParser:
         """Test that SSE transport is rejected with clear error."""
         config_file = tmp_path / "sse.mcp.json"
         config_file.write_text(
-            json.dumps({"mcpServers": {"sse-server": {"type": "sse", "url": "https://example.com/sse"}}})
+            json.dumps({"mcpServers": {"sse-server": {"type": "sse", "url": "https://example.com/sse"}}}),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -90,7 +95,7 @@ class TestStandardConfigParser:
     def test_missing_mcpservers_key(self, tmp_path):
         """Test error when mcpServers wrapper is missing."""
         config_file = tmp_path / "invalid.json"
-        config_file.write_text(json.dumps({"servers": {"test": {"command": "test"}}}))
+        config_file.write_text(json.dumps({"servers": {"test": {"command": "test"}}}), encoding="utf-8")
 
         manager = MCPServerManager()
         with pytest.raises(ValueError) as exc_info:
@@ -107,7 +112,7 @@ class TestStandardConfigParser:
     def test_invalid_json(self, tmp_path):
         """Test error handling for invalid JSON."""
         config_file = tmp_path / "invalid.json"
-        config_file.write_text("{ invalid json }")
+        config_file.write_text("{ invalid json }", encoding="utf-8")
 
         manager = MCPServerManager()
         with pytest.raises(ValueError) as exc_info:
@@ -125,7 +130,8 @@ class TestStandardConfigParser:
                     "server2": {"type": "http", "url": "https://example.com/mcp"},
                     "server3": {"command": "cmd3", "env": {"KEY": "value"}},
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -153,7 +159,8 @@ class TestAddServersFromFile:
         mcp_file.write_text(
             json.dumps({
                 "mcpServers": {"github": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]}}
-            })
+            }),
+            encoding="utf-8",
         )
 
         # Add servers from the file
@@ -173,12 +180,12 @@ class TestAddServersFromFile:
 
         # First add
         mcp_file1 = tmp_path / "test1.json"
-        mcp_file1.write_text(json.dumps({"mcpServers": {"test": {"command": "old-command"}}}))
+        mcp_file1.write_text(json.dumps({"mcpServers": {"test": {"command": "old-command"}}}), encoding="utf-8")
         manager.add_servers_from_file(mcp_file1)
 
         # Second add with same name
         mcp_file2 = tmp_path / "test2.json"
-        mcp_file2.write_text(json.dumps({"mcpServers": {"test": {"command": "new-command"}}}))
+        mcp_file2.write_text(json.dumps({"mcpServers": {"test": {"command": "new-command"}}}), encoding="utf-8")
         added = manager.add_servers_from_file(mcp_file2)
 
         assert added == ["test"]
@@ -200,7 +207,8 @@ class TestAddServersFromFile:
                     "server2": {"type": "http", "url": "https://example.com"},
                     "server3": {"command": "cmd3"},
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         added = manager.add_servers_from_file(mcp_file)
@@ -216,7 +224,7 @@ class TestAddServersFromFile:
         manager = MCPServerManager(config_path)
 
         mcp_file = tmp_path / "test.json"
-        mcp_file.write_text(json.dumps({"mcpServers": {"test": {"command": "test"}}}))
+        mcp_file.write_text(json.dumps({"mcpServers": {"test": {"command": "test"}}}), encoding="utf-8")
 
         manager.add_servers_from_file(mcp_file)
 
@@ -233,7 +241,10 @@ class TestEnvironmentVariableDefaults:
         """Test ${VAR:-default} syntax when VAR is not set."""
         config_file = tmp_path / "test.json"
         config_file.write_text(
-            json.dumps({"mcpServers": {"test": {"command": "test", "env": {"TOKEN": "${MISSING_VAR:-default_token}"}}}})
+            json.dumps({
+                "mcpServers": {"test": {"command": "test", "env": {"TOKEN": "${MISSING_VAR:-default_token}"}}}
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -248,7 +259,8 @@ class TestEnvironmentVariableDefaults:
         """Test default values in HTTP URLs."""
         config_file = tmp_path / "test.json"
         config_file.write_text(
-            json.dumps({"mcpServers": {"api": {"type": "http", "url": "${API_URL:-http://localhost:3000}/mcp"}}})
+            json.dumps({"mcpServers": {"api": {"type": "http", "url": "${API_URL:-http://localhost:3000}/mcp"}}}),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -271,7 +283,8 @@ class TestEnvironmentVariableDefaults:
                         },
                     }
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -290,7 +303,8 @@ class TestHTTPAuthConversion:
         config_file.write_text(
             json.dumps({
                 "mcpServers": {"api": {"type": "http", "url": "https://api.example.com", "token": "bearer_token_123"}}
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -313,7 +327,8 @@ class TestHTTPAuthConversion:
                         "apiKeyHeader": "X-Custom-Key",
                     }
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -332,7 +347,8 @@ class TestHTTPAuthConversion:
                 "mcpServers": {
                     "api": {"type": "http", "url": "https://api.example.com", "username": "user", "password": "pass"}
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()
@@ -355,7 +371,8 @@ class TestHTTPAuthConversion:
                         "auth": {"type": "custom", "special_field": "value"},
                     }
                 }
-            })
+            }),
+            encoding="utf-8",
         )
 
         manager = MCPServerManager()

--- a/tests/test_nodes/test_file/test_write_file.py
+++ b/tests/test_nodes/test_file/test_write_file.py
@@ -98,7 +98,7 @@ class TestWriteFileNode:
     def test_append_mode(self, tmp_path):
         """Test appending to existing file."""
         target = tmp_path / "append.txt"
-        target.write_text("Initial content\n")
+        target.write_text("Initial content\n", encoding="utf-8")
 
         node = WriteFileNode()
         node.set_params({"append": True, "content": "Appended content", "file_path": str(target)})
@@ -114,12 +114,12 @@ class TestWriteFileNode:
         assert "append" in success_msg.lower()
         assert str(target) in success_msg  # Shows actual file path
 
-        assert target.read_text() == "Initial content\nAppended content"
+        assert target.read_text(encoding="utf-8") == "Initial content\nAppended content"
 
     def test_overwrite_existing(self, tmp_path):
         """Test overwriting existing file."""
         target = tmp_path / "overwrite.txt"
-        target.write_text("Old content")
+        target.write_text("Old content", encoding="utf-8")
 
         node = WriteFileNode()
         node.set_params({"content": "New content", "file_path": str(target)})
@@ -131,7 +131,7 @@ class TestWriteFileNode:
 
         assert action == "default"
 
-        assert target.read_text() == "New content"
+        assert target.read_text(encoding="utf-8") == "New content"
 
     def test_empty_content(self):
         """Test writing empty content."""

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -97,7 +97,7 @@ class TestRegistryDataPersistence:
         """Test that empty registry files are handled gracefully."""
         with tempfile.TemporaryDirectory() as tmpdir:
             registry_path = Path(tmpdir) / "empty.json"
-            registry_path.write_text("")
+            registry_path.write_text("", encoding="utf-8")
             registry = Registry(registry_path)
 
             # Should return empty dict, not crash
@@ -108,7 +108,7 @@ class TestRegistryDataPersistence:
         """Test that corrupted JSON files are handled gracefully."""
         with tempfile.TemporaryDirectory() as tmpdir:
             registry_path = Path(tmpdir) / "corrupt.json"
-            registry_path.write_text("{ invalid json }")
+            registry_path.write_text("{ invalid json }", encoding="utf-8")
             registry = Registry(registry_path)
 
             # Should return empty dict, not crash
@@ -840,9 +840,9 @@ class TestRegistrySourceMtimeRefresh:
         # package's __dict__, so sys.modules manipulation alone is insufficient.)
         fake_nodes = tmp_path / "fake_nodes"
         fake_nodes.mkdir()
-        (fake_nodes / "__init__.py").write_text("")
+        (fake_nodes / "__init__.py").write_text("", encoding="utf-8")
         sample = fake_nodes / "sample.py"
-        sample.write_text("# placeholder")
+        sample.write_text("# placeholder", encoding="utf-8")
 
         monkeypatch.setattr(pflow.nodes, "__file__", str(fake_nodes / "__init__.py"))
 
@@ -881,7 +881,7 @@ class TestRegistrySourceMtimeRefresh:
         registry._auto_discover_core_nodes()
         after = time_mod.time()
 
-        stored_iso = json.loads((tmp_path / "registry.json").read_text())["last_core_scan"]
+        stored_iso = json.loads((tmp_path / "registry.json").read_text(encoding="utf-8"))["last_core_scan"]
         stored_ts = datetime.fromisoformat(stored_iso).timestamp()
 
         # Stored must be at/after invocation start AND at least ~40ms before scan end
@@ -906,11 +906,11 @@ class TestRegistrySourceMtimeRefresh:
 
         fake_nodes = tmp_path / "fake_nodes"
         fake_nodes.mkdir()
-        (fake_nodes / "__init__.py").write_text("")
+        (fake_nodes / "__init__.py").write_text("", encoding="utf-8")
         bad = fake_nodes / "a_bad.py"
-        bad.write_text("")
+        bad.write_text("", encoding="utf-8")
         good = fake_nodes / "b_good.py"
-        good.write_text("")
+        good.write_text("", encoding="utf-8")
 
         monkeypatch.setattr(pflow.nodes, "__file__", str(fake_nodes / "__init__.py"))
 
@@ -961,7 +961,7 @@ class TestRegistryFormatConsistency:
             registry.save(updated_nodes)
 
             # Step 3: Verify structured format is preserved
-            raw = json.loads(registry_path.read_text())
+            raw = json.loads(registry_path.read_text(encoding="utf-8"))
             assert "nodes" in raw, "save() must write structured format with 'nodes' key"
             assert "version" in raw, "save() must preserve version in structured format"
 
@@ -1002,7 +1002,7 @@ class TestRegistryFormatConsistency:
             assert registry.get_metadata("nonexistent", "default") == "default"
 
             # Verify file is structured
-            raw = json.loads(registry_path.read_text())
+            raw = json.loads(registry_path.read_text(encoding="utf-8"))
             assert "nodes" in raw
             assert "metadata" in raw
             assert raw["metadata"]["key1"] == "value1"
@@ -1017,7 +1017,7 @@ class TestRegistryFormatConsistency:
                 "shell": {"module": "m", "class_name": "C", "type": "core"},
                 "__metadata__": {"mcp_config_hash": "old"},
             }
-            registry_path.write_text(json.dumps(flat_data))
+            registry_path.write_text(json.dumps(flat_data), encoding="utf-8")
 
             registry = Registry(registry_path)
             nodes = registry._load_from_file()
@@ -1042,7 +1042,7 @@ class TestRegistryAtomicWrite:
             registry_path = Path(tmpdir) / "registry.json"
             registry = Registry(registry_path)
             registry.save({"shell": {"module": "m", "class_name": "C", "type": "core"}})
-            original = registry_path.read_text()
+            original = registry_path.read_text(encoding="utf-8")
 
             class _Unserializable:
                 pass
@@ -1052,7 +1052,7 @@ class TestRegistryAtomicWrite:
             with pytest.raises(TypeError):
                 registry._write_atomic({"nodes": {"bad": _Unserializable()}})
 
-            assert registry_path.read_text() == original, "failed write corrupted the registry"
+            assert registry_path.read_text(encoding="utf-8") == original, "failed write corrupted the registry"
             # Only the intact registry remains — no temp debris. iterdir is robust
             # to hidden dot-prefixed temp files across Python versions; glob is not.
             assert [p.name for p in Path(tmpdir).iterdir()] == ["registry.json"]
@@ -1077,7 +1077,7 @@ class TestRegistryAtomicWrite:
             registry = Registry(registry_path)
             registry.save({"shell": {"module": "m", "class_name": "C", "type": "core"}})
 
-            assert json.loads(registry_path.read_text())["nodes"]["shell"]["module"] == "m"
+            assert json.loads(registry_path.read_text(encoding="utf-8"))["nodes"]["shell"]["module"] == "m"
             assert [p.name for p in Path(tmpdir).iterdir()] == ["registry.json"]
 
     def test_concurrent_writes_serialize_replace_section(self):

--- a/tests/test_registry/test_registry_filtering.py
+++ b/tests/test_registry/test_registry_filtering.py
@@ -45,7 +45,7 @@ def test_registry_load_respects_settings(tmp_path):
 
     # Create test registry file
     registry_path = tmp_path / "registry.json"
-    registry_path.write_text(json.dumps(registry_data))
+    registry_path.write_text(json.dumps(registry_data), encoding="utf-8")
 
     # Create test settings that deny some nodes
     settings_data = {
@@ -55,7 +55,7 @@ def test_registry_load_respects_settings(tmp_path):
         },
     }
     settings_path = tmp_path / "settings.json"
-    settings_path.write_text(json.dumps(settings_data))
+    settings_path.write_text(json.dumps(settings_data), encoding="utf-8")
 
     # Mock the settings manager to use our test settings
     with patch("pflow.core.settings.SettingsManager") as MockSettingsManager:
@@ -138,7 +138,7 @@ def test_dotted_module_pattern_filtering(tmp_path):
 
     # Create test registry file
     registry_path = tmp_path / "registry.json"
-    registry_path.write_text(json.dumps(registry_data))
+    registry_path.write_text(json.dumps(registry_data), encoding="utf-8")
 
     # Create settings that deny http nodes using dotted pattern
     settings_data = {
@@ -148,7 +148,7 @@ def test_dotted_module_pattern_filtering(tmp_path):
         },
     }
     settings_path = tmp_path / "settings.json"
-    settings_path.write_text(json.dumps(settings_data))
+    settings_path.write_text(json.dumps(settings_data), encoding="utf-8")
 
     # Create registry and settings manager with test paths
     settings_manager = SettingsManager(settings_path=settings_path)

--- a/tests/test_registry/test_scanner.py
+++ b/tests/test_registry/test_scanner.py
@@ -124,7 +124,8 @@ class BaseNodeClass(BaseNode):
 
             # Create file with import error
             import_err_file = base_dir / "import_error.py"
-            import_err_file.write_text("""
+            import_err_file.write_text(
+                """
 import nonexistent_module
 
 from pflow.core.node import BaseNode
@@ -132,7 +133,9 @@ from pflow.core.node import BaseNode
 class WontLoad(BaseNode):
     def exec(self, shared):
         pass
-""")
+""",
+                encoding="utf-8",
+            )
 
             # Should handle import error gracefully
             results = scan_for_nodes([base_dir])
@@ -147,11 +150,14 @@ class WontLoad(BaseNode):
 
             # Create file with syntax error
             syntax_file = base_dir / "syntax_error.py"
-            syntax_file.write_text("""
+            syntax_file.write_text(
+                """
 # Intentional syntax error
 def broken(:
     pass
-""")
+""",
+                encoding="utf-8",
+            )
 
             # Should skip this file without crashing
             results = scan_for_nodes([base_dir])
@@ -164,7 +170,8 @@ def broken(:
 
             # Create node with custom name
             custom_file = base_dir / "custom.py"
-            custom_file.write_text('''
+            custom_file.write_text(
+                '''
 from pflow.core.node import BaseNode
 
 class CustomNode(BaseNode):
@@ -173,7 +180,9 @@ class CustomNode(BaseNode):
 
     def exec(self, shared):
         shared["custom"] = True
-''')
+''',
+                encoding="utf-8",
+            )
 
             project_root = Path(__file__).parent.parent
             pocketflow_path = project_root / "pocketflow"
@@ -192,7 +201,8 @@ class CustomNode(BaseNode):
             base_dir = Path(tmpdir)
 
             multi_file = base_dir / "multi_inherit.py"
-            multi_file.write_text('''
+            multi_file.write_text(
+                '''
 from pflow.core.node import BaseNode
 
 class Mixin:
@@ -205,7 +215,9 @@ class MultiInheritNode(BaseNode, Mixin):
 
     def exec(self, shared):
         shared["mixin"] = self.mixin_method()
-''')
+''',
+                encoding="utf-8",
+            )
 
             project_root = Path(__file__).parent.parent
             pocketflow_path = project_root / "pocketflow"
@@ -224,7 +236,8 @@ class MultiInheritNode(BaseNode, Mixin):
             base_dir = Path(tmpdir)
 
             indirect_file = base_dir / "indirect.py"
-            indirect_file.write_text('''
+            indirect_file.write_text(
+                '''
 from pflow.core.node import BaseNode
 
 class IntermediateNode(BaseNode):
@@ -241,7 +254,9 @@ class IndirectNode(IntermediateNode):
 
     def exec(self, shared):
         shared["result"] = "indirect inheritance works"
-''')
+''',
+                encoding="utf-8",
+            )
 
             project_root = Path(__file__).parent.parent
             pocketflow_path = project_root / "pocketflow"
@@ -263,7 +278,7 @@ class IndirectNode(IntermediateNode):
 
             # Add init files for proper package structure
             for p in [Path(tmpdir) / "a", Path(tmpdir) / "a" / "b", Path(tmpdir) / "a" / "b" / "c", deep_path]:
-                (p / "__init__.py").write_text("")
+                (p / "__init__.py").write_text("", encoding="utf-8")
 
             # Add a node in the deepest directory
             node_content = '''
@@ -274,7 +289,7 @@ class DeepNode(BaseNode):
     def exec(self, shared):
         pass
 '''
-            (deep_path / "deep_node.py").write_text(node_content)
+            (deep_path / "deep_node.py").write_text(node_content, encoding="utf-8")
 
             project_root = Path(__file__).parent.parent
             pocketflow_path = project_root / "pocketflow"
@@ -292,9 +307,9 @@ class DeepNode(BaseNode):
             directory = Path(tmpdir)
 
             # Create various special files
-            (directory / "__init__.py").write_text("")
-            (directory / "setup.py").write_text("# Setup file")
-            (directory / "conftest.py").write_text("# Pytest config")
+            (directory / "__init__.py").write_text("", encoding="utf-8")
+            (directory / "setup.py").write_text("# Setup file", encoding="utf-8")
+            (directory / "conftest.py").write_text("# Pytest config", encoding="utf-8")
 
             # Should handle these files without crashing
             results = scan_for_nodes([directory])
@@ -423,25 +438,31 @@ class TestScannerIntegrationScenarios:
 
             # Create valid node
             valid_file = base_dir / "valid.py"
-            valid_file.write_text('''
+            valid_file.write_text(
+                '''
 from pflow.core.node import BaseNode
 
 class ValidNode(BaseNode):
     """A valid node among errors."""
     def exec(self, shared):
         pass
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Create file with syntax error
-            (base_dir / "syntax_error.py").write_text("def broken(: pass")
+            (base_dir / "syntax_error.py").write_text("def broken(: pass", encoding="utf-8")
 
             # Create file with import error
-            (base_dir / "import_error.py").write_text("""
+            (base_dir / "import_error.py").write_text(
+                """
 import nonexistent
 from pflow.core.node import BaseNode
 class BadNode(BaseNode):
     def exec(self, shared): pass
-""")
+""",
+                encoding="utf-8",
+            )
 
             project_root = Path(__file__).parent.parent
             pocketflow_path = project_root / "pocketflow"
@@ -458,20 +479,26 @@ class BadNode(BaseNode):
         """Test scanning multiple directories at once."""
         with tempfile.TemporaryDirectory() as tmpdir1, tempfile.TemporaryDirectory() as tmpdir2:
             # Create node in first directory
-            (Path(tmpdir1) / "node1.py").write_text('''
+            (Path(tmpdir1) / "node1.py").write_text(
+                '''
 from pflow.core.node import BaseNode
 class Node1(BaseNode):
     """First test node."""
     def exec(self, shared): pass
-''')
+''',
+                encoding="utf-8",
+            )
 
             # Create node in second directory
-            (Path(tmpdir2) / "node2.py").write_text('''
+            (Path(tmpdir2) / "node2.py").write_text(
+                '''
 from pflow.core.node import BaseNode
 class Node2(BaseNode):
     """Second test node."""
     def exec(self, shared): pass
-''')
+''',
+                encoding="utf-8",
+            )
 
             project_root = Path(__file__).parent.parent
             pocketflow_path = project_root / "pocketflow"

--- a/tests/test_runtime/test_approval_gate.py
+++ b/tests/test_runtime/test_approval_gate.py
@@ -538,7 +538,8 @@ class TestRunnerBoundary:
             "### gated-child\n\nDo the child action.\n\n"
             "- type: shell\n"
             "- command: echo child-ran\n"
-            "- approval: required\n"
+            "- approval: required\n",
+            encoding="utf-8",
         )
         parent = {
             "ir_version": "0.1.0",
@@ -646,7 +647,8 @@ class TestSubWorkflowBoundary:
             "### gated-step\n\nDo the child action.\n\n"
             "- type: shell\n"
             f"- command: {gated_command}\n"
-            "- approval: required\n"
+            "- approval: required\n",
+            encoding="utf-8",
         )
         return str(child)
 

--- a/tests/test_runtime/test_cache_integration.py
+++ b/tests/test_runtime/test_cache_integration.py
@@ -156,11 +156,13 @@ def test_cache_prevents_reexecution(tmp_path: Any) -> None:
 
     # First run: node executes, writes to tracking file
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("executed") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("executed") == 1
 
     # Second run: node should be cached, NOT re-executed
     shared2 = _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("executed") == 1, "Node was re-executed on second run — cache failed!"
+    assert tracking_file.read_text(encoding="utf-8").count("executed") == 1, (
+        "Node was re-executed on second run — cache failed!"
+    )
 
     # Output should still be available from cache
     assert "tracked" in shared2
@@ -242,14 +244,14 @@ def test_no_cache_flag(tmp_path: Any) -> None:
     # First run: no-cache mode (writes to DB but never reads)
     cache_write_only = MemoizationCache(db_path=db_path, read_enabled=False)
     _run_workflow(ir, cache_write_only)
-    assert tracking_file.read_text().count("run") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("run") == 1
 
     # Second run: normal mode (reads enabled), same DB path
     cache_read_enabled = MemoizationCache(db_path=db_path, read_enabled=True)
     _run_workflow(ir, cache_read_enabled)
 
     # Node should NOT have re-executed (cache hit on second run)
-    assert tracking_file.read_text().count("run") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("run") == 1
 
 
 def test_only_flag_stops_after_target(tmp_path: Any) -> None:
@@ -382,11 +384,11 @@ def test_error_node_not_cached(tmp_path: Any) -> None:
 
     # First run: step-err returns "error"
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("fail") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("fail") == 1
 
     # Second run: step-err should re-execute (errors are never cached)
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("fail") == 2, (
+    assert tracking_file.read_text(encoding="utf-8").count("fail") == 2, (
         "Error node should re-execute on second run (errors are not cached)"
     )
 
@@ -436,7 +438,7 @@ def test_cache_ttl_expiry(tmp_path: Any) -> None:
 
     # First run: populate cache
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("run") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("run") == 1
 
     # Backdate ALL cache entries to beyond TTL (2 hours ago, TTL is 1 hour)
     conn = sqlite3.connect(str(db_path))
@@ -446,7 +448,7 @@ def test_cache_ttl_expiry(tmp_path: Any) -> None:
 
     # Second run: all entries expired -> cache misses -> re-execute
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("run") == 2, "Node should re-execute after TTL expiry"
+    assert tracking_file.read_text(encoding="utf-8").count("run") == 2, "Node should re-execute after TTL expiry"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime/test_compile_once_regression.py
+++ b/tests/test_runtime/test_compile_once_regression.py
@@ -436,12 +436,13 @@ def test_parallel_batch_workflow_resolves_child_file_refs(tmp_path: Path):
     # Create child workflow in a subdirectory with a sibling script
     child_dir = tmp_path / "child"
     child_dir.mkdir()
-    (child_dir / "greet.sh").write_text('echo "hello from child dir"')
+    (child_dir / "greet.sh").write_text('echo "hello from child dir"', encoding="utf-8")
 
     child_md = child_dir / "child.pflow.md"
     child_md.write_text(
         "# Child\n\nA child workflow.\n\n## Steps\n\n### greet\n\nRun greeting.\n\n"
-        "- type: shell\n- command: ./greet.sh\n"
+        "- type: shell\n- command: ./greet.sh\n",
+        encoding="utf-8",
     )
 
     # Parent workflow: workflow node in a parallel batch

--- a/tests/test_runtime/test_gate_pause.py
+++ b/tests/test_runtime/test_gate_pause.py
@@ -181,7 +181,8 @@ class TestNestingGuard:
         child.write_text(
             "# Child\n\nChild whose gated step shares the parent host's id.\n\n## Steps\n\n"
             "### review\n\nGated child step.\n\n- type: shell\n- approval: required\n\n"
-            "```shell command\necho child-review\n```\n"
+            "```shell command\necho child-review\n```\n",
+            encoding="utf-8",
         )
         ir = {
             "ir_version": "0.1.0",
@@ -205,7 +206,8 @@ class TestNestingGuard:
         child.write_text(
             "# Child\n\nChild with a gated step.\n\n## Steps\n\n"
             "### gated-step\n\nGated child action.\n\n- type: shell\n- approval: required\n\n"
-            "```shell command\necho child-action\n```\n"
+            "```shell command\necho child-action\n```\n",
+            encoding="utf-8",
         )
         ir = {
             "ir_version": "0.1.0",
@@ -276,7 +278,8 @@ def test_failed_child_gate_stop_still_refuses_naming_the_gate(tmp_path, monkeypa
     child.write_text(
         "# Child\n\nChild with a gated step.\n\n## Steps\n\n"
         "### child-gate\n\nGated child action.\n\n- type: shell\n- approval: required\n\n"
-        "```shell command\necho child-action\n```\n"
+        "```shell command\necho child-action\n```\n",
+        encoding="utf-8",
     )
     wf_path = tmp_path / "parent.pflow.md"
     ir = {

--- a/tests/test_runtime/test_gate_trace.py
+++ b/tests/test_runtime/test_gate_trace.py
@@ -190,7 +190,8 @@ class TestGateTraceEvents:
             "### sibling\n\nRuns first, recording an event under the host.\n\n"
             "- type: shell\n- command: echo sibling\n\n"
             "### gated-step\n\nThe gate stops here.\n\n"
-            "- type: shell\n- command: echo gated\n- approval: required\n"
+            "- type: shell\n- command: echo gated\n- approval: required\n",
+            encoding="utf-8",
         )
         return {
             "ir_version": "0.1.0",
@@ -261,7 +262,8 @@ class TestGateTraceEvents:
         child = tmp_path / "child.pflow.md"
         child.write_text(
             "# Child\n\nChild with a gated step.\n\n## Steps\n\n### gated-step\n\n"
-            "Do the child action.\n\n- type: shell\n- command: echo child-action\n- approval: required\n"
+            "Do the child action.\n\n- type: shell\n- command: echo child-action\n- approval: required\n",
+            encoding="utf-8",
         )
         ir = {
             "ir_version": "0.1.0",
@@ -287,7 +289,8 @@ class TestGateTraceEvents:
         child = tmp_path / "child.pflow.md"
         child.write_text(
             "# Child\n\nChild with a gated step.\n\n## Steps\n\n### gated-step\n\n"
-            "Do the child action.\n\n- type: shell\n- command: echo child-action\n- approval: required\n"
+            "Do the child action.\n\n- type: shell\n- command: echo child-action\n- approval: required\n",
+            encoding="utf-8",
         )
         ir = {
             "ir_version": "0.1.0",

--- a/tests/test_runtime/test_memoization_integration.py
+++ b/tests/test_runtime/test_memoization_integration.py
@@ -201,11 +201,11 @@ def test_memo_cache_prevents_reexecution(tmp_path: Any) -> None:
 
     # First run: node executes
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("exec") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("exec") == 1
 
     # Second run: node should be cached
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("exec") == 1, "Node was re-executed on memo cache hit!"
+    assert tracking_file.read_text(encoding="utf-8").count("exec") == 1, "Node was re-executed on memo cache hit!"
 
 
 def test_memo_cache_records_execution_state(tmp_path: Any) -> None:
@@ -356,11 +356,13 @@ def test_memo_cache_no_write_on_error(tmp_path: Any) -> None:
 
     # First run: node returns "error"
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("fail") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("fail") == 1
 
     # Second run: error result should NOT have been cached
     _run_workflow(ir, cache)
-    assert tracking_file.read_text().count("fail") == 2, "Error result should not be cached — node must re-execute"
+    assert tracking_file.read_text(encoding="utf-8").count("fail") == 2, (
+        "Error result should not be cached — node must re-execute"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime/test_only_snapshot.py
+++ b/tests/test_runtime/test_only_snapshot.py
@@ -753,7 +753,7 @@ def test_planner_cached_verdict_matches_engine_serving_cached(tmp_path: Path) ->
     full = WorkflowRunner().run(str(wf), {}, RunnerConfig())
     assert full.success, [d.message for d in full.diagnostics]
     full.trace.save_to_file()
-    assert sentinel.read_text().count("ran") == 1
+    assert sentinel.read_text(encoding="utf-8").count("ran") == 1
 
     # Planner verdict: single entry, target 'b' is a memo hit → cached.
     plan = WorkflowRunner().plan(str(wf), {}, RunnerConfig(only_node="b"))
@@ -763,7 +763,7 @@ def test_planner_cached_verdict_matches_engine_serving_cached(tmp_path: Path) ->
     # Engine behavior matches the verdict: b is served from cache, never re-run.
     result = WorkflowRunner().run(str(wf), {}, RunnerConfig(only_node="b"))
     assert result.success
-    assert sentinel.read_text().count("ran") == 1, "cached --only target must not re-execute"
+    assert sentinel.read_text(encoding="utf-8").count("ran") == 1, "cached --only target must not re-execute"
 
 
 @pytest.mark.trace_files
@@ -821,7 +821,7 @@ def test_planner_execute_verdict_matches_engine_executing(tmp_path: Path) -> Non
     full = WorkflowRunner().run(str(wf), {}, RunnerConfig())
     assert full.success, [d.message for d in full.diagnostics]
     full.trace.save_to_file()
-    before = sentinel.read_text().count("ran")
+    before = sentinel.read_text(encoding="utf-8").count("ran")
 
     # Planner verdict: target would execute.
     plan = WorkflowRunner().plan(str(wf), {}, RunnerConfig(only_node="target"))
@@ -832,7 +832,7 @@ def test_planner_execute_verdict_matches_engine_executing(tmp_path: Path) -> Non
     result = WorkflowRunner().run(str(wf), {}, RunnerConfig(only_node="target"))
     assert result.success
     assert result.shared_after["target"]["stdout"] == "got up"
-    assert sentinel.read_text().count("ran") == before + 1, "uncached --only target must execute"
+    assert sentinel.read_text(encoding="utf-8").count("ran") == before + 1, "uncached --only target must execute"
 
 
 # ---------------------------------------------------------------------------
@@ -945,14 +945,16 @@ def test_only_subworkflow_target_reruns_whole_child(tmp_path: Path) -> None:
     full = WorkflowRunner().run(str(parent_path), {}, RunnerConfig())
     assert full.success, [d.message for d in full.diagnostics]
     full.trace.save_to_file()
-    assert parent_sentinel.read_text().count("ran") == 1
-    assert child_sentinel.read_text().count("ran") == 1
+    assert parent_sentinel.read_text(encoding="utf-8").count("ran") == 1
+    assert child_sentinel.read_text(encoding="utf-8").count("ran") == 1
 
     # --only sub: parent upstream restored, the whole child reruns fresh.
     result = WorkflowRunner().run(str(parent_path), {}, RunnerConfig(only_node="sub"))
     assert result.success, [d.message for d in result.diagnostics]
-    assert parent_sentinel.read_text().count("ran") == 1, "parent upstream must NOT re-fire"
-    assert child_sentinel.read_text().count("ran") == 2, "sub-workflow target must rerun the whole child"
+    assert parent_sentinel.read_text(encoding="utf-8").count("ran") == 1, "parent upstream must NOT re-fire"
+    assert child_sentinel.read_text(encoding="utf-8").count("ran") == 2, (
+        "sub-workflow target must rerun the whole child"
+    )
     # The child ran against the RESTORED parent output.
     assert result.shared_after["sub"]["result"] == "preval"
     restored = result.shared_after["__execution__"]["restored_nodes"]

--- a/tests/test_runtime/test_prepare_inputs_extras.py
+++ b/tests/test_runtime/test_prepare_inputs_extras.py
@@ -267,7 +267,7 @@ The output.
     def test_cli_rejects_typo_with_fuzzy_suggestion(self, tmp_path, prepared_subprocess_env):
         """Typo 'lyric' for declared 'lyrics' → 'Did you mean' hint rendered to stderr."""
         workflow_file = tmp_path / "wf.pflow.md"
-        workflow_file.write_text(self._WORKFLOW)
+        workflow_file.write_text(self._WORKFLOW, encoding="utf-8")
 
         # Clean env to avoid CliRunner-style logger suppression
         env = {k: v for k, v in prepared_subprocess_env.items() if k != "PYTEST_CURRENT_TEST"}
@@ -275,6 +275,7 @@ The output.
             [sys.executable, "-m", "pflow.cli", str(workflow_file), "lyrics=song", "lyric=typo"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             env=env,
             timeout=60,
         )

--- a/tests/test_runtime/test_prompt_cache_dict.py
+++ b/tests/test_runtime/test_prompt_cache_dict.py
@@ -424,9 +424,9 @@ def test_subworkflow_isolation_via_monkeypatch(tmp_path: Any) -> None:
     from pflow.nodes.shell.shell import ShellNode
 
     parent_path = tmp_path / "parent.pflow.md"
-    parent_path.write_text(_PARENT_PFLOW)
+    parent_path.write_text(_PARENT_PFLOW, encoding="utf-8")
     child_path = tmp_path / "child.pflow.md"
-    child_path.write_text(_CHILD_PFLOW)
+    child_path.write_text(_CHILD_PFLOW, encoding="utf-8")
 
     captured: list[tuple[str, Any]] = []
     original_prep = ShellNode.prep

--- a/tests/test_runtime/test_resume_engine.py
+++ b/tests/test_runtime/test_resume_engine.py
@@ -259,7 +259,7 @@ def test_resume_of_a_resume_seeds_from_newest_attempt_alone(tmp_path, flaky_step
     """Chain: run1 fails at step2 → attempt A fails at step3 → attempt B resumes
     from A's trace ALONE (upstream present via A's re-recorded restored events)."""
     exit_file = tmp_path / "step3-exit"
-    exit_file.write_text("1")
+    exit_file.write_text("1", encoding="utf-8")
     wf = _write_three_step_workflow(tmp_path, step3_suffix=f"; exit $(cat {exit_file})")
     _, source_1 = _fail_then_load(wf, flaky_step2)
 
@@ -267,7 +267,7 @@ def test_resume_of_a_resume_seeds_from_newest_attempt_alone(tmp_path, flaky_step
     assert not attempt_a.success, "attempt A was supposed to fail at step3"
     a_path = attempt_a.trace.save_to_file()
 
-    exit_file.write_text("0")
+    exit_file.write_text("0", encoding="utf-8")
     source_a = load_resume_source(execution_id=attempt_a.trace.execution_id, debug_dir=a_path.parent)
     # Decision 6 direct pin: A's trace alone carries the restored step1 event.
     assert source_a.entry_node_id == "step3"
@@ -298,7 +298,7 @@ def test_restored_large_output_reinterns_blob_and_round_trips(tmp_path, flaky_st
     expected_text = json.dumps({"response": big_response})
 
     exit_file = tmp_path / "step3-exit"
-    exit_file.write_text("1")
+    exit_file.write_text("1", encoding="utf-8")
     wf = _write_three_step_workflow(tmp_path, step3_suffix=f"; exit $(cat {exit_file})")
     _, source_1 = _fail_then_load(wf, flaky_step2)
 
@@ -319,7 +319,7 @@ def test_restored_large_output_reinterns_blob_and_round_trips(tmp_path, flaky_st
     assert set(step1_line["node_output"]["response"]) == {BLOB_SENTINEL}
 
     # A second resume resolves the blob back to the FULL value and seeds it.
-    exit_file.write_text("0")
+    exit_file.write_text("0", encoding="utf-8")
     source_a = load_resume_source(execution_id=attempt_a.trace.execution_id, debug_dir=a_path.parent)
     step1_event = next(e for e in source_a.events if e["node_id"] == "step1")
     assert step1_event["node_output"]["response"] == expected_text
@@ -412,7 +412,9 @@ def test_has_resumable_step_agrees_with_the_loader_on_common_cases(tmp_path) -> 
 
     def run(ir: dict[str, Any], name: str) -> Any:
         path = tmp_path / f"{name}.pflow.md"
-        path.write_text(ir_to_markdown(ir, title=name, description=f"{name} workflow for the parity pin."))
+        path.write_text(
+            ir_to_markdown(ir, title=name, description=f"{name} workflow for the parity pin."), encoding="utf-8"
+        )
         return WorkflowRunner().run(str(path), {}, RunnerConfig())
 
     # (a) A normal node failure → resumable on BOTH surfaces.
@@ -595,7 +597,7 @@ def test_branch_resume_converged_coalesce_reads_restored_value(tmp_path) -> None
     """K sits on one conditional branch; after resume the converged ``??`` output
     resolves from the RESTORED branch node (a1), with the untaken branch absent."""
     exit_file = tmp_path / "a2-exit"
-    exit_file.write_text("1")
+    exit_file.write_text("1", encoding="utf-8")
     wf = tmp_path / "branch.pflow.md"
     wf.write_text(textwrap.dedent(_BRANCH_WORKFLOW).format(exit_file=exit_file), encoding="utf-8")
 
@@ -603,7 +605,7 @@ def test_branch_resume_converged_coalesce_reads_restored_value(tmp_path) -> None
     assert not run1.success
     trace_path = run1.trace.save_to_file()
 
-    exit_file.write_text("0")
+    exit_file.write_text("0", encoding="utf-8")
     source = load_resume_source(execution_id=run1.trace.execution_id, debug_dir=trace_path.parent)
     assert source.entry_node_id == "a2"
 
@@ -636,7 +638,7 @@ def test_restored_subworkflow_and_batch_hosts_are_childless_and_reseed(tmp_path)
         child,
     )
     exit_file = tmp_path / "k-exit"
-    exit_file.write_text("1")
+    exit_file.write_text("1", encoding="utf-8")
     wf = tmp_path / "parent.pflow.md"
     write_workflow_file(
         {
@@ -681,7 +683,7 @@ def test_restored_subworkflow_and_batch_hosts_are_childless_and_reseed(tmp_path)
     assert [r["stdout"] for r in a_events["fan"]["node_output"]["results"]] == ["item-a", "item-b"]
 
     # Attempt B seeds BOTH hosts from A's childless events alone.
-    exit_file.write_text("0")
+    exit_file.write_text("0", encoding="utf-8")
     source_a = load_resume_source(execution_id=attempt_a.trace.execution_id, debug_dir=a_path.parent)
     attempt_b = _resume(wf, source_a)
     assert attempt_b.success, [str(d) for d in attempt_b.diagnostics]
@@ -773,9 +775,9 @@ def test_loop_k_restarts_at_iteration_one(tmp_path) -> None:
             iteration: int
             from pathlib import Path
 
-            with Path("{iter_file_literal}").open("a") as fh:
+            with Path("{iter_file_literal}").open("a", encoding="utf-8") as fh:
                 fh.write(f"{{iteration}}\\n")
-            if Path("{fail_flag_literal}").read_text().strip() == "1":
+            if Path("{fail_flag_literal}").read_text(encoding="utf-8").strip() == "1":
                 raise RuntimeError("injected loop failure")
             result: bool = True
             ```

--- a/tests/test_runtime/test_resume_source.py
+++ b/tests/test_runtime/test_resume_source.py
@@ -103,7 +103,7 @@ def _write_trace(
         lines = flatten_trace_to_lines(data)
         rc_idx = next(i for i, line in enumerate(lines) if line.get("kind") == "run.complete")
         lines = lines[:rc_idx] + gate_lines + lines[rc_idx:]
-        path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+        path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
     else:
         write_trace_jsonl(path, data)
     return path
@@ -324,7 +324,7 @@ def _write_incomplete_trace(
             "run_id": execution_id,
         })
     path = debug_dir / format_trace_filename(workflow_path, name, timestamp)
-    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
     return path
 
 
@@ -962,23 +962,25 @@ def test_by_execution_id_skips_corrupt_matched_trace(tmp_path: Path) -> None:
     Mirrors the workflow_path arm's skip-corrupt posture (via _iter_workflow_traces).
     """
     path = _write_trace(tmp_path, execution_id="corrupt-1", timestamp="20260101-000000")
-    lines = path.read_text().splitlines()
+    lines = path.read_text(encoding="utf-8").splitlines()
     lines.insert(1, "{ this is not valid json")  # corrupt an EARLY line (not the tolerated final one)
-    path.write_text("\n".join(lines) + "\n")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     with pytest.raises(ResumeSourceMissingError):
         load_resume_source(execution_id="corrupt-1", debug_dir=tmp_path)
 
 
 def test_iter_raw_trace_lines_tolerates_truncated_final_line(tmp_path: Path) -> None:
     path = tmp_path / "t.json"
-    path.write_text('{"kind": "meta"}\n{"kind": "gate", "node_id": "g"}\n{"kind": "even')  # truncated tail
+    path.write_text(
+        '{"kind": "meta"}\n{"kind": "gate", "node_id": "g"}\n{"kind": "even', encoding="utf-8"
+    )  # truncated tail
     lines = list(_iter_raw_trace_lines(path))
     assert [line.get("kind") for line in lines] == ["meta", "gate"]  # tail dropped, no raise
 
 
 def test_iter_raw_trace_lines_raises_on_earlier_malformed_line(tmp_path: Path) -> None:
     path = tmp_path / "t.json"
-    path.write_text('{"kind": "meta"}\n{ broken\n{"kind": "run.complete"}\n')  # malformed MIDDLE line
+    path.write_text('{"kind": "meta"}\n{ broken\n{"kind": "run.complete"}\n', encoding="utf-8")  # malformed MIDDLE line
     with pytest.raises(json.JSONDecodeError):
         list(_iter_raw_trace_lines(path))
 

--- a/tests/test_runtime/test_retry_config.py
+++ b/tests/test_runtime/test_retry_config.py
@@ -260,14 +260,14 @@ def test_retry_config_does_not_change_memo_cache_key(tmp_path: Path) -> None:
     first_shared.update(first.resolved_defaults)
     WorkflowEngine().run(first, first_shared)
 
-    assert tracking_file.read_text().count("executed") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("executed") == 1
 
     second = compile_workflow(ir_with_retry({"max": 3, "wait": 0.25, "backoff": "exponential"}), registry)
     second_shared: dict[str, Any] = {"__memoization_cache__": cache}
     second_shared.update(second.resolved_defaults)
     WorkflowEngine().run(second, second_shared)
 
-    assert tracking_file.read_text().count("executed") == 1
+    assert tracking_file.read_text(encoding="utf-8").count("executed") == 1
     assert second_shared["tracked"] == first_shared["tracked"]
 
 

--- a/tests/test_runtime/test_trace_integration.py
+++ b/tests/test_runtime/test_trace_integration.py
@@ -1405,7 +1405,7 @@ class TestCachedSystemEndToEnd:
 
         report_dir = generate_report(str(trace_path), str(tmp_path / "report"))
         assert report_dir is not None
-        node_md = (report_dir / "01-answer.md").read_text()
+        node_md = (report_dir / "01-answer.md").read_text(encoding="utf-8")
         assert "## Cached System" in node_md
         assert "```json" in node_md
         assert "cache_control" in node_md

--- a/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
+++ b/tests/test_runtime/test_workflow_executor/test_workflow_executor_comprehensive.py
@@ -215,7 +215,7 @@ class TestWorkflowExecutorComprehensive:
         Without this, any _PREP_RECOVERABLE exception would satisfy the test.
         """
         workflow_file = tmp_path / "malformed.pflow.md"
-        workflow_file.write_text("# Bad Workflow\n\nJust some text, no steps.\n")
+        workflow_file.write_text("# Bad Workflow\n\nJust some text, no steps.\n", encoding="utf-8")
 
         node = WorkflowExecutor()
         node.set_params({"workflow": str(workflow_file)})


### PR DESCRIPTION
## Summary

Takes `make test` from **8742 passed, 521 warnings** to **8743 passed, 0 warnings** by treating the root cause: every text-mode file and subprocess I/O call in the repo now passes `encoding="utf-8"` explicitly, and the Task 116 `EncodingWarning` net is widened from `pflow.*`-scoped to a blanket `error::EncodingWarning` so the residue can never regrow.

Related follow-up (not closed by this PR): #575 tracks the same bug class in *user-authored* code-node snippets, which the net cannot reach.

## Changes

- **~470 call sites** across 76 test files: `write_text`/`read_text`/`open`/`fdopen` and `subprocess.run(text=True, ...)` calls gained `encoding="utf-8"`. Includes the sites ruff `PLW1514` is statically blind to (untyped `tmp_path`-derived paths, `os.fdopen`) and e2e-only paths invisible to the non-e2e warning census.
- **Embedded/dynamic code**: python-code-node snippet strings inside tests (warnings attributed to `<code>` at runtime, unreachable by module-scoped filters) and one generated user-node template fixed at the source-string level.
- **Two committed example workflows** (`generate-changelog`, `screenshot-pflow-web-ui/live-reload`): snippets now demonstrate explicit encoding — cross-platform-correct patterns for users to copy.
- **`pyproject.toml`**: `filterwarnings` becomes `["error::EncodingWarning", "ignore::EncodingWarning:litellm.*"]`. The 40-line comment justifying the half-blind scoped filter is replaced by a 10-line one — one rule, one documented third-party exception.
- **`tests/test_encoding_warning_net.py`**: the "net stays scoped away from tests" canary is inverted (test-module attribution must now hard-error) and a new canary pins the litellm ignore so it can't be silently dropped.
- **Docs**: `tests/CLAUDE.md` gains a suite-wide Encoding rule next to the existing Marker/External-tool/Trace rules; the Task 116 `task-review.md` scoped-net invariant carries a dated supersession note so future readers don't restore the old scoping in good faith.

## Explanation

The 521 warnings appeared with #564 (Task 116), which enabled PEP 597 (`PYTHONWARNDEFAULTENCODING=1`) for all test targets. That PR deliberately scoped the error filter to `pflow.*` and left test-code warnings as documented residue, because ruff `PLW1514` cannot see the offending sites statically. This PR finishes the job instead of suppressing it: the missing `encoding=` in tests is a real Windows hazard (locale cp1252 vs UTF-8 fixture bytes — exactly the bug class Task 116 exists to prevent), so the fix is explicit encoding everywhere plus a strictly stronger net.

Alternatives considered and rejected: `ignore::EncodingWarning` for non-pflow origins (hides the Windows-correctness signal, keeps the blind spot); `PYTHONUTF8=1` for test runs (smaller diff and aligned with PEP 686, but degrades Windows CI fidelity — CI would stop exercising the cp1252 locale environment real Windows users have; becomes the right simplification only when Python 3.15 is the floor).

Deliberate byte-semantics tests (binary stdin, invalid-UTF-8 payloads in `test_dual_mode_stdin.py`) are untouched.

Diff: 82 files, +674/−481 in two commits — the mechanical sweep, then the filter/canary/docs flip (each independently green).

## Testing

- `make test` — **8743 passed, 0 warnings** (baseline before this PR: 8742 passed, 521 warnings; +1 test from the canary split)
- `make test-all-local` (includes e2e, what Linux CI runs) — **8786 passed, 1 skipped, 0 warnings**; the blanket filter initially exposed 59 e2e-only sites (`subprocess.py`- and pathlib-attributed), all fixed
- `make check` — green (ruff, ruff format, mypy on 246 source files, deptry, all pre-commit hooks)
- `tests/test_encoding_warning_net.py` — `test_encoding_regression_in_pflow_source_fails_loudly` (unchanged), `test_net_covers_test_code_too` (new: test-module attribution raises), `test_third_party_litellm_stays_ignored` (new: litellm attribution neither raises nor surfaces)
- Strict spot-checks during the sweep: batch verifications ran with `-W error::EncodingWarning` (stricter than the shipped config) on their file subsets — all green
