### PR TITLE
chore: preserve Codex agent routing metadata (#577)

### DIFF
--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -2,6 +2,7 @@
 name: task-orchestrator
 description: Runs ONE pflow task end to end in its worktree — plans (or implements a task-planner's plan), delegates phases, gates quality, writes task-review.md, opens the PR. Launched only by the main orchestrator. Opus default; Fable via explicit param with a stated reason.
 model: opus
+effort: high
 ---
 
 You are the **task orchestrator** for exactly one pflow task. You own its quality end to end.

--- a/.claude/agents/task-phase-implementer.md
+++ b/.claude/agents/task-phase-implementer.md
@@ -2,6 +2,8 @@
 name: task-phase-implementer
 description: Implements exactly the assigned phase(s) of a task's implementation-plan.md in the task's worktree — tests as it goes, logs substance, stops on ambiguity. Model per launch: sonnet mechanical, opus default, fable for all UI phases. Never spawns agents.
 tools: Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch
+model: opus
+effort: high
 ---
 
 You are a **phase implementer**. Your launch prompt names your task folder, your **worktree's

--- a/.claude/agents/task-planner.md
+++ b/.claude/agents/task-planner.md
@@ -3,6 +3,7 @@ name: task-planner
 description: Investigates ONE pflow task in its worktree, writes + self-reviews its implementation-plan.md, commits it on the feature branch, then stops. Launched only by the main orchestrator, always on Fable.
 model: fable
 tools: Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch, Agent, Skill
+effort: high
 ---
 
 You are the **task planner** for exactly one pflow task. Your ONE deliverable is a complete,

--- a/.codex/agents/code-implementer.toml
+++ b/.codex/agents/code-implementer.toml
@@ -1,4 +1,7 @@
+name = "code-implementer"
 description = "Implement small, focused tasks in the pflow project: new functions/files, bug fixes, refactoring, or component integration. Caller MUST provide comprehensive context (requirements, file paths, patterns to follow, definition of done). Bigger tasks need bigger context. Do NOT use for: entire features, tasks requiring deep node/engine knowledge, or primary test writing (use test-writer-fixer instead)."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are a code implementation agent for pflow. You write production code that follows established patterns, integrates with existing components, and includes tests. Your code is not throwaway — it's the foundation others build upon.
@@ -134,4 +137,3 @@ Your task is complete when:
 4. No unrelated changes were made
 5. You've reported what was done with decisions and limitations
 '''
-name = "code-implementer"

--- a/.codex/agents/pflow-codebase-searcher.toml
+++ b/.codex/agents/pflow-codebase-searcher.toml
@@ -1,4 +1,7 @@
+name = "pflow-codebase-searcher"
 description = "Search and navigate the pflow codebase. Use for: finding implementations, tracing data flows through CLI/runtime/nodes, understanding node lifecycle patterns, locating test coverage, resolving doc-vs-code conflicts. Launch multiple instances in PARALLEL for complex searches. Do NOT use for: general Python questions, writing code, simple file reads, or easy searches. Supports DEPTH: quick | medium | thorough (default: medium)."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "low"
 developer_instructions = '''
 
 You are a search expert for the pflow codebase. You find implementations, trace data flows, and explain how components work together. You never write or modify code.
@@ -212,4 +215,3 @@ For "why was this built this way?" questions, check `.taskmaster/tasks/` and `.t
 
 These are historical records — they may be outdated. Verify against current code before treating as truth.
 '''
-name = "pflow-codebase-searcher"

--- a/.codex/agents/review-agent-ux.toml
+++ b/.codex/agents/review-agent-ux.toml
@@ -1,4 +1,7 @@
+name = "review-agent-ux"
 description = "Evaluate every user-facing output (errors, warnings, success results, reports, CLI output) for AI agent actionability. pflow is agent-first \u2014 every message must help an AI agent diagnose and fix the problem, and every result must be parseable for downstream reasoning."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 developer_instructions = '''
 
 You are an agent UX specialist for pflow. pflow's PRIMARY users are AI agents, not humans. Every error message, warning, result, and output must be optimized for AI agent consumption.
@@ -253,4 +256,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Agent UX Review`. Critical = messages that 
 
 **Put yourself in the agent's position.** You are an AI agent building a workflow. You run it. You get this error — or this success output. You have no other information — no debugger, no logs, no human to ask. Can you fix the problem from this error message alone? Can you reason about the result from this output alone? If not, the message has failed its purpose. If every message passes that test, say so — a clean report with "Good Examples" populated is a valid outcome.
 '''
-name = "review-agent-ux"

--- a/.codex/agents/review-concurrency-safety.toml
+++ b/.codex/agents/review-concurrency-safety.toml
@@ -1,4 +1,7 @@
+name = "review-concurrency-safety"
 description = "Find thread safety issues, resource lifecycle bugs, and Python-specific concurrency gotchas. Catches: shared mutable state across threads, ThreadPoolExecutor traps, deep copy crashes, copy semantics sharing instance state, TOCTOU races, asyncio-in-threads pitfalls, Python version-specific behavior differences."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are a concurrency safety specialist for pflow. You find thread safety issues, resource lifecycle bugs, and Python-specific concurrency gotchas.
@@ -333,4 +336,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Concurrency Safety Review`. Critical = thre
 
 **For every shared mutable state, assume it WILL be accessed concurrently and verify it's protected.** Mentally simulate interleaved execution: Thread A reads, Thread B writes, Thread A uses stale value. If that scenario is possible and unprotected, it's a bug — even if it works 99% of the time. The 1% is where production fails. If you cannot construct a concrete interleaving for any suspect, report "Verified Safe" with what you simulated — a clean result is a valid outcome.
 '''
-name = "review-concurrency-safety"

--- a/.codex/agents/review-feature-interactions.toml
+++ b/.codex/agents/review-feature-interactions.toml
@@ -1,4 +1,7 @@
+name = "review-feature-interactions"
 description = "Enumerate how changes interact with existing features (batch, nested workflows, branching, caching, error handling, MCP, output/display). Catches: untested feature combinations, new abstraction boundaries, three-way interaction bugs, error handling dimension mismatches, feature parity gaps."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 developer_instructions = '''
 
 You are a feature interaction specialist for pflow. You systematically enumerate how changes interact with existing features and check that each combination is handled.
@@ -233,4 +236,3 @@ REVIEW-PROTOCOL.md skeleton, with two extra leading sections: **Features Touched
 
 **Every feature works in isolation. Bugs live in the combinations.** Your job is to think combinatorially — not "does batch work?" but "does batch work when the items are nested workflows that use conditional branching with error_handling:continue and the cache is warm?" Start with the meta-question (new boundary?), then pairs, then triples. Enumerate systematically, check specifically using the method: find intersection code → trace edge cases → search for tests. If every relevant combination checks out, say so — a clean "Verified Combinations" report is a valid outcome.
 '''
-name = "review-feature-interactions"

--- a/.codex/agents/review-impact-completeness.toml
+++ b/.codex/agents/review-impact-completeness.toml
@@ -1,4 +1,7 @@
+name = "review-impact-completeness"
 description = "When a shared pattern is modified, find ALL consumers \u2014 including ad-hoc reimplementations that don't use shared code. The pattern behind the most subtle post-merge bugs. Catches: bypass paths that miss new capabilities, duplicate logic that diverged, code paths that should have changed but didn't."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are an impact completeness specialist for pflow. You find code that SHOULD have been updated but WASN'T — the consumers of a modified pattern that were missed.
@@ -257,4 +260,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Impact Completeness Review`. Critical = unc
 
 **The diff shows what changed. Your job is to find what SHOULD have changed but didn't.** For every modified function, trace its usage radiating outward: direct callers → indirect callers → ad-hoc reimplementations → tests → documentation → all feature surfaces. Use semantic search, not just keyword search. The further from the diff you look, the more likely you'll find something missed. If the impact really is complete, say so — "Verified Complete" with the consumer list you checked is a valid outcome.
 '''
-name = "review-impact-completeness"

--- a/.codex/agents/review-plan.toml
+++ b/.codex/agents/review-plan.toml
@@ -1,4 +1,7 @@
+name = "review-plan"
 description = "Review implementation plans for structural integrity before coding begins. Catches: unverified assumptions, missing phases, wrong approach, ambiguous instructions, incomplete code path coverage, missing verification strategy. Run BEFORE implementation to catch plan-level errors that cost hours to fix later."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 developer_instructions = '''
 
 You are a plan review specialist for pflow. You review implementation plans BEFORE coding begins, catching structural errors that become expensive bugs later.
@@ -240,4 +243,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Plan Review`. Critical = plan errors that w
 - **Question design choices** — don't just check if the plan is internally consistent, check if its approach is the RIGHT approach.
 - **Acknowledge what's good** — if the plan correctly identifies a tricky interaction, say so. The "Verified Assumptions" section builds trust in the parts of the plan that ARE correct.
 '''
-name = "review-plan"

--- a/.codex/agents/review-silent-failures.toml
+++ b/.codex/agents/review-silent-failures.toml
@@ -1,4 +1,7 @@
+name = "review-silent-failures"
 description = "Find operations that silently succeed when they should fail, warn, or produce empty results. The #1 post-merge bug category (30% of all fixes). Catches: missing guards for empty/null/zero, exception swallowing, return values silently ignored, data silently dropped, cross-boundary signal loss, stale state."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are a silent failure detection specialist for pflow. You find operations that silently succeed when they should fail, warn, or produce empty/wrong results.
@@ -217,4 +220,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Silent Failure Review`. Critical = operatio
 
 **The question is never "does this work?" — it's "what happens when this DOESN'T work?"** Every data transformation, every store read, every external call, every filter operation, every boundary crossing has a failure mode. Your job is to verify that each failure mode either produces a visible error or is intentionally and documentedly handled. If they all are, say so plainly — a clean report with a populated "Checked and Clear" section is a valid, valuable outcome; do not invent findings.
 '''
-name = "review-silent-failures"

--- a/.codex/agents/review-simplicity.toml
+++ b/.codex/agents/review-simplicity.toml
@@ -1,4 +1,7 @@
+name = "review-simplicity"
 description = "Judge whether the FINAL integrated code is as simple as it should be \u2014 the dimension a correctness reviewer misses. Catches: emergent duplication across separately-implemented segments, interfaces grown more complex than their use warrants, dead scaffolding, premature abstraction, cross-segment inconsistency, and accidental complexity that survived because each piece looked fine in isolation."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 developer_instructions = '''
 
 You are a simplicity reviewer. You judge ONE thing: is the final, integrated code as simple as it should be? Not "is it correct" (other reviewers own that) and not "does it work" (verification owns that) — is it as SIMPLE as the problem allows?
@@ -40,4 +43,3 @@ Per REVIEW-PROTOCOL.md you report, don't fix. Lens-specific bar: separate "genui
 
 REVIEW-PROTOCOL.md skeleton, with lens-specific section names. Title: `Simplicity Review`. Sections: **Worth simplifying** (files/symbols · the complexity · the simpler shape you'd expect) / **Minor — take or leave** / **Checked and clear** (parts verified appropriately simple) / **Summary** (is the final integrated code as simple as the problem allows? — the segmented path that produced it is exactly what introduces complexity the final reader shouldn't have to pay for).
 '''
-name = "review-simplicity"

--- a/.codex/agents/review-test-fidelity.toml
+++ b/.codex/agents/review-test-fidelity.toml
@@ -1,4 +1,7 @@
+name = "review-test-fidelity"
 description = "Check that tests actually test the right thing \u2014 correct assertions, production-matching fixtures, behavior not implementation. Catches: tests encoding wrong behavior, fixtures with wrong data shapes, comparisons that aren't assertions, tests testing implementation details, test bloat, missing regression tests for bug fixes."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 developer_instructions = '''
 
 You are a test fidelity specialist for pflow. You check whether tests are testing the right thing — not whether they pass, but whether passing MEANS something.
@@ -232,4 +235,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Test Fidelity Review`. Critical = tests tha
 
 **A test's value is not that it passes — it's that it would FAIL if the behavior were wrong.** For every assertion, ask: "If I introduced a bug here, would this test catch it?" If the answer is no, the test is theater, not safety. And remember: fewer good tests beat many weak ones. Finding no fidelity problems is an acceptable, reportable outcome — say so and populate "Good Tests" rather than inventing findings.
 '''
-name = "review-test-fidelity"

--- a/.codex/agents/review-validation-consistency.toml
+++ b/.codex/agents/review-validation-consistency.toml
@@ -1,4 +1,7 @@
+name = "review-validation-consistency"
 description = "Detect drift between validation and runtime behavior. When runtime changes, validation must match \u2014 and vice versa. Catches: validators rejecting valid workflows, validators accepting invalid workflows, asymmetric entry points, validation ordering bugs, validation side effects missed when paths diverge."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are a validation consistency specialist for pflow. You detect drift between what the validation layer accepts/rejects and what the runtime layer actually handles.
@@ -220,4 +223,3 @@ REVIEW-PROTOCOL.md skeleton. Title: `Validation Consistency Review`. Critical = 
 
 **For every behavior change, trace it through ALL THREE validation touchpoints AND the runtime.** A change that only touches one layer is suspicious until proven otherwise. Use the tracing recipe: identify which file changed, look up its counterparts in the table, read each one, verify agreement. The validation layer exists to catch errors before execution — if it can't see what the runtime can do, it's providing false confidence. Finding no drift is a valid outcome — report it with a populated "Verified Consistent" section showing what you checked.
 '''
-name = "review-validation-consistency"

--- a/.codex/agents/task-orchestrator.toml
+++ b/.codex/agents/task-orchestrator.toml
@@ -1,4 +1,7 @@
+name = "task-orchestrator"
 description = "Runs ONE pflow task end to end in its worktree \u2014 plans (or implements a task-planner's plan), delegates phases, gates quality, writes task-review.md, opens the PR. Launched only by the main orchestrator. Opus default; Fable via explicit param with a stated reason."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are the **task orchestrator** for exactly one pflow task. You own its quality end to end.
@@ -92,4 +95,3 @@ proceed on guesswork to avoid the round-trip.
   issue mode merges its own PR after CI green); never self-approve a checkpoint; never widen
   scope.
 '''
-name = "task-orchestrator"

--- a/.codex/agents/task-phase-implementer.toml
+++ b/.codex/agents/task-phase-implementer.toml
@@ -1,4 +1,7 @@
+name = "task-phase-implementer"
 description = "Implements exactly the assigned phase(s) of a task's implementation-plan.md in the task's worktree \u2014 tests as it goes, logs substance, stops on ambiguity. Model per launch: sonnet mechanical, opus default, fable for all UI phases. Never spawns agents."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are a **phase implementer**. Your launch prompt names your task folder, your **worktree's
@@ -55,4 +58,3 @@ you with your next phase(s) — treat each resumed assignment as a new contract 
   spec or the plan. Never touch files outside your phase's stated area — report the need instead.
 - Report reality: failing tests and skipped items get stated plainly in your log entry and report.
 '''
-name = "task-phase-implementer"

--- a/.codex/agents/task-planner.toml
+++ b/.codex/agents/task-planner.toml
@@ -1,4 +1,7 @@
+name = "task-planner"
 description = "Investigates ONE pflow task in its worktree, writes + self-reviews its implementation-plan.md, commits it on the feature branch, then stops. Launched only by the main orchestrator, always on Fable."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
 developer_instructions = '''
 
 You are the **task planner** for exactly one pflow task. Your ONE deliverable is a complete,
@@ -71,4 +74,3 @@ First acts: verify the base ref (`git log -1` vs `origin/main`) and `make instal
   that violate it are planning bugs.
 - Prioritize simplicity of the FINAL code, not how easy it is to get there.
 '''
-name = "task-planner"

--- a/.codex/agents/test-writer-fixer.toml
+++ b/.codex/agents/test-writer-fixer.toml
@@ -1,4 +1,7 @@
+name = "test-writer-fixer"
 description = "Write new tests or fix failing tests in the pflow project. Specializes in tests that catch real bugs rather than achieving coverage metrics. Caller should provide: specific files/functions to test, the behavior to verify, and any relevant context. Give small tasks \u2014 one file at a time. Do NOT use for: implementing features (use code-implementer), searching codebase (use pflow-codebase-searcher), or running the full test suite without reason."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 developer_instructions = '''
 
 You are a test implementation agent for pflow. You write and fix tests that serve as guardrails for AI-driven development — catching real bugs, not stylistic changes. You find root causes, not shortcuts.
@@ -306,4 +309,3 @@ Your task is complete when:
 5. No duplicate tests were created
 6. You've reported what was done
 '''
-name = "test-writer-fixer"

--- a/.taskmaster/orchestration/ORCHESTRATION.md
+++ b/.taskmaster/orchestration/ORCHESTRATION.md
@@ -193,10 +193,12 @@ Runner model names are an execution detail; plans continue to use the tier names
 | Opus | `opus` | `gpt-5.6-sol` |
 | Fable | `fable` | `gpt-5.6-sol` |
 
-Claude agent `effort` maps directly to Codex `reasoning_effort`: `low` → `low`, `medium` →
-`medium`, `high` → `high`. When the contract does not pin effort, omit the launch override and
-inherit the runner default. `scripts/sync_claude_assets.py` applies the same model and effort
-mapping to generated `.codex/agents/*.toml`; an unknown source value is a generation error.
+Claude agent `effort` maps directly to the same Codex reasoning level: `low` → `low`, `medium` →
+`medium`, `high` → `high`. Generated agent TOML uses `model_reasoning_effort`; dynamic launches
+use the `reasoning_effort` parameter. When the contract does not pin effort, omit the launch
+override and inherit the runner default. `scripts/sync_claude_assets.py` applies the same model
+and effort mapping to generated `.codex/agents/*.toml`; an unknown source value is a generation
+error.
 
 - **Pass the explicit `model` param on EVERY launch** — agent frontmatter is cached per session;
   the param is the live lever. Use the runner-specific model name from the table above.

--- a/.taskmaster/orchestration/ORCHESTRATION.md
+++ b/.taskmaster/orchestration/ORCHESTRATION.md
@@ -185,8 +185,21 @@ them**, not in up-front documents.
 | **Opus** | **The default for everything with real judgment**: task orchestrators, most implementer phases, searchers (pinned) | Plans state decisions; bounded judgment may be left to the implementer |
 | **Fable** | **Task planners — always.** **ALL web-UI implementation phases — always** (user ruling 2026-07-11, DECISIONS #8): every phase that writes UI (`web/` → `src/pflow/ui`) routes to a Fable `task-phase-implementer` — never implemented inline by the task orchestrator, never a lower tier — and is built with **deliberate design/UX care**: the plan states the phase's use case + look/feel intent, and visual quality/UX are acceptance criteria verified by driving the UI. Otherwise opt-in via the explicit `model` param with a one-line justification: hard architecture, subtle seam design (engine, trace, resume/gate semantics), gnarly debugging. Lane C's terminal builder is the historical Fable home and stays one | Never an ambient default for non-UI implementation |
 
+Runner model names are an execution detail; plans continue to use the tier names above:
+
+| Contract tier | Claude launch model | Codex launch model |
+|---------------|---------------------|--------------------|
+| Sonnet | `sonnet` | `gpt-5.6-terra` |
+| Opus | `opus` | `gpt-5.6-sol` |
+| Fable | `fable` | `gpt-5.6-sol` |
+
+Claude agent `effort` maps directly to Codex `reasoning_effort`: `low` → `low`, `medium` →
+`medium`, `high` → `high`. When the contract does not pin effort, omit the launch override and
+inherit the runner default. `scripts/sync_claude_assets.py` applies the same model and effort
+mapping to generated `.codex/agents/*.toml`; an unknown source value is a generation error.
+
 - **Pass the explicit `model` param on EVERY launch** — agent frontmatter is cached per session;
-  the param is the live lever.
+  the param is the live lever. Use the runner-specific model name from the table above.
 - **Lane B**: Opus floor, never lower; Fable for complex/hard-debugging issues only with the
   user's per-launch approval (DECISIONS #9).
 - **Planner-implements exception:** when a planner finds the implementation small, it may offer in

--- a/scripts/sync_claude_assets.py
+++ b/scripts/sync_claude_assets.py
@@ -15,6 +15,16 @@ TRIPLE_LITERAL_QUOTE = "'''"
 CLAUDE_COMMAND_INPUT = "$ARGUMENTS"
 CLAUDE_COMMAND_AGENT = re.compile(r"@agent-([A-Za-z0-9_-]+)")
 CLAUDE_COMMAND_AUTORUN = re.compile(r"^!`(?P<command>[^`]+)`$", re.MULTILINE)
+CLAUDE_AGENT_MODEL_TO_CODEX = {
+    "fable": "gpt-5.6-sol",
+    "opus": "gpt-5.6-sol",
+    "sonnet": "gpt-5.6-terra",
+}
+CLAUDE_AGENT_EFFORT_TO_CODEX = {
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+}
 
 
 @dataclass
@@ -30,15 +40,41 @@ def split_frontmatter(content: str, source: Path) -> tuple[str, str]:
     return match.group("metadata"), content[match.end() :]
 
 
-def metadata_value(metadata: str, key: str, source: Path) -> str:
+def optional_metadata_value(metadata: str, key: str) -> str | None:
     prefix = f"{key}:"
     for line in metadata.splitlines():
         if line.startswith(prefix):
             value = line[len(prefix) :].strip()
             if len(value) >= 2 and value[0] == value[-1] == '"':
-                return json.loads(value)
+                decoded = json.loads(value)
+                if not isinstance(decoded, str):
+                    raise ValueError(f"frontmatter {key!r} must decode to a string")
+                return decoded
             return value
+    return None
+
+
+def metadata_value(metadata: str, key: str, source: Path) -> str:
+    value = optional_metadata_value(metadata, key)
+    if value is not None:
+        return value
     raise ValueError(f"{source}: frontmatter is missing {key!r}")
+
+
+def mapped_agent_metadata(
+    metadata: str,
+    key: str,
+    mapping: dict[str, str],
+    source: Path,
+) -> str | None:
+    value = optional_metadata_value(metadata, key)
+    if value is None:
+        return None
+    try:
+        return mapping[value]
+    except KeyError as error:
+        supported = ", ".join(sorted(mapping))
+        raise ValueError(f"{source}: unsupported agent {key} {value!r}; expected one of: {supported}") from error
 
 
 def render_skill(source: Path, name: str | None = None) -> str:
@@ -82,12 +118,18 @@ def render_agent(source: Path) -> str:
         raise ValueError(f"{source}: instructions contain {TRIPLE_LITERAL_QUOTE!r}")
     name = metadata_value(metadata, "name", source)
     description = metadata_value(metadata, "description", source)
-    return (
-        f"description = {json.dumps(description)}\n"
-        f"developer_instructions = {TRIPLE_LITERAL_QUOTE}\n"
-        f"{body}{TRIPLE_LITERAL_QUOTE}\n"
-        f"name = {json.dumps(name)}\n"
-    )
+    model = mapped_agent_metadata(metadata, "model", CLAUDE_AGENT_MODEL_TO_CODEX, source)
+    effort = mapped_agent_metadata(metadata, "effort", CLAUDE_AGENT_EFFORT_TO_CODEX, source)
+    lines = [f"name = {json.dumps(name)}", f"description = {json.dumps(description)}"]
+    if model is not None:
+        lines.append(f"model = {json.dumps(model)}")
+    if effort is not None:
+        lines.append(f"model_reasoning_effort = {json.dumps(effort)}")
+    lines.extend((
+        f"developer_instructions = {TRIPLE_LITERAL_QUOTE}",
+        f"{body}{TRIPLE_LITERAL_QUOTE}",
+    ))
+    return "\n".join(lines) + "\n"
 
 
 def ensure_content(target: Path, expected: str, write: bool, result: SyncResult) -> None:

--- a/tests/test_docs/test_agent_references.py
+++ b/tests/test_docs/test_agent_references.py
@@ -35,7 +35,7 @@ _BARE_FILE_RE = re.compile(r"`([A-Za-z_][\w.-]*\.(?:py|md))`")
 _SYMBOL_RE = re.compile(r"`([A-Za-z_][\w.]*\(\)|_[a-z]\w+|[A-Z][a-z]+(?:[A-Z][a-zA-Z]+)+)`")
 
 # Template placeholders and example names — not real references.
-_PLACEHOLDER_RE = re.compile(r"[{*<>]|task_N|test_X|test_Y|_N\b|\bX\b|\bY\b|item-\d+")
+_PLACEHOLDER_RE = re.compile(r"[{*<>]|task[-_]N|test_X|test_Y|_N\b|\bX\b|\bY\b|item-\d+")
 
 # Deliberate historical citations ("then X, now Y") and other intentional
 # mentions of things that no longer (or never) exist in the codebase. Each

--- a/tests/test_scripts/test_sync_claude_assets.py
+++ b/tests/test_scripts/test_sync_claude_assets.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts/sync_claude_assets.py"
 SPEC = importlib.util.spec_from_file_location("sync_claude_assets", SCRIPT_PATH)
 assert SPEC is not None and SPEC.loader is not None
@@ -25,7 +27,7 @@ def make_root(tmp_path: Path) -> Path:
     skill = (
         "---\nname: demo-skill\ndescription: Demo skill\nargument-hint: ignored\n---\n\n# Demo\n\n● TIGHT dependency.\n"
     )
-    agent = "---\nname: demo-agent\ndescription: Demo agent\nmodel: ignored\n---\n\nDo the work. 🔍\n"
+    agent = "---\nname: demo-agent\ndescription: Demo agent\nmodel: opus\neffort: high\n---\n\nDo the work. 🔍\n"
     command = (
         "---\ndescription: Demo command\nargument-hint: ignored\n---\n\nDo the command.\n\nPreserve “smart quotes”.\n"
     )
@@ -52,12 +54,44 @@ def test_write_generates_codex_assets(tmp_path: Path) -> None:
         '---\nname: "demo-command"\ndescription: "Demo command"\n---\n'
     )
     agent = read_file(root / ".codex/agents/demo-agent.toml")
+    assert agent.startswith('name = "demo-agent"\n')
     assert 'description = "Demo agent"' in agent
+    assert 'model = "gpt-5.6-sol"' in agent
+    assert 'model_reasoning_effort = "high"' in agent
     assert "developer_instructions = '''" in agent
-    assert 'name = "demo-agent"' in agent
     assert "Do the work. 🔍" in agent
     assert "● TIGHT dependency." in read_file(root / ".agents/skills/demo-skill/SKILL.md")
     assert "Preserve “smart quotes”." in read_file(root / ".agents/skills/demo-command/SKILL.md")
+
+
+def test_render_agent_maps_models_and_preserves_unpinned_settings(tmp_path: Path) -> None:
+    source = tmp_path / "agent.md"
+    cases = (
+        ("fable", "medium", 'model = "gpt-5.6-sol"', 'model_reasoning_effort = "medium"'),
+        ("sonnet", "low", 'model = "gpt-5.6-terra"', 'model_reasoning_effort = "low"'),
+    )
+    for model, effort, expected_model, expected_effort in cases:
+        write_file(
+            source,
+            f"---\nname: demo\ndescription: Demo\nmodel: {model}\neffort: {effort}\n---\nInstructions.\n",
+        )
+        rendered = sync_claude_assets.render_agent(source)
+        assert expected_model in rendered
+        assert expected_effort in rendered
+
+    write_file(source, "---\nname: demo\ndescription: Demo\n---\nInstructions.\n")
+    rendered = sync_claude_assets.render_agent(source)
+    assert "model =" not in rendered
+    assert "model_reasoning_effort =" not in rendered
+
+
+@pytest.mark.parametrize(("key", "value"), (("model", "unknown"), ("effort", "extreme")))
+def test_render_agent_rejects_unmapped_routing_metadata(tmp_path: Path, key: str, value: str) -> None:
+    source = tmp_path / "agent.md"
+    write_file(source, f"---\nname: demo\ndescription: Demo\n{key}: {value}\n---\nInstructions.\n")
+
+    with pytest.raises(ValueError, match=rf"unsupported agent {key} {value!r}"):
+        sync_claude_assets.render_agent(source)
 
 
 def test_check_reports_generated_asset_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Preserves Claude agent model and reasoning-effort routing when generating Codex agent definitions, and documents the equivalent launch-time routing for the orchestration hierarchy.

Fixes #577

## Changes

- Emit required agent identity metadata first in every generated Codex TOML.
- Map Claude `fable` and `opus` roles to `gpt-5.6-sol`, and `sonnet` roles to `gpt-5.6-terra`.
- Map Claude `low`, `medium`, and `high` effort directly to Codex `model_reasoning_effort`.
- Preserve inheritance when optional routing metadata is absent and reject unknown routing values.
- Pin high effort for the planner, task orchestrator, and default phase implementer source roles.
- Regenerate all 15 Codex agent definitions and document dynamic launch mappings.

## Explanation

The synchronization script previously copied agent descriptions and instructions but discarded the source model and effort metadata. As a result, Codex custom agents inherited the parent session's routing even when the orchestration contract intended a specific model tier.

The generator now owns an explicit, validated translation between the Claude-authored source metadata and Codex configuration fields. Static roles receive their mapped defaults, while the orchestration contract carries the same mapping for phase implementers whose model is selected dynamically at launch time.

## Testing

- `HOME=/private/tmp/pflow-test-home PYTHONWARNDEFAULTENCODING=1 .venv/bin/python -m pytest tests/test_scripts/test_sync_claude_assets.py -q` — 7 tests covering model mapping, effort mapping, inheritance, rejected unknown values, and generated output.
- `.venv/bin/python scripts/sync_claude_assets.py --check` — verifies all generated mirrors are synchronized.
- `.venv/bin/ruff check --ignore T201 scripts/sync_claude_assets.py tests/test_scripts/test_sync_claude_assets.py` — focused lint check; `T201` is excluded for the script's existing CLI output.
- `.venv/bin/ruff format --check scripts/sync_claude_assets.py tests/test_scripts/test_sync_claude_assets.py` — verifies formatting.
- `.venv/bin/mypy scripts/sync_claude_assets.py` — verifies generator typing.
- Manual TOML validation — parsed all 15 generated agent files and checked allowed model/reasoning values and name-first ordering.
- Commit-time pre-commit hooks — all applicable hooks passed.
