### PR TITLE
fix: retry transient Windows MCP config replacements (#585)

### DIFF
--- a/src/pflow/mcp/manager.py
+++ b/src/pflow/mcp/manager.py
@@ -6,12 +6,28 @@ import logging
 import os
 import tempfile
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 _CONFIG_SAVE_LOCK = threading.RLock()
+_WINDOWS_REPLACE_RETRY_DELAYS = (0.01, 0.02, 0.04, 0.08)
+
+
+def _replace_config_file(source: Path, destination: Path) -> None:
+    """Atomically replace the config, tolerating brief Windows file locks."""
+    for delay in _WINDOWS_REPLACE_RETRY_DELAYS:
+        try:
+            source.replace(destination)
+            return
+        except PermissionError as exc:
+            if getattr(exc, "winerror", None) != 5:
+                raise
+            time.sleep(delay)
+
+    source.replace(destination)
 
 
 class MCPServerManager:
@@ -134,7 +150,7 @@ class MCPServerManager:
                 f.write("\n")  # Add final newline
 
             # Atomic rename (overwrites existing file)
-            Path(temp_path).replace(self.config_path)
+            _replace_config_file(Path(temp_path), self.config_path)
 
             logger.info(f"Saved {len(config.get('mcpServers', {}))} MCP servers to configuration")
 

--- a/src/pflow/mcp/manager.py
+++ b/src/pflow/mcp/manager.py
@@ -13,6 +13,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _CONFIG_SAVE_LOCK = threading.RLock()
+_WINDOWS_TRANSIENT_REPLACE_ERRORS = frozenset({5, 32})
 _WINDOWS_REPLACE_RETRY_DELAYS = (0.01, 0.02, 0.04, 0.08)
 
 
@@ -23,7 +24,7 @@ def _replace_config_file(source: Path, destination: Path) -> None:
             source.replace(destination)
             return
         except PermissionError as exc:
-            if getattr(exc, "winerror", None) != 5:
+            if getattr(exc, "winerror", None) not in _WINDOWS_TRANSIENT_REPLACE_ERRORS:
                 raise
             time.sleep(delay)
 

--- a/tests/test_mcp/test_config_management.py
+++ b/tests/test_mcp/test_config_management.py
@@ -91,7 +91,8 @@ class TestAtomicWriteProtection:
             assert "test1" in config["mcpServers"]
             assert "test2" not in config["mcpServers"]
 
-    def test_windows_access_denied_during_replace_is_retried(self):
+    @pytest.mark.parametrize("winerror", [5, 32])
+    def test_transient_windows_replace_error_is_retried(self, winerror: int):
         """A brief Windows destination lock must not fail an atomic save."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "mcp-servers.json"
@@ -106,7 +107,7 @@ class TestAtomicWriteProtection:
                 replace_attempts += 1
                 if replace_attempts < 3:
                     error = PermissionError("Access denied")
-                    error.winerror = 5
+                    error.winerror = winerror
                     raise error
                 return original_replace(source, destination)
 
@@ -145,7 +146,8 @@ class TestAtomicWriteProtection:
             assert config_path.read_text(encoding="utf-8") == original_content
             assert not list(Path(tmpdir).glob(".mcp-servers-*.tmp"))
 
-    def test_permission_error_without_windows_access_denied_code_is_not_retried(self):
+    @pytest.mark.parametrize("winerror", [None, 65])
+    def test_non_transient_permission_error_during_replace_is_not_retried(self, winerror: int | None):
         """Unrelated permission failures must still propagate immediately."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "mcp-servers.json"
@@ -153,8 +155,12 @@ class TestAtomicWriteProtection:
             manager.add_server("initial", "stdio", "cmd", [])
             original_content = config_path.read_text(encoding="utf-8")
 
+            error = PermissionError("read-only")
+            if winerror is not None:
+                error.winerror = winerror
+
             with (
-                patch.object(Path, "replace", autospec=True, side_effect=PermissionError("read-only")) as replace,
+                patch.object(Path, "replace", autospec=True, side_effect=error) as replace,
                 patch("pflow.mcp.manager.time.sleep") as sleep,
                 pytest.raises(PermissionError, match="read-only"),
             ):

--- a/tests/test_mcp/test_config_management.py
+++ b/tests/test_mcp/test_config_management.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import threading
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -90,6 +90,80 @@ class TestAtomicWriteProtection:
             config = manager.load()
             assert "test1" in config["mcpServers"]
             assert "test2" not in config["mcpServers"]
+
+    def test_windows_access_denied_during_replace_is_retried(self):
+        """A brief Windows destination lock must not fail an atomic save."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "mcp-servers.json"
+            manager = MCPServerManager(config_path=config_path)
+            manager.add_server("initial", "stdio", "cmd", [])
+
+            original_replace = Path.replace
+            replace_attempts = 0
+
+            def intermittently_denied(source: Path, destination: Path) -> Path:
+                nonlocal replace_attempts
+                replace_attempts += 1
+                if replace_attempts < 3:
+                    error = PermissionError("Access denied")
+                    error.winerror = 5
+                    raise error
+                return original_replace(source, destination)
+
+            with (
+                patch.object(Path, "replace", autospec=True, side_effect=intermittently_denied),
+                patch("pflow.mcp.manager.time.sleep") as sleep,
+            ):
+                manager.add_server("second", "stdio", "cmd", [])
+
+            assert replace_attempts == 3
+            assert sleep.call_args_list == [call(0.01), call(0.02)]
+            assert set(manager.load()["mcpServers"]) == {"initial", "second"}
+
+    def test_persistent_windows_access_denied_remains_a_save_error(self):
+        """Retry exhaustion must preserve the original config and report failure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "mcp-servers.json"
+            manager = MCPServerManager(config_path=config_path)
+            manager.add_server("initial", "stdio", "cmd", [])
+            original_content = config_path.read_text(encoding="utf-8")
+
+            def access_denied(_source: Path, _destination: Path) -> None:
+                error = PermissionError("Access denied")
+                error.winerror = 5
+                raise error
+
+            with (
+                patch.object(Path, "replace", autospec=True, side_effect=access_denied) as replace,
+                patch("pflow.mcp.manager.time.sleep") as sleep,
+                pytest.raises(PermissionError, match="Access denied"),
+            ):
+                manager.add_server("second", "stdio", "cmd", [])
+
+            assert replace.call_count == 5
+            assert sleep.call_args_list == [call(0.01), call(0.02), call(0.04), call(0.08)]
+            assert config_path.read_text(encoding="utf-8") == original_content
+            assert not list(Path(tmpdir).glob(".mcp-servers-*.tmp"))
+
+    def test_permission_error_without_windows_access_denied_code_is_not_retried(self):
+        """Unrelated permission failures must still propagate immediately."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "mcp-servers.json"
+            manager = MCPServerManager(config_path=config_path)
+            manager.add_server("initial", "stdio", "cmd", [])
+            original_content = config_path.read_text(encoding="utf-8")
+
+            with (
+                patch.object(Path, "replace", autospec=True, side_effect=PermissionError("read-only")) as replace,
+                patch("pflow.mcp.manager.time.sleep") as sleep,
+                pytest.raises(PermissionError, match="read-only"),
+            ):
+                manager.add_server("second", "stdio", "cmd", [])
+
+            replace.assert_called_once()
+            sleep.assert_not_called()
+            assert config_path.read_text(encoding="utf-8") == original_content
+            assert not list(Path(tmpdir).glob(".mcp-servers-*.tmp"))
 
 
 class TestConcurrentAccess:


### PR DESCRIPTION
## Summary

Make atomic MCP configuration saves tolerate the brief destination locks that Windows can expose during file replacement.

Closes #585

## Changes

- Retry only Windows `ERROR_ACCESS_DENIED` (5) and `ERROR_SHARING_VIOLATION` (32) failures from the atomic replace operation.
- Bound replacement to five total attempts and 150 ms of backoff while preserving the same fully written, same-directory temporary file.
- Keep unrelated permission errors immediate and propagate persistent transient errors after retry exhaustion.
- Add regression coverage for eventual success, bounded exhaustion, original-file preservation, and temporary-file cleanup.

## Explanation

`MCPServerManager` instances already share a module-level reentrant lock, and `add_server()` holds it across the complete read-modify-write transaction. The intermittent Windows traceback therefore was not caused by missing synchronization between the ten managers in the failing test.

Windows replacement can still fail while a non-cooperating opener briefly holds the destination. The fix retries only the two Windows codes associated with that open-handle window. Every attempt replaces from the same complete temporary file, so successful writes remain atomic. Permanent or unrelated filesystem failures are not hidden, and retry exhaustion leaves the previous configuration intact.

## Testing

- `tests/test_mcp/test_config_management.py` — 12 passed; covers WinError 5/32 recovery, bounded exhaustion, non-target permission errors, atomic preservation, and cleanup.
- Mutation check — removing the retry loop makes the transient-replacement regression test fail on the original behavior.
- `make check` — passed, including ruff, formatting, pre-commit, mypy, and deptry.
- `make test-all-local` — 8837 passed, 1 skipped.
- Scaled concurrency-safety and test-fidelity deep review — no outstanding findings after re-review.
- Windows GitHub Actions remains the blocking real-platform verification gate.
