### PR TITLE
fix: deep-copy messages at the LiteLLM boundary to stop in-place trace corruption (#413)

### DIFF
--- a/.agents/skills/start-orchestration/SKILL.md
+++ b/.agents/skills/start-orchestration/SKILL.md
@@ -30,7 +30,7 @@ between what documents claim and what code does.
    merge, or reconcile without it), then `CURRENT-STATE.md` + the LATEST `sessions/session-NN.md`
    — if that file is thin (a short check-in, an aborted session), read one further back until you
    hit a substantive one (DECISIONS #10) — then `BRAINDUMP.md` (the role's tacit layer, refreshed
-   at each close). Treat every claim as a **pointer to verify, not a fact**. Read all these files in full before you continue.
+   at each close). Treat every claim as a **pointer to verify, not a fact**.
 2. Verify reality: `git fetch` + `git log --oneline -15 origin/main` · `gh pr list --state merged
    --limit 10` · `gh issue list --state open --limit 40` (scan for new since the stamp) ·
    `./scripts/tasks` · `git worktree list` · TaskList for live subagents.

--- a/.taskmaster/orchestration/CURRENT-STATE.md
+++ b/.taskmaster/orchestration/CURRENT-STATE.md
@@ -20,15 +20,25 @@ Every claim here is a pointer to verify, not a fact._
   **Opus**, not Fable — scope is planners only; #8 (UI phases → Fable) and #9 (lane-B Fable
   opt-in) stand. DECISIONS #3 amended; ORCHESTRATION + agent def reconciled.
 
-## In flight
+## In flight (launched 2026-07-13, session-04 — 3 parallel lane-B Opus builds)
 
-- ~~**#565 (MCP probe output paths)**~~ — MERGED via PR #583 as `bd6f520a`; all merged-result gates
-  green after #581, worktree/branch safely pruned.
-- ~~**#581 (flaky Windows caplog tests)**~~ — MERGED via PR #584 as `08b319ca`; issue-specific Windows
-  gate passed, authorized unrelated-flake rerun passed, worktree/branch safely pruned.
-- ~~**#585 (Windows MCP config replace WinError 5)**~~ — MERGED via PR #586 as `2ee5fefc`; all
-  Windows gates green, worktree/branch safely pruned. Verified cause: Windows replacement can
-  transiently reject despite existing process-wide `RLock`; fix narrowly retries WinError 5/32.
+Surfaces verified against main by 3 searchers before launch; collision matrix confirmed disjoint
+(files + semantics); none touch `runtime/engine/`/`workflow_executor` or trace format.
+
+- **#413** LiteLLM mutates pflow's `system_blocks` in place → trace lies for OpenAI/Gemini cache
+  runs. Fix = deep-copy at the one adapter boundary (`core/llm_client.py:358`, before
+  `litellm.completion`); Option A (issue's Option C sidecar-refactor rejected as over-eng).
+- **#497** `_*_source_line` sidecar leaks through MCP node's forward filter → `Unknown argument`.
+  Fix = one line at `nodes/mcp/node.py:153` (`and not k.endswith("_source_line")`, matching the
+  `instrumentation.py:166` precedent). No shared helper (one forwarding node → deletion test).
+- **#183** secrets embedded in shell `command`/`stdout`/`stderr` leak to CLI **and** MCP error
+  output. Single shared seam = `_enrich_error_from_node_output` (`executor_service.py:354-359`);
+  covers both. TRAP: `sanitize_parameters` redacts by KEY — a secret inside a string value needs
+  **value-level** substring redaction of known-secret values (env/sensitive param values). Scope
+  = shell fields only (HTTP already redacted; consolidation is a separate follow-up).
+  **Launched PLAN-FIRST** (user directive): investigate secret-value provenance + plumbing, write
+  approach + failure scenarios, self-review the seam before coding; escalate if redaction must
+  reach beyond the enrichment seam.
 
 ## Current arc
 
@@ -45,7 +55,7 @@ Resume/HITL: 125 ✅ → 164 ✅ → 174 ✅ → 171 ✅ → 176 ✅ (#579). Rea
   **#561** TTS clip cache (backlog) · **#538** liveness backstop (check
   overlap with #566 first) · **#544** `llm_*` canonicalization · **#549** post-#539 visibility ·
   **#528** `--output-format` stragglers · **#566/#567/#572/#574/#575** Windows/test-infra tail.
-- **#357** memo-cache drift — issue state UNVERIFIED since 2026-06-23; check before acting.
+- ~~**#357**~~ memo-cache drift — verified CLOSED 2026-06-18; remove from picks.
 - ~~**#581**~~ shipped via #584. ~~**#585**~~ shipped via #586.
 
 ## Watch list (non-obvious, easy to miss)

--- a/.taskmaster/orchestration/sessions/session-04.md
+++ b/.taskmaster/orchestration/sessions/session-04.md
@@ -1,0 +1,29 @@
+# session-04 — 2026-07-13
+
+## [2026-07-13] main orchestrator — boot + state verification
+
+- Did: booted through `/start-orchestration`. Read ORCHESTRATION + DECISIONS + CURRENT-STATE +
+  session-03 + BRAINDUMP. Verified reality: `git fetch`, `git log origin/main`, merged PRs, 40
+  open issues, `./scripts/tasks`, worktrees, TaskList.
+- Verified: local `main` == `origin/main` == `735368bf`, clean tree; only `main` worktree; no
+  live child agents; no in-flight PRs. Session-03's close edits are committed/pushed (the
+  "ahead 8/behind 3" state it ended on was reconciled by `64c15904`..`735368bf`). #565/#581/#585
+  all merged+closed. Planner routing = Opus (`647d86f9`, DECISIONS #3 amended).
+- Drift found + fixed: CURRENT-STATE flagged #357 UNVERIFIED — verified CLOSED (2026-06-18),
+  struck from parallel-lane candidates.
+- State: clean board, nothing in flight. Ready to pick next work. Awaiting user steer.
+
+## [2026-07-13] main orchestrator — issue scan → picked 3 lane-B builds
+
+- User steered: scanned last-month + all 122 open issues. Flagged #183 (secret leak to error
+  output, 3mo old), #413 (LiteLLM in-place mutation → trace lies), #497 (sidecar breaks MCP-node
+  fenced params). User deprioritized MCP-*agent* work (CLI focus) → #183's value is the shared
+  CLI path, not the MCP-server path. User: fix all 3, orchestrate end to end.
+- Verified all 3 fix surfaces against main via 3 parallel searchers (issue file:line refs stale).
+  Collision matrix: pairwise disjoint (files + semantics); none touch engine/trace-format.
+- Locked decisions (user go, my recs unopposed): #413 Option A (boundary deep-copy; Option C
+  rejected as over-eng) · #183 shell-fields-only + single shared seam + value-level redaction ·
+  3 parallel · commit bookkeeping to local main (push user-gated).
+- User directive: **#183 plans first** (trap: key-based sanitize misses value-embedded secrets).
+- Next: docs-commit-first → provision 3 worktrees sequentially → launch 3 Opus issue-mode
+  task-orchestrators (#413/#497 implement-direct; #183 plan-first) → shepherd → merge → reconcile.

--- a/src/pflow/core/llm_client.py
+++ b/src/pflow/core/llm_client.py
@@ -35,6 +35,7 @@ The adapter does NOT:
 from __future__ import annotations
 
 import base64
+import copy
 import logging
 import mimetypes
 from collections.abc import Callable
@@ -353,6 +354,16 @@ def complete(
     # completion() by inspecting model_cost, so the merge must precede the
     # call for cost_usd to populate naturally.
     ensure_model_priced(model)
+
+    # LiteLLM mutates the message content lists in place while normalizing
+    # the request for non-Anthropic providers (e.g. it strips ``cache_control``
+    # keys off content blocks). Those blocks are shared by reference with the
+    # caller's ``system`` / ``user_message_blocks`` lists — and the trace hook
+    # holds a reference to ``system`` for the trace record — so an in-place
+    # mutation would silently corrupt pflow's own data after we hand it off.
+    # Give LiteLLM a deep copy: it mutates a throwaway, our originals stay
+    # pristine, and the trace reflects what pflow actually placed.
+    kwargs["messages"] = copy.deepcopy(messages)
 
     try:
         raw_response = litellm.completion(**kwargs)

--- a/tests/test_core/test_llm_client.py
+++ b/tests/test_core/test_llm_client.py
@@ -420,6 +420,71 @@ class TestCompleteHappyPath:
         assert mock_completion.call_args.kwargs["timeout"] == 30.0
 
 
+class TestCompleteDoesNotMutateCallerBlocks:
+    """Regression for issue #413.
+
+    LiteLLM mutates its ``messages`` content lists in place while normalizing
+    the request for non-Anthropic providers (it strips ``cache_control`` keys).
+    ``_build_messages`` places the caller's ``system`` / ``user_message_blocks``
+    list objects into ``messages`` by reference, and the trace hook holds a
+    reference to ``system`` — so before the fix the mutation silently corrupted
+    pflow's own data (the trace showed zero cache markers even though pflow
+    placed one). ``complete()`` now hands LiteLLM a deep copy; the caller's
+    lists must survive untouched. Each test's mock reproduces LiteLLM's
+    in-place mutation, so it FAILS on the unfixed code.
+    """
+
+    @staticmethod
+    def _strip_cache_control_in_place(**kwargs):
+        # Simulate LiteLLM's provider normalization: delete cache_control keys
+        # from every content block it received.
+        for message in kwargs["messages"]:
+            content = message.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        block.pop("cache_control", None)
+        return make_litellm_response()
+
+    @patch("litellm.completion")
+    def test_system_blocks_not_mutated(self, mock_completion):
+        mock_completion.side_effect = self._strip_cache_control_in_place
+        system_blocks = [
+            {"type": "text", "text": "Block A"},
+            {"type": "text", "text": "Block B", "cache_control": {"type": "ephemeral"}},
+        ]
+
+        complete(model="openai/gpt-4o-mini", prompt="hi", system=system_blocks)
+
+        # The mock stripped cache_control from the copy it received; pflow's
+        # original list must still carry the marker it placed.
+        assert "cache_control" in system_blocks[1]
+        assert system_blocks[1]["cache_control"] == {"type": "ephemeral"}
+        # Sanity: the mock really did mutate what it was handed (the deep copy).
+        sent_blocks = mock_completion.call_args.kwargs["messages"][0]["content"]
+        assert all("cache_control" not in b for b in sent_blocks)
+
+    @patch("litellm.completion")
+    def test_user_message_blocks_not_mutated(self, mock_completion):
+        mock_completion.side_effect = self._strip_cache_control_in_place
+        user_blocks = [
+            {"type": "text", "text": "static prefix", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "dynamic suffix"},
+        ]
+
+        complete(
+            model="openai/gpt-4o-mini",
+            prompt="ignored",
+            user_message_blocks=user_blocks,
+        )
+
+        assert "cache_control" in user_blocks[0]
+        assert user_blocks[0]["cache_control"] == {"type": "ephemeral"}
+        # Sanity: the mock really did mutate the copy it was handed.
+        sent_blocks = mock_completion.call_args.kwargs["messages"][0]["content"]
+        assert all("cache_control" not in b for b in sent_blocks)
+
+
 class TestCompleteUsageNormalization:
     @patch("litellm.completion")
     def test_anthropic_cache_fields(self, mock_completion):


### PR DESCRIPTION
## Summary

LiteLLM mutates pflow's message content lists **in place** when normalizing a
request for non-Anthropic providers — it strips `cache_control` keys off the
content blocks. Those block dicts are shared by reference with the caller's
`system` / `user_message_blocks` lists, and the trace hook holds a reference to
`system` for the trace record. So the in-place mutation silently corrupted
pflow's own data: an OpenAI/Gemini cache workflow's trace showed **zero** cache
markers even though pflow placed one.

Fixed by handing LiteLLM a deep copy of `messages` at the adapter boundary, so
it mutates a throwaway and pflow's originals stay pristine. One-site defensive
copy at the trust boundary; the trace code is untouched (with the original never
mutated, the trace is automatically correct).

Fixes #413

## Changes

- `src/pflow/core/llm_client.py` — `import copy`; in `complete()`, set
  `kwargs["messages"] = copy.deepcopy(messages)` immediately before
  `litellm.completion(**kwargs)`, with a comment documenting LiteLLM's in-place
  mutation.
- `tests/test_core/test_llm_client.py` — new `TestCompleteDoesNotMutateCallerBlocks`
  regression class covering both the `system` and `user_message_blocks` paths.

Also carries one unrelated `[skip review]` commit that regenerates
`.agents/skills/start-orchestration/SKILL.md` — a pre-existing sync drift on the
base ref (the source `.claude` skill was edited without regenerating the Codex
copy) that fails `make check` / CI. Deterministic regeneration via
`scripts/sync_claude_assets.py --write`; unrelated to #413, carried only to keep
this branch's CI green.

## Explanation

`_build_messages` places the caller's `system` list and `user_message_blocks`
(the same dict objects) directly into `messages`. LiteLLM's provider
normalization then does `del block["cache_control"]` on those nested block
dicts. Because the trace hook stored a reference to the same `system` list, the
serialized `llm_system` reflected post-mutation (corrupted) state. A **deep**
copy is required (not shallow): the mutation targets nested block dicts that a
shallow copy would still share. The per-call cost is negligible — `deepcopy`
shares immutable strings by reference, so even large base64 image payloads are
not duplicated; only the handful of small dict/list scaffolds are rebuilt.

Note: this PR's base includes the orchestration docs commit `19bfbbba`
(session-04 state) that was on local `main` but not yet on `origin/main` when the
worktree was branched; it rides along and lands with the merge.

## Testing

- `TestCompleteDoesNotMutateCallerBlocks::test_system_blocks_not_mutated` — the
  mock reproduces LiteLLM's in-place `del block["cache_control"]`; asserts the
  caller's original `system` list still carries the marker, plus a sanity check
  that the mock genuinely stripped the copy it received. **Fails without the
  fix** (verified by reverting the `deepcopy` — `AssertionError`).
- `TestCompleteDoesNotMutateCallerBlocks::test_user_message_blocks_not_mutated` —
  same for the `user_message_blocks` path. Also fails without the fix.
- Real-surface exercise: drove the committed multi-chunk `## Cache` workflow on
  `openai/gpt-4o-mini` through the real `WorkflowRunner` + real
  `llm_client.complete()`, with `litellm.completion` mocked to strip
  `cache_control` in place exactly like the real library. With the fix, the
  emitted trace's `llm_system` still shows the placed terminal marker at index
  `(2,)` for both LLM nodes even though litellm stripped it from its copy;
  without the fix the trace shows `()` (markers lost) — the exact issue #413
  symptom. Anthropic markers remain covered end-to-end by
  `test_prompt_cache_multi_chunk.py`.
- `make check`, `make test` (8796 passed), and `make test-all-local`
  (8839 passed, 1 skipped) all green.
- Completion-gate deep-review (concurrency-safety + test-fidelity specialists):
  both clean, no Critical/Warning; one symmetry suggestion applied.
