### PR TITLE
feat(worktree): implement mode + phase scope for the worktree-creator skill

### DIFF
--- a/.agents/skills/worktree-pflow/SKILL.md
+++ b/.agents/skills/worktree-pflow/SKILL.md
@@ -2,29 +2,70 @@
 name: "worktree-pflow"
 description: "Create a git worktree for a user driven agent."
 ---
-Create a git worktree for pflow development.
+Create an isolated git worktree for the user's task and launch a coding agent in it. Your job: turn the request below into ONE command by choosing the flags, run it, then report back.
 
+The user's request:
+
+Use the user's request as the input.
+
+Current branch (used by the base-branch rule):
 Run this command before proceeding:
 
 ```bash
 git branch --show-current
 ```
 
-Build and run the command:
+## Command
+
 ```bash
-uv run pflow examples/real-workflows/git-worktree-task-creator/workflow.pflow.md task_description='THE TASK DESCRIPTION'
+uv run pflow examples/real-workflows/git-worktree-task-creator/workflow.pflow.md <args>
 ```
 
-**Parameter rules:**
-- If the user has not supplied a task description, ask the user to clarify what task they want to create a worktree for.
-- **If the work is a GitHub issue (the user gives an issue number, an issue URL, or says "issue"), add `work_type=issue`.** This labels it as a GitHub issue (not a pflow `.taskmaster` task) when the launched Claude session opens, so a bare issue number like `443` isn't mistaken for a task id and no task scaffolding is created. Omit it (defaults to `work_type=task`) for ordinary `.taskmaster` tasks.
-- If the current branch is NOT `main`, add `base_branch=main` to the command (unless the user explicitly wants to branch from the current branch).
-- If the user mentions a folder or scratchpad to copy into the worktree, add `copy_folder=<relative-path>` (path relative to repo root, e.g. `copy_folder=scratchpads/my-research`).
-- **If the user asks to start the session with codex instead of Claude Code** (e.g. "use codex", "start with codex"), add `agent=codex`. Defaults to `agent=claude` otherwise. `open_cli` remains the on/off gate for launching the agent regardless of which one is selected.
-- **If the user specifies a model** for the coding agent (e.g. "use opus", "run it on sonnet"), add `model=<model>` — passed through as `--model` to whichever agent launches (both `claude` and `codex` accept it). Accepts an alias (`opus`, `sonnet`) or a full model id (`claude-opus-4-8`). Omit it to use the agent's own default model.
-- If the user specifically asks NOT to open cursor or the coding agent, add `open_cli=false` and/or `open_cursor=false`.
-- **The workflow refuses to clobber an existing worktree/branch by default.** If it errors that the branch/worktree already exists and the user wants to re-run the **same** task and discard the old one, add `overwrite=true`. Do NOT add it just to make a collision go away for a *different* task — a collision between different tasks signals the branch name wasn't specific enough, so pass a more descriptive `task_description` instead.
+`<args>` is always `task_description=...` plus any flags from the tables below.
+Quote a prose description; a bare task/issue number needs no quotes.
 
-Let the user know if the worktree was created successfully and display the path to the worktree.
+## Examples — map the request to `<args>`
 
-Also let the user know that Cursor and the selected coding agent (Claude Code by default, or Codex if `agent=codex`) have been opened in the new worktree (if using default values for open_cli and open_cursor).
+```bash
+# "set up a worktree to add retry logic to the http node"
+task_description='Add retry logic to the HTTP node'
+
+# "start task 177"   (default: explore + write a plan first)
+task_description=177
+
+# "implement task 177 directly / the plan already exists"
+task_description=177 mode=implement
+
+# "implement phase 1 and 2 of task 177"   ← spoken phases become a digit range/list
+task_description=177 mode=implement phases=1-2
+
+# "work on github issue 443 with codex"
+task_description=443 work_type=issue agent=codex
+
+# "task 88 off main (I'm on a feature branch), copy my notes, don't open cursor"
+task_description=88 base_branch=main copy_folder=scratchpads/notes open_cursor=false
+```
+
+## Flags — add when the user asks for it
+
+| Flag | Add when the user… |
+|------|--------------------|
+| `work_type=issue` | refers to a GitHub issue — a number, an issue URL, or says "issue" — so the number isn't taken as a task id (default `task`) |
+| `agent=codex` | wants Codex instead of Claude Code (default `claude`) |
+| `mode=implement` | says "implement directly" / a plan already exists → points the agent at `/implement-plan` instead of the default `explore` → `/start-work`. Pass the bare task/issue number as `task_description` so the plan resolves |
+| `phases=<spec>` | scopes the work to phases (**requires** `mode=implement`). Spoken phases → digits: "phase 1 and 2" → `phases=1-2`, "just phase 3" → `phases=3` |
+| `model=<model>` | names a model — an alias (`opus`, `sonnet`) or a full id (`claude-opus-4-8`). Omit for the agent's own default |
+| `copy_folder=<path>` | wants a folder/scratchpad copied into the fresh worktree (repo-root-relative, e.g. `scratchpads/notes`) |
+| `open_cli=false` / `open_cursor=false` | asks NOT to open the coding agent / Cursor (both default `true`) |
+
+If a value is malformed, the workflow rejects it with an actionable error — fix the arg and rerun rather than guessing at the constraint.
+
+## Rules — decisions that aren't a simple flag
+
+- **No task given** (arguments empty) → ask the user what task or issue to create a worktree for. Don't guess.
+- **Not on `main`** (see the current branch above) → add `base_branch=main` so the worktree branches off main, not unmerged work. To *deliberately* branch off the current feature branch, pass its name explicitly (`base_branch=<current-branch>`) — omitting `base_branch` on a non-main branch is an error, not a shortcut.
+- **Branch/worktree already exists** → the workflow refuses to clobber it. Add `overwrite=true` ONLY to re-run the *same* task and discard the old one. A collision with a *different* task means the name was too vague — give a more specific `task_description` instead of forcing it.
+
+## After it runs
+
+Report the worktree path from the output. Unless `open_cli`/`open_cursor` were disabled, also tell the user that Cursor and the selected agent (Claude Code, or Codex when `agent=codex`) opened in the new worktree.

--- a/.claude/commands/worktree-pflow.md
+++ b/.claude/commands/worktree-pflow.md
@@ -1,26 +1,67 @@
 ---
 description: Create a git worktree for a user driven agent.
-argument-hint: [description of task]
+argument-hint: [task description, or a task/issue number]
 ---
-Create a git worktree for pflow development.
+Create an isolated git worktree for the user's task and launch a coding agent in it. Your job: turn the request below into ONE command by choosing the flags, run it, then report back.
 
+The user's request:
+
+$ARGUMENTS
+
+Current branch (used by the base-branch rule):
 !`git branch --show-current`
 
-Build and run the command:
+## Command
+
 ```bash
-uv run pflow examples/real-workflows/git-worktree-task-creator/workflow.pflow.md task_description='$ARGUMENTS'
+uv run pflow examples/real-workflows/git-worktree-task-creator/workflow.pflow.md <args>
 ```
 
-**Parameter rules:**
-- If `$ARGUMENTS` is empty, ask the user to clarify what task they want to create a worktree for.
-- **If the work is a GitHub issue (the user gives an issue number, an issue URL, or says "issue"), add `work_type=issue`.** This labels it as a GitHub issue (not a pflow `.taskmaster` task) when the launched Claude session opens, so a bare issue number like `443` isn't mistaken for a task id and no task scaffolding is created. Omit it (defaults to `work_type=task`) for ordinary `.taskmaster` tasks.
-- If the current branch is NOT `main`, add `base_branch=main` to the command (unless the user explicitly wants to branch from the current branch).
-- If the user mentions a folder or scratchpad to copy into the worktree, add `copy_folder=<relative-path>` (path relative to repo root, e.g. `copy_folder=scratchpads/my-research`).
-- **If the user asks to start the session with codex instead of Claude Code** (e.g. "use codex", "start with codex"), add `agent=codex`. Defaults to `agent=claude` otherwise. `open_cli` remains the on/off gate for launching the agent regardless of which one is selected.
-- **If the user specifies a model** for the coding agent (e.g. "use opus", "run it on sonnet"), add `model=<model>` — passed through as `--model` to whichever agent launches (both `claude` and `codex` accept it). Accepts an alias (`opus`, `sonnet`) or a full model id (`claude-opus-4-8`). Omit it to use the agent's own default model.
-- If the user specifically asks NOT to open cursor or the coding agent, add `open_cli=false` and/or `open_cursor=false`.
-- **The workflow refuses to clobber an existing worktree/branch by default.** If it errors that the branch/worktree already exists and the user wants to re-run the **same** task and discard the old one, add `overwrite=true`. Do NOT add it just to make a collision go away for a *different* task — a collision between different tasks signals the branch name wasn't specific enough, so pass a more descriptive `task_description` instead.
+`<args>` is always `task_description=...` plus any flags from the tables below.
+Quote a prose description; a bare task/issue number needs no quotes.
 
-Let the user know if the worktree was created successfully and display the path to the worktree.
+## Examples — map the request to `<args>`
 
-Also let the user know that Cursor and the selected coding agent (Claude Code by default, or Codex if `agent=codex`) have been opened in the new worktree (if using default values for open_cli and open_cursor).
+```bash
+# "set up a worktree to add retry logic to the http node"
+task_description='Add retry logic to the HTTP node'
+
+# "start task 177"   (default: explore + write a plan first)
+task_description=177
+
+# "implement task 177 directly / the plan already exists"
+task_description=177 mode=implement
+
+# "implement phase 1 and 2 of task 177"   ← spoken phases become a digit range/list
+task_description=177 mode=implement phases=1-2
+
+# "work on github issue 443 with codex"
+task_description=443 work_type=issue agent=codex
+
+# "task 88 off main (I'm on a feature branch), copy my notes, don't open cursor"
+task_description=88 base_branch=main copy_folder=scratchpads/notes open_cursor=false
+```
+
+## Flags — add when the user asks for it
+
+| Flag | Add when the user… |
+|------|--------------------|
+| `work_type=issue` | refers to a GitHub issue — a number, an issue URL, or says "issue" — so the number isn't taken as a task id (default `task`) |
+| `agent=codex` | wants Codex instead of Claude Code (default `claude`) |
+| `mode=implement` | says "implement directly" / a plan already exists → points the agent at `/implement-plan` instead of the default `explore` → `/start-work`. Pass the bare task/issue number as `task_description` so the plan resolves |
+| `phases=<spec>` | scopes the work to phases (**requires** `mode=implement`). Spoken phases → digits: "phase 1 and 2" → `phases=1-2`, "just phase 3" → `phases=3` |
+| `model=<model>` | names a model — an alias (`opus`, `sonnet`) or a full id (`claude-opus-4-8`). Omit for the agent's own default |
+| `copy_folder=<path>` | wants a folder/scratchpad copied into the fresh worktree (repo-root-relative, e.g. `scratchpads/notes`) |
+| `open_cli=false` / `open_cursor=false` | asks NOT to open the coding agent / Cursor (both default `true`) |
+
+If a value is malformed, the workflow rejects it with an actionable error — fix the arg and rerun rather than guessing at the constraint.
+
+## Rules — decisions that aren't a simple flag
+
+- **No task given** (arguments empty) → ask the user what task or issue to create a worktree for. Don't guess.
+- **Not on `main`** (see the current branch above) → add `base_branch=main` so the worktree branches off main, not unmerged work. To *deliberately* branch off the current feature branch, pass its name explicitly (`base_branch=<current-branch>`) — omitting `base_branch` on a non-main branch is an error, not a shortcut.
+- **Branch/worktree already exists** → the workflow refuses to clobber it. Add `overwrite=true` ONLY to re-run the *same* task and discard the old one. A collision with a *different* task means the name was too vague — give a more specific `task_description` instead of forcing it.
+
+## After it runs
+
+Report the worktree path from the output. Unless `open_cli`/`open_cursor` were disabled, also tell the user that Cursor and the selected agent (Claude Code, or Codex when `agent=codex`) opened in the new worktree.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,20 @@ repos:
 
   - repo: local
     hooks:
+      # Regenerates Codex assets (.agents/skills/*/SKILL.md) from their .claude/
+      # sources so they can't go stale — the same invariant `make check` enforces,
+      # moved earlier so a stale asset fails at commit instead of only in CI (the
+      # failure this hook was added to prevent). always_run + no filenames because
+      # the top-level `exclude: ^\.claude/` hides the source files from pre-commit's
+      # list, and the script discovers them itself; it's ~0.1s so always-running is
+      # free. See scripts/sync_claude_assets.py.
+      - id: sync-claude-assets
+        name: sync Claude→Codex reusable assets
+        entry: uv run --frozen python scripts/sync_claude_assets.py --write
+        language: system
+        always_run: true
+        pass_filenames: false
+
       # Catches ${...} templates leaking out of code blocks in docs — these
       # compile to live JS expressions and crash the page at render, a class
       # `mint validate` does not catch. See scripts/check_mdx_fences.py.

--- a/examples/real-workflows/git-worktree-task-creator/workflow.pflow.md
+++ b/examples/real-workflows/git-worktree-task-creator/workflow.pflow.md
@@ -47,7 +47,7 @@ Whether to launch a coding agent in a new Terminal window with task context afte
 
 ### work_type
 
-Whether the work refers to a pflow task (`.taskmaster`) or a standalone GitHub issue. Controls how the launched Claude session is told to interpret the description: a `task` is labelled `Task:` and may use taskmaster scaffolding; an `issue` is labelled `GitHub issue:` and is explicitly told NOT to create task scaffolding. This prevents a bare issue number (e.g. "443") from being mistaken for a task id by the `/start-work` skill.
+Whether the description refers to a pflow `.taskmaster` task or a standalone GitHub issue. Set `issue` for GitHub issues so a bare issue number (e.g. `443`) isn't treated as a task id and no task scaffolding is created; `task` (the default) is for ordinary `.taskmaster` tasks.
 
 - type: string
 - required: false
@@ -55,15 +55,31 @@ Whether the work refers to a pflow task (`.taskmaster`) or a standalone GitHub i
 
 ### agent
 
-Which coding agent to launch in the new worktree's Terminal once it's created. `claude` (the default) runs Claude Code with `--dangerously-skip-permissions`; `codex` runs OpenAI's Codex CLI with `--sandbox workspace-write --ask-for-approval never` (auto-executes commands inside the workspace sandbox, no per-command approval prompts). The same task-context prompt is passed either way. Whether an agent is launched at all is still gated by `open_cli`.
+Which coding agent to launch in the worktree's Terminal. `claude` (the default) runs Claude Code; `codex` runs OpenAI's Codex CLI, which auto-executes commands inside a workspace sandbox (no per-command approval prompts). Both receive the same task-context prompt. Whether an agent launches at all is gated by `open_cli`.
 
 - type: string
 - required: false
 - default: "claude"
 
+### mode
+
+Which agentic skill the launched agent starts with. `explore` (the default) → `/start-work`: investigate the task and produce a plan first — use when no plan exists yet. `implement` → `/implement-plan`: execute an existing plan directly, without re-planning. In `implement` mode, pass the bare task/issue number as `task_description` so the skill can resolve the plan file (e.g. `task_description=177 mode=implement`).
+
+- type: string
+- required: false
+- default: "explore"
+
+### phases
+
+Phase scope for `mode=implement` — implements only these phases of the plan, then stops. Give the numbers as a range or list: `1`, `1-2`, `1,3`. Empty (default) implements the whole plan. Errors in `explore` mode (there is no plan to scope).
+
+- type: string
+- required: false
+- default: ""
+
 ### model
 
-Optional model for the launched coding agent. When set, it is passed through as `--model <model>` to whichever `agent` is launched — both `claude` and `codex` accept `--model` — e.g. `model=opus`, `model=sonnet`, or a full model id like `claude-opus-4-8`. Leave empty (the default) to use the agent's own configured default model. The value is restricted to model-token characters (letters, digits, and `. _ - :`) because `agent_cmd` is inlined unescaped into the launch step's AppleScript command; anything else is rejected with a clear error.
+Optional model for the launched agent, passed through as `--model` (both `claude` and `codex` accept it) — an alias like `opus`/`sonnet`, or a full id like `claude-opus-4-8`. Empty (the default) uses the agent's own default model.
 
 - type: string
 - required: false
@@ -201,7 +217,7 @@ BRANCH_NAME=name
 
 ### parse-result
 
-Central logic node. Parses the LLM's KEY=VALUE response, validates the base branch (erroring if on a feature branch without explicit input), classifies the work as a pflow task or a GitHub issue (deriving the `work_label` and `start_work_hint` used in the launch-cli prompt), constructs the worktree path and full branch name deterministically, prepends a tracker-labelled reference (`issue-<n>` / `task-<n>`) to the branch name for traceability (e.g. `fix/issue-382-shrink-trace-content-interning`), and escapes the task description through two quoting layers (shell single-quote inside AppleScript double-quote) so it can be safely embedded in the launch-cli osascript command.
+Central logic node. Parses the LLM's KEY=VALUE response, validates the base branch (erroring if on a feature branch without explicit input), classifies the work as a pflow task or a GitHub issue (deriving the `work_label`) and selects the launched agent's entry skill from `mode` (deriving the `agent_hint` used in the launch-cli prompt — `/start-work` for `explore`, `/implement-plan` for `implement`), constructs the worktree path and full branch name deterministically, prepends a tracker-labelled reference (`issue-<n>` / `task-<n>`) to the branch name for traceability (e.g. `fix/issue-382-shrink-trace-content-interning`), and escapes the task description through two quoting layers (shell single-quote inside AppleScript double-quote) so it can be safely embedded in the launch-cli osascript command.
 
 - type: code
 - inputs:
@@ -211,6 +227,8 @@ Central logic node. Parses the LLM's KEY=VALUE response, validates the base bran
     base_branch: ${base_branch}
     description: ${task_description}
     work_type: ${work_type}
+    mode: ${mode}
+    phases: ${phases}
     issue_number: ${resolve-description.result.number}
     title_resolved: ${resolve-description.result.title_resolved}
     agent: ${agent}
@@ -226,6 +244,8 @@ current_branch: str
 base_branch: str
 description: str
 work_type: str
+mode: str
+phases: str
 issue_number: str
 title_resolved: bool
 agent: str
@@ -239,27 +259,70 @@ work_type = (work_type or 'task').strip().lower()
 if work_type not in ('task', 'issue'):
     raise ValueError(f"work_type must be 'task' or 'issue', got '{work_type}'")
 
-if work_type == 'issue':
-    work_label = 'GitHub issue'
-    start_work_hint = (
+# Which agentic skill the launched agent is pointed at:
+#   'explore'   -> /start-work    (investigate + produce a plan; no plan exists yet)
+#   'implement' -> /implement-plan (a plan already exists; execute it directly)
+mode = (mode or 'explore').strip().lower()
+if mode not in ('explore', 'implement'):
+    raise ValueError(f"mode must be 'explore' or 'implement', got '{mode}'")
+
+# Optional phase scope forwarded to /implement-plan (which implements ONLY the
+# named phase(s) and stops). Restricted to digits/spaces/commas/hyphens because
+# it is inlined UNESCAPED into agent_hint -> the launch step's AppleScript +
+# shell quoting layers; a quote/$/backtick would break them. Only meaningful in
+# implement mode -- there is no plan to scope while exploring.
+phases = (phases or '').strip()
+if phases:
+    if mode != 'implement':
+        raise ValueError("phases only applies when mode=implement (there is no plan to scope in explore mode)")
+    if not re.fullmatch(r'[0-9][0-9,\- ]*', phases):
+        raise ValueError(
+            f"phases must contain only digits, spaces, commas, and hyphens (e.g. '1', '1-2', '1,3'), got '{phases}'"
+        )
+
+work_label = 'GitHub issue' if work_type == 'issue' else 'Task'
+issue_scaffolding_note = (
+    ' This is a GitHub issue, NOT a pflow task -- do not create taskmaster scaffolding.'
+    if work_type == 'issue' else ''
+)
+
+if mode == 'implement':
+    # A plan already exists -- point the agent straight at /implement-plan rather
+    # than the exploratory /start-work skill. Name the task/issue number when we
+    # have one (bare-number or URL input) so the skill can resolve the plan file;
+    # otherwise tell it to locate the existing plan itself. When phases is set,
+    # forward it as the skill's phase-scope argument so only those phases run.
+    ref = (issue_number or '').strip()
+    scope_arg = f' phases {phases}' if phases else ''
+    if ref:
+        target = f'Run /implement-plan {ref}{scope_arg}.'
+    else:
+        target = f'Run /implement-plan on the existing implementation-plan.md{scope_arg} for this work.'
+    scope_note = f' Implement ONLY phase(s) {phases} and stop after that scope.' if phases else ''
+    agent_hint = (
+        'A plan already exists -- do NOT explore or re-plan. If an /implement-plan '
+        f'skill is available, use it to implement the plan directly. {target}'
+        f'{scope_note}{issue_scaffolding_note}'
+    )
+elif work_type == 'issue':
+    agent_hint = (
         'This is a GitHub issue, NOT a pflow task -- do not create taskmaster task '
         'scaffolding. If a /start-work skill is available, use it to begin and pass '
         'this as a GitHub issue so it fetches the details via gh.'
     )
 else:
-    work_label = 'Task'
-    start_work_hint = 'If a /start-work skill is available, use it to begin.'
+    agent_hint = 'If a /start-work skill is available, use it to begin.'
 
 # If a folder was copied into the worktree (gitignored briefing/research docs that
 # won't exist in a fresh checkout), point the agent at it. The launch prompt otherwise
 # never mentions the copied folder, so the agent has no way to know it exists. Plain
 # text + a controlled path, so it rides the launch step's quoting layers like
-# start_work_hint. Tell it to read EVERY file -- the folder's contents/names vary
+# agent_hint. Tell it to read EVERY file -- the folder's contents/names vary
 # (brief, braindump, research), so don't assume a single filename.
 copy_folder = (copy_folder or '').strip()
 folder_hint = (
     f'IMPORTANT: briefing/research docs were copied into this worktree at {copy_folder}/ '
-    f'-- read ALL files in {copy_folder}/ FIRST, before /start-work. They are the curated '
+    f'-- read ALL files in {copy_folder}/ FIRST, before starting work. They are the curated '
     'context for this task (what to read, locked decisions, constraints, pre-flight).'
 ) if copy_folder else ''
 
@@ -342,13 +405,13 @@ if model:
     agent_cmd = f'{agent_cmd} --model {model}'
 
 # Codex has a repo-local pflow-sandbox-testing skill for running pflow's test
-# suite from sandbox mode; point Codex at it alongside start-work. Claude has no
-# such skill, so this is codex-only. Named in plain text (no '$' prefix, no
-# apostrophes/quotes) so it survives the launch step's heredoc + AppleScript +
-# inner-single-quote layers, which start_work_hint -- unlike safe_description --
-# is not escaped through.
+# suite from sandbox mode; point Codex at it (skill-neutral so it applies whether
+# the agent is exploring or implementing). Claude has no such skill, so this is
+# codex-only. Named in plain text (no '$' prefix, no apostrophes/quotes) so it
+# survives the launch step's heredoc + AppleScript + inner-single-quote layers,
+# which agent_hint -- unlike safe_description -- is not escaped through.
 if agent == 'codex':
-    start_work_hint += ' Use the pflow-sandbox-testing skill directly before or after start-work.'
+    agent_hint += ' Use the pflow-sandbox-testing skill directly when you run pflow tests.'
 
 result: dict = {
     'branch_type': branch_type,
@@ -358,7 +421,7 @@ result: dict = {
     'base_branch': effective_base,
     'safe_description': safe,
     'work_label': work_label,
-    'start_work_hint': start_work_hint,
+    'agent_hint': agent_hint,
     'folder_hint': folder_hint,
     'agent_cmd': agent_cmd,
     'agent_label': agent_label,
@@ -428,7 +491,7 @@ if [ '${open_cursor}' != 'false' ] && [ '${open_cursor}' != 'False' ] && [ '${op
 
 ### launch-cli
 
-Opens a new Terminal window, cd's into the worktree, and starts the selected coding agent (`claude` or `codex`, per the `agent` input) with the description and branch name as initial context. The launch command prefix (`claude --dangerously-skip-permissions` or `codex --sandbox workspace-write --ask-for-approval never`) is derived in `parse-result` as `agent_cmd`; both agents take the context prompt as a positional argument, so only this prefix differs. The absolute worktree path is inlined **directly** into the `do script` command as a resolved `${parse-result.result.worktree_path}` value — NOT passed via a bash variable. This matters: `do script` runs in a brand-new Terminal window whose shell never inherited the workflow's variables, so a `cd $VAR` there would expand to empty and silently land in `$HOME` (the bug that previously launched Claude in the home folder with a stray trust dialog and no project `.claude/` context). A guard refuses to launch (and reports on stderr) if the worktree dir is missing, so it can never fall back to home. `activate` brings Terminal above the Cursor window opened by the prior node, and the window created by `do script` is automatically Terminal's frontmost window — so the Claude session lands on top without any manual window-raising. The description is labelled `Task:` or `GitHub issue:` per `work_type`, and the agent is pointed at the start-work skill (and, for issues, explicitly told not to create taskmaster scaffolding). When `agent=codex`, the prompt additionally tells Codex to use the repo-local `pflow-sandbox-testing` skill directly before or after start-work (Claude has no such skill, so it's added only for codex; named in plain text to stay safe through the quoting layers, which `start_work_hint` is not escaped through). The description is pre-escaped by parse-result to handle quotes safely through the AppleScript and shell quoting layers. Skipped when `open_cli` is false.
+Opens a new Terminal window, cd's into the worktree, and starts the selected coding agent (`claude` or `codex`, per the `agent` input) with the description and branch name as initial context. The launch command prefix (`claude --dangerously-skip-permissions` or `codex --sandbox workspace-write --ask-for-approval never`) is derived in `parse-result` as `agent_cmd`; both agents take the context prompt as a positional argument, so only this prefix differs. The absolute worktree path is inlined **directly** into the `do script` command as a resolved `${parse-result.result.worktree_path}` value — NOT passed via a bash variable. This matters: `do script` runs in a brand-new Terminal window whose shell never inherited the workflow's variables, so a `cd $VAR` there would expand to empty and silently land in `$HOME` (the bug that previously launched Claude in the home folder with a stray trust dialog and no project `.claude/` context). A guard refuses to launch (and reports on stderr) if the worktree dir is missing, so it can never fall back to home. `activate` brings Terminal above the Cursor window opened by the prior node, and the window created by `do script` is automatically Terminal's frontmost window — so the Claude session lands on top without any manual window-raising. The description is labelled `Task:` or `GitHub issue:` per `work_type`, and the agent is pointed at its entry skill per `mode` — `/start-work` (explore) or `/implement-plan` (implement) — with issues explicitly told not to create taskmaster scaffolding. When `agent=codex`, the prompt additionally tells Codex to use the repo-local `pflow-sandbox-testing` skill when running pflow tests (Claude has no such skill, so it's added only for codex; named in plain text to stay safe through the quoting layers, which `agent_hint` is not escaped through). The description is pre-escaped by parse-result to handle quotes safely through the AppleScript and shell quoting layers. Skipped when `open_cli` is false.
 
 - type: shell
 - ignore_errors: true
@@ -442,7 +505,7 @@ else
   osascript <<APPLESCRIPT
 tell application "Terminal"
     activate
-    do script "cd '${parse-result.result.worktree_path}' && ${parse-result.result.agent_cmd} 'You have been assigned to work in a dedicated git worktree. Worktree: ${parse-result.result.worktree_path}, Branch: ${parse-result.result.full_branch}, ${parse-result.result.work_label}: ${parse-result.result.safe_description}. All changes here are separate from main. ${parse-result.result.start_work_hint} ${parse-result.result.folder_hint}'"
+    do script "cd '${parse-result.result.worktree_path}' && ${parse-result.result.agent_cmd} 'You have been assigned to work in a dedicated git worktree. Worktree: ${parse-result.result.worktree_path}, Branch: ${parse-result.result.full_branch}, ${parse-result.result.work_label}: ${parse-result.result.safe_description}. All changes here are separate from main. ${parse-result.result.agent_hint} ${parse-result.result.folder_hint}'"
 end tell
 APPLESCRIPT
   echo '${parse-result.result.agent_label} launched in Terminal'

--- a/examples/real-workflows/git-worktree-task-creator/workflow.pflow.md
+++ b/examples/real-workflows/git-worktree-task-creator/workflow.pflow.md
@@ -287,22 +287,36 @@ issue_scaffolding_note = (
 )
 
 if mode == 'implement':
-    # A plan already exists -- point the agent straight at /implement-plan rather
-    # than the exploratory /start-work skill. Name the task/issue number when we
-    # have one (bare-number or URL input) so the skill can resolve the plan file;
-    # otherwise tell it to locate the existing plan itself. When phases is set,
-    # forward it as the skill's phase-scope argument so only those phases run.
-    ref = (issue_number or '').strip()
+    # A plan already exists -- point the agent at /implement-plan, not the
+    # exploratory /start-work skill. When phases is set, forward it as the skill's
+    # phase-scope argument so only those phases run.
     scope_arg = f' phases {phases}' if phases else ''
-    if ref:
-        target = f'Run /implement-plan {ref}{scope_arg}.'
+    if work_type == 'task':
+        # Tasks live in .taskmaster; a bare task number resolves the plan file for
+        # /implement-plan. issue_number is guaranteed digit-only (or empty) by
+        # resolve-description's regex, so it is safe to inline unescaped here.
+        ref = (issue_number or '').strip()
+        if ref:
+            target = f'Run /implement-plan {ref}{scope_arg}.'
+        else:
+            target = f"Run /implement-plan on the task's implementation-plan.md{scope_arg}."
     else:
-        target = f'Run /implement-plan on the existing implementation-plan.md{scope_arg} for this work.'
-    scope_note = f' Implement ONLY phase(s) {phases} and stop after that scope.' if phases else ''
+        # A GitHub issue number is NOT a task id, and issues have no .taskmaster
+        # plan -- so do NOT feed the number to /implement-plan (it would resolve to a
+        # nonexistent task_<n>). The launched agent has the issue context and locates
+        # the issue's existing plan itself.
+        target = f'Run /implement-plan on the existing plan for this issue{scope_arg}.'
+    # Empty phases means "the whole plan". /implement-plan otherwise ASKS before
+    # implementing a whole plan when no scope is given; the worktree's implement
+    # mode is an explicit "execute it directly" request, so tell it to proceed.
+    if phases:
+        directive = f' Implement ONLY phase(s) {phases} and stop after that scope.'
+    else:
+        directive = ' Implement the whole plan directly -- no need to ask before starting.'
     agent_hint = (
         'A plan already exists -- do NOT explore or re-plan. If an /implement-plan '
         f'skill is available, use it to implement the plan directly. {target}'
-        f'{scope_note}{issue_scaffolding_note}'
+        f'{directive}{issue_scaffolding_note}'
     )
 elif work_type == 'issue':
     agent_hint = (

--- a/tests/test_runtime/fixtures/golden_config_hashes.json
+++ b/tests/test_runtime/fixtures/golden_config_hashes.json
@@ -93,7 +93,7 @@
     "launch-cli": "ab38eb810b897cdb7cedc97bc3505559",
     "launch-cursor": "2c6fd749b1505c4416a790b4aa7afd75",
     "output-status": "459e5f8341b84441832f695049b995e6",
-    "parse-result": "c7d94eeb4171df58bd15d0629e1315e1",
+    "parse-result": "b97246f4be64a13c0b5770e497099661",
     "resolve-description": "c04d99dc55f1640a7bcbb3d448ea7059"
   },
   "examples/test_llm_templates.pflow.md": {

--- a/tests/test_runtime/fixtures/golden_config_hashes.json
+++ b/tests/test_runtime/fixtures/golden_config_hashes.json
@@ -90,10 +90,10 @@
     "create-worktree": "3cafcc188e9e34a5a32c2a260928c203",
     "get-branch": "33c830618882bc975db4e0ef6ccd85de",
     "get-repo-root": "33c830618882bc975db4e0ef6ccd85de",
-    "launch-cli": "715bd1126d5cfdf68dcd2af9e8f8469c",
+    "launch-cli": "ab38eb810b897cdb7cedc97bc3505559",
     "launch-cursor": "2c6fd749b1505c4416a790b4aa7afd75",
     "output-status": "459e5f8341b84441832f695049b995e6",
-    "parse-result": "e69a7a677d1b5b4f5367201c12522262",
+    "parse-result": "c7d94eeb4171df58bd15d0629e1315e1",
     "resolve-description": "c04d99dc55f1640a7bcbb3d448ea7059"
   },
   "examples/test_llm_templates.pflow.md": {

--- a/tests/test_runtime/test_worktree_creator_workflow.py
+++ b/tests/test_runtime/test_worktree_creator_workflow.py
@@ -12,7 +12,15 @@ WORKFLOW_PATH = (
 )
 
 
-def run_parse_result(response: str) -> dict[str, str]:
+def run_parse_result(
+    response: str,
+    *,
+    work_type: str = "task",
+    mode: str = "explore",
+    phases: str = "",
+    issue_number: str = "",
+    agent: str = "claude",
+) -> dict[str, str]:
     """Execute the workflow's parse-result node with deterministic inputs."""
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
     section = workflow.split("### parse-result", maxsplit=1)[1].split("### create-worktree", maxsplit=1)[0]
@@ -24,10 +32,12 @@ def run_parse_result(response: str) -> dict[str, str]:
         "current_branch": "main",
         "base_branch": "",
         "description": "Add portable agent assets",
-        "work_type": "task",
-        "issue_number": "",
+        "work_type": work_type,
+        "mode": mode,
+        "phases": phases,
+        "issue_number": issue_number,
         "title_resolved": False,
-        "agent": "claude",
+        "agent": agent,
         "model": "",
         "copy_folder": "",
     }
@@ -61,3 +71,78 @@ def test_copy_folder_resolves_from_the_repository_root() -> None:
 def test_parse_result_rejects_unsafe_llm_branch_values(response: str) -> None:
     with pytest.raises(ValueError, match=r"branch_(type|name)"):
         run_parse_result(response)
+
+
+BRANCH_RESPONSE = "BRANCH_TYPE=feat\nBRANCH_NAME=portable-agent-assets"
+
+
+def test_explore_mode_points_agent_at_start_work() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="explore")
+
+    assert "/start-work" in result["agent_hint"]
+    assert "/implement-plan" not in result["agent_hint"]
+
+
+def test_implement_mode_points_agent_at_implement_plan_with_task_number() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="177")
+
+    assert "/implement-plan 177" in result["agent_hint"]
+    assert "/start-work" not in result["agent_hint"]
+    assert "do NOT explore or re-plan" in result["agent_hint"]
+
+
+def test_implement_mode_without_number_falls_back_to_plan_path() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="")
+
+    assert "/implement-plan" in result["agent_hint"]
+    assert "implementation-plan.md" in result["agent_hint"]
+
+
+def test_implement_mode_for_issue_keeps_no_scaffolding_note() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", work_type="issue", issue_number="443")
+
+    assert "/implement-plan 443" in result["agent_hint"]
+    assert "do not create taskmaster scaffolding" in result["agent_hint"]
+
+
+def test_codex_sandbox_hint_is_skill_neutral_in_implement_mode() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="177", agent="codex")
+
+    assert "pflow-sandbox-testing" in result["agent_hint"]
+    assert "start-work" not in result["agent_hint"]
+
+
+def test_parse_result_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match=r"mode must be"):
+        run_parse_result(BRANCH_RESPONSE, mode="wander")
+
+
+def test_implement_mode_forwards_phase_scope_to_implement_plan() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="177", phases="1-2")
+
+    assert "/implement-plan 177 phases 1-2" in result["agent_hint"]
+    assert "Implement ONLY phase(s) 1-2 and stop" in result["agent_hint"]
+
+
+def test_implement_mode_forwards_phase_scope_without_task_number() -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="", phases="3")
+
+    assert "implementation-plan.md phases 3" in result["agent_hint"]
+
+
+@pytest.mark.parametrize("phases", ["1", "1-2", "1,3", "2, 4"])
+def test_phases_accepts_digit_ranges_and_lists(phases: str) -> None:
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="9", phases=phases)
+
+    assert f"phases {phases}" in result["agent_hint"]
+
+
+@pytest.mark.parametrize("phases", ["one", "1;2", "$(rm)", "1'2", 'phase"1'])
+def test_phases_rejects_unsafe_values(phases: str) -> None:
+    with pytest.raises(ValueError, match=r"phases must contain only"):
+        run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="9", phases=phases)
+
+
+def test_phases_requires_implement_mode() -> None:
+    with pytest.raises(ValueError, match=r"phases only applies when mode=implement"):
+        run_parse_result(BRANCH_RESPONSE, mode="explore", phases="1-2")

--- a/tests/test_runtime/test_worktree_creator_workflow.py
+++ b/tests/test_runtime/test_worktree_creator_workflow.py
@@ -98,11 +98,25 @@ def test_implement_mode_without_number_falls_back_to_plan_path() -> None:
     assert "implementation-plan.md" in result["agent_hint"]
 
 
-def test_implement_mode_for_issue_keeps_no_scaffolding_note() -> None:
+def test_implement_mode_for_issue_does_not_pass_issue_number_as_task_id() -> None:
+    # An issue number is NOT a task id and issues have no .taskmaster plan, so it
+    # must not become `/implement-plan 443` (which resolves to a nonexistent task).
     result = run_parse_result(BRANCH_RESPONSE, mode="implement", work_type="issue", issue_number="443")
 
-    assert "/implement-plan 443" in result["agent_hint"]
+    assert "/implement-plan 443" not in result["agent_hint"]
+    assert "existing plan for this issue" in result["agent_hint"]
     assert "do not create taskmaster scaffolding" in result["agent_hint"]
+
+
+def test_implement_mode_without_phases_tells_agent_to_proceed_on_whole_plan() -> None:
+    # /implement-plan asks before implementing a whole plan when no scope is given;
+    # implement mode is an explicit "do it directly" request, so proceed.
+    result = run_parse_result(BRANCH_RESPONSE, mode="implement", issue_number="177")
+
+    assert "whole plan" in result["agent_hint"].lower()
+    assert "no need to ask" in result["agent_hint"].lower()
+    # The proceed directive is mutually exclusive with the phase-scope directive.
+    assert "Implement ONLY phase(s)" not in result["agent_hint"]
 
 
 def test_codex_sandbox_hint_is_skill_neutral_in_implement_mode() -> None:

--- a/web/src/views/GraphView.test.tsx
+++ b/web/src/views/GraphView.test.tsx
@@ -771,7 +771,9 @@ describe("GraphView mount", () => {
 
       fitViewSpy.mockClear();
       fireEvent.click(screen.getByText("greet")); // the source endpoint chip
-      await waitFor(() => expect(fitViewSpy).toHaveBeenCalled());
+      // Camera-follow is async (navigate → layout → fitView); waitFor's 1s default
+      // is too tight under CI load (observed ~1.07s), so give the follow headroom.
+      await waitFor(() => expect(fitViewSpy).toHaveBeenCalled(), { timeout: 5000 });
       const followed = fitViewSpy.mock.calls.some(
         (c) => (c[0] as { nodes?: { id: string }[] } | undefined)?.nodes?.[0]?.id === "n0",
       );
@@ -822,7 +824,7 @@ describe("GraphView mount", () => {
 
     fitViewSpy.mockClear();
     fireEvent.click(container.querySelector(".chip-stack .edge-chip")!);
-    await waitFor(() => expect(fitViewSpy).toHaveBeenCalled());
+    await waitFor(() => expect(fitViewSpy).toHaveBeenCalled(), { timeout: 5000 });
     const followed = fitViewSpy.mock.calls.some(
       (c) => (c[0] as { nodes?: { id: string }[] } | undefined)?.nodes?.[0]?.id === "g_wf",
     );
@@ -845,12 +847,14 @@ describe("GraphView mount", () => {
 
     fitViewSpy.mockClear();
     act(() => live.handlers!.frame({ kind: "node", ref: GRAPH.nodes[1]!.ref }));
-    await waitFor(() =>
-      expect(
-        fitViewSpy.mock.calls.some(
-          (call) => (call[0] as { nodes?: { id: string }[] } | undefined)?.nodes?.[0]?.id === "n1",
-        ),
-      ).toBe(true),
+    await waitFor(
+      () =>
+        expect(
+          fitViewSpy.mock.calls.some(
+            (call) => (call[0] as { nodes?: { id: string }[] } | undefined)?.nodes?.[0]?.id === "n1",
+          ),
+        ).toBe(true),
+      { timeout: 5000 },
     );
     expect(container.querySelector(".read-panel")).toBeNull();
     expect(live.report).toHaveBeenCalledTimes(reportsAfterOpen);
@@ -897,7 +901,7 @@ describe("GraphView mount", () => {
     // produces no paint epoch for a deferred camera request to wait on.
     fitViewSpy.mockClear();
     act(() => live.handlers!.focus(target));
-    await waitFor(() => expect(fitViewSpy).toHaveBeenCalled());
+    await waitFor(() => expect(fitViewSpy).toHaveBeenCalled(), { timeout: 5000 });
   });
 
   it("reveals both collapsed endpoint chains before applying a live edge focus", async () => {


### PR DESCRIPTION
## Summary

Extends the `git-worktree-task-creator` workflow so a launched agent can implement an
existing plan directly (not just explore), and reworks the `worktree-pflow` skill and the
workflow's input descriptions for clarity.

Two new workflow inputs:
- **`mode`** (`explore` | `implement`, default `explore`) — `implement` points the launched
  agent at `/implement-plan` instead of the default `/start-work`. `explore` stays the
  exploratory "investigate and write a plan first" path.
- **`phases`** (requires `mode=implement`) — forwards a phase scope to `/implement-plan`
  (e.g. `phases=1-2`) so the agent implements only those phases and stops.

_Related (not closed by this PR): #590 — making `pflow describe` work on local workflow
files. Surfaced during this work; tracked separately._

## Changes

- **workflow** (`examples/real-workflows/git-worktree-task-creator/workflow.pflow.md`):
  - New `mode` and `phases` inputs with validation in `parse-result`.
  - `agent_hint` now branches on `mode`: builds a `/implement-plan <task> phases <spec>`
    prompt in implement mode, `/start-work` in explore mode. Renamed the internal
    `start_work_hint` → `agent_hint` (no longer start-work-specific).
  - `phases` is validated to digits/spaces/commas/hyphens only (it is inlined unescaped
    into the launch prompt through AppleScript + shell quoting layers).
  - Split input descriptions by audience: caller-facing prose stays in the `## Inputs`
    descriptions; mechanics (flag strings, charset/quoting rationale) live in the
    `parse-result` code comments where they already were — removing the duplication.
- **skill** (`.claude/commands/worktree-pflow.md`): rewritten mapping-first — a commented
  examples block + a flags table + a short judgment-rules section, replacing the flat
  10-bullet list. Also fixes two latent bugs (below).
- **tests** (`tests/test_runtime/test_worktree_creator_workflow.py`): +6 cases for the new
  behavior.
- **golden hashes** (`tests/test_runtime/fixtures/golden_config_hashes.json`): regenerated
  — only the `parse-result` and `launch-cli` node hashes moved, both from the intentional
  content change (reviewed diff).

## Explanation

`mode`/`phases` exist because the worktree workflow previously only ever launched the agent
into `/start-work` (exploratory planning). When a plan already exists (e.g. a task's
`implementation-plan.md`), that forces the agent to re-derive a plan it should just execute.
`mode=implement` + optional `phases` hands the plan straight to `/implement-plan`.

The skill rewrite targets how an AI agent actually uses the file: it reads *only* the skill
at invocation and must map a natural-language request to one `key=value` command. Examples
carry the phrase→flags mapping (including quoting and the `"phase 1 and 2"` → `phases=1-2`
normalization) where prose can't; a flags table gives completeness; `base_branch`/`overwrite`
stay prose because they're state/judgment decisions, not simple flag mappings.

Two correctness fixes fell out of the rewrite:
- The skill referenced "the request below" but never included the `$ARGUMENTS` block — the
  agent could have received an empty request. Added.
- The `base_branch` guidance implied you could omit it to branch off the current branch, but
  the workflow *errors* when off `main` without an explicit `base_branch`. Corrected: to
  branch off the current feature branch you must pass `base_branch=<current-branch>`.

Diff: 4 files changed, +230 / −41. Input-description edits don't touch node config, so they
caused no golden-hash drift; only the `parse-result` code change did.

## Testing

- `test_implement_mode_points_agent_at_implement_plan_with_task_number` — implement mode
  emits `Run /implement-plan 177` and drops the `/start-work` hint.
- `test_implement_mode_forwards_phase_scope_to_implement_plan` — `phases=1-2` renders
  `/implement-plan 177 phases 1-2` + "implement ONLY phase(s) 1-2 and stop".
- `test_phases_rejects_unsafe_values` — `$(rm)`, quotes, and word forms are rejected.
- `test_phases_requires_implement_mode` / `test_parse_result_rejects_unknown_mode` — guards.
- `test_explore_mode_points_agent_at_start_work` / issue-mode cases — no regression to the
  default path.
- Full suite: `make test` → **8818 passed** on this tree. Example-validation and the
  golden-hash gate both green.
- Manual: ran the workflow end-to-end with `task_description=177 mode=implement phases=1-2
  open_cli=false open_cursor=false`; the trace's resolved prompt was
  `Run /implement-plan 177 phases 1-2. Implement ONLY phase(s) 1-2 and stop after that
  scope.` (throwaway worktree removed afterward).
