### PR TITLE
fix(cli): describe local workflow files

### DIFF
--- a/docs/reference/cli/describe.mdx
+++ b/docs/reference/cli/describe.mdx
@@ -1,13 +1,19 @@
 ---
 title: "pflow describe"
-description: "Show a saved workflow's interface"
+description: "Show a saved workflow or local workflow file's interface"
 icon: "file-search"
 ---
 
 ## Usage
 
 ```bash
-pflow describe <WORKFLOW>
+pflow describe <NAME_OR_PATH>
 ```
 
-Shows inputs, outputs, history summary, and example usage for a saved workflow.
+Shows inputs, outputs, and a copyable example command. Saved workflows also include their execution history; unsaved files omit history.
+
+```bash
+pflow describe my-saved-workflow
+pflow describe ./drafts/release-notes.pflow.md
+pflow describe './draft workflows/release notes.pflow.md'
+```

--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -23,7 +23,7 @@ pflow [command] [options] [arguments]
     Run workflows by name or file
   </Card>
   <Card title="pflow list / find / describe" icon="workflow" href="/reference/cli/list">
-    Find and inspect saved workflows
+    Find saved workflows and inspect them by saved name or file path
   </Card>
   <Card title="pflow skill" icon="wand-magic-sparkles" href="/reference/cli/skill">
     Publish workflows as AI agent skills

--- a/src/pflow/cli/commands/describe.py
+++ b/src/pflow/cli/commands/describe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import sys
 
 import click
@@ -10,23 +11,47 @@ from pflow.core.workflow.manager import WorkflowManager
 
 
 @click.command(name="describe")
-@click.argument("name")
+@click.argument("name", metavar="NAME_OR_PATH")
 def describe_cmd(name: str) -> None:
-    """Show workflow interface — inputs, outputs, and example usage.
+    """Show a saved or local workflow's inputs, outputs, and example usage.
 
     \b
     Examples:
       pflow describe my-workflow
-      pflow describe fetch-github-prs
+      pflow describe ./drafts/fetch-github-prs.pflow.md
     """
+    from pflow.core.exceptions import WorkflowNotFoundError
+    from pflow.core.user_errors import UserFriendlyError
     from pflow.execution.formatters.workflow_describe_formatter import format_workflow_interface
+    from pflow.execution.workflow_resolver import resolve_workflow
 
     workflow_manager = WorkflowManager()
-    if not workflow_manager.exists(name):
-        _handle_workflow_not_found(name, workflow_manager)
+    example_name = name
+    if workflow_manager.exists(name):
+        metadata = workflow_manager.load(name)
+    else:
+        try:
+            resolved = resolve_workflow(name, workflow_manager)
+        except WorkflowNotFoundError as e:
+            if e.hint:
+                raise
+            _handle_workflow_not_found(name, workflow_manager)
+        except (OSError, UnicodeError) as e:
+            raise UserFriendlyError(
+                title="Could not read workflow file",
+                explanation=f"pflow could not read '{name}': {e}",
+                suggestions=["Check that the path points to a readable UTF-8 .pflow.md file."],
+                technical_details=repr(e),
+            ) from e
+        if resolved.source != "file":
+            _handle_workflow_not_found(name, workflow_manager)
+        metadata = {"ir": resolved.ir, "description": resolved.description or "No description"}
+        example_name = shlex.quote(name)
 
-    metadata = workflow_manager.load(name)
-    click.echo(format_workflow_interface(name, metadata))
+    formatted = format_workflow_interface(example_name, metadata)
+    if example_name != name:
+        formatted = formatted.replace(f"Workflow: {example_name}", f"Workflow: {name}", 1)
+    click.echo(formatted)
 
 
 def _handle_workflow_not_found(name: str, workflow_manager: WorkflowManager) -> None:

--- a/src/pflow/cli/commands/describe.py
+++ b/src/pflow/cli/commands/describe.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shlex
 import sys
+from typing import NoReturn
 
 import click
 
@@ -20,9 +21,9 @@ def describe_cmd(name: str) -> None:
       pflow describe my-workflow
       pflow describe ./drafts/fetch-github-prs.pflow.md
     """
+    from pflow.cli.workflow_interface import format_workflow_interface_for_cli
     from pflow.core.exceptions import WorkflowNotFoundError
     from pflow.core.user_errors import UserFriendlyError
-    from pflow.execution.formatters.workflow_describe_formatter import format_workflow_interface
     from pflow.execution.workflow_resolver import resolve_workflow
 
     workflow_manager = WorkflowManager()
@@ -48,13 +49,11 @@ def describe_cmd(name: str) -> None:
         metadata = {"ir": resolved.ir, "description": resolved.description or "No description"}
         example_name = shlex.quote(name)
 
-    formatted = format_workflow_interface(example_name, metadata)
-    if example_name != name:
-        formatted = formatted.replace(f"Workflow: {example_name}", f"Workflow: {name}", 1)
+    formatted = format_workflow_interface_for_cli(name, metadata, example_name=example_name)
     click.echo(formatted)
 
 
-def _handle_workflow_not_found(name: str, workflow_manager: WorkflowManager) -> None:
+def _handle_workflow_not_found(name: str, workflow_manager: WorkflowManager) -> NoReturn:
     all_names = workflow_manager.list_names()
     similar = [n for n in all_names if name.lower() in n.lower()][:3]
     click.echo(f"Error: Workflow '{name}' not found.", err=True)

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -6,6 +6,7 @@ import dataclasses
 import json
 import logging
 import os
+import shlex
 import sys
 import time
 import warnings
@@ -856,9 +857,10 @@ def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
 
     # The name/path the user typed, so suggestions are concrete and copy-pasteable.
     # `<workflow>` only when the name was omitted (workflow[0] is itself a dash).
-    # Per-workflow `--help` (not `pflow describe`) is used to list inputs because
-    # it accepts BOTH file paths and saved names; `describe` only takes saved names.
+    # Per-workflow `--help` lists inputs without requiring a separate command.
+    # Quote concrete paths so every suggestion remains copy-pasteable.
     target = workflow[0] if workflow and not workflow[0].startswith("-") else "<workflow>"
+    quoted_target = target if target == "<workflow>" else shlex.quote(target)
 
     misplaced = [arg for arg in stray if arg in _PFLOW_FLAGS]
     if misplaced:
@@ -867,7 +869,7 @@ def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
             explanation=(
                 f"pflow flags configure the run and must precede the workflow. Found after it: {', '.join(misplaced)}"
             ),
-            suggestions=[f"pflow {misplaced[0]} {target}"],
+            suggestions=[f"pflow {misplaced[0]} {quoted_target}"],
         )
 
     bad = stray[0]
@@ -875,7 +877,7 @@ def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
         raise UserFriendlyError(
             title="Unknown option '-h'",
             explanation="pflow uses '--help' to show a workflow's inputs and outputs.",
-            suggestions=[f"pflow {target} --help"],
+            suggestions=[f"pflow {quoted_target} --help"],
         )
 
     raise UserFriendlyError(
@@ -886,7 +888,7 @@ def _validate_workflow_flags(workflow: tuple[str, ...]) -> None:
         ),
         suggestions=[
             f"Did you mean '{_suggest_key_value(bad, workflow)}'?",
-            f"See this workflow's inputs: pflow {target} --help",
+            f"See this workflow's inputs: pflow {quoted_target} --help",
         ],
     )
 
@@ -1055,7 +1057,10 @@ def _show_workflow_help(
         click.echo(f"Source: {first_arg}")
     click.echo()
 
-    formatted = format_workflow_interface(name, metadata)
+    example_name = name if source == "library" else shlex.quote(first_arg)
+    formatted = format_workflow_interface(example_name, metadata)
+    if example_name != name:
+        formatted = formatted.replace(f"Workflow: {example_name}", f"Workflow: {name}", 1)
     click.echo(formatted)
 
 

--- a/src/pflow/cli/commands/run.py
+++ b/src/pflow/cli/commands/run.py
@@ -1042,7 +1042,7 @@ def _show_workflow_help(
     source: str | None,
 ) -> None:
     """Display workflow help information."""
-    from pflow.execution.formatters.workflow_describe_formatter import format_workflow_interface
+    from pflow.cli.workflow_interface import format_workflow_interface_for_cli
 
     name = os.path.basename(first_arg) if "/" in first_arg else first_arg
     metadata = {"ir": workflow_ir}
@@ -1058,9 +1058,7 @@ def _show_workflow_help(
     click.echo()
 
     example_name = name if source == "library" else shlex.quote(first_arg)
-    formatted = format_workflow_interface(example_name, metadata)
-    if example_name != name:
-        formatted = formatted.replace(f"Workflow: {example_name}", f"Workflow: {name}", 1)
+    formatted = format_workflow_interface_for_cli(name, metadata, example_name=example_name)
     click.echo(formatted)
 
 

--- a/src/pflow/cli/workflow_interface.py
+++ b/src/pflow/cli/workflow_interface.py
@@ -1,0 +1,28 @@
+"""CLI adapter for workflow-interface formatting."""
+
+from typing import Any
+
+from pflow.execution.formatters.workflow_describe_formatter import format_workflow_interface
+
+
+def format_workflow_interface_for_cli(
+    name: str,
+    metadata: dict[str, Any],
+    *,
+    example_name: str,
+) -> str:
+    """Render a raw heading and a separately shell-safe example command.
+
+    The shared formatter intentionally has one name argument because MCP and
+    saved-workflow callers use the same value for both surfaces. Local CLI
+    paths need different display and shell representations, so adapt the
+    formatter output at this boundary and fail loudly if its heading contract
+    ever changes.
+    """
+    formatted = format_workflow_interface(example_name, metadata)
+    heading, separator, remainder = formatted.partition("\n")
+    expected_heading = f"Workflow: {example_name}"
+    if heading != expected_heading:
+        raise RuntimeError(f"Unexpected workflow interface heading: {heading!r}")
+
+    return f"Workflow: {name}{separator}{remainder}"

--- a/src/pflow/cli/workflow_resolution.py
+++ b/src/pflow/cli/workflow_resolution.py
@@ -29,11 +29,6 @@ def is_likely_workflow_name(text: str, remaining_args: tuple[str, ...]) -> bool:
     if not text:
         return False
 
-    # Text with spaces is never a workflow name (even with params)
-    # Workflow names are single words or kebab-case
-    if " " in text:
-        return False
-
     # Detect file paths (platform separators) and workflow file extensions
     lower = text.lower()
     if (
@@ -44,6 +39,11 @@ def is_likely_workflow_name(text: str, remaining_args: tuple[str, ...]) -> bool:
         or lower.endswith(".md")
     ):
         return True
+
+    # Arbitrary text with spaces is never a workflow name (even with params).
+    # Path-like arguments were handled above because valid file paths may contain spaces.
+    if " " in text:
+        return False
 
     # If there are parameter-like arguments following (key=value), likely a workflow name
     # But check that it's not CLI syntax (=> or --)

--- a/tests/test_cli/test_unknown_flag_handling.py
+++ b/tests/test_cli/test_unknown_flag_handling.py
@@ -62,10 +62,21 @@ class TestValidateWorkflowFlagsGuard:
         assert err.title == "Unknown option '--scenario'"
         assert "key=value" in err.explanation
         assert any("scenario=fail-mid" in s for s in err.suggestions)
-        # Inputs are listed via per-workflow --help (accepts file paths), using the
-        # concrete name — NOT `pflow describe`, which only resolves saved names.
+        # Inputs are listed via per-workflow --help using the concrete name.
         assert any("pflow wf.pflow.md --help" in s for s in err.suggestions)
         assert not any("describe" in s for s in err.suggestions)
+
+    def test_spaced_workflow_path_is_quoted_in_suggestions(self):
+        """Commands emitted for spaced paths must remain copy-pasteable."""
+        target = "./draft files/wf.pflow.md"
+
+        with pytest.raises(UserFriendlyError) as misplaced:
+            _validate_workflow_flags((target, "--verbose"))
+        assert misplaced.value.suggestions == [f"pflow --verbose '{target}'"]
+
+        with pytest.raises(UserFriendlyError) as unknown:
+            _validate_workflow_flags((target, "--scenario"))
+        assert any(f"pflow '{target}' --help" in suggestion for suggestion in unknown.value.suggestions)
 
     def test_unknown_flag_pairs_its_following_value(self):
         """An unknown flag pairs with the token that follows it for the hint."""

--- a/tests/test_cli/test_workflow_commands.py
+++ b/tests/test_cli/test_workflow_commands.py
@@ -3,8 +3,13 @@
 import json
 import sys
 from io import StringIO
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+
+import pytest
+
+from tests.shared.markdown_utils import write_workflow_file
 
 
 def invoke_cli(args: list[str]) -> Any:
@@ -406,6 +411,74 @@ class TestWorkflowDescribeCommand:
             assert "Example Usage:" in result.output
             assert "pflow data-processor input_file=<value>" in result.output
 
+    def test_describe_saved_workflow_preserves_execution_history(self) -> None:
+        """Saved workflows retain their library metadata and history section."""
+        mock_metadata = {
+            "description": "A saved workflow",
+            "execution_count": 2,
+            "last_execution_timestamp": "2026-07-15T08:00:00Z",
+            "last_execution_success": True,
+            "ir": {"nodes": []},
+        }
+
+        with patch("pflow.cli.commands.describe.WorkflowManager") as MockWM:
+            mock_wm = MockWM.return_value
+            mock_wm.exists.return_value = True
+            mock_wm.load.return_value = mock_metadata
+
+            result = invoke_cli(["describe", "saved-workflow"])
+
+        assert result.exit_code == 0
+        assert "Workflow: saved-workflow" in result.output
+        assert "Execution History:" in result.output
+        assert "Runs: 2 times" in result.output
+        mock_wm.load.assert_called_once_with("saved-workflow")
+
+    def test_describe_local_file_preserves_typed_path_without_history_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unsaved files use the typed path for both display and copyable usage."""
+        workflow_path = tmp_path / "draft files" / "local-workflow.pflow.md"
+        workflow_path.parent.mkdir()
+        write_workflow_file(
+            {
+                "inputs": {"subject": {"required": True, "description": "Subject to greet"}},
+                "outputs": {"message": {"description": "Greeting text"}},
+                "nodes": [
+                    {
+                        "id": "greet",
+                        "type": "shell",
+                        "purpose": "Create the greeting",
+                        "params": {"command": "echo hello"},
+                    }
+                ],
+            },
+            workflow_path,
+            title="Local Workflow",
+            description="A local draft",
+        )
+        typed_path = "./draft files/local-workflow.pflow.md"
+        monkeypatch.chdir(tmp_path)
+
+        with patch("pflow.cli.commands.describe.WorkflowManager") as MockWM:
+            MockWM.return_value.exists.return_value = False
+            result = invoke_cli(["describe", typed_path])
+
+        assert result.exit_code == 0
+        assert result.output == (
+            f"Workflow: {typed_path}\n"
+            "Description: A local draft\n"
+            "\n"
+            "Inputs:\n"
+            "  - subject (required): Subject to greet\n"
+            "\n"
+            "Outputs:\n"
+            "  - message: Greeting text\n"
+            "\n"
+            "Example Usage:\n"
+            f"  pflow '{typed_path}' subject=<value>\n"
+        )
+
     def test_describe_workflow_no_inputs_outputs(self) -> None:
         """Test describing a workflow with no inputs or outputs."""
         mock_metadata = {
@@ -502,6 +575,60 @@ class TestWorkflowDescribeCommand:
             assert result.exit_code == 1
             assert "Error: Workflow 'xyz-task' not found." in result.stderr
             assert "Did you mean:" not in result.stderr
+
+    def test_describe_missing_file_does_not_fall_back_to_saved_workflow(self) -> None:
+        """A path-like argument must resolve to a file, not a stripped library name."""
+        with patch("pflow.cli.commands.describe.WorkflowManager") as MockWM:
+            mock_wm = MockWM.return_value
+            mock_wm.exists.side_effect = lambda name: name == "report"
+            mock_wm.get_path.return_value = "/missing/library/report.pflow.md"
+            mock_wm.load_ir.return_value = {"nodes": []}
+            mock_wm.list_names.return_value = ["report"]
+
+            result = invoke_cli(["describe", "report.pflow.md"])
+
+        assert result.exit_code == 1
+        assert "Error: Workflow 'report.pflow.md' not found." in result.stderr
+        assert "Did you mean:" not in result.stderr
+        mock_wm.load.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("typed_name", "expected_hint"),
+        [
+            ("draft.md", "Did you mean"),
+            ("legacy.json", "JSON workflow format is no longer supported"),
+        ],
+    )
+    def test_describe_preserves_format_specific_resolution_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, typed_name: str, expected_hint: str
+    ) -> None:
+        """Local-file format guidance must not be replaced by generic name suggestions."""
+        if typed_name.endswith(".md"):
+            write_workflow_file({"nodes": []}, tmp_path / "draft.pflow.md")
+        monkeypatch.chdir(tmp_path)
+
+        result = invoke_cli(["describe", typed_name])
+
+        assert result.exit_code == 1
+        assert expected_hint in result.stderr
+        assert "Use 'pflow list'" not in result.stderr
+
+    @pytest.mark.parametrize("failure", ["directory", "invalid_utf8"])
+    def test_describe_file_read_failure_is_actionable(self, tmp_path: Path, failure: str) -> None:
+        """Unreadable workflow paths render diagnostics instead of tracebacks."""
+        workflow_path = tmp_path / f"{failure}.pflow.md"
+        if failure == "directory":
+            workflow_path.mkdir()
+        else:
+            workflow_path.write_bytes(b"\xff")
+
+        result = invoke_cli(["describe", str(workflow_path)])
+
+        assert result.exit_code == 1
+        assert "Error: Could not read workflow file" in result.stderr
+        assert f"pflow could not read '{workflow_path}'" in result.stderr
+        assert "Check that the path points to a readable UTF-8 .pflow.md file." in result.stderr
+        assert "Traceback" not in result.stderr
 
     def test_describe_workflow_case_insensitive_suggestions(self) -> None:
         """Test that suggestions are case-insensitive."""

--- a/tests/test_cli/test_workflow_resolution.py
+++ b/tests/test_cli/test_workflow_resolution.py
@@ -465,11 +465,19 @@ class TestIsLikelyWorkflowName:
         assert is_likely_workflow_name("github-sync", ())
 
     def test_text_with_spaces_not_workflow_name(self):
-        """Test that text with spaces is never a workflow name."""
+        """Ordinary natural language with spaces is not a workflow name."""
         from pflow.cli.workflow_resolution import is_likely_workflow_name
 
         assert not is_likely_workflow_name("analyze this text", ())
         assert not is_likely_workflow_name("process my data", ("param=value",))
+
+    def test_file_path_with_spaces_is_workflow_name(self):
+        """Quoted paths remain one argument and must reach workflow resolution."""
+        from pflow.cli.workflow_resolution import is_likely_workflow_name
+
+        assert is_likely_workflow_name("./workflow drafts/test.pflow.md", ())
+        # The separator makes this intentionally path-like despite the prose prefix.
+        assert is_likely_workflow_name("explain docs/readme.md", ())
 
     def test_file_paths_are_workflow_names(self):
         """Test that file paths are recognized as workflow references."""
@@ -518,6 +526,21 @@ class TestEdgeCases:
 
         assert result.exit_code == 1
         assert "not found" in result.output.lower()
+
+    def test_spaced_workflow_path_help_has_copyable_example(self, tmp_path):
+        """Per-workflow help quotes the full typed path in its usage example."""
+        runner = click.testing.CliRunner()
+        workflow_path = tmp_path / "draft files" / "help workflow.pflow.md"
+        workflow_path.parent.mkdir()
+        write_workflow_file(
+            {"nodes": [{"id": "emit", "type": "shell", "params": {"command": "echo ok"}}]},
+            workflow_path,
+        )
+
+        result = runner.invoke(main, [str(workflow_path), "--help"])
+
+        assert result.exit_code == 0
+        assert f"  pflow '{workflow_path}'" in result.output
 
     def test_invalid_markdown_in_file(self):
         """Test error handling for invalid markdown in workflow file."""


### PR DESCRIPTION
Closes #590

Summary:
- resolve local workflow files through the existing unified resolver while preserving saved-workflow history and unknown-name suggestions
- preserve the typed path in the heading and emit shell-copyable usage, including paths with spaces
- make shared CLI path routing and adjacent guidance consistent, with reference docs and regressions

Verification:
- make check
- make test-all-local: 9059 passed, 2 skipped
- mandatory manual-verification skill: copied spaced-path example executed successfully
- final deep-review re-reviews: no Critical or Warning findings