### PR TITLE
fix(llm): unwrap nested structured responses

### DIFF
--- a/src/pflow/nodes/llm/llm.py
+++ b/src/pflow/nodes/llm/llm.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from jsonschema.validators import validator_for
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 
 from pflow.core.cache_ttl import is_cache_ttl_supported_by_provider, parse_cache_ttl
@@ -1342,7 +1344,20 @@ class LLMNode(Node):
         # error_class consistently with the _call_llm path.
         if exec_res["has_schema"]:
             try:
-                shared["response"] = json.loads(raw_response)
+                parsed_response = json.loads(raw_response)
+                output_schema = prep_res.get("output_schema")
+                if (
+                    isinstance(parsed_response, dict)
+                    and set(parsed_response) == {"json_tool_call"}
+                    and isinstance(parsed_response["json_tool_call"], dict)
+                    and isinstance(output_schema, dict)
+                ):
+                    validator = validator_for(output_schema)(output_schema)
+                    inner_response = parsed_response["json_tool_call"]
+                    if not validator.is_valid(parsed_response) and validator.is_valid(inner_response):
+                        logger.warning("Unwrapped structured output nested under LiteLLM's internal tool name")
+                        parsed_response = inner_response
+                shared["response"] = parsed_response
             except json.JSONDecodeError as e:
                 # Build the same error dict shape as _call_llm so the runtime
                 # path produces the same structured Diagnostic. Use

--- a/tests/test_nodes/test_llm/test_llm.py
+++ b/tests/test_nodes/test_llm/test_llm.py
@@ -915,6 +915,32 @@ class TestStructuredOutput:
         assert isinstance(shared["response"], dict)
         assert shared["response"] == {"name": "Alice", "age": 30}
 
+    def test_structured_response_unwraps_litellm_tool_name(self, monkeypatch):
+        """A schema-valid value nested under LiteLLM's internal tool name is recovered."""
+
+        def custom_complete(**kwargs):
+            return AdapterResponse(
+                text='{"json_tool_call":{"name":"Alice","age":30}}',
+                usage={},
+                model=kwargs.get("model", "test"),
+                has_schema=True,
+            )
+
+        monkeypatch.setattr("pflow.nodes.llm.llm.complete", custom_complete)
+
+        node = LLMNode()
+        node.set_params({
+            "prompt": "Extract",
+            "output_schema": self.SIMPLE_SCHEMA,
+            "model": "anthropic/claude-sonnet-5",
+        })
+        shared: dict = {}
+
+        action = node.run(shared)
+
+        assert action == "default"
+        assert shared["response"] == {"name": "Alice", "age": 30}
+
     def test_structured_output_skips_strip_code_block(self, mock_llm_client):
         """output_schema set → _strip_code_block is NOT called."""
         mock_llm_client.set_response("*", self.SIMPLE_SCHEMA, {"name": "Bob"})


### PR DESCRIPTION
Closes #598.

LiteLLM can return otherwise valid structured output nested under its internal `json_tool_call` name. Unwrap that shape only when the outer value fails the requested schema and the inner value passes it; all other responses remain unchanged.

Test: `pytest -q tests/test_nodes/test_llm/test_llm.py` (81 passed)
