### PR TITLE
fix: validate LLM structured output schemas (#598)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -18,6 +18,11 @@ Source: https://github.com/python-jsonschema/jsonschema
 Copyright: 2013 Julian Berman
 License: MIT
 
+Python package: referencing
+Source: https://github.com/python-jsonschema/referencing
+Copyright: 2022 Julian Berman
+License: MIT
+
 Python package: pydantic
 Source: https://github.com/pydantic/pydantic
 Copyright: 2017-present Pydantic Services Inc. and individual contributors

--- a/docs/reference/nodes/llm.mdx
+++ b/docs/reference/nodes/llm.mdx
@@ -52,7 +52,7 @@ The same `reasoning_effort` value maps to provider-specific knobs under the hood
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `response` | str or dict | Text response (str), or parsed JSON (dict) when `output_schema` is set |
+| `response` | any | Text response (str), any parsed JSON value when `output_schema` is set, or the original raw text when structured-output validation fails |
 | `llm_usage` | dict | Token usage metrics |
 | `error` | str | Error message (only present on failure) |
 
@@ -180,7 +180,7 @@ Translate the input text to Spanish.
 
 ### Structured output
 
-Use `output_schema` to get guaranteed JSON matching a schema. The schema is passed to the model's constrained decoding API — the model literally cannot produce non-conforming output.
+Use `output_schema` to request JSON matching a schema. Provider mechanisms vary: some use constrained decoding, while others use tool calls with best-effort arguments. pflow validates the returned JSON locally before publishing it, so a non-conforming value fails at the LLM step instead of breaking a downstream template.
 
 `````markdown
 ### extract
@@ -208,7 +208,13 @@ required:
 ```
 `````
 
-When `output_schema` is set, `response` is a dict — downstream templates access fields directly: `${extract.response.people}`.
+For an object schema, `response` is a dict and downstream templates access fields directly: `${extract.response.people}`. Array and primitive schemas produce their corresponding parsed JSON values. JSON numbers must be finite; `NaN`, infinities, and overflow-to-infinity values are rejected as invalid JSON. If the provider returns invalid JSON or a value that does not match the schema, pflow keeps the original response text, sets `error`, and follows the step's error edge.
+
+Schemas may use references that resolve within the authored schema, including local fragments, anchors, nested IDs, and same-document absolute references. Missing or external references are rejected before the provider call; pflow never retrieves schemas from the network.
+
+For compatibility with providers that implement structured output through an internal tool, pflow also repairs one narrowly defined transport artifact: an otherwise invalid response shaped exactly as `{"json_tool_call": { ...valid result... }}`. A valid schema-authored object containing `json_tool_call` is never rewritten.
+
+After upgrading from a version without local schema validation, a pre-existing memo-cache entry can replay its old output until the default 24-hour TTL expires. Run with `--no-cache` to bypass that stale read and force a fresh validated call.
 
 Without `output_schema`, you can still get JSON by prompting for it. The template system auto-parses JSON strings when you use dot notation: `${extract.response.people}`. But the model may not always comply — `output_schema` is the reliable approach.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "click>=8.1,<8.2", # CLI framework (more flexible than Typer). Self-pinned to 8.1.x to DECOUPLE the click 8.x migration from the litellm bump: litellm 1.86.1 relaxed its transitive click constraint to <9.0, so without this ceiling uv would resolve click to 8.3.x — which removed CliRunner's mix_stderr kwarg, flipped stream-merging defaults (breaking ~128 mix_stderr=False sites + ~160 bare CliRunner() output assertions), and changed subgroup empty-invocation exit codes (0→2). Removing this ceiling is the job of GH #426 (click 8.x migration). <8.2 not <8.3 because 8.1.x is the only line empirically confirmed green.
     "jsonschema>=4.20.0", # JSON Schema validation for workflow IR
+    "referencing>=0.28.4", # Offline JSON Schema reference registry for self-contained LLM output_schema validation
     "pydantic", # IR/metadata validation
     "mcp[cli]>=1.17.0", # Model Context Protocol for MCP server support
     "requests>=2.32.5", # HTTP requests library for HttpNode (2.32.5 fixes SSLContext regression). Slated for removal in favor of httpx — see GH #422.

--- a/src/pflow/core/exceptions.py
+++ b/src/pflow/core/exceptions.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from typing import Any, Literal
 
 from pflow.core.cache_ttl import build_unsupported_cache_ttl_diagnostic, unsupported_cache_ttl_message
-from pflow.core.diagnostic import LLM_FAILURE_CATEGORY, Diagnostic, Severity
+from pflow.core.diagnostic import LLM_FAILURE_CATEGORY, LLM_VALIDATION_CATEGORY, Diagnostic, Severity
 from pflow.core.gate import GATE_KIND_APPROVAL, GateRequest
 from pflow.core.llm_providers import detect_provider, extract_provider_prefix
 
@@ -16,6 +16,7 @@ from pflow.core.llm_providers import detect_provider, extract_provider_prefix
 UnknownModelReason = Literal["unknown_name", "missing_prefix"]
 MissingApiKeyKind = Literal["missing_key", "lacks_permission"]
 LLMTransientKind = Literal["timeout", "rate_limit", "server_error", "connection"]
+LLMResponseParseKind = Literal["invalid_json", "schema_mismatch"]
 
 # Canonical list of dynamic attributes the engine/runner attach to exceptions
 # for cross-boundary context threading.  Used by copy_pflow_annotations() and
@@ -589,6 +590,39 @@ class MissingSdkError(LLMCallError):
         ]
 
 
+class LLMOutputSchemaError(PflowError):
+    """An LLM ``output_schema`` is not safe or valid for execution."""
+
+    retriable = False
+    batch_fatal = False
+
+    def __init__(self, message: str, *, schema_path: str | None = None) -> None:
+        super().__init__(message)
+        self.schema_path = schema_path
+
+    def to_diagnostics(self) -> list[Diagnostic]:
+        context: dict[str, Any] = {
+            "category": LLM_VALIDATION_CATEGORY,
+            "error_class": type(self).__name__,
+        }
+        if self.schema_path is not None:
+            context["schema_path"] = self.schema_path
+        return [
+            Diagnostic(
+                severity=Severity.ERROR,
+                message=str(self),
+                title="LLM Configuration",
+                suggestions=[
+                    "Fix `output_schema` so it is a self-contained valid JSON Schema.",
+                    "Use only references resolvable within the authored schema; external schema retrieval is disabled.",
+                ],
+                source="runtime",
+                context=context,
+                see_also=["llm"],
+            )
+        ]
+
+
 class LLMResponseParseError(LLMCallError):
     """Model response could not be parsed against the requested schema.
 
@@ -598,20 +632,35 @@ class LLMResponseParseError(LLMCallError):
     likely to produce the same bad response.
     """
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        model: str | None = None,
+        provider_message: str | None = None,
+        kind: LLMResponseParseKind | None = None,
+        path: str | None = None,
+    ) -> None:
+        super().__init__(message, model=model, provider_message=provider_message)
+        self.kind = kind
+        self.path = path
+
     def to_diagnostics(self) -> list[Diagnostic]:
         # Returns single-element list (PflowError convention).
         return [
             Diagnostic(
                 severity=Severity.ERROR,
                 message=str(self),
-                title="Response Parse Failed",
+                title=(
+                    "Structured Output Validation Failed" if self.kind == "schema_mismatch" else "Response Parse Failed"
+                ),
                 suggestions=[
                     "Verify the requested 'output_schema' matches what the model can produce.",
                     "Check the raw response in the trace JSON to see what the model actually returned.",
                     "Consider simplifying the schema if the model consistently fails to match it.",
                 ],
                 source="runtime",
-                context=self.diagnostic_context(),
+                context=self.diagnostic_context(kind=self.kind, path=self.path),
                 see_also=["llm"],
             )
         ]

--- a/src/pflow/core/workflow/validator.py
+++ b/src/pflow/core/workflow/validator.py
@@ -816,6 +816,7 @@ class WorkflowValidator:
             if node_type == "agent":
                 diagnostics.extend(WorkflowValidator._validate_agent_params(node_id, params))
             elif node_type == "llm":
+                diagnostics.extend(WorkflowValidator._validate_llm_output_schema(node_id, params))
                 llm_diags, display_model, provider_name, forms = WorkflowValidator._validate_llm_model_id_lite(
                     node_id, params
                 )
@@ -1102,6 +1103,36 @@ class WorkflowValidator:
     # =========================================================================
     # LLM Model-Id Static Validation (Step 9 — LLM branch)
     # =========================================================================
+
+    @staticmethod
+    def _validate_llm_output_schema(node_id: str, params: dict[str, Any]) -> list[Diagnostic]:
+        """Apply runtime's schema check to literal LLM schemas at validate time."""
+        import dataclasses
+
+        from pflow.core.exceptions import LLMOutputSchemaError
+        from pflow.nodes.llm.schema_validation import prepare_output_schema_validator
+
+        if "output_schema" not in params or params["output_schema"] is None:
+            return []
+        output_schema = params["output_schema"]
+        if TemplateResolver.has_templates(output_schema):
+            return []
+
+        try:
+            prepare_output_schema_validator(output_schema)
+        except LLMOutputSchemaError as exc:
+            diagnostic = exc.to_diagnostics()[0]
+            context = dict(diagnostic.context or {})
+            context["path"] = f"nodes[id={node_id}].params.output_schema"
+            return [
+                dataclasses.replace(
+                    diagnostic,
+                    source="validator",
+                    node_id=node_id,
+                    context=context,
+                )
+            ]
+        return []
 
     @staticmethod
     def _strip_provider_prefix_case_preserving(model: str, provider_prefix: str) -> str:

--- a/src/pflow/execution/executor_service.py
+++ b/src/pflow/execution/executor_service.py
@@ -105,12 +105,17 @@ def build_error_list(success: bool, action_result: str | None, shared_store: dic
             context["category"] = _map_failure_category_to_diagnostic(str(failure["category"]))
 
     category = str(context["category"])
+    diagnostic_title = None
+    if failed_node:
+        node_output = get_node_output(shared_store, failed_node) or {}
+        if isinstance(node_output, dict) and isinstance(node_output.get("_diagnostic_title"), str):
+            diagnostic_title = node_output["_diagnostic_title"]
 
     return [
         Diagnostic(
             severity=Severity.ERROR,
             message=error_info["message"] or "Workflow execution failed",
-            title=CATEGORY_TITLES.get(category, "Execution Failed"),
+            title=diagnostic_title or CATEGORY_TITLES.get(category, "Execution Failed"),
             node_id=failed_node,
             source="runtime",
             context=context,

--- a/src/pflow/guide/nodes/llm.md
+++ b/src/pflow/guide/nodes/llm.md
@@ -6,7 +6,7 @@
 
 **The test**: Can you write a deterministic algorithm for it? YES → `code` node. NO → LLM.
 
-Use `output_schema` for structured responses (guarantees valid JSON via constrained decoding).
+Use `output_schema` for structured responses. Providers use different structured-output mechanisms; pflow validates the returned JSON locally before publishing it. Schemas may use self-contained references, but pflow does not fetch external schemas. Structured responses use strict JSON numbers, so `NaN` and infinities fail validation.
 
 **Prompt format**: Put multi-line prompts in a ` ```prompt ` block — real line breaks, no `\n` escapes and no quote/colon escaping hazards. Reserve inline `- prompt: "..."` for genuinely single-line prompts.
 

--- a/src/pflow/nodes/llm/README.md
+++ b/src/pflow/nodes/llm/README.md
@@ -190,7 +190,7 @@ Common models (always include the provider prefix — bare names route via Verte
 
 ## Structured Output
 
-Use `output_schema` to get guaranteed JSON responses matching a JSON Schema. The schema is passed to the model's constrained decoding API (supported by Anthropic, Google, OpenAI).
+Use `output_schema` to request JSON matching a JSON Schema. Provider mechanisms vary between constrained decoding and tool-based structured output, so pflow validates the returned JSON locally before publishing it.
 
 ### In a workflow (.pflow.md):
 
@@ -221,12 +221,18 @@ required:
 ````
 
 When `output_schema` is set:
-- The response is guaranteed valid JSON matching the schema
-- `shared["response"]` is a `dict` (not a string)
-- Downstream templates access fields directly: `${extract.response.people}`
+- A conforming response is parsed to its JSON value (object, array, or primitive)
+- JSON numbers must be finite; `NaN`, infinities, and overflow-to-infinity values are invalid JSON
+- Object schemas produce a `dict`, and downstream templates access fields directly: `${extract.response.people}`
+- Invalid JSON or a schema mismatch preserves the original text in the node's `response` output (`shared["<node-id>"]["response"]` with namespacing), sets `error`, and follows the error edge
+- An exact invalid outer `{"json_tool_call": <valid dict>}` transport wrapper is repaired; valid authored wrappers are preserved
 - Code block stripping is skipped (the API returns clean JSON)
 
-Without `output_schema`, behavior is unchanged — `shared["response"]` is always a string.
+Schema references must resolve within the authored schema (local fragments, anchors, nested IDs, and same-document absolute references are supported). Missing or external references fail before the provider call; schemas are never fetched from the network.
+
+Without `output_schema`, behavior is unchanged — the node's `response` output is always a string.
+
+After upgrading from a version without local schema validation, an old memo-cache entry may replay for up to the default 24-hour TTL. Use `--no-cache` to bypass the stale read and force a fresh validated call.
 
 ## Token Usage Tracking
 

--- a/src/pflow/nodes/llm/llm.py
+++ b/src/pflow/nodes/llm/llm.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -9,10 +10,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from jsonschema.protocols import Validator
+from referencing.exceptions import Unresolvable
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 
 from pflow.core.cache_ttl import is_cache_ttl_supported_by_provider, parse_cache_ttl
-from pflow.core.exceptions import LLMCallError, LLMTransientError, UnsupportedCacheTTLError
+from pflow.core.exceptions import LLMCallError, LLMResponseParseError, LLMTransientError, UnsupportedCacheTTLError
 from pflow.core.llm_capabilities import get_min_cache_tokens
 from pflow.core.llm_client import Attachment, TraceHook, complete
 from pflow.core.llm_providers import detect_provider
@@ -38,8 +42,11 @@ from pflow.core.prompt_cache_analysis.below_min_tokens_detector import (
 )
 from pflow.core.prompt_cache_analysis.warning_catalog import make_diagnostic
 from pflow.core.prompt_refs import first_per_item_position
+from pflow.nodes.llm.schema_validation import prepare_output_schema_validator
 
 logger = logging.getLogger(__name__)
+
+_LITELLM_RESPONSE_FORMAT_TOOL_NAME = "json_tool_call"
 
 # Re-exported for backward compatibility with code that imported these names
 # from pflow.nodes.llm.llm. The canonical home is pflow.core.llm_reasoning_map.
@@ -68,7 +75,7 @@ def _error_dict_from_exception(exc: LLMCallError) -> dict[str, Any]:
     message = diagnostic.message
     if diagnostic.suggestions:
         message = message + "\n\n" + "\n".join(diagnostic.suggestions)
-    return {
+    result: dict[str, Any] = {
         "response": "",
         "error": message,
         "error_class": type(exc).__name__,
@@ -77,6 +84,9 @@ def _error_dict_from_exception(exc: LLMCallError) -> dict[str, Any]:
         "status": "error",
         "_diagnostic_context": dict(diagnostic.context or {}),
     }
+    if isinstance(exc, LLMResponseParseError):
+        result["_diagnostic_title"] = diagnostic.title
+    return result
 
 
 def _error_dict_for_timeout(model: str, message: str) -> dict[str, Any]:
@@ -154,6 +164,74 @@ def _error_dict_for_generic_failure(model: str, exc: Exception, attempts: int) -
             "kind": kind,
         },
     }
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite JSON number {value!r}")
+    return parsed
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant {value!r}")
+
+
+def _parse_and_validate_structured_response(
+    raw_response: str,
+    validator: Validator,
+    *,
+    model: str | None,
+) -> tuple[Any, bool]:
+    """Parse and validate structured output, recovering one LiteLLM wrapper.
+
+    Returns ``(accepted_value, recovered_wrapper)``. The outer JSON value is
+    authoritative whenever it validates. The compatibility unwrap is allowed
+    only for the exact observed ``{"json_tool_call": <dict>}`` shape when the
+    outer value fails and the inner dict validates.
+    """
+    try:
+        parsed = json.loads(
+            raw_response,
+            parse_float=_finite_json_float,
+            parse_constant=_reject_json_constant,
+        )
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise LLMResponseParseError(
+            f"Structured output JSON parse failed: {exc}",
+            model=model,
+            kind="invalid_json",
+        ) from exc
+
+    try:
+        outer_error = next(validator.iter_errors(parsed), None)
+        if outer_error is None:
+            return parsed, False
+
+        if (
+            isinstance(parsed, dict)
+            and len(parsed) == 1
+            and _LITELLM_RESPONSE_FORMAT_TOOL_NAME in parsed
+            and isinstance(parsed[_LITELLM_RESPONSE_FORMAT_TOOL_NAME], dict)
+        ):
+            inner = parsed[_LITELLM_RESPONSE_FORMAT_TOOL_NAME]
+            if next(validator.iter_errors(inner), None) is None:
+                return inner, True
+    except (Unresolvable, RecursionError) as exc:
+        raise LLMResponseParseError(
+            f"Structured output validation could not resolve output_schema reference: {exc}",
+            model=model,
+            kind="schema_mismatch",
+            path="$",
+        ) from exc
+
+    location = outer_error.json_path or "$"
+    raise LLMResponseParseError(
+        f"Structured output does not match output_schema at {location}: {outer_error.message}",
+        model=model,
+        kind="schema_mismatch",
+        path=location,
+    )
 
 
 def _read_prompt_cache_context(shared: dict[str, Any], node_id: str | None) -> CacheRenderContext | None:
@@ -926,8 +1004,8 @@ class LLMNode(Node):
     - Params: reasoning_effort: str  # Reasoning depth: xhigh/high/medium/low/minimal/none (optional, mapped to provider-specific params). Sets reasoning depth; max_tokens only caps the budget, never raises it.
     - Params: reasoning_max_tokens: int  # Direct reasoning token budget, mutually exclusive with reasoning_effort (optional). Still capped to stay under max_tokens when both are set.
     - Params: model_options: dict  # Additional provider-specific model options passed as kwargs (optional; reasoning keys must use reasoning_effort/reasoning_max_tokens)
-    - Writes: shared["response"]: str|dict  # Text (str), parsed JSON (dict) when output_schema is set, or raw text on parse failure
-    - Writes: shared["error"]: str  # Error message if LLM call or JSON parsing failed
+    - Writes: shared["response"]: any  # Parsed JSON root with output_schema, raw response text on validation failure, or text without a schema
+    - Writes: shared["error"]: str  # Error message if LLM call or structured-output validation failed
     - Writes: shared["prompt"]: str  # Rendered prompt actually sent to the model (populated for tracing/audit, including per-item batch traces)
     - Writes: shared["llm_usage"]: dict  # Token usage metrics (empty dict {} if unavailable)
         - model: str  # Model identifier used
@@ -1061,6 +1139,13 @@ class LLMNode(Node):
                 "'model' explicitly via node.set_params({'model': '<provider>/<model>'})."
             )
 
+        # Validate the effective (already template-resolved) authored schema in
+        # prep, before cache rendering and before ``complete()`` can dispatch a
+        # paid provider call. The validator is reused in post() so draft
+        # selection and schema validity cannot drift between the two seams.
+        output_schema = self.params.get("output_schema")
+        output_schema_validator = prepare_output_schema_validator(output_schema)
+
         # Cache rendering (Task 159 C1.2 + C3) — build structured
         # ``system_blocks`` with per-provider ``cache_control`` markers, plus
         # OpenAI-specific ``prompt_cache_key`` / ``prompt_cache_retention``
@@ -1110,7 +1195,8 @@ class LLMNode(Node):
             "__prewarm_disabled_reason__": prewarm_disabled_reason,
             "max_tokens": self.params.get("max_tokens"),
             "attachments": attachments,
-            "output_schema": self.params.get("output_schema"),
+            "output_schema": output_schema,
+            "_output_schema_validator": output_schema_validator,
             "reasoning_effort": reasoning_effort,
             "reasoning_max_tokens": self.params.get("reasoning_max_tokens"),
             "model_options": merged_model_options,
@@ -1201,7 +1287,6 @@ class LLMNode(Node):
             "response": adapter_response.text,
             "usage": adapter_response.usage,
             "model": adapter_response.model,
-            "has_schema": adapter_response.has_schema,
             # Pass adapter warnings through to post() so they can be lifted
             # into shared["__warnings__"] for JSON-output visibility.
             "warnings": adapter_response.warnings,
@@ -1334,26 +1419,29 @@ class LLMNode(Node):
             # future case needs multiple, change the contract to a list value.
             shared.setdefault("__warnings__", {})[node_id] = warnings_list[0]
 
-        # Parse response — schema mode or plain text. Schema mode goes
-        # through json.loads first (today's contract); LLMResponseParseError
-        # would also be raisable here in a future version that uses
-        # parse_structured_response, but right now LLMNode's schema path is
-        # the inline json.loads. We catch the typed exception to surface
-        # error_class consistently with the _call_llm path.
-        if exec_res["has_schema"]:
+        # Parse and authoritatively validate structured output. The prepared
+        # validator is the schema-mode discriminator: it was created from the
+        # effective schema before dispatch and is therefore present for every
+        # structured call, including the valid empty-schema case.
+        output_schema_validator = prep_res.get("_output_schema_validator")
+        if output_schema_validator is not None:
             try:
-                shared["response"] = json.loads(raw_response)
-            except json.JSONDecodeError as e:
-                # Build the same error dict shape as _call_llm so the runtime
-                # path produces the same structured Diagnostic. Use
-                # LLMResponseParseError so the override produces the right
-                # remediation suggestions.
-                from pflow.core.exceptions import LLMResponseParseError
-
-                err = LLMResponseParseError(
-                    f"Structured output JSON parse failed: {e}",
+                accepted_response, recovered_wrapper = _parse_and_validate_structured_response(
+                    raw_response,
+                    output_schema_validator,
                     model=exec_res.get("model"),
                 )
+                shared["response"] = accepted_response
+                if recovered_wrapper:
+                    logger.warning(
+                        "Recovered structured output from LiteLLM's %s wrapper",
+                        _LITELLM_RESPONSE_FORMAT_TOOL_NAME,
+                        extra={"node_id": node_id, "model": exec_res.get("model")},
+                    )
+            except LLMResponseParseError as err:
+                # Build the same error dict shape as _call_llm so the runtime
+                # path produces the same structured Diagnostic for JSON syntax
+                # and schema-conformance failures.
                 error_dict = _error_dict_from_exception(err)
                 # Task 159 C1.2 cross-layer co-edit (cache_chunks_skipped) —
                 # wrap at the caller. ``prep_res`` is this method's arg.
@@ -1412,6 +1500,9 @@ class LLMNode(Node):
         diagnostic_context = exec_res.get("_diagnostic_context")
         if diagnostic_context:
             shared["_diagnostic_context"] = diagnostic_context
+        diagnostic_title = exec_res.get("_diagnostic_title")
+        if diagnostic_title:
+            shared["_diagnostic_title"] = diagnostic_title
         if not response_already_set:
             shared["response"] = ""
         if not preserve_usage:

--- a/src/pflow/nodes/llm/schema_validation.py
+++ b/src/pflow/nodes/llm/schema_validation.py
@@ -1,0 +1,143 @@
+"""Shared static/runtime validation for LLM structured-output schemas."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+from typing import Any, cast
+
+from jsonschema import SchemaError
+from jsonschema.protocols import Validator
+from jsonschema.validators import validator_for
+from referencing import Registry, Resource
+from referencing.exceptions import Unresolvable
+from referencing.jsonschema import DRAFT202012, Schema
+
+from pflow.core.exceptions import LLMOutputSchemaError
+
+_ROOT_SCHEMA_URI = "urn:pflow:llm-output-schema"
+_REFERENCE_KEYWORDS = ("$ref", "$dynamicRef", "$recursiveRef")
+_SIMPLE_JSON_PATH_KEY = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _child_json_path(parent: str, child: str | int) -> str:
+    if isinstance(child, int):
+        return f"{parent}[{child}]"
+    if _SIMPLE_JSON_PATH_KEY.fullmatch(child):
+        return f"{parent}.{child}"
+    return f"{parent}[{json.dumps(child)}]"
+
+
+def _schema_identity_paths(output_schema: dict[str, Any]) -> dict[int, str]:
+    """Index authored object identities without deciding which dicts are schemas."""
+    paths: dict[int, str] = {}
+    visited: set[int] = set()
+
+    def walk(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            identity = id(value)
+            paths.setdefault(identity, path)
+            if identity in visited:
+                return
+            visited.add(identity)
+            for key, child in value.items():
+                walk(child, _child_json_path(path, str(key)))
+        elif isinstance(value, list):
+            identity = id(value)
+            if identity in visited:
+                return
+            visited.add(identity)
+            for index, child in enumerate(value):
+                walk(child, _child_json_path(path, index))
+
+    walk(output_schema, "$")
+    return paths
+
+
+def _resource_tree(
+    resource: Resource[Schema],
+    resolver: Any,
+) -> Iterator[tuple[Resource[Schema], Any]]:
+    """Yield schema resources with their draft-aware resolution scope."""
+    yield resource, resolver
+    for subresource in resource.subresources():
+        resource_id = subresource.id()
+        child_resolver = resolver.lookup(resource_id).resolver if resource_id else resolver
+        yield from _resource_tree(subresource, child_resolver)
+
+
+def _build_self_contained_registry(output_schema: dict[str, Any]) -> Registry[Schema]:
+    """Build an offline registry and prove every authored reference resolves."""
+    resource = Resource.from_contents(output_schema, default_specification=DRAFT202012)
+    root_uri = resource.id() or _ROOT_SCHEMA_URI
+    registry = Registry().with_resource(root_uri, resource).crawl()
+    resolver = registry.resolver(root_uri)
+    identity_paths = _schema_identity_paths(output_schema)
+    current_path = "$"
+
+    try:
+        for current, current_resolver in _resource_tree(resource, resolver):
+            contents = current.contents
+            if not isinstance(contents, dict):
+                continue
+            current_path = identity_paths.get(id(contents), "$")
+            for keyword in _REFERENCE_KEYWORDS:
+                reference = contents.get(keyword)
+                if isinstance(reference, str):
+                    try:
+                        current_resolver.lookup(reference)
+                    except Unresolvable as exc:
+                        schema_path = _child_json_path(current_path, keyword)
+                        raise LLMOutputSchemaError(
+                            f"Invalid output_schema at {schema_path}: reference {exc.ref!r} "
+                            "cannot be resolved within the authored schema",
+                            schema_path=schema_path,
+                        ) from None
+    except Unresolvable as exc:
+        raise LLMOutputSchemaError(
+            f"Invalid output_schema at {current_path}: reference {exc.ref!r} "
+            "cannot be resolved within the authored schema",
+            schema_path=current_path,
+        ) from None
+
+    return cast("Registry[Schema]", registry)
+
+
+def prepare_output_schema_validator(output_schema: Any) -> Validator | None:
+    """Validate an authored schema and return its offline draft-aware validator."""
+    if output_schema is None:
+        return None
+    if not isinstance(output_schema, dict):
+        raise LLMOutputSchemaError(
+            f"Invalid output_schema: expected a JSON Schema dict, got {type(output_schema).__name__}",
+            schema_path="$",
+        )
+
+    if "$schema" in output_schema:
+        dialect = output_schema["$schema"]
+        if not isinstance(dialect, str):
+            raise LLMOutputSchemaError("Invalid output_schema: '$schema' must be a string", schema_path="$.$schema")
+        validator_class = cast(
+            "type[Validator] | None",
+            validator_for(output_schema, default=cast(Any, None)),
+        )
+        if validator_class is None:
+            raise LLMOutputSchemaError(
+                f"Invalid output_schema: unsupported $schema dialect {dialect!r}",
+                schema_path="$.$schema",
+            )
+    else:
+        validator_class = validator_for(output_schema)
+
+    try:
+        validator_class.check_schema(output_schema)
+    except SchemaError as exc:
+        location = exc.json_path or "$"
+        raise LLMOutputSchemaError(
+            f"Invalid output_schema at {location}: {exc.message}",
+            schema_path=location,
+        ) from None
+
+    registry = _build_self_contained_registry(output_schema)
+    return validator_class(output_schema, registry=registry)

--- a/src/pflow/runtime/engine/batch_executor.py
+++ b/src/pflow/runtime/engine/batch_executor.py
@@ -342,7 +342,10 @@ def _execute_batch_item(
                 last_exception = e
                 break
             if not getattr(e, "retriable", True):
-                raise  # Deterministic/fatal errors should not burn batch retries
+                if getattr(e, "batch_fatal", True):
+                    raise  # Deterministic/fatal errors should not burn batch retries
+                last_exception = e
+                break
             last_exception = e
             if retry < batch_config.max_retries - 1:
                 if batch_config.retry_wait > 0:

--- a/src/pflow/runtime/template_validation/validator.py
+++ b/src/pflow/runtime/template_validation/validator.py
@@ -950,6 +950,7 @@ def extract_node_outputs(
                 registry,
                 error_handling=batch_config.get("error_handling", "fail_fast"),
                 code_annotations=code_annotations,
+                node_params=node.get("params"),
             )
             _register_batch_item_variables(node_outputs, node_id, node_type, batch_config)
         else:
@@ -961,6 +962,7 @@ def extract_node_outputs(
                 enable_namespacing,
                 registry,
                 code_annotations=code_annotations,
+                node_params=node.get("params"),
             )
 
     _register_loop_node_outputs(node_outputs, workflow_ir, enable_namespacing)
@@ -1201,6 +1203,61 @@ def _get_inner_outputs_from_registry(node_type: str, registry: Registry) -> dict
     return inner_outputs
 
 
+_LLM_SCHEMA_TYPE_TO_TEMPLATE_TYPE = {
+    "array": "list",
+    "boolean": "bool",
+    "integer": "int",
+    "number": "number",
+    "object": "dict",
+    "string": "str",
+}
+_LLM_ROOT_COMBINATORS = frozenset({"allOf", "anyOf", "oneOf", "not", "if", "then", "else"})
+
+
+def _llm_response_type(node_params: dict[str, Any] | None) -> str:
+    """Infer only an LLM schema's explicit root type; remain permissive otherwise."""
+    if not isinstance(node_params, dict) or node_params.get("output_schema") is None:
+        return "str"
+    schema = node_params["output_schema"]
+    if TemplateResolver.has_templates(schema) or not isinstance(schema, dict) or not schema:
+        return "any"
+    if "$ref" in schema or _LLM_ROOT_COMBINATORS.intersection(schema):
+        return "any"
+
+    declared_type = schema.get("type")
+    if isinstance(declared_type, str):
+        return _LLM_SCHEMA_TYPE_TO_TEMPLATE_TYPE.get(declared_type, "any")
+    if not isinstance(declared_type, list) or not declared_type:
+        return "any"
+
+    resolved: list[str] = []
+    for member in declared_type:
+        if not isinstance(member, str) or member == "null":
+            return "any"
+        mapped = _LLM_SCHEMA_TYPE_TO_TEMPLATE_TYPE.get(member)
+        if mapped is None:
+            return "any"
+        if mapped not in resolved:
+            resolved.append(mapped)
+    return "|".join(resolved) if resolved else "any"
+
+
+def _specialize_llm_response_output(
+    inner_outputs: dict[str, Any],
+    node_type: str,
+    node_params: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if node_type != "llm" or "response" not in inner_outputs:
+        return inner_outputs
+    return {
+        **inner_outputs,
+        "response": {
+            **inner_outputs["response"],
+            "type": _llm_response_type(node_params),
+        },
+    }
+
+
 def _enrich_code_result_output_type(
     output_key: str,
     output_info: dict[str, Any],
@@ -1233,6 +1290,7 @@ def _register_batch_outputs(
     skip_results_structure: bool = False,
     error_handling: str = "fail_fast",
     code_annotations: dict[str, str] | None = None,
+    node_params: dict[str, Any] | None = None,
 ) -> None:
     """Register batch-specific outputs for a node with batch configuration.
 
@@ -1259,6 +1317,8 @@ def _register_batch_outputs(
         inner_outputs_structure = inner_outputs_override
     else:
         inner_outputs_structure = _get_inner_outputs_from_registry(node_type, registry)
+
+    inner_outputs_structure = _specialize_llm_response_output(inner_outputs_structure, node_type, node_params)
 
     if code_annotations and node_type == "code" and "result" in inner_outputs_structure:
         inner_outputs_structure = {
@@ -1310,6 +1370,7 @@ def _register_node_outputs_from_registry(
     enable_namespacing: bool,
     registry: Registry,
     code_annotations: dict[str, str] | None = None,
+    node_params: dict[str, Any] | None = None,
 ) -> None:
     """Register outputs from registry interface metadata for non-batch nodes.
 
@@ -1344,6 +1405,8 @@ def _register_node_outputs_from_registry(
             }
 
         output_info = _enrich_code_result_output_type(key, output_info, code_annotations)
+        if node_type == "llm" and key == "response":
+            output_info = {**output_info, "type": _llm_response_type(node_params)}
 
         node_outputs[key] = output_info
 

--- a/tests/test_cli/test_dry_run.py
+++ b/tests/test_cli/test_dry_run.py
@@ -225,6 +225,31 @@ def test_dry_run_rejects_agent_invalid_schema_before_plan(tmp_path) -> None:
     assert "top-level type: object" in result.stderr
 
 
+@pytest.mark.parametrize("mode", [["--dry-run"], ["--validate-only"]])
+def test_validation_modes_reject_literal_invalid_llm_schema_before_dispatch(tmp_path, mode) -> None:
+    workflow_path = tmp_path / "llm-invalid-schema.pflow.md"
+    write_workflow_file(
+        {
+            "nodes": [
+                {
+                    "id": "ask",
+                    "type": "llm",
+                    "params": {"prompt": "answer", "output_schema": {"type": "intger"}},
+                }
+            ],
+            "edges": [],
+        },
+        workflow_path,
+    )
+
+    with patch("pflow.nodes.llm.llm.complete") as mock_complete:
+        result = invoke_cli([*mode, str(workflow_path)])
+
+    assert result.exit_code == 1
+    assert "Invalid output_schema" in result.output + result.stderr
+    mock_complete.assert_not_called()
+
+
 def test_dry_run_classifies_agent_for_cost_and_display(tmp_path) -> None:
     """AgentNode keeps the former agentic cost/duration planning behavior."""
     workflow_path = tmp_path / "agent-plan.pflow.md"

--- a/tests/test_core/test_workflow_validator_llm_output_schema.py
+++ b/tests/test_core/test_workflow_validator_llm_output_schema.py
@@ -1,0 +1,82 @@
+"""Static/runtime parity tests for LLM ``output_schema`` validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pflow.core.diagnostic import Severity
+from pflow.core.workflow.validator import WorkflowValidator
+
+
+def _workflow(output_schema: Any) -> dict[str, Any]:
+    return {
+        "ir_version": "0.1.0",
+        "nodes": [
+            {
+                "id": "ask",
+                "type": "llm",
+                "params": {"prompt": "answer", "output_schema": output_schema},
+            }
+        ],
+    }
+
+
+def _schema_errors(output_schema: Any) -> list:
+    return [
+        diagnostic
+        for diagnostic in WorkflowValidator.validate(_workflow(output_schema), skip_node_types=True)
+        if diagnostic.severity == Severity.ERROR and (diagnostic.context or {}).get("category") == "llm_validation"
+    ]
+
+
+@pytest.mark.parametrize(
+    "output_schema",
+    [
+        {},
+        {"$defs": {"answer": {"type": "string"}}, "$ref": "#/$defs/answer"},
+        {"const": {"$ref": "https://schemas.example/not-a-schema-reference"}},
+    ],
+)
+def test_literal_valid_schemas_pass_static_validation(output_schema):
+    assert _schema_errors(output_schema) == []
+
+
+@pytest.mark.parametrize(
+    "output_schema",
+    [
+        "${schema}",
+        {"type": "${schema.type}"},
+    ],
+)
+def test_templated_schemas_defer_to_runtime(output_schema):
+    assert _schema_errors(output_schema) == []
+
+
+@pytest.mark.parametrize(
+    ("output_schema", "schema_path"),
+    [
+        (["not", "a", "schema"], "$"),
+        ({"type": "intger"}, "$.type"),
+        ({"$schema": "https://example.invalid/draft", "type": "object"}, "$.$schema"),
+        ({"$ref": "#/$defs/missing"}, "$.$ref"),
+        ({"$ref": "https://schemas.example/external"}, "$.$ref"),
+        (
+            {"type": "object", "properties": {"result": {"$ref": "#/$defs/missing"}}},
+            "$.properties.result.$ref",
+        ),
+        ({"allOf": [{"$ref": "https://schemas.example/external"}]}, "$.allOf[0].$ref"),
+    ],
+)
+def test_literal_invalid_schemas_emit_llm_configuration_diagnostic(output_schema, schema_path):
+    errors = _schema_errors(output_schema)
+
+    assert len(errors) == 1
+    diagnostic = errors[0]
+    assert diagnostic.title == "LLM Configuration"
+    assert diagnostic.source == "validator"
+    assert diagnostic.node_id == "ask"
+    assert diagnostic.context["path"] == "nodes[id=ask].params.output_schema"
+    assert diagnostic.context.get("schema_path") == schema_path
+    assert diagnostic.see_also == ["llm"]

--- a/tests/test_execution/test_executor_service_llm.py
+++ b/tests/test_execution/test_executor_service_llm.py
@@ -11,6 +11,7 @@ import pytest
 from pflow.core.exceptions import InvalidRequestError, MissingApiKeyError, UnknownModelError
 from pflow.core.llm_client import AdapterResponse
 from pflow.core.llm_client import complete as real_complete
+from pflow.core.workflow.status import WorkflowStatus
 from pflow.execution.result import RunnerConfig
 from pflow.execution.runner import WorkflowRunner
 from pflow.runtime.node_state import FAILURE_CATEGORY_LLM
@@ -145,6 +146,9 @@ def test_llm_response_parse_error_context_reaches_runner_diagnostics(monkeypatch
     assert context["category"] == FAILURE_CATEGORY_LLM
     assert context["error_class"] == "LLMResponseParseError"
     assert context["model"] == "anthropic/claude-sonnet-4-5"
+    assert context["kind"] == "invalid_json"
+    assert "path" not in context
+    assert result.errors[0].title == "Response Parse Failed"
 
     failure = result.shared_after["__failures__"]["ask"]
     assert failure["category"] == FAILURE_CATEGORY_LLM
@@ -153,6 +157,155 @@ def test_llm_response_parse_error_context_reaches_runner_diagnostics(monkeypatch
     assert node_output["error_class"] == "LLMResponseParseError"
     assert node_output["_diagnostic_context"]["error_class"] == "LLMResponseParseError"
     assert node_output["_diagnostic_context"]["model"] == "anthropic/claude-sonnet-4-5"
+
+
+def test_templated_invalid_output_schema_fails_after_resolution_before_dispatch(monkeypatch):
+    calls = []
+
+    def unexpected_complete(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("provider must not be called for an invalid resolved schema")
+
+    monkeypatch.setattr("pflow.nodes.llm.llm.complete", unexpected_complete)
+    workflow_ir = _llm_workflow_ir({"output_schema": "${schema}"})
+    workflow_ir["inputs"] = {"schema": {"type": "any", "required": True, "description": "Runtime output schema"}}
+
+    result = WorkflowRunner().run(workflow_ir, {"schema": {"type": "intger"}}, RunnerConfig())
+
+    assert result.success is False
+    assert calls == []
+    assert result.errors[0].title == "LLM Configuration"
+    assert result.errors[0].context["category"] == "llm_validation"
+    assert result.errors[0].context["error_class"] == "LLMOutputSchemaError"
+    assert result.errors[0].context["schema_path"] == "$.type"
+
+
+def test_llm_schema_mismatch_preserves_raw_response_usage_and_trace(monkeypatch):
+    raw_response = '{"answer":7}'
+    usage = {
+        "model": "anthropic/claude-sonnet-4-5",
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "cost_usd": 0.0001,
+    }
+    calls = []
+
+    def complete_with_schema_mismatch(**kwargs):
+        calls.append(kwargs)
+        return AdapterResponse(
+            text=raw_response,
+            usage=usage,
+            model=kwargs["model"],
+            has_schema=True,
+        )
+
+    monkeypatch.setattr("pflow.nodes.llm.llm.complete", complete_with_schema_mismatch)
+
+    result = WorkflowRunner().run(
+        _llm_workflow_ir({
+            "output_schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            }
+        }),
+        {},
+        RunnerConfig(),
+    )
+
+    assert result.success is False
+    assert len(calls) == 1
+    context = result.errors[0].context or {}
+    assert context["category"] == FAILURE_CATEGORY_LLM
+    assert context["error_class"] == "LLMResponseParseError"
+    assert context["model"] == "anthropic/claude-sonnet-4-5"
+    assert context["kind"] == "schema_mismatch"
+    assert context["path"] == "$.answer"
+    assert result.errors[0].title == "Structured Output Validation Failed"
+
+    failure = result.shared_after["__failures__"]["ask"]
+    assert failure["category"] == FAILURE_CATEGORY_LLM
+    node_output = failure["data"]
+    assert node_output["response"] == raw_response
+    assert node_output["error_class"] == "LLMResponseParseError"
+    assert node_output["llm_usage"]["input_tokens"] == 10
+    assert node_output["llm_usage"]["cost_usd"] == 0.0001
+
+    event = next(event for event in result.trace.events if event["node_id"] == "ask")
+    assert event["status"] == "failed"
+    assert event["llm_response"] == raw_response
+    assert event["llm_call"]["total_tokens"] == 15
+    assert event["node_output"]["response"] == raw_response
+
+
+def test_llm_schema_mismatch_routes_to_on_error_without_retry(monkeypatch):
+    calls = []
+    raw_response = '{"answer":7}'
+    usage = {
+        "model": "anthropic/claude-sonnet-4-5",
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "cost_usd": 0.0001,
+    }
+
+    def complete_with_schema_mismatch(**kwargs):
+        calls.append(kwargs)
+        return AdapterResponse(
+            text=raw_response,
+            usage={**usage, "model": kwargs["model"]},
+            model=kwargs["model"],
+            has_schema=True,
+        )
+
+    monkeypatch.setattr("pflow.nodes.llm.llm.complete", complete_with_schema_mismatch)
+    workflow_ir = _llm_workflow_ir({
+        "output_schema": {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+        }
+    })
+    workflow_ir["nodes"].extend([
+        {
+            "id": "normal-successor",
+            "type": "code",
+            "params": {"code": 'result: str = "normal"'},
+        },
+        {
+            "id": "recovery",
+            "type": "code",
+            "params": {"code": 'result: str = "recovered"'},
+        },
+    ])
+    workflow_ir["edges"] = [
+        {"from": "ask", "to": "normal-successor", "action": "default"},
+        {"from": "ask", "to": "recovery", "action": "error"},
+    ]
+    workflow_ir["start_node"] = "ask"
+
+    result = WorkflowRunner().run(workflow_ir, {}, RunnerConfig())
+
+    assert result.success is True
+    assert result.status == WorkflowStatus.DEGRADED
+    assert len(calls) == 1
+    assert "normal-successor" not in result.shared_after
+    assert result.shared_after["recovery"]["result"] == "recovered"
+    assert "ask" not in result.shared_after
+    failure = result.shared_after["__failures__"]["ask"]
+    assert failure["category"] == FAILURE_CATEGORY_LLM
+    assert failure["data"]["response"] == raw_response
+    assert {key: failure["data"]["llm_usage"][key] for key in usage} == usage
+    assert failure["data"]["error_class"] == "LLMResponseParseError"
+
+    recovery_warnings = [
+        diagnostic
+        for diagnostic in result.diagnostics
+        if diagnostic.context and diagnostic.context.get("type") == "on_error_recovery"
+    ]
+    assert len(recovery_warnings) == 1
+    assert recovery_warnings[0].context["category"] == FAILURE_CATEGORY_LLM
 
 
 def test_real_litellm_exception_provider_message_reaches_runner_diagnostics(monkeypatch):

--- a/tests/test_nodes/test_llm/test_llm.py
+++ b/tests/test_nodes/test_llm/test_llm.py
@@ -12,8 +12,15 @@ from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
+from jsonschema import Draft202012Validator
 
-from pflow.core.exceptions import InvalidRequestError, LLMTransientError, MissingApiKeyError, UnknownModelError
+from pflow.core.exceptions import (
+    InvalidRequestError,
+    LLMOutputSchemaError,
+    LLMTransientError,
+    MissingApiKeyError,
+    UnknownModelError,
+)
 from pflow.core.llm_client import AdapterResponse
 from pflow.nodes.llm import LLMNode
 
@@ -872,6 +879,33 @@ class TestStructuredOutput:
         "required": ["name", "age"],
     }
 
+    @staticmethod
+    def _run_raw_structured_response(monkeypatch, schema, raw_response):
+        calls = []
+
+        def custom_complete(**kwargs):
+            calls.append(kwargs)
+            model = kwargs.get("model", "test")
+            return AdapterResponse(
+                text=raw_response,
+                usage={
+                    "model": model,
+                    "input_tokens": 20,
+                    "output_tokens": 10,
+                    "total_tokens": 30,
+                    "cost_usd": 0.001,
+                },
+                model=model,
+                has_schema=True,
+            )
+
+        monkeypatch.setattr("pflow.nodes.llm.llm.complete", custom_complete)
+        node = LLMNode(wait=0)
+        node.set_params({"prompt": "Extract", "output_schema": schema, "model": "openai/gpt-4o-mini"})
+        shared = {}
+        action = node.run(shared)
+        return action, shared, calls
+
     def test_output_schema_passed_to_model_prompt(self, mock_llm_client):
         """output_schema in params → schema=<dict> recorded in adapter call."""
         # Mock returns valid JSON for the schema (default fallback would be
@@ -917,7 +951,7 @@ class TestStructuredOutput:
 
     def test_structured_output_skips_strip_code_block(self, mock_llm_client):
         """output_schema set → _strip_code_block is NOT called."""
-        mock_llm_client.set_response("*", self.SIMPLE_SCHEMA, {"name": "Bob"})
+        mock_llm_client.set_response("*", self.SIMPLE_SCHEMA, {"name": "Bob", "age": 42})
 
         node = LLMNode()
         node.set_params({"prompt": "Extract", "output_schema": self.SIMPLE_SCHEMA, "model": "openai/gpt-4o-mini"})
@@ -989,7 +1023,7 @@ class TestStructuredOutput:
 
         def custom_complete(**kwargs):
             return AdapterResponse(
-                text='{"name": "Alice"}',
+                text='{"name": "Alice", "age": 30}',
                 usage={
                     "model": kwargs.get("model", "test"),
                     "input_tokens": 100,
@@ -1051,7 +1085,7 @@ class TestStructuredOutput:
 
     def test_action_returns_default_with_schema(self, mock_llm_client):
         """run() returns 'default' when output_schema is set."""
-        mock_llm_client.set_response("*", self.SIMPLE_SCHEMA, {"name": "Alice"})
+        mock_llm_client.set_response("*", self.SIMPLE_SCHEMA, {"name": "Alice", "age": 30})
 
         node = LLMNode()
         node.set_params({"prompt": "Extract", "output_schema": self.SIMPLE_SCHEMA, "model": "openai/gpt-4o-mini"})
@@ -1128,10 +1162,15 @@ class TestStructuredOutput:
 
     def test_valid_json_with_schema_unchanged(self, mock_llm_client):
         """Regression: valid JSON with output_schema still parses to dict, no error."""
-        mock_llm_client.set_response("*", self.SIMPLE_SCHEMA, {"score": 5})
+        score_schema = {
+            "type": "object",
+            "properties": {"score": {"type": "integer"}},
+            "required": ["score"],
+        }
+        mock_llm_client.set_response("*", score_schema, {"score": 5})
 
         node = LLMNode(wait=0)
-        node.set_params({"prompt": "Rate it", "output_schema": self.SIMPLE_SCHEMA, "model": "openai/gpt-4o-mini"})
+        node.set_params({"prompt": "Rate it", "output_schema": score_schema, "model": "openai/gpt-4o-mini"})
         shared: dict = {}
 
         action = node.run(shared)
@@ -1140,6 +1179,325 @@ class TestStructuredOutput:
         assert shared["response"] == {"score": 5}
         assert isinstance(shared["response"], dict)
         assert "error" not in shared
+
+    def test_exact_litellm_wrapper_unwraps_when_only_inner_valid(self, monkeypatch, caplog):
+        raw_response = '{"json_tool_call":{"name":"Alice","age":30}}'
+        caplog.set_level("WARNING", logger="pflow.nodes.llm.llm")
+
+        action, shared, calls = self._run_raw_structured_response(
+            monkeypatch,
+            self.SIMPLE_SCHEMA,
+            raw_response,
+        )
+
+        assert action == "default"
+        assert shared["response"] == {"name": "Alice", "age": 30}
+        assert "error" not in shared
+        assert shared["llm_usage"]["input_tokens"] == 20
+        assert len(calls) == 1
+        assert "Recovered structured output from LiteLLM's json_tool_call wrapper" in caplog.text
+
+    def test_valid_authored_json_tool_call_wrapper_is_preserved(self, monkeypatch):
+        wrapper_schema = {
+            "type": "object",
+            "properties": {
+                "json_tool_call": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                }
+            },
+            "required": ["json_tool_call"],
+            "additionalProperties": False,
+        }
+        raw_response = '{"json_tool_call":{"name":"authored"}}'
+
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, wrapper_schema, raw_response)
+
+        assert action == "default"
+        assert shared["response"] == {"json_tool_call": {"name": "authored"}}
+        assert len(calls) == 1
+
+    def test_permissive_outer_schema_is_not_unwrapped(self, monkeypatch):
+        raw_response = '{"json_tool_call":{"name":"authored"}}'
+
+        action, shared, _calls = self._run_raw_structured_response(
+            monkeypatch,
+            {"type": "object"},
+            raw_response,
+        )
+
+        assert action == "default"
+        assert shared["response"] == {"json_tool_call": {"name": "authored"}}
+
+    @pytest.mark.parametrize(
+        "raw_response",
+        [
+            '{"other":{"name":"Alice","age":30}}',
+            '{"json_tool_call":{"name":"Alice","age":30},"extra":true}',
+            '{"json_tool_call":"not an object"}',
+            '{"json_tool_call":{"name":"Alice"}}',
+        ],
+    )
+    def test_wrapper_near_misses_fail_without_retry(self, monkeypatch, raw_response):
+        action, shared, calls = self._run_raw_structured_response(
+            monkeypatch,
+            self.SIMPLE_SCHEMA,
+            raw_response,
+        )
+
+        assert action == "error"
+        assert shared["response"] == raw_response
+        assert shared["error_class"] == "LLMResponseParseError"
+        assert shared["llm_usage"]["cost_usd"] == 0.001
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize(
+        ("schema", "raw_response"),
+        [
+            (
+                {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+                "{}",
+            ),
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "profile": {
+                            "type": "object",
+                            "properties": {"age": {"type": "integer"}},
+                            "required": ["age"],
+                        }
+                    },
+                    "required": ["profile"],
+                },
+                '{"profile":{"age":"old"}}',
+            ),
+            ({"type": "string", "enum": ["yes", "no"]}, '"maybe"'),
+            (
+                {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "additionalProperties": False,
+                },
+                '{  "name" : "Alice", "age" : 30  }\n',
+            ),
+        ],
+    )
+    def test_schema_violations_preserve_raw_response_and_usage(self, monkeypatch, schema, raw_response):
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, schema, raw_response)
+
+        assert action == "error"
+        assert shared["response"] == raw_response
+        assert shared["error_class"] == "LLMResponseParseError"
+        assert "does not match output_schema" in shared["error"]
+        assert shared["llm_usage"]["total_tokens"] == 30
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize(
+        ("schema", "raw_response", "expected"),
+        [
+            ({}, '{"anything":true}', {"anything": True}),
+            ({"type": "object"}, '{"ok":true}', {"ok": True}),
+            ({"type": "array", "items": {"type": "integer"}}, "[1,2]", [1, 2]),
+            ({"type": "string"}, '"hello"', "hello"),
+            ({"type": "number"}, "1.5", 1.5),
+            ({"type": "boolean"}, "true", True),
+            ({"type": "null"}, "null", None),
+        ],
+    )
+    def test_valid_json_root_types_are_preserved(self, monkeypatch, schema, raw_response, expected):
+        action, shared, _calls = self._run_raw_structured_response(monkeypatch, schema, raw_response)
+
+        assert action == "default"
+        assert shared["response"] == expected
+
+    @pytest.mark.parametrize("raw_response", ["NaN", "Infinity", "-Infinity", "1e999"])
+    def test_non_finite_numbers_are_invalid_json_without_retry(self, monkeypatch, raw_response):
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, {"type": "number"}, raw_response)
+
+        assert action == "error"
+        assert shared["response"] == raw_response
+        assert shared["error_class"] == "LLMResponseParseError"
+        assert shared["_diagnostic_context"]["kind"] == "invalid_json"
+        assert shared["llm_usage"]["total_tokens"] == 30
+        assert len(calls) == 1
+
+    def test_non_finite_name_is_valid_as_a_string(self, monkeypatch):
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, {"type": "string"}, '"NaN"')
+
+        assert action == "default"
+        assert shared["response"] == "NaN"
+        assert len(calls) == 1
+
+    def test_explicit_draft_is_used_for_validation(self, monkeypatch):
+        draft4_schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "number",
+            "minimum": 5,
+            "exclusiveMinimum": True,
+        }
+
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, draft4_schema, "5")
+
+        assert action == "error"
+        assert shared["response"] == "5"
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            {"$defs": {"value": {"type": "string"}}, "$ref": "#/$defs/value"},
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$defs": {"value": {"$anchor": "value", "type": "string"}},
+                "$ref": "#value",
+            },
+            {
+                "$id": "https://schemas.example/root",
+                "$defs": {"value": {"$id": "value", "type": "string"}},
+                "$ref": "value",
+            },
+            {
+                "$id": "https://schemas.example/root",
+                "$defs": {"value": {"type": "string"}},
+                "$ref": "https://schemas.example/root#/$defs/value",
+            },
+        ],
+    )
+    def test_self_contained_schema_references_are_supported(self, monkeypatch, schema):
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, schema, '"ok"')
+
+        assert action == "default"
+        assert shared["response"] == "ok"
+        assert len(calls) == 1
+
+    def test_ref_looking_const_data_is_not_preflighted(self, monkeypatch):
+        schema = {"const": {"$ref": "https://schemas.example/not-a-schema-reference"}}
+        raw_response = '{"$ref":"https://schemas.example/not-a-schema-reference"}'
+
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, schema, raw_response)
+
+        assert action == "default"
+        assert shared["response"] == {"$ref": "https://schemas.example/not-a-schema-reference"}
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize(
+        ("schema", "message", "schema_path"),
+        [
+            (
+                {"$schema": "https://example.invalid/unknown-schema", "type": "object"},
+                r"unsupported \$schema",
+                "$.$schema",
+            ),
+            ({"type": "intger"}, "Invalid output_schema", "$.type"),
+            (["not", "a", "schema"], "expected a JSON Schema dict", "$"),
+            ({"$ref": "#/$defs/missing"}, "cannot be resolved within the authored schema", "$.$ref"),
+            (
+                {"$ref": "https://schemas.example/external"},
+                "cannot be resolved within the authored schema",
+                "$.$ref",
+            ),
+            (
+                {"type": "object", "properties": {"result": {"$ref": "#/$defs/missing"}}},
+                r"Invalid output_schema at \$\.properties\.result\.\$ref",
+                "$.properties.result.$ref",
+            ),
+            (
+                {"allOf": [{"$ref": "https://schemas.example/external"}]},
+                r"Invalid output_schema at \$\.allOf\[0\]\.\$ref",
+                "$.allOf[0].$ref",
+            ),
+        ],
+    )
+    def test_invalid_authored_schema_fails_before_provider_call(self, mock_llm_client, schema, message, schema_path):
+        node = LLMNode(wait=0)
+        node.set_params({"prompt": "Extract", "output_schema": schema, "model": "openai/gpt-4o-mini"})
+        calls_before = len(mock_llm_client.call_history)
+
+        with pytest.raises(LLMOutputSchemaError, match=message) as exc_info:
+            node.run({})
+
+        assert len(mock_llm_client.call_history) == calls_before
+        diagnostic = exc_info.value.to_diagnostics()[0]
+        assert diagnostic.title == "LLM Configuration"
+        assert diagnostic.context["category"] == "llm_validation"
+        assert diagnostic.context["schema_path"] == schema_path
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            {"$ref": "#"},
+            {
+                "$defs": {
+                    "left": {"$ref": "#/$defs/right"},
+                    "right": {"$ref": "#/$defs/left"},
+                },
+                "$ref": "#/$defs/left",
+            },
+        ],
+    )
+    def test_reference_only_cycles_are_soft_errors_without_retry(self, monkeypatch, schema):
+        raw_response = '{"value":"finite"}'
+
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, schema, raw_response)
+
+        assert action == "error"
+        assert shared["response"] == raw_response
+        assert shared["error_class"] == "LLMResponseParseError"
+        assert shared["_diagnostic_context"]["kind"] == "schema_mismatch"
+        assert shared["llm_usage"]["total_tokens"] == 30
+        assert len(calls) == 1
+
+    def test_recursive_object_schema_accepts_a_finite_instance(self, monkeypatch):
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {"type": "string"},
+                "child": {"$ref": "#"},
+            },
+            "required": ["value"],
+        }
+        raw_response = '{"value":"root","child":{"value":"leaf"}}'
+
+        action, shared, calls = self._run_raw_structured_response(monkeypatch, schema, raw_response)
+
+        assert action == "default"
+        assert shared["response"] == {"value": "root", "child": {"value": "leaf"}}
+        assert len(calls) == 1
+
+    def test_runtime_reference_resolution_failure_is_a_soft_error(self, monkeypatch):
+        unresolved_validator = Draft202012Validator({"$ref": "https://schemas.example/missing"})
+        monkeypatch.setattr(
+            "pflow.nodes.llm.llm.prepare_output_schema_validator",
+            lambda _schema: unresolved_validator,
+        )
+
+        action, shared, calls = self._run_raw_structured_response(
+            monkeypatch,
+            {"type": "object"},
+            '{"answer":"ok"}',
+        )
+
+        assert action == "error"
+        assert shared["response"] == '{"answer":"ok"}'
+        assert shared["error_class"] == "LLMResponseParseError"
+        assert shared["_diagnostic_context"]["kind"] == "schema_mismatch"
+        assert shared["_diagnostic_context"]["path"] == "$"
+        assert shared["llm_usage"]["total_tokens"] == 30
+        assert len(calls) == 1
+
+    def test_format_is_annotation_only(self, monkeypatch):
+        schema = {"type": "string", "format": "email"}
+
+        action, shared, _calls = self._run_raw_structured_response(monkeypatch, schema, '"not-an-email"')
+
+        assert action == "default"
+        assert shared["response"] == "not-an-email"
 
 
 class TestTimeout:

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -363,6 +363,15 @@ class TestRegistryNodeRetrieval:
         assert types["shell"]["exit_code"] == "int"
         assert all("any" not in fields.values() for fields in types.values())
 
+    def test_real_llm_response_metadata_is_truthful_any(self):
+        registry = Registry()
+
+        metadata = registry.get_nodes_metadata(["llm"])["llm"]
+        response = next(output for output in metadata["interface"]["outputs"] if output["key"] == "response")
+
+        assert response["type"] == "any"
+        assert "response" not in registry.output_types_by_kind()["llm"]
+
     def test_filters_invalid_node_names(self):
         """Test that invalid node names are filtered out."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_runtime/test_batch_node.py
+++ b/tests/test_runtime/test_batch_node.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 import pytest
 
 from pflow.core.diagnostic import Diagnostic
+from pflow.core.exceptions import LLMOutputSchemaError
 from pflow.nodes.agent.exceptions import AgentValidationError
 from pflow.runtime.engine.batch_executor import (
     _detect_empty_output_items,
@@ -656,6 +657,57 @@ class TestErrorHandling:
         assert attempts == 1
         assert "test_node" not in shared
         sleep.assert_not_called()
+
+    @pytest.mark.parametrize("parallel", [False, True])
+    def test_nonfatal_llm_schema_error_is_per_item_in_continue_mode(self, parallel):
+        attempts: list[str] = []
+
+        def execute_single_fn(node, config, item_shared):
+            item = item_shared["item"]
+            attempts.append(item)
+            if item == "bad":
+                raise LLMOutputSchemaError("invalid resolved output_schema", schema_path="$.type")
+            item_shared[config.node_id] = {"response": item}
+            return ("default", {}, [])
+
+        shared: dict = {"data": ["ok1", "bad", "ok2"]}
+
+        _run_batch(
+            MockInnerNode("test_node"),
+            shared,
+            error_handling="continue",
+            parallel=parallel,
+            max_retries=3,
+            execute_single_fn=execute_single_fn,
+        )
+
+        assert [result["response"] for result in shared["test_node"]["results"]] == ["ok1", "ok2"]
+        assert shared["test_node"]["error_count"] == 1
+        assert isinstance(shared["test_node"]["errors"][0]["exception"], LLMOutputSchemaError)
+        assert attempts.count("bad") == 1
+
+    def test_nonfatal_llm_schema_error_fail_fast_raises_original_without_retry(self):
+        attempts = 0
+        error = LLMOutputSchemaError("invalid resolved output_schema", schema_path="$.type")
+
+        def execute_single_fn(node, config, item_shared):
+            nonlocal attempts
+            attempts += 1
+            raise error
+
+        shared: dict = {"data": ["bad", "unreached"]}
+
+        with pytest.raises(LLMOutputSchemaError) as exc_info:
+            _run_batch(
+                MockInnerNode("test_node"),
+                shared,
+                error_handling="fail_fast",
+                max_retries=3,
+                execute_single_fn=execute_single_fn,
+            )
+
+        assert exc_info.value is error
+        assert attempts == 1
 
     def test_agent_validation_error_is_per_item_not_fatal_in_continue_mode(self):
         """Regression (#592): an ``agent`` param error in one item must NOT abort a

--- a/tests/test_runtime/test_template_validation/test_types.py
+++ b/tests/test_runtime/test_template_validation/test_types.py
@@ -56,7 +56,7 @@ def test_registry(tmp_path):
             "class_name": "LLMNode",
             "module": "test",
             "interface": {
-                "outputs": [{"key": "response", "type": "dict|str", "description": "LLM response"}],
+                "outputs": [{"key": "response", "type": "any", "description": "LLM response"}],
                 "params": [
                     {"key": "prompt", "type": "str", "description": "Prompt text"},
                     {"key": "max_tokens", "type": "int", "description": "Max tokens"},
@@ -81,6 +81,38 @@ def test_registry(tmp_path):
                 "params": [
                     {"key": "count", "type": "int", "description": "Count value"},
                 ],
+            },
+        },
+        "list-consumer": {
+            "class_name": "ListConsumer",
+            "module": "test",
+            "interface": {
+                "outputs": [],
+                "params": [{"key": "items", "type": "list", "description": "Items"}],
+            },
+        },
+        "bool-consumer": {
+            "class_name": "BoolConsumer",
+            "module": "test",
+            "interface": {
+                "outputs": [],
+                "params": [{"key": "enabled", "type": "bool", "description": "Flag"}],
+            },
+        },
+        "dict-consumer": {
+            "class_name": "DictConsumer",
+            "module": "test",
+            "interface": {
+                "outputs": [],
+                "params": [{"key": "value", "type": "dict", "description": "Object"}],
+            },
+        },
+        "number-consumer": {
+            "class_name": "NumberConsumer",
+            "module": "test",
+            "interface": {
+                "outputs": [],
+                "params": [{"key": "value", "type": "number", "description": "Number"}],
             },
         },
         "shell": {
@@ -318,8 +350,8 @@ class TestTypeValidationIntegration:
         type_errors = [d for d in errors if "Type mismatch" in d.message]
         assert len(type_errors) == 0
 
-    def test_union_type_compatibility(self, test_registry):
-        """Union types should work correctly."""
+    def test_llm_any_output_accepts_string_consumer(self, test_registry):
+        """A schema-less LLM response is correctly specialized to string."""
         workflow_ir = {
             "enable_namespacing": True,
             "inputs": {},
@@ -328,7 +360,7 @@ class TestTypeValidationIntegration:
                 {
                     "id": "consumer",
                     "type": "string-consumer",
-                    "params": {"text": "${llm.response}"},  # dict|str → str (both now compatible)
+                    "params": {"text": "${llm.response}"},
                 },
             ],
             "edges": [{"from": "llm", "to": "consumer"}],
@@ -337,20 +369,52 @@ class TestTypeValidationIntegration:
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
 
         type_errors = [d for d in errors if "Type mismatch" in d.message]
-        # dict|str → str now passes because both dict and str can serialize to str
         assert len(type_errors) == 0
 
-    def test_union_type_incompatibility(self, test_registry):
-        """Union types with incompatible members should fail."""
+    def test_schema_less_llm_response_rejects_integer_consumer(self, test_registry):
         workflow_ir = {
             "enable_namespacing": True,
             "inputs": {},
             "nodes": [
-                {"id": "llm", "type": "llm", "params": {"prompt": "test", "max_tokens": 100}},
+                {"id": "llm", "type": "llm", "params": {"prompt": "test"}},
+                {"id": "consumer", "type": "int-consumer", "params": {"count": "${llm.response}"}},
+            ],
+            "edges": [{"from": "llm", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+
+        type_errors = [d for d in errors if "Type mismatch" in d.message]
+        assert len(type_errors) == 1
+        assert type_errors[0].context["inferred_type"] == "str"
+
+    @pytest.mark.parametrize(
+        ("schema", "consumer_type", "param_name"),
+        [
+            ({"type": "array"}, "list-consumer", "items"),
+            ({"type": "integer"}, "int-consumer", "count"),
+            ({"type": "number"}, "number-consumer", "value"),
+            ({"type": "boolean"}, "bool-consumer", "enabled"),
+            ({"type": "object"}, "dict-consumer", "value"),
+            ({"type": "string"}, "string-consumer", "text"),
+            ({"type": ["integer", "string"]}, "string-consumer", "text"),
+        ],
+    )
+    def test_llm_json_root_types_reach_typed_consumers(self, test_registry, schema, consumer_type, param_name):
+        """Recognized direct schema roots specialize the per-node response type."""
+        workflow_ir = {
+            "enable_namespacing": True,
+            "inputs": {},
+            "nodes": [
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "params": {"prompt": "test", "max_tokens": 100, "output_schema": schema},
+                },
                 {
                     "id": "consumer",
-                    "type": "int-consumer",
-                    "params": {"count": "${llm.response}"},  # dict|str → int (incompatible)
+                    "type": consumer_type,
+                    "params": {param_name: "${llm.response}"},
                 },
             ],
             "edges": [{"from": "llm", "to": "consumer"}],
@@ -359,8 +423,125 @@ class TestTypeValidationIntegration:
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
 
         type_errors = [d for d in errors if "Type mismatch" in d.message]
-        # dict|str → int should fail because neither dict nor str can convert to int
+        assert len(type_errors) == 0
+
+    @pytest.mark.parametrize(
+        ("schema", "consumer_type", "param_name", "inferred_type"),
+        [
+            ({"type": "array"}, "int-consumer", "count", "list"),
+            ({"type": "integer"}, "bool-consumer", "enabled", "int"),
+            ({"type": "number"}, "bool-consumer", "enabled", "number"),
+            ({"type": "boolean"}, "int-consumer", "count", "bool"),
+            ({"type": "object"}, "list-consumer", "items", "dict"),
+            ({"type": "string"}, "bool-consumer", "enabled", "str"),
+            ({"type": ["integer", "string"]}, "bool-consumer", "enabled", "int|str"),
+        ],
+    )
+    def test_llm_json_root_types_reject_incompatible_consumers(
+        self, test_registry, schema, consumer_type, param_name, inferred_type
+    ):
+        workflow_ir = {
+            "enable_namespacing": True,
+            "inputs": {},
+            "nodes": [
+                {"id": "llm", "type": "llm", "params": {"prompt": "test", "output_schema": schema}},
+                {
+                    "id": "consumer",
+                    "type": consumer_type,
+                    "params": {param_name: "${llm.response}"},
+                },
+            ],
+            "edges": [{"from": "llm", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+
+        type_errors = [d for d in errors if "Type mismatch" in d.message]
         assert len(type_errors) == 1
+        assert type_errors[0].context["inferred_type"] == inferred_type
+
+    def test_llm_object_output_allows_object_path_traversal(self, test_registry):
+        workflow_ir = {
+            "enable_namespacing": True,
+            "inputs": {},
+            "nodes": [
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "params": {"prompt": "test", "output_schema": {"type": "object"}},
+                },
+                {
+                    "id": "consumer",
+                    "type": "string-consumer",
+                    "params": {"text": "${llm.response.name}"},
+                },
+            ],
+            "edges": [{"from": "llm", "to": "consumer"}],
+        }
+
+        errors, warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+
+        assert errors == []
+        assert warnings == []
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            {},
+            {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+            {"$ref": "#/$defs/value", "$defs": {"value": {"type": "integer"}}},
+            {"type": "${schema_type}"},
+            {"type": "intger"},
+        ],
+    )
+    def test_ambiguous_llm_schemas_remain_permissive(self, test_registry, schema):
+        workflow_ir = {
+            "enable_namespacing": True,
+            "inputs": {"schema_type": {"type": "string", "required": False}},
+            "nodes": [
+                {"id": "llm", "type": "llm", "params": {"prompt": "test", "output_schema": schema}},
+                {"id": "consumer", "type": "bool-consumer", "params": {"enabled": "${llm.response}"}},
+            ],
+            "edges": [{"from": "llm", "to": "consumer"}],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {"schema_type": "boolean"}, test_registry)
+
+        assert [d for d in errors if "Type mismatch" in d.message] == []
+
+    def test_batch_llm_response_uses_schema_specialization(self, test_registry):
+        workflow_ir = {
+            "enable_namespacing": True,
+            "inputs": {},
+            "nodes": [
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "params": {"prompt": "test", "output_schema": {"type": "array"}},
+                    "batch": {"items": ["a"], "as": "item"},
+                },
+                {
+                    "id": "consumer",
+                    "type": "list-consumer",
+                    "params": {"items": "${llm.results[0].response}"},
+                },
+                {
+                    "id": "incompatible-consumer",
+                    "type": "int-consumer",
+                    "params": {"count": "${llm.results[0].response}"},
+                },
+            ],
+            "edges": [
+                {"from": "llm", "to": "consumer"},
+                {"from": "llm", "to": "incompatible-consumer"},
+            ],
+        }
+
+        errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
+
+        type_errors = [d for d in errors if "Type mismatch" in d.message]
+        assert len(type_errors) == 1
+        assert type_errors[0].context["inferred_type"] == "list"
 
     def test_any_type_skips_validation(self, test_registry):
         """Parameters with type 'any' should skip type checking."""
@@ -611,22 +792,15 @@ class TestTypeValidationIntegration:
         assert len(shell_errors) == 0
 
     def test_shell_command_allows_union_with_str(self, test_registry):
-        """Union type containing str should be ALLOWED in shell command (Tier 1).
-
-        dict|str contains a safe type (str), so it's auto-allowed.
-        Runtime coercion will handle dict → JSON string if needed.
-        Uses the LLM node from test_registry which has output type dict|str.
-        """
+        """The LLM's ``any`` response is shell-safe because its root varies."""
         workflow_ir = {
             "enable_namespacing": True,
             "inputs": {},
             "nodes": [
-                # LLM node has output type "dict|str" - contains str, so allowed
                 {"id": "llm-node", "type": "llm", "params": {"prompt": "test", "max_tokens": 100}},
                 {
                     "id": "shell-node",
                     "type": "shell",
-                    # Note: even without quotes, dict|str is allowed due to Tier 1
                     "params": {"command": "echo ${llm-node.response}"},
                 },
             ],
@@ -635,7 +809,6 @@ class TestTypeValidationIntegration:
 
         errors, _warnings = split_template_diagnostics(workflow_ir, {}, test_registry)
 
-        # Should pass - dict|str contains str, which is a safe type
         shell_errors = [d for d in errors if "Shell node" in d.message]
         assert len(shell_errors) == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -1475,6 +1475,7 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "referencing" },
     { name = "requests" },
 ]
 
@@ -1513,6 +1514,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0" },
     { name = "pydantic" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "referencing", specifier = ">=0.28.4" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "starlette", marker = "extra == 'ui'", specifier = ">=0.40" },
     { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.30" },

--- a/web/src/test/fixtures/contracts/deep-research.json
+++ b/web/src/test/fixtures/contracts/deep-research.json
@@ -1892,7 +1892,6 @@
       "error": "str"
     },
     "llm": {
-      "response": "str|dict",
       "error": "str",
       "prompt": "str",
       "llm_usage": "dict"

--- a/web/src/test/fixtures/contracts/prompt-caching-multi-chunk.json
+++ b/web/src/test/fixtures/contracts/prompt-caching-multi-chunk.json
@@ -538,7 +538,6 @@
   ],
   "kind_output_types": {
     "llm": {
-      "response": "str|dict",
       "error": "str",
       "prompt": "str",
       "llm_usage": "dict"

--- a/web/src/test/fixtures/contracts/run-cycle.json
+++ b/web/src/test/fixtures/contracts/run-cycle.json
@@ -1683,7 +1683,6 @@
       "error": "str"
     },
     "llm": {
-      "response": "str|dict",
       "error": "str",
       "prompt": "str",
       "llm_usage": "dict"


### PR DESCRIPTION
## Summary

Make LLM structured output enforce the authored JSON Schema locally and safely recover LiteLLM's intermittent Anthropic `json_tool_call` wrapper.

Fixes #598

## Changes

- Validate literal schemas during workflow validation and resolved schemas immediately before provider dispatch.
- Validate every parsed structured response, reject non-finite JSON numbers, and preserve raw response and usage on mismatch.
- Unwrap only an exact outer-invalid, inner-valid `json_tool_call` compatibility wrapper.
- Support self-contained JSON Schema references without network retrieval and report precise reference paths.
- Preserve retry, `on-error`, batch continuation, trace, cache, and non-object JSON-root behavior.
- Specialize LLM response types conservatively for template validation while keeping ambiguous schemas permissive.
- Update LLM documentation to describe provider structured-output behavior and pflow's local validation guarantee accurately.

## Explanation

Provider-native structured output is not a sufficient trust boundary on every backend. Anthropic structured output is implemented by LiteLLM through a forced tool call, and the model can intermittently place the internal tool name inside otherwise valid arguments. Previously pflow parsed the returned JSON but never checked it against `output_schema`, allowing invalid data to fail later in unrelated downstream nodes.

The LLM Step now treats local JSON Schema validation as authoritative. It performs one narrowly proven compatibility recovery without coercion or another paid model call, and otherwise fails at the source with typed diagnostics. The same schema preparation is shared by validation-only, dry-run, runtime, and templated-schema paths.

## Testing

- `make check` — lockfile, generated assets, Ruff, formatting, pre-commit, mypy across 256 source files, and dependency checks passed.
- `make test` — 9,102 tests passed.
- `make test-all-local` — 9,146 tests passed and 2 skipped.
- Focused structured-output, workflow-validator, batch, template-type, CLI, and diagnostic regressions — 104 tests passed.
- Affected module and generated-contract suites — 806 tests passed and 9 skipped.
- Manual CLI verification drove disposable `pflow.md` workflows through the real runner for malformed schemas, unknown dialects, exact wrapper recovery, false-positive wrappers, `on-error`, no-retry behavior, raw response and usage preservation, references, and every JSON root type without a paid provider call.
- `test-reflect` strengthened raw-response and archived-usage assertions.
- Six-dimension deep review was repeated after fixes until every specialist returned clean.
