### PR TITLE
ci: smoke-test a real pip install of the built wheel (#603)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,13 +76,75 @@ jobs:
       - name: Check typing
         run: uv run mypy
 
-  # Summary job for branch protection — Linux-version and Windows-shard matrix
-  # jobs have suffixed display names, so their bare names never resolve as
-  # stable required checks. Point branch protection at this job; it gates both
-  # matrices, Windows MCP smoke, and the macOS Make compatibility smoke test.
+  # Real-pip installability of the wheel we publish. Rationale, measurements, and
+  # the full list of deliberate choices: GH #603.
+  #
+  # NOT redundant with tests-and-type-check: that matrix installs via
+  # `uv sync --frozen`, which never re-checks a dependency's Requires-Python, and
+  # uv ignores Requires-Python UPPER bounds by design. Only real pip catches it.
+  #
+  # Three things here are load-bearing — do not "simplify" them:
+  #   - install the BUILT WHEEL, not `pip install pflow-cli` (no older release for
+  #     pip to silently backtrack to, so a bad pin fails loudly)
+  #   - never use uv for the install step (it would pass unconditionally)
+  #   - never add a pip cache; pip caches index responses, so a warm cache can
+  #     agree with a stale view of PyPI while real installs fail (hit while
+  #     diagnosing #602). The cold download IS the check.
+  #
+  # 3.14 is deliberately absent — the one interpreter where pip is known to fail
+  # (litellm==1.86.1 caps Requires-Python <3.14), so the leg would be red on
+  # arrival. Add "3.14" when the litellm pin moves; that leg going green is the
+  # acceptance criterion for GH #602. Do not paper it over by relaxing this job.
+  pip-install-smoke:
+    name: pip-install-smoke (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      # Deliberately NOT ./.github/actions/setup-python-env — that composite runs
+      # `uv sync --frozen` and installs a dev toolchain this job never touches.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.6.14"
+
+      - name: Build the wheel
+        run: uv build --wheel --out-dir dist
+
+      - name: Install the wheel with real pip
+        # stdlib venv + real pip (see the load-bearing list above). `--upgrade pip`
+        # keeps the resolver current, so the signal matches what users actually run.
+        run: |
+          python -m venv /tmp/pip-smoke
+          /tmp/pip-smoke/bin/python -m pip install --upgrade pip
+          /tmp/pip-smoke/bin/python -m pip install --no-cache-dir dist/*.whl
+
+      - name: Verify the installed CLI runs
+        run: |
+          /tmp/pip-smoke/bin/pflow --version
+          /tmp/pip-smoke/bin/pflow --help > /dev/null
+
+  # Summary job for branch protection — Linux-version, Windows-shard, and
+  # pip-install-smoke matrix jobs have suffixed display names, so their bare
+  # names never resolve as stable required checks. Point branch protection at
+  # this job; it gates all three matrices, Windows MCP smoke, and the macOS Make
+  # compatibility smoke test.
   tests-and-type-check-done:
     if: always()
-    needs: [tests-and-type-check, tests-windows, tests-windows-mcp-smoke, tests-macos-make]
+    needs: [tests-and-type-check, tests-windows, tests-windows-mcp-smoke, tests-macos-make, pip-install-smoke]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -96,6 +158,9 @@ jobs:
             exit 1
           fi
           if [[ "${{ needs.tests-macos-make.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.pip-install-smoke.result }}" != "success" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,10 @@ jobs:
   pip-install-smoke:
     name: pip-install-smoke (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Same reasoning as tests-windows' cap: a required check must not be able to
+    # burn a runner for the 6h default. The one plausible hang here is a stalled
+    # PyPI download, and the job is measured at ~40s, so this is ~14x headroom.
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]
@@ -121,21 +125,34 @@ jobs:
         with:
           version: "0.6.14"
 
+      # Plain `uv build` (sdist -> wheel), NOT `uv build --wheel` — this is the path
+      # the release workflow uses, so the artifact under test matches the published
+      # one. METADATA is identical either way, but the sdist's `exclude` entry for
+      # CLAUDE.md matches by basename recursively, so `--wheel` would test a file set
+      # we never ship. Also emits an sdist; the glob below still matches one wheel.
       - name: Build the wheel
-        run: uv build --wheel --out-dir dist
+        run: uv build --out-dir dist
 
       - name: Install the wheel with real pip
         # stdlib venv + real pip (see the load-bearing list above). `--upgrade pip`
         # keeps the resolver current, so the signal matches what users actually run.
         run: |
           python -m venv /tmp/pip-smoke
-          /tmp/pip-smoke/bin/python -m pip install --upgrade pip
+          /tmp/pip-smoke/bin/python -m pip install --no-cache-dir --upgrade pip
           /tmp/pip-smoke/bin/python -m pip install --no-cache-dir dist/*.whl
 
       - name: Verify the installed CLI runs
+        # `--version` / `--help` exercise the click layer and already pull mcp,
+        # starlette, uvicorn and httpx — but NOT litellm or claude_agent_sdk, which
+        # are deliberately lazy (tests/test_cli/test_lazy_imports.py). Without the
+        # third line a wheel that installs cleanly and then dies on first real LLM
+        # call would pass. Import them through pflow's own seam: a bare
+        # `import litellm` makes a 5s-timeout cost-map fetch to GitHub, which
+        # import_litellm() avoids by setting LITELLM_LOCAL_MODEL_COST_MAP first.
         run: |
           /tmp/pip-smoke/bin/pflow --version
           /tmp/pip-smoke/bin/pflow --help > /dev/null
+          /tmp/pip-smoke/bin/python -c "import pflow.nodes.agent.claude_backend; from pflow.core.litellm_runtime import import_litellm; import_litellm()"
 
   # Summary job for branch protection — Linux-version, Windows-shard, and
   # pip-install-smoke matrix jobs have suffixed display names, so their bare
@@ -144,6 +161,9 @@ jobs:
   # compatibility smoke test.
   tests-and-type-check-done:
     if: always()
+    # Every job listed here needs a matching result check below. `if: always()` means
+    # a missing check silently un-gates that job: it gets waited on, its result is
+    # never inspected, and this job still exits 0.
     needs: [tests-and-type-check, tests-windows, tests-windows-mcp-smoke, tests-macos-make, pip-install-smoke]
     runs-on: ubuntu-latest
     steps:

--- a/.taskmaster/orchestration/CURRENT-STATE.md
+++ b/.taskmaster/orchestration/CURRENT-STATE.md
@@ -41,13 +41,13 @@ Every claim here is a pointer to verify, not a fact._
   `task_171/task-review.md` + `task_176/task-review.md` before resume/gate/trace work.
 - No task, issue, PR, or child agent is in flight. **Tasks 142 and 46 are parked in Later by user
   ruling 2026-07-15.**
+  Task 142's observed bugs are fixed and explicit dependency edges remain necessary. Task 46's
+  planner/wrapper premises were removed by Tasks 92/135; modern runtime parity would duplicate
+  the runtime without observed demand. Its spec carries the full stale/parked warning.
 - **Between sessions (2026-08-02, no session record):** filed **#602** (pip on 3.14 silently
   installs pflow-cli 0.12.0 — `litellm==1.86.1` caps `Requires-Python <3.14`; blocked on upstream
   macOS wheels, BerriAI/litellm#31261) and **#603** (CI never real-`pip install`s the wheel).
   #603's `pip-install-smoke` job (3.10/3.13) is written + verified; in review (PR linked from #603).
-  Task 142's observed bugs are fixed and explicit dependency edges remain necessary. Task 46's
-  planner/wrapper premises were removed by Tasks 92/135; modern runtime parity would duplicate
-  the runtime without observed demand. Its spec carries the full stale/parked warning.
 - **Task 94 spec REWRITTEN + design LOCKED (session-06); not yet started.** Original spec was
   substantially stale (targeted the removed `registry describe` surface; false "no detection"
   premise; obsolete `llm`-library). Refreshed `task_94/task-94.md` in place with provenance. Locked

--- a/.taskmaster/orchestration/CURRENT-STATE.md
+++ b/.taskmaster/orchestration/CURRENT-STATE.md
@@ -41,6 +41,10 @@ Every claim here is a pointer to verify, not a fact._
   `task_171/task-review.md` + `task_176/task-review.md` before resume/gate/trace work.
 - No task, issue, PR, or child agent is in flight. **Tasks 142 and 46 are parked in Later by user
   ruling 2026-07-15.**
+- **Between sessions (2026-08-02, no session record):** filed **#602** (pip on 3.14 silently
+  installs pflow-cli 0.12.0 — `litellm==1.86.1` caps `Requires-Python <3.14`; blocked on upstream
+  macOS wheels, BerriAI/litellm#31261) and **#603** (CI never real-`pip install`s the wheel).
+  #603's `pip-install-smoke` job (3.10/3.13) is written + verified; in review (PR linked from #603).
   Task 142's observed bugs are fixed and explicit dependency edges remain necessary. Task 46's
   planner/wrapper premises were removed by Tasks 92/135; modern runtime parity would duplicate
   the runtime without observed demand. Its spec carries the full stale/parked warning.
@@ -88,4 +92,4 @@ Every claim here is a pointer to verify, not a fact._
 - Worktrees: only `main`; no live subagents. `main == origin/main` at the session-06 close commit
   (Task 94 spec + DECISIONS #3 Fable/Sonnet-ban amendment + this file + BRAINDUMP + session-06.md);
   code tip is `573718cb` (#597/#592). Session-06 CLOSED — user-authorized commit+push. Nothing
-  uncommitted.
+  uncommitted; one branch in review since (see Current arc, between-sessions bullet).


### PR DESCRIPTION
## Summary

CI never performed a real `pip install` of the artifact we publish, so it could be fully green on an interpreter where `pip install pflow-cli` does not work. This adds a `pip-install-smoke` job that builds the wheel and installs it with real pip, then runs the CLI.

Fixes #603

Related: #602 (not closed by this PR — it is blocked on upstream litellm shipping macOS wheels).

## Changes

- `.github/workflows/main.yml`: new `pip-install-smoke` matrix job (3.10, 3.13); wired into the `tests-and-type-check-done` summary gate so it is covered by existing branch protection with no settings change
- `.taskmaster/orchestration/CURRENT-STATE.md`: two-line between-sessions note recording #602/#603 and this branch

## Explanation

Two structural reasons CI could not catch this class of bug:

1. Every test job installs deps with `uv sync --frozen` (`.github/actions/setup-python-env`), which resolves straight from `uv.lock` and never re-checks each dependency's `Requires-Python`.
2. uv ignores `Requires-Python` **upper** bounds by design; pip enforces them. So even a non-frozen uv install cannot surface what a pip user hits.

Net effect: #602 went undetected across 0.13.0, 0.14.0 and 0.15.0 while the 3.14 matrix leg reported success the whole time.

Three choices in the job are load-bearing and commented as such, because each is a plausible "simplification" that would silently void the check:

- **Install the built wheel, not `pip install pflow-cli`.** An unsatisfiable dependency then fails loudly — pip has no older pflow-cli release to backtrack to. Installing by name is what produces the silent downgrade in #602. It also tests the artifact in hand rather than waiting on PyPI propagation.
- **Never use uv for the install step.** uv ignoring `Requires-Python` upper bounds is precisely what is being checked; using uv would make the job pass unconditionally.
- **Never add a pip cache.** pip caches index responses, not just wheels, so a warm cache can hide newly published releases and let the job agree with a stale view of PyPI while real installs fail. This was hit while diagnosing #602: a stale cache hid litellm 1.93/1.94 entirely and produced a confidently wrong result. The cold download *is* the check.

Scope choices: boundary versions only (3.10, 3.13), since the risk is version-boundary dependency metadata and middle versions resolve identically at ~25s of dependency download each. The job also skips the `setup-python-env` composite, which would `uv sync --frozen` a dev toolchain (pytest, mypy, ruff) this job never touches.

**Known limitation, deliberate:** 3.14 is excluded — the one interpreter where pip is known to fail (`litellm==1.86.1` caps `Requires-Python <3.14`), so that leg would be red on arrival. The job therefore guards regressions on working interpreters but does not yet cover the failure that motivated it. Adding `"3.14"` is #602's acceptance criterion, and the comment says not to paper over it by relaxing the job.

Diff: 2 files, +75/−6 (the workflow change is largely comments explaining the above).

## Testing

No unit tests — this is a CI job. Verified by running its exact command sequence locally against real interpreters:

- **Real CPython 3.10** (boundary leg): full sequence green in 24.8s → `pflow version 0.15.0`, `pflow --help` ok
- **Real CPython 3.13**: same, green
- **Real CPython 3.14**: correctly fails at the install step with `ERROR: No matching distribution found for litellm==1.86.1` — confirming the job would detect #602's class of bug rather than silently pass
- **Bundle-less checkout** (the state a CI runner is in — `src/pflow/ui/static` is gitignored and built only at release): `uv build --wheel` succeeds, wheel contains 0 `ui/static` entries, that wheel installs and the CLI runs. This was a real gap: every earlier local build had the bundle present, so without this check the build step could have failed on CI.
- `uv 0.6.14` (the version the setup action pins) confirmed to support both `uv build --wheel` and `--out-dir`
- `make check` green — ruff, pre-commit (including the `check yaml` hook on the workflow), mypy 256 files, deptry
- `make test-all-local`: **9146 passed, 2 skipped** on the exact shipping tree
