### PR TITLE
fix: make core registry refresh single-snapshot (#611)

### DIFF
--- a/src/pflow/registry/CLAUDE.md
+++ b/src/pflow/registry/CLAUDE.md
@@ -28,7 +28,7 @@ File: `~/.pflow/registry.json`. Auto-created on first use by scanning `src/pflow
 
 | Type | Set by | Survives core refresh? |
 |------|--------|----------------------|
-| `"core"` | `_auto_discover_core_nodes()` | No — re-scanned on version change |
+| `"core"` | `_scan_core_nodes()` | No — re-scanned on version change |
 | `"user"` | `scan_user_nodes()` (Python API only — `pflow registry scan` CLI was removed in Task 151) | Yes |
 | `"mcp"` | `MCPRegistrar` (from `mcp/registrar.py`) | Yes |
 
@@ -88,7 +88,7 @@ The safe pattern: always use `load(include_filtered=True)` before any `save()` c
 
 User and MCP nodes are preserved through the refresh via `_refresh_core_nodes()`. Structured-wrapper registries missing either `version` or `last_core_scan` still hit the mtime path (the `not version and not last_scan` gate short-circuits only when BOTH are absent — legacy flat-format registries, which still heal via a version bump). Timestamps are written in UTC; naive legacy timestamps are interpreted as local time for backward compatibility.
 
-**Race-safety**: `_auto_discover_core_nodes()` captures the scan-start timestamp BEFORE `scan_for_nodes()` reads sources, and `_refresh_core_nodes()` propagates that timestamp through the final merge write. Stamping `last_core_scan` with a POST-scan time would lose any concurrent edit made during the scan window (mtime < stored timestamp on the next load → no refresh).
+**Race-safety**: `_scan_core_nodes()` captures the scan-start timestamp BEFORE `scan_for_nodes()` reads sources and does not persist anything itself. First-use initialization saves the discovered core nodes once; `_refresh_core_nodes()` merges preserved non-core nodes in memory and saves one complete snapshot. Stamping `last_core_scan` with a POST-scan time would lose any concurrent edit made during the scan window (mtime < stored timestamp on the next load → no refresh).
 
 **Limits**:
 - **Deletions aren't detected.** Removing a `src/pflow/nodes/**/*.py` file doesn't bump the mtime of surviving files, so the mtime path keeps serving the dead entry. Heals via version bump. Stat'ing the nodes dir itself would catch the immediate parent but is accepted complexity for a rare case.

--- a/src/pflow/registry/registry.py
+++ b/src/pflow/registry/registry.py
@@ -449,15 +449,19 @@ class Registry:
         with _REGISTRY_IO_LOCK:
             # Preserve existing metadata (MCP sync hashes, etc.)
             existing = self._read_wrapper()
+            version = self._get_version()
+            last_core_scan = scan_time or self._now_iso()
 
             data = {
-                "version": self._get_version(),
-                "last_core_scan": scan_time or self._now_iso(),
+                "version": version,
+                "last_core_scan": last_core_scan,
                 "metadata": existing.get("metadata", {}),
                 "nodes": nodes,
             }
 
             self._write_atomic(data)
+            self._registry_version = version
+            self._registry_last_scan = last_core_scan
 
             logger.info(f"Saved {len(nodes)} nodes to registry with metadata")
 

--- a/src/pflow/registry/registry.py
+++ b/src/pflow/registry/registry.py
@@ -110,8 +110,8 @@ class Registry:
             # Check if registry exists
             if not self.registry_path.exists():
                 logger.info("Registry not found, auto-discovering core nodes...")
-                # First time - auto-discover core nodes
-                self._auto_discover_core_nodes()
+                core_nodes, scan_started_at = self._scan_core_nodes()
+                self._save_with_metadata(core_nodes, scan_time=scan_started_at)
 
             # Try to load from file
             nodes = self._load_from_file()
@@ -392,8 +392,12 @@ class Registry:
                 types[kind] = fields
         return types
 
-    def _auto_discover_core_nodes(self) -> None:
-        """Auto-discover and save core nodes on first use."""
+    def _scan_core_nodes(self) -> tuple[dict[str, dict[str, Any]], str]:
+        """Return registry-ready core nodes and the pre-scan timestamp.
+
+        Scanning imports trusted pflow node modules, but does not read or write
+        the registry. Callers decide which complete node set to persist.
+        """
         import pflow.nodes
         from pflow.registry.scanner import scan_for_nodes
 
@@ -410,7 +414,7 @@ class Registry:
         # with a POST-scan timestamp would lose concurrent edits made during the
         # scan window (their mtime would sit < stored timestamp, so the next
         # mtime check wouldn't refresh).
-        scan_start = self._now_iso()
+        scan_started_at = self._now_iso()
         scan_results = scan_for_nodes(subdirs)
 
         # Convert to registry format with type marking
@@ -427,10 +431,8 @@ class Registry:
             del node_copy["name"]  # Registry doesn't store name in value
             registry_nodes[name] = node_copy
 
-        logger.info(f"Auto-discovered {len(registry_nodes)} core nodes")
-
-        # Save with metadata, using the pre-scan timestamp
-        self._save_with_metadata(registry_nodes, scan_time=scan_start)
+        logger.info(f"Discovered {len(registry_nodes)} core nodes")
+        return registry_nodes, scan_started_at
 
     def _save_with_metadata(self, nodes: dict[str, dict[str, Any]], scan_time: str | None = None) -> None:
         """Save nodes with updated version and timestamp.
@@ -556,24 +558,15 @@ class Registry:
         # Preserve every non-core node (see docstring: fail-safe, self-healing).
         preserved = {name: data for name, data in nodes.items() if data.get("type") != "core"}
 
-        # Re-discover core nodes — _auto_discover_core_nodes stamps
-        # last_core_scan with a PRE-scan timestamp (race-safe).
-        self._auto_discover_core_nodes()
+        core_nodes, scan_started_at = self._scan_core_nodes()
 
-        # Reload — populates self._registry_last_scan from the pre-scan stamp.
-        refreshed = self._load_from_file()
+        # Merge preserved nodes UNDER the fresh core scan, so fresh core
+        # metadata always wins a name collision.
+        refreshed = {**preserved, **core_nodes}
 
-        # Merge preserved nodes UNDER the fresh core scan: setdefault adds a
-        # preserved entry only when its name is free, so fresh core metadata
-        # always wins a name collision (see docstring).
-        for name, data in preserved.items():
-            refreshed.setdefault(name, data)
-
-        # Save the merged result, propagating the pre-scan timestamp so the
-        # race-safety is preserved through the final merge write. Without this,
-        # the merge save would stamp "now" (post-scan) and lose any edit made
-        # during the scan window.
-        self._save_with_metadata(refreshed, scan_time=self._registry_last_scan)
+        # Persist one complete snapshot. Propagating the pre-scan timestamp
+        # ensures a source edit made during scanning triggers the next refresh.
+        self._save_with_metadata(refreshed, scan_time=scan_started_at)
 
         return refreshed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,9 +176,7 @@ def precomputed_core_registry_nodes(tmp_path_factory):
 
     session_registry_path = tmp_path_factory.mktemp("session_core") / "registry.json"
     reg = Registry(session_registry_path)
-    reg._auto_discover_core_nodes()  # safe in tests
-    raw = reg._load_from_file()
-    return raw.get("nodes", raw)
+    return reg.load(include_filtered=True)
 
 
 def _create_registry_patcher(test_registry_path) -> callable:

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -8,7 +8,6 @@ REFACTOR HISTORY:
 - 2024-01-30: Added more integration tests and real workflow scenarios
 """
 
-import copy
 import json
 import os
 import sys
@@ -750,47 +749,39 @@ class TestRegistryVersionRefresh:
         """Core refresh must never persist a core-only intermediate snapshot."""
         registry_path = tmp_path / "registry.json"
         registry = Registry(registry_path)
+        scan_started_at = "2030-01-01T00:00:00+00:00"
         original_nodes = {
-            "shell": {
-                "module": "stale.shell",
-                "class_name": "StaleShellNode",
-                "type": "core",
-            },
             "removed-core": {
                 "module": "stale.removed",
                 "class_name": "RemovedCoreNode",
                 "type": "core",
             },
-            "my-user-node": {
-                "module": "my_project.nodes.user",
-                "class_name": "UserNode",
-                "type": "user",
-            },
-            "mcp-current-tool": {
+            "mcp-sentinel": {
                 "module": "pflow.nodes.mcp.node",
                 "class_name": "MCPNode",
                 "file_path": "virtual://mcp",
                 "type": "mcp",
             },
-            "mcp-legacy-tool": {
-                "module": "pflow.nodes.mcp.node",
-                "class_name": "MCPNode",
-                "file_path": "virtual://mcp",
-            },
         }
-        registry._save_with_metadata(original_nodes, scan_time="2000-01-01T00:00:00+00:00")
-        registry.set_metadata("sentinel", "keep")
+        registry._write_atomic({
+            "version": "stale-version",
+            "last_core_scan": "2000-01-01T00:00:00+00:00",
+            "metadata": {"sentinel": "keep"},
+            "nodes": original_nodes,
+        })
 
         registry = Registry(registry_path)
         loaded = registry._load_from_file()
         fresh_scan = [{"name": "shell", "module": "fresh.shell", "class_name": "ShellNode"}]
         monkeypatch.setattr("pflow.registry.scanner.scan_for_nodes", lambda _subdirs: fresh_scan)
+        timestamps = iter([scan_started_at, "2040-01-01T00:00:00+00:00"])
+        monkeypatch.setattr(registry, "_now_iso", lambda: next(timestamps))
 
         writes = []
         original_write = registry._write_atomic
 
         def record_write(data):
-            writes.append(copy.deepcopy(data))
+            writes.append(data)
             original_write(data)
 
         monkeypatch.setattr(registry, "_write_atomic", record_write)
@@ -799,14 +790,14 @@ class TestRegistryVersionRefresh:
 
         assert len(writes) == 1, "refresh must persist exactly one complete registry snapshot"
         written = writes[0]
+        assert written["last_core_scan"] == scan_started_at
         assert written["metadata"] == {"sentinel": "keep"}
-        assert written["version"] == registry._get_version()
         assert written["nodes"] == refreshed
         assert written["nodes"]["shell"]["module"] == "fresh.shell"
-        assert written["nodes"]["shell"]["type"] == "core"
         assert "removed-core" not in written["nodes"]
-        for name in ("my-user-node", "mcp-current-tool", "mcp-legacy-tool"):
-            assert written["nodes"][name] == original_nodes[name]
+        assert written["nodes"]["mcp-sentinel"] == original_nodes["mcp-sentinel"]
+        assert registry._registry_version == written["version"]
+        assert registry._registry_last_scan == scan_started_at
 
         persisted = json.loads(registry_path.read_text(encoding="utf-8"))
         assert persisted == written

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -8,6 +8,7 @@ REFACTOR HISTORY:
 - 2024-01-30: Added more integration tests and real workflow scenarios
 """
 
+import copy
 import json
 import os
 import sys
@@ -745,6 +746,71 @@ class TestRegistryVersionRefresh:
             # Non-colliding untyped entry still self-heals through the refresh.
             assert "mcp-legacy-tool" in refreshed
 
+    def test_refresh_persists_one_complete_snapshot(self, tmp_path, monkeypatch):
+        """Core refresh must never persist a core-only intermediate snapshot."""
+        registry_path = tmp_path / "registry.json"
+        registry = Registry(registry_path)
+        original_nodes = {
+            "shell": {
+                "module": "stale.shell",
+                "class_name": "StaleShellNode",
+                "type": "core",
+            },
+            "removed-core": {
+                "module": "stale.removed",
+                "class_name": "RemovedCoreNode",
+                "type": "core",
+            },
+            "my-user-node": {
+                "module": "my_project.nodes.user",
+                "class_name": "UserNode",
+                "type": "user",
+            },
+            "mcp-current-tool": {
+                "module": "pflow.nodes.mcp.node",
+                "class_name": "MCPNode",
+                "file_path": "virtual://mcp",
+                "type": "mcp",
+            },
+            "mcp-legacy-tool": {
+                "module": "pflow.nodes.mcp.node",
+                "class_name": "MCPNode",
+                "file_path": "virtual://mcp",
+            },
+        }
+        registry._save_with_metadata(original_nodes, scan_time="2000-01-01T00:00:00+00:00")
+        registry.set_metadata("sentinel", "keep")
+
+        registry = Registry(registry_path)
+        loaded = registry._load_from_file()
+        fresh_scan = [{"name": "shell", "module": "fresh.shell", "class_name": "ShellNode"}]
+        monkeypatch.setattr("pflow.registry.scanner.scan_for_nodes", lambda _subdirs: fresh_scan)
+
+        writes = []
+        original_write = registry._write_atomic
+
+        def record_write(data):
+            writes.append(copy.deepcopy(data))
+            original_write(data)
+
+        monkeypatch.setattr(registry, "_write_atomic", record_write)
+
+        refreshed = registry._refresh_core_nodes(loaded)
+
+        assert len(writes) == 1, "refresh must persist exactly one complete registry snapshot"
+        written = writes[0]
+        assert written["metadata"] == {"sentinel": "keep"}
+        assert written["version"] == registry._get_version()
+        assert written["nodes"] == refreshed
+        assert written["nodes"]["shell"]["module"] == "fresh.shell"
+        assert written["nodes"]["shell"]["type"] == "core"
+        assert "removed-core" not in written["nodes"]
+        for name in ("my-user-node", "mcp-current-tool", "mcp-legacy-tool"):
+            assert written["nodes"][name] == original_nodes[name]
+
+        persisted = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert persisted == written
+
 
 class TestRegistrySourceMtimeRefresh:
     """Test mtime-based refresh when core node source files change.
@@ -915,7 +981,7 @@ class TestRegistrySourceMtimeRefresh:
 
         registry = Registry(tmp_path / "registry.json")
         before = time_mod.time()
-        registry._auto_discover_core_nodes()
+        registry.load(include_filtered=True)
         after = time_mod.time()
 
         stored_iso = json.loads((tmp_path / "registry.json").read_text(encoding="utf-8"))["last_core_scan"]
@@ -986,7 +1052,7 @@ class TestRegistryFormatConsistency:
             registry_path = Path(tmpdir) / "registry.json"
             registry = Registry(registry_path)
 
-            # Step 1: Write structured format (simulates _auto_discover_core_nodes)
+            # Step 1: Write structured format (simulates core initialization)
             test_nodes = {
                 "shell": {"module": "pflow.nodes.shell.shell", "class_name": "ShellNode", "type": "core"},
             }


### PR DESCRIPTION
## Summary

Core-node refresh now builds the complete registry snapshot in memory and persists it once, preventing concurrent pflow processes from observing and retaining the previous core-only intermediate state.

Fixes #611

## Changes

- Separated core-node scanning from registry persistence with `_scan_core_nodes()`.
- Changed refresh to preserve non-core entries, merge fresh core metadata in memory, and perform one atomic write.
- Kept cold initialization, wrapper metadata, version stamping, and pre-scan timestamp behavior intact.
- Added a deterministic regression test that records every persisted refresh snapshot and requires the sole snapshot to be complete.
- Updated the shared registry fixture and registry guidance for the new lifecycle.

## Explanation

Atomic file replacement guaranteed valid JSON but did not make the old two-write refresh sequence transactional. Refresh first persisted only scanned core nodes, then reloaded that file, restored non-core entries from process memory, and persisted again. A concurrent process could load the intermediate core-only snapshot and later make that loss permanent.

Discovery is now persistence-free. Cold initialization still writes core nodes once when no registry exists; refresh merges existing non-core entries with fresh core entries before its only write. Fresh core metadata continues to win name collisions, and the timestamp captured before scanning is forwarded unchanged so source edits made during scanning remain detectable.

This intentionally avoids a partial locking solution. General cross-process read-modify-write isolation remains separate from the concrete intermediate-snapshot defect addressed here.

## Testing

- `test_refresh_persists_one_complete_snapshot` — mutation-verified against the old implementation; asserts exactly one complete refresh write, non-core preservation, core replacement, metadata preservation, and disk/result parity.
- Existing registry preservation, collision, cold-initialization, and pre-scan timestamp tests.
- `PYTHONWARNDEFAULTENCODING=1 .venv/bin/python -m pytest tests/test_registry/test_registry.py -q` — 50 passed.
- `make check` — lock consistency, asset sync, Ruff, pre-commit, mypy, and deptry passed.
- Full non-paid/non-e2e suite — 9,143 passed.
