### PR TITLE
fix: preserve MCP tools across partial sync failures (#612)

### DIFF
--- a/src/pflow/cli/CLAUDE.md
+++ b/src/pflow/cli/CLAUDE.md
@@ -211,7 +211,7 @@ Full list readable in `_initialize_context` and `_setup_workflow_execution` in `
 
 ## MCP Auto-Discovery (mcp_sync.py)
 
-Runs at startup on every `pflow` invocation. Smart skip: checks MCP config file mtime + SHA-256 hash of server list against stored metadata. Only re-syncs when config actually changed.
+Runs before workflow execution, not before other top-level commands. Each raw persisted server block has an independent SHA-256 fingerprint in registry metadata, so only added or changed servers start. Successful servers replace their exact owned tool set and advance independently; failures retain their tools/fingerprint for retry. A missing config is a no-op, while an explicit empty config reconciles MCP state to empty.
 
 Note: has its own copy of `_get_output_controller` (duplicated from `commands/run.py` to avoid circular imports).
 
@@ -264,7 +264,7 @@ See `core/CLAUDE.md` (shell_integration section) for FIFO detection, StdinData m
 | `error_output.py` | `test_unified_error_output.py`, `test_enhanced_error_output.py` |
 | `workflow_output.py` | `test_shell_stderr_warnings.py`, `test_direct_execution_helpers.py`, `test_workflow_output_source_simple.py` |
 | `workflow_resolution.py` | `test_workflow_resolution.py` |
-| `mcp_sync.py` | `test_mcp_auto_discovery.py` |
+| `mcp_sync.py` | `test_mcp_auto_discovery.py`, `test_mcp_auto_sync_state.py` |
 | `param_parsing.py` | `test_rerun_display.py`, `test_direct_execution_helpers.py` |
 | `commands/*` | See `commands/CLAUDE.md` |
 

--- a/src/pflow/cli/commands/CLAUDE.md
+++ b/src/pflow/cli/commands/CLAUDE.md
@@ -40,10 +40,10 @@ Subcommands: `list`, `find`, `describe`, `servers`, `add`, `sync`, `remove`, `se
 - `mcp find "description"` — LLM-powered MCP tool search via `find_components()`.
 - `mcp describe <tool>` — detailed tool info with parameters, outputs, and `.pflow.md` usage snippet.
 - `mcp servers` — lists configured **servers** (transport type, command/URL, timestamps). This was the old `mcp list`.
-- `mcp add|remove|sync` — server lifecycle management (unchanged).
+- `mcp add|remove|sync` — server lifecycle management. Manual sync is forced discovery but uses the same coherent per-server fingerprint/replacement path as workflow-start auto-sync.
 - `mcp serve` — launches pflow as an MCP server (stdio transport). Fundamentally different from the management commands.
 
-**Smart auto-discovery**: Runs at pflow startup on every command (via `mcp_sync.py`, not this file). Only syncs when config modified or servers changed.
+**Smart auto-discovery**: Runs only before workflow execution (via `mcp_sync.py`, not this file). Raw per-server config fingerprints prevent unchanged servers from starting; failures remain due without rolling back successful peers.
 
 **MCP tool normalization** (`normalize_node_id` in `registry/node_id.py`, 3-tier matching for `describe`/`probe`):
 1. Exact match: `mcp-slack-composio-SLACK_SEND_MESSAGE`

--- a/src/pflow/cli/commands/mcp.py
+++ b/src/pflow/cli/commands/mcp.py
@@ -4,11 +4,9 @@ Registered as a subgroup of the PflowCLI group in main.py via cli.add_command(mc
 Click handles subcommand routing natively.
 """
 
-import hashlib
 import json
 import logging
 import sys
-import time
 from typing import ClassVar
 
 import click
@@ -507,7 +505,7 @@ def remove(name: str, force: bool) -> None:
             sys.exit(1)
 
         # Count registered tools
-        registered_tools = registrar.list_registered_tools(name)
+        registered_tools = registrar.list_registered_tools(name, include_filtered=True)
 
         # Confirm removal
         if not force:
@@ -518,9 +516,9 @@ def remove(name: str, force: bool) -> None:
                 click.echo("Cancelled.")
                 return
 
-        # Remove tools from registry
-        if registered_tools:
-            removed = registrar.remove_server_tools(name)
+        # Remove exact owned tools and the server fingerprint before config removal.
+        removed = registrar.remove_server_tools(name)
+        if removed:
             click.echo(f"  Removed {removed} tools from registry")
 
         # Remove server configuration
@@ -561,32 +559,31 @@ def _sync_all_servers(manager: MCPServerManager, registrar: MCPRegistrar, verbos
         registrar: MCPRegistrar instance
         verbose: Whether to show technical error details
     """
-    from pflow.registry import Registry
-
-    servers = manager.list_servers()
-    if not servers:
-        click.echo("No MCP servers configured.")
+    click.echo("Syncing all configured servers...")
+    batch = registrar.sync_servers(None, reconcile_all=True)
+    if batch.config_missing and not batch.aborted_reason:
+        click.echo("No MCP server configuration found.")
         return
-
-    click.echo(f"Syncing {len(servers)} servers...")
-    results = registrar.sync_all_servers()
+    if batch.aborted_reason:
+        click.echo(f"Error: {batch.aborted_reason}", err=True)
+        sys.exit(1)
 
     total_discovered = 0
     total_registered = 0
     has_failures = False
 
-    for result in results:
-        server = result["server"]
-        discovered = result["tools_discovered"]
-        registered = result["tools_registered"]
+    for result in batch.servers:
+        server = result.server
+        discovered = result.tools_discovered
+        registered = result.tools_registered
 
         total_discovered += discovered
         total_registered += registered
 
-        if "error" in result:
+        if result.error is not None:
             has_failures = True
-            click.echo(f"  ✗ {server}: {result['error']}", err=True)
-            diagnostic = result.get("diagnostic")
+            click.echo(f"  ✗ {server}: {result.error}", err=True)
+            diagnostic = result.diagnostic
             if diagnostic:
                 if diagnostic.suggestions:
                     for suggestion in diagnostic.suggestions:
@@ -603,15 +600,6 @@ def _sync_all_servers(manager: MCPServerManager, registrar: MCPRegistrar, verbos
     if has_failures and not verbose:
         click.echo("Run with --verbose for technical error details.", err=True)
 
-    # Update sync metadata after successful sync
-    registry = Registry()
-    registry.set_metadata("mcp_last_sync_time", time.time())
-
-    # Store hash of current servers
-    current_servers = sorted(servers)
-    servers_hash = hashlib.sha256(json.dumps(current_servers).encode()).hexdigest()
-    registry.set_metadata("mcp_servers_hash", servers_hash)
-
 
 def _sync_single_server(name: str, manager: MCPServerManager, registrar: MCPRegistrar, verbose: bool = False) -> None:
     """Sync tools from a single server.
@@ -625,25 +613,29 @@ def _sync_single_server(name: str, manager: MCPServerManager, registrar: MCPRegi
     Raises:
         SystemExit: If server not found or sync fails
     """
-    if not manager.get_server(name):
+    if manager.get_server(name) is None:
         click.echo(f"Error: Server '{name}' not found", err=True)
         sys.exit(1)
 
     click.echo(f"Syncing server '{name}'...")
-    result = registrar.sync_server(name)
+    batch = registrar.sync_servers([name], reconcile_all=False)
+    if batch.aborted_reason:
+        click.echo(f"Error: {batch.aborted_reason}", err=True)
+        sys.exit(1)
+    result = batch.servers[0]
 
-    if "error" in result:
-        diagnostic = result.get("diagnostic")
+    if result.error is not None:
+        diagnostic = result.diagnostic
         if diagnostic:
             from pflow.core.diagnostic_render import format_diagnostic
 
             click.echo(format_diagnostic(diagnostic, verbose=verbose), err=True)
         else:
-            click.echo(f"Error: {result['error']}", err=True)
+            click.echo(f"Error: {result.error}", err=True)
         sys.exit(1)
 
-    discovered = result["tools_discovered"]
-    registered = result["tools_registered"]
+    discovered = result.tools_discovered
+    registered = result.tools_registered
 
     click.echo(f"✓ Discovered {discovered} tools")
     click.echo(f"✓ Registered {registered} tools in pflow registry")

--- a/src/pflow/cli/commands/mcp.py
+++ b/src/pflow/cli/commands/mcp.py
@@ -13,6 +13,7 @@ import click
 
 from pflow.core.suggestion_utils import find_similar_items, format_did_you_mean
 from pflow.mcp import MCPRegistrar, MCPServerManager
+from pflow.mcp.registrar import SyncBatchResult
 
 logger = logging.getLogger(__name__)
 
@@ -551,11 +552,17 @@ def _validate_sync_arguments(name: str | None, all_servers: bool) -> None:
         sys.exit(1)
 
 
-def _sync_all_servers(manager: MCPServerManager, registrar: MCPRegistrar, verbose: bool = False) -> None:
+def _exit_on_sync_abort(batch: SyncBatchResult) -> None:
+    """Exit with the coordinator's reason when it declined to publish."""
+    if batch.aborted_reason:
+        click.echo(f"Error: {batch.aborted_reason}", err=True)
+        sys.exit(1)
+
+
+def _sync_all_servers(registrar: MCPRegistrar, verbose: bool = False) -> None:
     """Sync tools from all configured servers.
 
     Args:
-        manager: MCPServerManager instance
         registrar: MCPRegistrar instance
         verbose: Whether to show technical error details
     """
@@ -564,9 +571,10 @@ def _sync_all_servers(manager: MCPServerManager, registrar: MCPRegistrar, verbos
     if batch.config_missing and not batch.aborted_reason:
         click.echo("No MCP server configuration found.")
         return
-    if batch.aborted_reason:
-        click.echo(f"Error: {batch.aborted_reason}", err=True)
-        sys.exit(1)
+    _exit_on_sync_abort(batch)
+    if not batch.servers:
+        click.echo("No MCP servers configured.")
+        return
 
     total_discovered = 0
     total_registered = 0
@@ -619,9 +627,10 @@ def _sync_single_server(name: str, manager: MCPServerManager, registrar: MCPRegi
 
     click.echo(f"Syncing server '{name}'...")
     batch = registrar.sync_servers([name], reconcile_all=False)
-    if batch.aborted_reason:
-        click.echo(f"Error: {batch.aborted_reason}", err=True)
+    if batch.config_missing and not batch.aborted_reason:
+        click.echo("Error: MCP configuration is no longer available", err=True)
         sys.exit(1)
+    _exit_on_sync_abort(batch)
     result = batch.servers[0]
 
     if result.error is not None:
@@ -678,7 +687,7 @@ def sync(name: str | None, all_servers: bool, verbose: bool) -> None:
 
     try:
         if all_servers:
-            _sync_all_servers(manager, registrar, verbose=verbose)
+            _sync_all_servers(registrar, verbose=verbose)
         else:
             if name:
                 _sync_single_server(name, manager, registrar, verbose=verbose)

--- a/src/pflow/cli/mcp_sync.py
+++ b/src/pflow/cli/mcp_sync.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
-import time
-from pathlib import Path
 from typing import Any, cast
 
 import click
@@ -34,167 +30,92 @@ def _get_output_controller(ctx: click.Context) -> OutputController:
     )
 
 
-def _check_mcp_sync_needed(config_path: Path, registry: Any, servers: list[str]) -> tuple[bool, str]:
-    """Check if MCP sync is needed based on config changes.
+def _registry_reconciliation_needed(
+    nodes: dict[str, dict[str, Any]],
+    configs: dict[str, dict[str, Any]],
+    stored_fingerprints: dict[str, Any],
+) -> bool:
+    """Return whether full reconciliation has cleanup work beyond discovery."""
+    from pflow.mcp import MCPRegistrar
 
-    Args:
-        config_path: Path to MCP configuration file
-        registry: Registry instance for metadata storage
-        servers: List of configured server names
-
-    Returns:
-        Tuple of (needs_sync, current_hash)
-    """
-    config_mtime = config_path.stat().st_mtime
-    last_sync = registry.get_metadata("mcp_last_sync_time", 0)
-    last_sync_hash = registry.get_metadata("mcp_servers_hash", "")
-
-    # Calculate current servers hash using SHA256 for security
-    current_servers = sorted(servers)
-    current_hash = hashlib.sha256(json.dumps(current_servers).encode()).hexdigest()
-
-    # Skip sync if config hasn't changed AND server list is same
-    if config_mtime <= last_sync and current_hash == last_sync_hash:
-        logger.debug(
-            f"MCP config unchanged since last sync (mtime={config_mtime}, last_sync={last_sync}), skipping discovery"
-        )
-        return False, current_hash
-
-    return True, current_hash
+    removals = MCPRegistrar.full_reconciliation_removals(nodes, set(configs))
+    return bool(removals or set(stored_fingerprints) - set(configs))
 
 
-def _clean_old_mcp_entries(registry: Any) -> None:
-    """Remove all existing MCP entries from registry for clean sync.
+def _show_sync_result(batch: Any, *, show_progress: bool, verbose: bool) -> None:
+    """Render interactive auto-sync results without contaminating structured output."""
+    if not show_progress:
+        return
+    if batch.aborted_reason:
+        click.echo(f"⚠ {batch.aborted_reason}", err=True)
+        return
 
-    Args:
-        registry: Registry instance to clean
-    """
-    all_nodes = registry.list_nodes()
-    existing_mcp_count = len([n for n in all_nodes if n.startswith("mcp-")])
-
-    if existing_mcp_count > 0:
-        # Load full registry including filtered nodes
-        nodes = registry.load(include_filtered=True)
-        removed = 0
-        for node_name in list(nodes.keys()):
-            if node_name.startswith("mcp-"):
-                del nodes[node_name]
-                removed += 1
-
-        if removed > 0:
-            registry.save(nodes)
-            logger.debug(f"Removed {removed} old MCP entries for clean sync")
-
-
-def _discover_and_register_servers(
-    servers: list[str], discovery: Any, registrar: Any, show_progress: bool, verbose: bool
-) -> tuple[int, list[str]]:
-    """Discover tools from MCP servers and register them.
-
-    Args:
-        servers: List of server names to discover
-        discovery: MCPDiscovery instance
-        registrar: MCPRegistrar instance
-        show_progress: Whether to show progress messages
-        verbose: Whether to show verbose output
-
-    Returns:
-        Tuple of (total_tools_discovered, failed_servers)
-    """
-    total_tools = 0
-    failed_servers = []
-
-    for server_name in servers:
-        try:
-            if show_progress and verbose:
-                click.echo(f"Discovering tools from MCP server '{server_name}'...", err=True)
-
-            # Discover tools (pass verbose to control stderr output)
-            tools = discovery.discover_tools(server_name, verbose=verbose)
-
-            if tools:
-                # Register the discovered tools
-                registrar.register_tools(server_name, tools)
-                total_tools += len(tools)
-
-                if show_progress and verbose:
-                    click.echo(f"  ✓ Discovered {len(tools)} tool(s) from {server_name}", err=True)
-        except Exception as e:
-            logger.debug(f"Failed to discover tools from {server_name}: {e}")
-            failed_servers.append(server_name)
-            if show_progress and verbose:
-                click.echo(f"  ⚠ Failed to connect to {server_name}", err=True)
-
-    return total_tools, failed_servers
+    successful = [result for result in batch.servers if result.error is None]
+    failed = [result.server for result in batch.servers if result.error is not None]
+    if verbose:
+        for result in successful:
+            click.echo(f"  ✓ Discovered {result.tools_discovered} tool(s) from {result.server}", err=True)
+    elif successful:
+        total_tools = sum(result.tools_discovered for result in successful)
+        click.echo(f"✓ Synced {total_tools} MCP tool(s) from {len(successful)} server(s)", err=True)
+    if failed:
+        click.echo(f"⚠ Failed to connect to MCP server(s): {', '.join(failed)}", err=True)
 
 
 def _auto_discover_mcp_servers(ctx: click.Context, verbose: bool) -> None:
-    """Smart auto-discovery that only syncs when MCP config changes.
-
-    Checks config file modification time and server list hash to determine
-    if sync is needed. This eliminates unnecessary overhead on every pflow run.
-    """
+    """Reconcile only MCP servers whose persisted configuration changed."""
     try:
         from pflow.mcp import MCPDiscovery, MCPRegistrar, MCPServerManager
+        from pflow.mcp.sync_state import (
+            MCP_SERVER_FINGERPRINTS_KEY,
+            fingerprint_server_configs,
+            parse_server_fingerprints,
+        )
         from pflow.registry import Registry
 
-        # Check if we should show progress messages
         output_controller = _get_output_controller(ctx)
         show_progress = output_controller.is_interactive()
-
-        # Load MCP server configuration
         manager = MCPServerManager()
-        config_path = manager.config_path
-
-        # Check if config exists
-        if not config_path.exists():
-            # No config, nothing to sync
+        configs = manager.get_all_servers_if_configured()
+        if configs is None:
             return
 
-        servers = manager.list_servers()
-        if not servers:
-            # No servers configured, nothing to do
-            return
-
-        # Check if sync is needed
+        current_fingerprints = fingerprint_server_configs(configs)
         registry = Registry()
-        needs_sync, current_hash = _check_mcp_sync_needed(config_path, registry, servers)
+        missing = object()
+        raw_fingerprints = registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY, missing)
+        stored_fingerprints, fingerprints_valid = parse_server_fingerprints(raw_fingerprints)
+        due_servers = [name for name in configs if stored_fingerprints.get(name) != current_fingerprints[name]]
 
-        if not needs_sync:
+        inspection_nodes = registry.load(include_filtered=True)
+        cleanup_needed = _registry_reconciliation_needed(
+            inspection_nodes,
+            configs,
+            stored_fingerprints,
+        )
+        if not due_servers and fingerprints_valid and not cleanup_needed:
             return
 
-        # Config changed or first run - do full sync
         if show_progress and not verbose:
-            click.echo("🔄 MCP config changed, syncing servers...", err=True)
+            click.echo("🔄 MCP configuration changed, syncing servers...", err=True)
 
-        # CRITICAL: Remove ALL existing MCP entries first
-        # This handles renames cleanly
-        _clean_old_mcp_entries(registry)
-
-        # Now discover and register from all servers
         discovery = MCPDiscovery(manager)
-        registrar = MCPRegistrar(registry=registry, manager=manager)
+        registrar = MCPRegistrar(registry=registry, manager=manager, discovery=discovery)
 
-        total_tools, failed_servers = _discover_and_register_servers(
-            servers, discovery, registrar, show_progress, verbose
+        def show_server_start(server_name: str) -> None:
+            if show_progress and verbose:
+                click.echo(f"Discovering tools from MCP server '{server_name}'...", err=True)
+
+        batch = registrar.sync_servers(
+            due_servers,
+            reconcile_all=True,
+            verbose=verbose,
+            on_server_start=show_server_start,
         )
 
-        # Update metadata for next run
-        registry.set_metadata("mcp_last_sync_time", time.time())
-        registry.set_metadata("mcp_servers_hash", current_hash)
+        _show_sync_result(batch, show_progress=show_progress, verbose=verbose)
 
-        # Show summary
-        if show_progress and total_tools > 0 and not verbose:
-            click.echo(
-                f"✓ Synced {total_tools} MCP tool(s) from {len(servers) - len(failed_servers)} server(s)", err=True
-            )
-
-        if show_progress and failed_servers and verbose:
-            click.echo(f"⚠ Failed to connect to {len(failed_servers)} server(s): {', '.join(failed_servers)}", err=True)
-
-    except ImportError as e:
-        # MCP modules not available
-        logger.debug(f"MCP modules not available: {e}")
-    except Exception as e:
-        # Log auto-discovery failure at debug level - this is optional functionality
-        logger.debug(f"Failed to auto-discover MCP servers: {e}")
+    except ImportError as error:
+        logger.debug(f"MCP modules not available: {error}")
+    except Exception as error:
+        logger.debug(f"Failed to auto-discover MCP servers: {error}")

--- a/src/pflow/cli/mcp_sync.py
+++ b/src/pflow/cli/mcp_sync.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 
 from pflow.core.output_controller import OutputController
+
+if TYPE_CHECKING:
+    from pflow.mcp.registrar import SyncBatchResult
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +45,7 @@ def _registry_reconciliation_needed(
     return bool(removals or set(stored_fingerprints) - set(configs))
 
 
-def _show_sync_result(batch: Any, *, show_progress: bool, verbose: bool) -> None:
+def _show_sync_result(batch: SyncBatchResult, *, show_progress: bool, verbose: bool) -> None:
     """Render interactive auto-sync results without contaminating structured output."""
     if not show_progress:
         return
@@ -56,7 +59,7 @@ def _show_sync_result(batch: Any, *, show_progress: bool, verbose: bool) -> None
         for result in successful:
             click.echo(f"  ✓ Discovered {result.tools_discovered} tool(s) from {result.server}", err=True)
     elif successful:
-        total_tools = sum(result.tools_discovered for result in successful)
+        total_tools = sum(result.tools_registered for result in successful)
         click.echo(f"✓ Synced {total_tools} MCP tool(s) from {len(successful)} server(s)", err=True)
     if failed:
         click.echo(f"⚠ Failed to connect to MCP server(s): {', '.join(failed)}", err=True)
@@ -67,9 +70,8 @@ def _auto_discover_mcp_servers(ctx: click.Context, verbose: bool) -> None:
     try:
         from pflow.mcp import MCPDiscovery, MCPRegistrar, MCPServerManager
         from pflow.mcp.sync_state import (
-            MCP_SERVER_FINGERPRINTS_KEY,
             fingerprint_server_configs,
-            parse_server_fingerprints,
+            load_server_fingerprints,
         )
         from pflow.registry import Registry
 
@@ -82,9 +84,7 @@ def _auto_discover_mcp_servers(ctx: click.Context, verbose: bool) -> None:
 
         current_fingerprints = fingerprint_server_configs(configs)
         registry = Registry()
-        missing = object()
-        raw_fingerprints = registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY, missing)
-        stored_fingerprints, fingerprints_valid = parse_server_fingerprints(raw_fingerprints)
+        stored_fingerprints, fingerprints_valid = load_server_fingerprints(registry)
         due_servers = [name for name in configs if stored_fingerprints.get(name) != current_fingerprints[name]]
 
         inspection_nodes = registry.load(include_filtered=True)

--- a/src/pflow/mcp/CLAUDE.md
+++ b/src/pflow/mcp/CLAUDE.md
@@ -16,6 +16,7 @@ mcp/
 ├── discovery.py       # Connect to MCP servers, list tools, convert schemas to pflow format
 ├── manager.py         # CRUD for ~/.pflow/mcp-servers.json (standard MCP config format)
 ├── registrar.py       # Bridge: discovered tools → virtual pflow registry entries
+├── sync_state.py      # Stable raw-config fingerprints shared by auto/manual sync
 └── pool.py            # Connection pool: keeps server sessions alive across workflow steps
 ```
 
@@ -29,13 +30,13 @@ pflow mcp add      pflow mcp sync        (called by sync)        pflow run workf
 mcp-servers.json   lists tools+schemas   registry entries         for stateful sessions
 ```
 
-**Auto-sync at startup**: `pflow run` auto-discovers MCP tools before execution (`cli/mcp_sync.py:_auto_discover_mcp_servers`, invoked from `cli/commands/run.py`). Uses smart sync — compares config file mtime + SHA256 hash of server names against stored values in Registry metadata. Skips sync when config hasn't changed. Errors are silently swallowed (auto-discovery is optional).
+**Auto-sync before workflow execution**: `cli/mcp_sync.py:_auto_discover_mcp_servers` fingerprints each raw persisted server config independently. Only added/changed servers are discovered; each success advances independently, while failures preserve the prior tools/fingerprint and remain due. User-visible warnings are interactive-only because auto-discovery is optional.
 
 ## Integration Points
 
 | Integration | From → To | Mechanism |
 |-------------|-----------|-----------|
-| Auto-sync at startup | `cli/mcp_sync.py` (via `cli/commands/run.py`) → `MCPDiscovery` + `MCPRegistrar` | Smart sync on mtime+hash change; cleans ALL old `mcp-` entries before re-syncing |
+| Auto-sync before workflow execution | `cli/mcp_sync.py` (via `cli/commands/run.py`) → `MCPDiscovery` + `MCPRegistrar` | Per-server raw-config fingerprints; discover first, then exact-owner reconciliation in one registry write |
 | Compiler param injection | `runtime/compilation/compiler.py:inject_special_parameters` → MCPNode params | Injects `__mcp_server__`/`__mcp_tool__`; the server/tool split is delegated to `mcp_resolution._parse_mcp_node_type` (greedy longest-match). Does **NOT** use `mcp_metadata` from registry |
 | Pool creation | `execution/runner.py:_initialize_shared_store` → `shared["__mcp_pool__"]` | Created unconditionally for every workflow, but background thread starts lazily on first `call_tool()` |
 | Pool consumption | `nodes/mcp/node.py:prep()` → `pool.call_tool()` | Falls back to `asyncio.run()` if no pool (e.g., `pflow probe`) |
@@ -49,6 +50,8 @@ All MCP tools create registry entries pointing to the **same** `MCPNode` class (
 - `file_path`: always `"virtual://mcp"` (not a real file)
 - `interface.mcp_metadata`: contains `server`, `tool`, and `original_schema` (stored for reference but NOT used by the compiler at runtime)
 - Node name format: `mcp-{server_name}-{tool_name}`
+
+Registry mutation never parses that ambiguous node name. Replacement, removal, and server-filtered listing use exact equality on the non-empty `interface.mcp_metadata.server` owner. Full reconciliation discards reserved MCP entries without a canonical owner.
 
 ### Node Naming Ambiguity
 `mcp-slack-http-remote-SEND_MESSAGE` — where does server end and tool begin? The authoritative parser is **`runtime/compilation/mcp_resolution.py:_parse_mcp_node_type`**: greedy longest-match against known servers from `MCPServerManager().list_servers()`.
@@ -85,6 +88,8 @@ Storage: `~/.pflow/mcp-servers.json` with `mcpServers` wrapper (standard MCP for
 
 ### Registry Load Correctness
 Registrar always calls `registry.load(include_filtered=True)`. If you load with default `include_filtered=False` and save, you **permanently lose** all filtered-out entries. `save()` does a complete replacement of the registry file.
+
+Batch sync performs all network discovery first, rechecks the raw config, then late-loads the unfiltered registry and publishes nodes plus `mcp_server_fingerprints` in one atomic replacement. This prevents intermediate same-process snapshots, but Registry has no cross-process read-modify-write transaction isolation.
 
 ### Result Extraction Priority (in MCPNode)
 1. `structuredContent` — typed JSON matching outputSchema (preferred)

--- a/src/pflow/mcp/discovery.py
+++ b/src/pflow/mcp/discovery.py
@@ -80,12 +80,18 @@ class MCPDiscovery:
             available = ", ".join(self.manager.list_servers()) or "none"
             raise ValueError(f"MCP server '{server_name}' not found. Available servers: {available}")
 
+        timeout = server_config.get("timeout", 30)
         try:
-            return asyncio.run(self._discover_async(server_name, server_config, verbose))
+            return asyncio.run(
+                asyncio.wait_for(
+                    self._discover_async(server_name, server_config, verbose),
+                    timeout=timeout,
+                )
+            )
         except Exception as e:
             from pflow.mcp.errors import describe_mcp_error
 
-            diagnostic = describe_mcp_error(e)
+            diagnostic = describe_mcp_error(e, timeout=timeout)
             logger.debug("Discovery failed for %s: %s", server_name, diagnostic.message, exc_info=True)
             raise RuntimeError(f"Tool discovery failed for {server_name}: {diagnostic.message}") from e
 

--- a/src/pflow/mcp/discovery.py
+++ b/src/pflow/mcp/discovery.py
@@ -51,12 +51,20 @@ class MCPDiscovery:
             with open(os.devnull, "w", encoding="utf-8") as devnull:
                 yield devnull
 
-    def discover_tools(self, server_name: str, verbose: bool = False) -> list[dict[str, Any]]:
+    def discover_tools(
+        self,
+        server_name: str,
+        verbose: bool = False,
+        *,
+        server_config: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
         """Discover tools from an MCP server (synchronous wrapper).
 
         Args:
             server_name: Name of the configured MCP server
             verbose: Whether to show server output to stderr
+            server_config: Optional raw configuration snapshot. When supplied,
+                discovery uses it instead of re-reading the manager.
 
         Returns:
             List of tool definitions with metadata
@@ -65,7 +73,8 @@ class MCPDiscovery:
             ValueError: If server not found in configuration
             RuntimeError: If discovery fails
         """
-        server_config = self.manager.get_server(server_name)
+        if server_config is None:
+            server_config = self.manager.get_server(server_name)
 
         if not server_config:
             available = ", ".join(self.manager.list_servers()) or "none"

--- a/src/pflow/mcp/discovery.py
+++ b/src/pflow/mcp/discovery.py
@@ -16,6 +16,8 @@ from .manager import MCPServerManager
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_DISCOVERY_TIMEOUT_SECONDS = 60
+
 
 class MCPDiscovery:
     """Discovers tools from MCP servers.
@@ -80,7 +82,7 @@ class MCPDiscovery:
             available = ", ".join(self.manager.list_servers()) or "none"
             raise ValueError(f"MCP server '{server_name}' not found. Available servers: {available}")
 
-        timeout = server_config.get("timeout", 30)
+        timeout = server_config.get("timeout", DEFAULT_DISCOVERY_TIMEOUT_SECONDS)
         try:
             return asyncio.run(
                 asyncio.wait_for(

--- a/src/pflow/mcp/manager.py
+++ b/src/pflow/mcp/manager.py
@@ -102,10 +102,14 @@ class MCPServerManager:
             return self._load_locked()
 
     def _load_locked(self) -> dict[str, Any]:
-        if not self.config_path.exists():
+        config = self._read_config_locked()
+        if config is None:
             logger.info(f"No MCP server configuration found at {self.config_path}, returning empty config")
             return {"mcpServers": {}}
+        return config
 
+    def _read_config_locked(self) -> dict[str, Any] | None:
+        """Read one config snapshot, preserving missing-file state."""
         try:
             with open(self.config_path, encoding="utf-8") as f:
                 config = json.load(f)
@@ -117,6 +121,8 @@ class MCPServerManager:
             logger.debug(f"Loaded {len(config.get('mcpServers', {}))} MCP servers from configuration")
             return dict(config)
 
+        except FileNotFoundError:
+            return None
         except json.JSONDecodeError as e:
             logger.exception("Failed to parse MCP server configuration")
             raise ValueError(f"Invalid JSON in MCP server configuration file: {e}") from e
@@ -402,6 +408,14 @@ class MCPServerManager:
 
         """
         config = self.load()
+        return dict(config["mcpServers"])
+
+    def get_all_servers_if_configured(self) -> dict[str, dict[str, Any]] | None:
+        """Return one raw server snapshot, or None when the config is missing."""
+        with _CONFIG_SAVE_LOCK:
+            config = self._read_config_locked()
+        if config is None:
+            return None
         return dict(config["mcpServers"])
 
     def parse_command_string(self, command_str: str) -> tuple[str, list[str]]:

--- a/src/pflow/mcp/registrar.py
+++ b/src/pflow/mcp/registrar.py
@@ -9,7 +9,7 @@ from pflow.core.diagnostic import Diagnostic
 from pflow.registry import Registry
 from pflow.registry.constants import MCP_CANONICAL_OUTPUT
 
-from .discovery import MCPDiscovery
+from .discovery import DEFAULT_DISCOVERY_TIMEOUT_SECONDS, MCPDiscovery
 from .errors import describe_mcp_error
 from .manager import MCPServerManager
 from .sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_configs, load_server_fingerprints
@@ -161,7 +161,10 @@ class MCPRegistrar:
                 results.append(ServerSyncResult(server=server_name, tools_discovered=len(tools)))
             except Exception as error:
                 original = error.__cause__ if error.__cause__ else error
-                diagnostic = describe_mcp_error(original, timeout=server_config.get("timeout", 30))
+                diagnostic = describe_mcp_error(
+                    original,
+                    timeout=server_config.get("timeout", DEFAULT_DISCOVERY_TIMEOUT_SECONDS),
+                )
                 results.append(
                     ServerSyncResult(
                         server=server_name,

--- a/src/pflow/mcp/registrar.py
+++ b/src/pflow/mcp/registrar.py
@@ -1,15 +1,43 @@
 """MCP tool registration for pflow registry."""
 
 import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
 
+from pflow.core.diagnostic import Diagnostic
 from pflow.registry import Registry
 from pflow.registry.constants import MCP_CANONICAL_OUTPUT
 
 from .discovery import MCPDiscovery
+from .errors import describe_mcp_error
 from .manager import MCPServerManager
+from .sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_configs, parse_server_fingerprints
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ServerSyncResult:
+    """Outcome of one server discovery within a reconciliation batch."""
+
+    server: str
+    tools_discovered: int = 0
+    tools_registered: int = 0
+    tools_filtered: int = 0
+    error: str | None = None
+    diagnostic: Diagnostic | None = None
+
+
+@dataclass(frozen=True)
+class SyncBatchResult:
+    """Outcome of one coherent MCP reconciliation attempt."""
+
+    servers: list[ServerSyncResult]
+    removed_tools: int
+    registry_updated: bool
+    aborted_reason: str | None = None
+    config_missing: bool = False
 
 
 class MCPRegistrar:
@@ -46,148 +74,248 @@ class MCPRegistrar:
             self._settings_manager = SettingsManager()
         return self._settings_manager
 
-    def register_tools(self, server_name: str, tools: list[dict[str, Any]]) -> None:
-        """Register discovered tools in the registry.
+    @staticmethod
+    def get_server_owner(entry: dict[str, Any]) -> str | None:
+        """Return an entry's exact canonical MCP server owner, if valid."""
+        interface = entry.get("interface")
+        if not isinstance(interface, dict):
+            return None
+        metadata = interface.get("mcp_metadata")
+        if not isinstance(metadata, dict):
+            return None
+        owner = metadata.get("server")
+        if not isinstance(owner, str) or not owner.strip():
+            return None
+        return owner
 
-        This is the method called by auto-discovery to register tools
-        without re-discovering them.
+    @staticmethod
+    def is_mcp_entry(node_name: str, entry: dict[str, Any]) -> bool:
+        """Return whether an entry occupies the reserved MCP namespace."""
+        return entry.get("type") == "mcp" or node_name.startswith("mcp-")
 
-        Args:
-            server_name: Name of the MCP server
-            tools: List of tool definitions discovered from the server
-        """
-        # Load complete registry (unfiltered) to avoid persisting a filtered subset
-        nodes = self.registry.load(include_filtered=True)
+    @classmethod
+    def full_reconciliation_removals(
+        cls,
+        nodes: dict[str, dict[str, Any]],
+        configured_servers: set[str],
+    ) -> list[str]:
+        """Identify absent owners and unsupported entries for full reconciliation."""
+        removals = []
+        for node_name, entry in nodes.items():
+            owner = cls.get_server_owner(entry)
+            if (cls.is_mcp_entry(node_name, entry) and owner is None) or (
+                owner is not None and owner not in configured_servers
+            ):
+                removals.append(node_name)
+        return removals
 
+    def _replace_server_tools(
+        self,
+        nodes: dict[str, dict[str, Any]],
+        server_name: str,
+        tools: list[dict[str, Any]],
+    ) -> tuple[int, int]:
+        """Replace one server's exact owned entries in an in-memory snapshot."""
         registered_count = 0
         filtered_count = 0
-
+        replacements: dict[str, dict[str, Any]] = {}
         for tool in tools:
-            # Create node name following mcp-{server}-{tool} pattern
             node_name = f"mcp-{server_name}-{tool['name']}"
-
-            # Check if node should be included based on settings
             if not self.settings_manager.should_include_node(node_name):
                 filtered_count += 1
                 logger.debug(f"Filtering out MCP tool '{node_name}' based on settings")
-                # Remove from registry if it was previously registered
-                if node_name in nodes:
-                    del nodes[node_name]
                 continue
-
-            # Check if already exists
-            if node_name in nodes:
-                logger.debug(f"Updating existing registry entry for {node_name}")
-            else:
-                logger.debug(f"Creating new registry entry for {node_name}")
-
-            # Create virtual registry entry
-            nodes[node_name] = self._create_registry_entry(server_name, tool)
+            replacements[node_name] = self._create_registry_entry(server_name, tool)
             registered_count += 1
 
-        # Save updated registry
-        self.registry.save(nodes)
+        for node_name, entry in list(nodes.items()):
+            if self.get_server_owner(entry) == server_name:
+                del nodes[node_name]
+        nodes.update(replacements)
 
-        if filtered_count > 0:
-            logger.info(f"Registered {registered_count} tools from {server_name} ({filtered_count} filtered out)")
-        else:
-            logger.info(f"Registered {registered_count} tools from {server_name}")
+        return registered_count, filtered_count
 
-    def sync_server(self, server_name: str) -> dict[str, Any]:
-        """Sync tools from an MCP server to the registry.
+    def _discover_targets(
+        self,
+        targets: list[str],
+        configs: dict[str, dict[str, Any]],
+        *,
+        verbose: bool,
+        on_server_start: Callable[[str], None] | None,
+    ) -> tuple[dict[str, list[dict[str, Any]]], list[ServerSyncResult]]:
+        """Discover targets without reading or writing registry state."""
+        discovered_tools: dict[str, list[dict[str, Any]]] = {}
+        results: list[ServerSyncResult] = []
+        for server_name in targets:
+            server_config = configs.get(server_name)
+            if server_config is None:
+                results.append(ServerSyncResult(server=server_name, error="Server is not configured"))
+                continue
+            if on_server_start:
+                on_server_start(server_name)
+            try:
+                tools = self.discovery.discover_tools(
+                    server_name,
+                    verbose=verbose,
+                    server_config=server_config,
+                )
+                discovered_tools[server_name] = tools
+                results.append(ServerSyncResult(server=server_name, tools_discovered=len(tools)))
+            except Exception as error:
+                original = error.__cause__ if error.__cause__ else error
+                diagnostic = describe_mcp_error(original)
+                results.append(
+                    ServerSyncResult(
+                        server=server_name,
+                        error=diagnostic.message,
+                        diagnostic=diagnostic,
+                    )
+                )
+        return discovered_tools, results
 
-        This discovers all tools from the specified server and creates
-        virtual registry entries for each one.
+    @staticmethod
+    def _configuration_changed(
+        initial: dict[str, str],
+        latest: dict[str, str],
+        targets: list[str],
+        *,
+        reconcile_all: bool,
+    ) -> bool:
+        if reconcile_all:
+            return latest != initial
+        return any(latest.get(name) != initial.get(name) for name in targets)
 
-        Args:
-            server_name: Name of the configured MCP server
+    def _clean_full_reconciliation(
+        self,
+        nodes: dict[str, dict[str, Any]],
+        configured_servers: set[str],
+    ) -> int:
+        """Remove absent canonical owners and unsupported reserved MCP entries."""
+        removed = 0
+        for node_name in self.full_reconciliation_removals(nodes, configured_servers):
+            del nodes[node_name]
+            removed += 1
+        return removed
 
-        Returns:
-            Summary of sync operation with counts
-        """
-        logger.info(f"Syncing MCP server '{server_name}'...")
+    def _apply_successful_replacements(
+        self,
+        nodes: dict[str, dict[str, Any]],
+        results: list[ServerSyncResult],
+        discovered_tools: dict[str, list[dict[str, Any]]],
+        fingerprints: dict[str, Any],
+        initial_fingerprints: dict[str, str],
+    ) -> list[ServerSyncResult]:
+        """Apply successful server replacements to one in-memory snapshot."""
+        final_results: list[ServerSyncResult] = []
+        for result in results:
+            tools = discovered_tools.get(result.server)
+            if tools is None:
+                final_results.append(result)
+                continue
+            try:
+                registered, filtered = self._replace_server_tools(nodes, result.server, tools)
+            except Exception as error:
+                diagnostic = describe_mcp_error(error)
+                final_results.append(
+                    ServerSyncResult(
+                        server=result.server,
+                        tools_discovered=len(tools),
+                        error=diagnostic.message,
+                        diagnostic=diagnostic,
+                    )
+                )
+                continue
+            fingerprints[result.server] = initial_fingerprints[result.server]
+            final_results.append(
+                ServerSyncResult(
+                    server=result.server,
+                    tools_discovered=len(tools),
+                    tools_registered=registered,
+                    tools_filtered=filtered,
+                )
+            )
+        return final_results
 
-        # Discover tools from server
-        try:
-            # Don't show server output during sync (not verbose)
-            tools = self.discovery.discover_tools(server_name, verbose=False)
-        except Exception as e:
-            from pflow.mcp.errors import describe_mcp_error
+    def sync_servers(
+        self,
+        server_names: Iterable[str] | None,
+        *,
+        reconcile_all: bool,
+        verbose: bool = False,
+        on_server_start: Callable[[str], None] | None = None,
+    ) -> SyncBatchResult:
+        """Discover target servers, then publish one coherent reconciliation."""
+        initial_configs = self.manager.get_all_servers_if_configured()
+        if initial_configs is None:
+            return SyncBatchResult([], 0, False, config_missing=True)
+        targets = list(initial_configs) if server_names is None else list(server_names)
+        initial_fingerprints = fingerprint_server_configs(initial_configs)
+        discovered_tools, results = self._discover_targets(
+            targets,
+            initial_configs,
+            verbose=verbose,
+            on_server_start=on_server_start,
+        )
 
-            # Get the original MCP exception (before RuntimeError wrapping in discover_tools)
-            original = e.__cause__ if e.__cause__ else e
-            diagnostic = describe_mcp_error(original)
-            return {
-                "server": server_name,
-                "tools_discovered": 0,
-                "tools_registered": 0,
-                "error": diagnostic.message,
-                "diagnostic": diagnostic,
+        latest_configs = self.manager.get_all_servers_if_configured()
+        if latest_configs is None:
+            return SyncBatchResult(
+                servers=results,
+                removed_tools=0,
+                registry_updated=False,
+                aborted_reason="MCP configuration was removed during discovery; no registry updates were published.",
+                config_missing=True,
+            )
+        latest_fingerprints = fingerprint_server_configs(latest_configs)
+        if self._configuration_changed(
+            initial_fingerprints,
+            latest_fingerprints,
+            targets,
+            reconcile_all=reconcile_all,
+        ):
+            return SyncBatchResult(
+                servers=results,
+                removed_tools=0,
+                registry_updated=False,
+                aborted_reason="MCP configuration changed during discovery; no registry updates were published. Retry sync.",
+            )
+
+        nodes = self.registry.load(include_filtered=True)
+        original_nodes = dict(nodes)
+        missing = object()
+        raw_fingerprints = self.registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY, missing)
+        stored_fingerprints, fingerprints_valid = parse_server_fingerprints(raw_fingerprints)
+        final_fingerprints = dict(stored_fingerprints)
+        removed_tools = 0
+
+        if reconcile_all:
+            configured_servers = set(latest_configs)
+            removed_tools = self._clean_full_reconciliation(nodes, configured_servers)
+            final_fingerprints = {
+                name: fingerprint for name, fingerprint in final_fingerprints.items() if name in configured_servers
             }
 
-        # Load complete registry (unfiltered) to avoid persisting a filtered subset
-        nodes = self.registry.load(include_filtered=True)
+        final_results = self._apply_successful_replacements(
+            nodes,
+            results,
+            discovered_tools,
+            final_fingerprints,
+            initial_fingerprints,
+        )
 
-        registered_count = 0
-        filtered_count = 0
+        metadata_changed = not fingerprints_valid or final_fingerprints != stored_fingerprints
+        registry_updated = nodes != original_nodes or metadata_changed
+        if registry_updated:
+            self.registry.save(
+                nodes,
+                metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: final_fingerprints},
+            )
 
-        for tool in tools:
-            # Create node name following mcp-{server}-{tool} pattern
-            node_name = f"mcp-{server_name}-{tool['name']}"
-
-            # Check if node should be included based on settings
-            if not self.settings_manager.should_include_node(node_name):
-                filtered_count += 1
-                logger.debug(f"Filtering out MCP tool '{node_name}' based on settings")
-                # Remove from registry if it was previously registered
-                if node_name in nodes:
-                    del nodes[node_name]
-                continue
-
-            # Check if already exists
-            if node_name in nodes:
-                logger.debug(f"Updating existing registry entry for {node_name}")
-            else:
-                logger.debug(f"Creating new registry entry for {node_name}")
-
-            # Create virtual registry entry
-            nodes[node_name] = self._create_registry_entry(server_name, tool)
-            registered_count += 1
-
-        # Save updated registry
-        self.registry.save(nodes)
-
-        if filtered_count > 0:
-            logger.info(f"Registered {registered_count} tools from {server_name} ({filtered_count} filtered out)")
-        else:
-            logger.info(f"Registered {registered_count} tools from {server_name}")
-
-        return {
-            "server": server_name,
-            "tools_discovered": len(tools),
-            "tools_registered": registered_count,
-            "tools_filtered": filtered_count,
-        }
-
-    def sync_all_servers(self) -> list[dict[str, Any]]:
-        """Sync tools from all configured MCP servers.
-
-        Returns:
-            List of sync summaries for each server
-        """
-        results = []
-        servers = self.manager.list_servers()
-
-        logger.info(f"Syncing {len(servers)} MCP servers...")
-
-        for server_name in servers:
-            result = self.sync_server(server_name)
-            results.append(result)
-
-        total_registered = sum(r["tools_registered"] for r in results)
-        logger.info(f"Sync complete: registered {total_registered} tools from {len(servers)} servers")
-
-        return results
+        return SyncBatchResult(
+            servers=final_results,
+            removed_tools=removed_tools,
+            registry_updated=registry_updated,
+        )
 
     def remove_server_tools(self, server_name: str) -> int:
         """Remove all registry entries for a specific MCP server.
@@ -198,20 +326,21 @@ class MCPRegistrar:
         Returns:
             Number of entries removed
         """
-        # Load complete registry (unfiltered) to ensure removal even if tools are filtered
         nodes = self.registry.load(include_filtered=True)
-        prefix = f"mcp-{server_name}-"
-
-        # Find all nodes for this server
-        to_remove = [node_name for node_name in nodes if node_name.startswith(prefix)]
-
-        # Remove them
+        to_remove = [node_name for node_name, entry in nodes.items() if self.get_server_owner(entry) == server_name]
         for node_name in to_remove:
             del nodes[node_name]
             logger.debug(f"Removed registry entry: {node_name}")
 
+        missing = object()
+        raw_fingerprints = self.registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY, missing)
+        fingerprints, _ = parse_server_fingerprints(raw_fingerprints)
+        fingerprint_removed = server_name in fingerprints
+        fingerprints.pop(server_name, None)
+
+        if to_remove or fingerprint_removed:
+            self.registry.save(nodes, metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: fingerprints})
         if to_remove:
-            self.registry.save(nodes)
             logger.info(f"Removed {len(to_remove)} tools for server '{server_name}'")
 
         return len(to_remove)
@@ -269,23 +398,26 @@ class MCPRegistrar:
 
         return entry
 
-    def list_registered_tools(self, server_name: str | None = None) -> list[str]:
+    def list_registered_tools(
+        self,
+        server_name: str | None = None,
+        *,
+        include_filtered: bool = False,
+    ) -> list[str]:
         """List all registered MCP tools in the registry.
 
         Args:
             server_name: Optional server name to filter by
+            include_filtered: Include settings-filtered persisted entries.
 
         Returns:
             List of registered tool node names
         """
-        nodes = self.registry.load()
+        nodes = self.registry.load(include_filtered=include_filtered)
 
-        if server_name:
-            prefix = f"mcp-{server_name}-"
-            return [node_name for node_name in nodes if node_name.startswith(prefix)]
-        else:
-            # All MCP nodes
-            return [node_name for node_name in nodes if node_name.startswith("mcp-")]
+        if server_name is not None:
+            return [node_name for node_name, entry in nodes.items() if self.get_server_owner(entry) == server_name]
+        return [node_name for node_name, entry in nodes.items() if self.get_server_owner(entry) is not None]
 
     def get_tool_info(self, node_name: str) -> dict[str, Any] | None:
         """Get detailed information about a registered MCP tool.

--- a/src/pflow/mcp/registrar.py
+++ b/src/pflow/mcp/registrar.py
@@ -12,7 +12,7 @@ from pflow.registry.constants import MCP_CANONICAL_OUTPUT
 from .discovery import MCPDiscovery
 from .errors import describe_mcp_error
 from .manager import MCPServerManager
-from .sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_configs, parse_server_fingerprints
+from .sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_configs, load_server_fingerprints
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,6 @@ class SyncBatchResult:
     """Outcome of one coherent MCP reconciliation attempt."""
 
     servers: list[ServerSyncResult]
-    removed_tools: int
-    registry_updated: bool
     aborted_reason: str | None = None
     config_missing: bool = False
 
@@ -163,7 +161,7 @@ class MCPRegistrar:
                 results.append(ServerSyncResult(server=server_name, tools_discovered=len(tools)))
             except Exception as error:
                 original = error.__cause__ if error.__cause__ else error
-                diagnostic = describe_mcp_error(original)
+                diagnostic = describe_mcp_error(original, timeout=server_config.get("timeout", 30))
                 results.append(
                     ServerSyncResult(
                         server=server_name,
@@ -189,13 +187,10 @@ class MCPRegistrar:
         self,
         nodes: dict[str, dict[str, Any]],
         configured_servers: set[str],
-    ) -> int:
+    ) -> None:
         """Remove absent canonical owners and unsupported reserved MCP entries."""
-        removed = 0
         for node_name in self.full_reconciliation_removals(nodes, configured_servers):
             del nodes[node_name]
-            removed += 1
-        return removed
 
     def _apply_successful_replacements(
         self,
@@ -213,9 +208,11 @@ class MCPRegistrar:
                 final_results.append(result)
                 continue
             try:
+                # Build every replacement before removing the server's working entries.
                 registered, filtered = self._replace_server_tools(nodes, result.server, tools)
             except Exception as error:
                 diagnostic = describe_mcp_error(error)
+                diagnostic.message = f"Could not build registry entries for '{result.server}': {diagnostic.message}"
                 final_results.append(
                     ServerSyncResult(
                         server=result.server,
@@ -247,7 +244,7 @@ class MCPRegistrar:
         """Discover target servers, then publish one coherent reconciliation."""
         initial_configs = self.manager.get_all_servers_if_configured()
         if initial_configs is None:
-            return SyncBatchResult([], 0, False, config_missing=True)
+            return SyncBatchResult([], config_missing=True)
         targets = list(initial_configs) if server_names is None else list(server_names)
         initial_fingerprints = fingerprint_server_configs(initial_configs)
         discovered_tools, results = self._discover_targets(
@@ -261,8 +258,6 @@ class MCPRegistrar:
         if latest_configs is None:
             return SyncBatchResult(
                 servers=results,
-                removed_tools=0,
-                registry_updated=False,
                 aborted_reason="MCP configuration was removed during discovery; no registry updates were published.",
                 config_missing=True,
             )
@@ -275,22 +270,17 @@ class MCPRegistrar:
         ):
             return SyncBatchResult(
                 servers=results,
-                removed_tools=0,
-                registry_updated=False,
                 aborted_reason="MCP configuration changed during discovery; no registry updates were published. Retry sync.",
             )
 
         nodes = self.registry.load(include_filtered=True)
         original_nodes = dict(nodes)
-        missing = object()
-        raw_fingerprints = self.registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY, missing)
-        stored_fingerprints, fingerprints_valid = parse_server_fingerprints(raw_fingerprints)
+        stored_fingerprints, fingerprints_valid = load_server_fingerprints(self.registry)
         final_fingerprints = dict(stored_fingerprints)
-        removed_tools = 0
 
         if reconcile_all:
             configured_servers = set(latest_configs)
-            removed_tools = self._clean_full_reconciliation(nodes, configured_servers)
+            self._clean_full_reconciliation(nodes, configured_servers)
             final_fingerprints = {
                 name: fingerprint for name, fingerprint in final_fingerprints.items() if name in configured_servers
             }
@@ -311,11 +301,7 @@ class MCPRegistrar:
                 metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: final_fingerprints},
             )
 
-        return SyncBatchResult(
-            servers=final_results,
-            removed_tools=removed_tools,
-            registry_updated=registry_updated,
-        )
+        return SyncBatchResult(servers=final_results)
 
     def remove_server_tools(self, server_name: str) -> int:
         """Remove all registry entries for a specific MCP server.
@@ -332,9 +318,7 @@ class MCPRegistrar:
             del nodes[node_name]
             logger.debug(f"Removed registry entry: {node_name}")
 
-        missing = object()
-        raw_fingerprints = self.registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY, missing)
-        fingerprints, _ = parse_server_fingerprints(raw_fingerprints)
+        fingerprints, _ = load_server_fingerprints(self.registry)
         fingerprint_removed = server_name in fingerprints
         fingerprints.pop(server_name, None)
 

--- a/src/pflow/mcp/sync_state.py
+++ b/src/pflow/mcp/sync_state.py
@@ -1,0 +1,25 @@
+"""Persisted state helpers for MCP server synchronization."""
+
+import hashlib
+import json
+from typing import Any
+
+MCP_SERVER_FINGERPRINTS_KEY = "mcp_server_fingerprints"
+
+
+def fingerprint_server_config(config: dict[str, Any]) -> str:
+    """Return a stable fingerprint of one raw persisted server config."""
+    canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def fingerprint_server_configs(configs: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """Fingerprint each raw server config without resolving environment references."""
+    return {name: fingerprint_server_config(config) for name, config in configs.items()}
+
+
+def parse_server_fingerprints(value: Any) -> tuple[dict[str, Any], bool]:
+    """Return a defensive fingerprint-map copy and whether persisted state was valid."""
+    if not isinstance(value, dict):
+        return {}, False
+    return dict(value), True

--- a/src/pflow/mcp/sync_state.py
+++ b/src/pflow/mcp/sync_state.py
@@ -23,3 +23,8 @@ def parse_server_fingerprints(value: Any) -> tuple[dict[str, Any], bool]:
     if not isinstance(value, dict):
         return {}, False
     return dict(value), True
+
+
+def load_server_fingerprints(registry: Any) -> tuple[dict[str, Any], bool]:
+    """Load the persisted fingerprint map without exposing missing-value sentinels."""
+    return parse_server_fingerprints(registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY))

--- a/src/pflow/registry/CLAUDE.md
+++ b/src/pflow/registry/CLAUDE.md
@@ -56,8 +56,8 @@ Enhanced format supports nested structures for dict/list outputs. See `nodes/CLA
 | Consumer | Usage | `include_filtered` |
 |----------|-------|-------------------|
 | `runtime/compilation/` | Node class resolution, interface metadata, MCP validation, output validation | Default (filtered) |
-| `mcp/registrar.py` | Register/remove virtual MCP tool entries | **True** (safe) |
-| `cli/mcp_sync.py` auto-sync (via `cli/commands/run.py`) | Clean old MCP entries before re-syncing | **True** (safe) |
+| `mcp/registrar.py` | Reconcile virtual MCP tools and fingerprints after discovery | **True** (safe) |
+| `cli/mcp_sync.py` auto-sync (via `cli/commands/run.py`) | Inspect MCP ownership before selecting due servers | **True** (read-only snapshot) |
 | `cli/commands/mcp.py`, `_probe_impl.py` | MCP list/find/describe, probe | Default (filtered) |
 | `core/workflow/validator.py` | Validate node types exist | Default (filtered) |
 | `mcp_server/services/` | Registry service for MCP server | Default (filtered) |
@@ -100,12 +100,14 @@ All writes use a unified structured format:
 {
   "version": "0.10.0",
   "last_core_scan": "2026-03-22T...",
-  "metadata": {"mcp_config_hash": "..."},
+  "metadata": {"mcp_server_fingerprints": {"github": "..."}},
   "nodes": {"shell": {...}, "llm": {...}}
 }
 ```
 
-- `save()` preserves existing version/timestamp/metadata, only replaces nodes
+- `save()` preserves existing version/timestamp/metadata and replaces nodes; optional `metadata_updates=` values are merged into the same atomic write
 - `_save_with_metadata()` updates version and timestamp (used after core node discovery)
 - `get_metadata()`/`set_metadata()` read/write the `metadata` field directly
 - `_load_from_file()` still handles legacy flat format (`{node1: ..., node2: ...}`) for backward compatibility, stripping any `__metadata__` keys
+
+Atomic replacement means readers see a complete old or new wrapper. The module-level lock serializes in-process I/O only; Registry does not provide cross-process read-modify-write isolation.

--- a/src/pflow/registry/registry.py
+++ b/src/pflow/registry/registry.py
@@ -195,7 +195,12 @@ class Registry:
             logger.warning(f"Error reading registry file: {e}")
             return {}
 
-    def save(self, nodes: dict[str, dict[str, Any]]) -> None:
+    def save(
+        self,
+        nodes: dict[str, dict[str, Any]],
+        *,
+        metadata_updates: dict[str, Any] | None = None,
+    ) -> None:
         """Save nodes dictionary to registry JSON file in structured format.
 
         Always writes the structured wrapper format: {version, last_core_scan,
@@ -207,6 +212,8 @@ class Registry:
 
         Args:
             nodes: Dictionary mapping node names to metadata
+            metadata_updates: Values to merge into wrapper metadata in the same
+                atomic write as the node replacement.
 
         Note:
             This completely replaces the nodes in the registry file.
@@ -216,10 +223,15 @@ class Registry:
             # Preserve existing wrapper metadata (version, timestamps, metadata)
             existing = self._read_wrapper()
 
+            metadata = existing.get("metadata", {})
+            metadata = dict(metadata) if isinstance(metadata, dict) else {}
+            if metadata_updates:
+                metadata.update(metadata_updates)
+
             data = {
                 "version": existing.get("version", self._get_version()),
                 "last_core_scan": existing.get("last_core_scan", self._now_iso()),
-                "metadata": existing.get("metadata", {}),
+                "metadata": metadata,
                 "nodes": nodes,
             }
 

--- a/tests/test_cli/test_mcp_auto_discovery.py
+++ b/tests/test_cli/test_mcp_auto_discovery.py
@@ -8,9 +8,11 @@ at pflow startup to automatically sync MCP servers. The tests focus on:
 4. Output control - interactive vs non-interactive modes
 """
 
-from unittest.mock import Mock, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 from pflow.cli.mcp_sync import _auto_discover_mcp_servers
+from pflow.mcp.registrar import ServerSyncResult, SyncBatchResult
+from pflow.mcp.sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_configs
 
 
 class TestAutoDiscovery:
@@ -31,23 +33,23 @@ class TestAutoDiscovery:
         with (
             patch("pflow.cli.mcp_sync._get_output_controller", return_value=output_controller),
             patch("pflow.mcp.MCPServerManager") as mock_manager_class,
-            patch("pflow.registry.Registry") as mock_registry_class,
+            patch("pflow.registry.Registry"),
             patch("pflow.mcp.MCPDiscovery") as mock_discovery_class,
             patch("pflow.mcp.MCPRegistrar") as mock_registrar_class,
         ):
-            # Configure manager to return no servers
+            # Existing empty config is explicit reconciliation state.
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = []
+            mock_manager.get_all_servers_if_configured.return_value = {}
+            mock_registrar_class.return_value.sync_servers.return_value = SyncBatchResult([], 0, True)
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=True)
 
-            # Should exit early, not attempt discovery
-            mock_manager.list_servers.assert_called_once()
-            # These should never be instantiated when no servers
-            mock_registry_class.assert_not_called()
-            mock_discovery_class.assert_not_called()
-            mock_registrar_class.assert_not_called()
+            mock_manager.get_all_servers_if_configured.assert_called_once()
+            mock_discovery_class.assert_called_once_with(mock_manager)
+            mock_registrar_class.return_value.sync_servers.assert_called_once_with(
+                [], reconcile_all=True, verbose=True, on_server_start=ANY
+            )
 
     def test_successful_discovery_all_servers(self, tmp_path, monkeypatch):
         """Test successful discovery of tools from all configured servers."""
@@ -71,7 +73,10 @@ class TestAutoDiscovery:
         ):
             # Configure manager to return servers
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["github", "slack"]
+            mock_manager.get_all_servers_if_configured.return_value = {
+                "github": {"command": "github"},
+                "slack": {"command": "slack"},
+            }
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             mock_manager.config_path.touch()  # Create the config file
@@ -79,22 +84,19 @@ class TestAutoDiscovery:
             # Configure registry
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            # Make it appear that sync is needed (old sync time)
-            mock_registry.get_metadata.side_effect = lambda key, default: {
-                "mcp_last_sync_time": 0,  # Very old sync
-                "mcp_servers_hash": "",  # No previous hash
-            }.get(key, default)
+            mock_registry.get_metadata.side_effect = lambda _key, default: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
-            # Configure discovery to return tools
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.side_effect = [
-                ["create-issue", "list-issues"],  # github tools
-                ["send-message", "list-channels"],  # slack tools
-            ]
-
-            # Configure registrar
+            # Configure the shared batch coordinator result.
             mock_registrar = mock_registrar_class.return_value
+            mock_registrar.sync_servers.return_value = SyncBatchResult(
+                [
+                    ServerSyncResult("github", tools_discovered=2, tools_registered=2),
+                    ServerSyncResult("slack", tools_discovered=2, tools_registered=2),
+                ],
+                0,
+                True,
+            )
 
             # Run auto-discovery with verbose=False (summary only)
             _auto_discover_mcp_servers(ctx, verbose=False)
@@ -102,21 +104,15 @@ class TestAutoDiscovery:
             # Verify MCPDiscovery was instantiated with manager
             mock_discovery_class.assert_called_once_with(mock_manager)
 
-            # Verify discovery was called for each server
-            assert mock_discovery.discover_tools.call_count == 2
-            mock_discovery.discover_tools.assert_any_call("github", verbose=False)
-            mock_discovery.discover_tools.assert_any_call("slack", verbose=False)
-
-            # Verify tools were registered
-            assert mock_registrar.register_tools.call_count == 2
-            mock_registrar.register_tools.assert_any_call("github", ["create-issue", "list-issues"])
-            mock_registrar.register_tools.assert_any_call("slack", ["send-message", "list-channels"])
+            mock_registrar.sync_servers.assert_called_once_with(
+                ["github", "slack"], reconcile_all=True, verbose=False, on_server_start=ANY
+            )
 
             # Verify summary message shown
             mock_echo.assert_called_with("✓ Synced 4 MCP tool(s) from 2 server(s)", err=True)
 
-    def test_partial_failure_continues_with_other_servers(self, tmp_path, monkeypatch):
-        """Test that failure on one server doesn't stop discovery of others."""
+    def test_partial_failure_result_renders_success_and_warning(self, tmp_path, monkeypatch):
+        """The auto-sync boundary renders a completed mixed batch result."""
         monkeypatch.setenv("HOME", str(tmp_path))
 
         ctx = Mock()
@@ -129,13 +125,17 @@ class TestAutoDiscovery:
             patch("pflow.cli.mcp_sync._get_output_controller", return_value=output_controller),
             patch("pflow.mcp.MCPServerManager") as mock_manager_class,
             patch("pflow.registry.Registry") as mock_registry_class,
-            patch("pflow.mcp.MCPDiscovery") as mock_discovery_class,
+            patch("pflow.mcp.MCPDiscovery"),
             patch("pflow.mcp.MCPRegistrar") as mock_registrar_class,
             patch("pflow.cli.mcp_sync.logger") as mock_logger,
+            patch("pflow.cli.mcp_sync.click.echo") as mock_echo,
         ):
             # Configure manager
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["broken", "working"]
+            mock_manager.get_all_servers_if_configured.return_value = {
+                "broken": {"command": "broken"},
+                "working": {"command": "working"},
+            }
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             mock_manager.config_path.touch()  # Create the config file
@@ -143,34 +143,28 @@ class TestAutoDiscovery:
             # Configure registry
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            # Make it appear that sync is needed (old sync time)
-            mock_registry.get_metadata.side_effect = lambda key, default: {
-                "mcp_last_sync_time": 0,  # Very old sync
-                "mcp_servers_hash": "",  # No previous hash
-            }.get(key, default)
+            mock_registry.get_metadata.side_effect = lambda _key, default: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
-            # Configure discovery - first fails, second works
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.side_effect = [
-                Exception("Connection failed"),  # broken server
-                ["tool1", "tool2"],  # working server
-            ]
-
-            # Configure registrar
             mock_registrar = mock_registrar_class.return_value
+            mock_registrar.sync_servers.return_value = SyncBatchResult(
+                [
+                    ServerSyncResult("broken", error="Connection failed"),
+                    ServerSyncResult("working", tools_discovered=2, tools_registered=2),
+                ],
+                0,
+                True,
+            )
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
 
-            # Verify both servers were attempted
-            assert mock_discovery.discover_tools.call_count == 2
-
-            # Verify only working server's tools were registered
-            mock_registrar.register_tools.assert_called_once_with("working", ["tool1", "tool2"])
-
-            # Verify error was logged
-            mock_logger.debug.assert_any_call("Failed to discover tools from broken: Connection failed")
+            mock_registrar.sync_servers.assert_called_once_with(
+                ["broken", "working"], reconcile_all=True, verbose=False, on_server_start=ANY
+            )
+            mock_logger.debug.assert_not_called()
+            mock_echo.assert_any_call("✓ Synced 2 MCP tool(s) from 1 server(s)", err=True)
+            mock_echo.assert_any_call("⚠ Failed to connect to MCP server(s): broken", err=True)
 
     def test_verbose_mode_shows_progress(self, tmp_path, monkeypatch):
         """Test that verbose mode shows detailed progress messages."""
@@ -186,30 +180,34 @@ class TestAutoDiscovery:
             patch("pflow.cli.mcp_sync._get_output_controller", return_value=output_controller),
             patch("pflow.mcp.MCPServerManager") as mock_manager_class,
             patch("pflow.registry.Registry") as mock_registry_class,
-            patch("pflow.mcp.MCPDiscovery") as mock_discovery_class,
+            patch("pflow.mcp.MCPDiscovery"),
             patch("pflow.mcp.MCPRegistrar"),
             patch("pflow.cli.mcp_sync.click.echo") as mock_echo,
         ):
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["test-server"]
+            mock_manager.get_all_servers_if_configured.return_value = {"test-server": {"command": "test"}}
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             mock_manager.config_path.touch()  # Create the config file
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            # Make it appear that sync is needed (old sync time)
-            mock_registry.get_metadata.side_effect = lambda key, default: {
-                "mcp_last_sync_time": 0,  # Very old sync
-                "mcp_servers_hash": "",  # No previous hash
-            }.get(key, default)
+            mock_registry.get_metadata.side_effect = lambda _key, default: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.return_value = ["tool1", "tool2"]
+            registrar = Mock()
+
+            def sync_servers(_servers, **kwargs):
+                kwargs["on_server_start"]("test-server")
+                return SyncBatchResult(
+                    [ServerSyncResult("test-server", tools_discovered=2, tools_registered=2)], 0, True
+                )
+
+            registrar.sync_servers.side_effect = sync_servers
 
             # Run with verbose=True
-            _auto_discover_mcp_servers(ctx, verbose=True)
+            with patch("pflow.mcp.MCPRegistrar", return_value=registrar):
+                _auto_discover_mcp_servers(ctx, verbose=True)
 
             # Verify verbose messages shown
             mock_echo.assert_any_call("Discovering tools from MCP server 'test-server'...", err=True)
@@ -308,30 +306,26 @@ class TestAutoDiscovery:
             patch("pflow.cli.mcp_sync._get_output_controller", return_value=output_controller),
             patch("pflow.mcp.MCPServerManager") as mock_manager_class,
             patch("pflow.registry.Registry") as mock_registry_class,
-            patch("pflow.mcp.MCPDiscovery") as mock_discovery_class,
+            patch("pflow.mcp.MCPDiscovery"),
             patch("pflow.mcp.MCPRegistrar") as mock_registrar_class,
             patch("pflow.cli.mcp_sync.click.echo") as mock_echo,
         ):
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["empty-server"]
+            mock_manager.get_all_servers_if_configured.return_value = {"empty-server": {"command": "empty"}}
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
 
-            # Server returns empty list (valid but no tools)
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.return_value = []
-
             mock_registrar = mock_registrar_class.return_value
+            mock_registrar.sync_servers.return_value = SyncBatchResult([ServerSyncResult("empty-server")], 0, True)
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
 
-            # Should not register anything for empty tool list
-            mock_registrar.register_tools.assert_not_called()
-
-            # Should not show summary for 0 tools
-            mock_echo.assert_not_called()
+            mock_registrar.sync_servers.assert_called_once_with(
+                ["empty-server"], reconcile_all=True, verbose=False, on_server_start=ANY
+            )
+            mock_echo.assert_any_call("✓ Synced 0 MCP tool(s) from 1 server(s)", err=True)
 
     def test_mixed_success_and_empty_servers(self, tmp_path, monkeypatch):
         """Test mix of successful servers and servers with no tools."""
@@ -347,39 +341,40 @@ class TestAutoDiscovery:
             patch("pflow.cli.mcp_sync._get_output_controller", return_value=output_controller),
             patch("pflow.mcp.MCPServerManager") as mock_manager_class,
             patch("pflow.registry.Registry") as mock_registry_class,
-            patch("pflow.mcp.MCPDiscovery") as mock_discovery_class,
+            patch("pflow.mcp.MCPDiscovery"),
             patch("pflow.mcp.MCPRegistrar") as mock_registrar_class,
             patch("pflow.cli.mcp_sync.click.echo") as mock_echo,
         ):
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["empty", "github", "another-empty"]
+            mock_manager.get_all_servers_if_configured.return_value = {
+                "empty": {"command": "empty"},
+                "github": {"command": "github"},
+                "another-empty": {"command": "another-empty"},
+            }
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             mock_manager.config_path.touch()  # Create the config file
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            # Make it appear that sync is needed (old sync time)
-            mock_registry.get_metadata.side_effect = lambda key, default: {
-                "mcp_last_sync_time": 0,  # Very old sync
-                "mcp_servers_hash": "",  # No previous hash
-            }.get(key, default)
+            mock_registry.get_metadata.side_effect = lambda _key, default: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.side_effect = [
-                [],  # empty server
-                ["create-issue", "list-issues"],  # github
-                [],  # another empty
-            ]
-
             mock_registrar = mock_registrar_class.return_value
+            mock_registrar.sync_servers.return_value = SyncBatchResult(
+                [
+                    ServerSyncResult("empty"),
+                    ServerSyncResult("github", tools_discovered=2, tools_registered=2),
+                    ServerSyncResult("another-empty"),
+                ],
+                0,
+                True,
+            )
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
 
-            # Should only register for non-empty server
-            mock_registrar.register_tools.assert_called_once_with("github", ["create-issue", "list-issues"])
+            mock_registrar.sync_servers.assert_called_once()
 
             # Summary counts servers that didn't fail (even if they had no tools)
             mock_echo.assert_called_with("✓ Synced 2 MCP tool(s) from 3 server(s)", err=True)
@@ -398,46 +393,55 @@ class TestAutoDiscovery:
             patch("pflow.cli.mcp_sync._get_output_controller", return_value=output_controller),
             patch("pflow.mcp.MCPServerManager") as mock_manager_class,
             patch("pflow.registry.Registry") as mock_registry_class,
-            patch("pflow.mcp.MCPDiscovery") as mock_discovery_class,
+            patch("pflow.mcp.MCPDiscovery"),
             patch("pflow.mcp.MCPRegistrar"),
             patch("pflow.cli.mcp_sync.click.echo") as mock_echo,
         ):
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["failing-server", "working-server"]
+            mock_manager.get_all_servers_if_configured.return_value = {
+                "failing-server": {"command": "failing"},
+                "working-server": {"command": "working"},
+            }
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             mock_manager.config_path.touch()  # Create the config file
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            # Make it appear that sync is needed (old sync time)
-            mock_registry.get_metadata.side_effect = lambda key, default: {
-                "mcp_last_sync_time": 0,  # Very old sync
-                "mcp_servers_hash": "",  # No previous hash
-            }.get(key, default)
+            mock_registry.get_metadata.side_effect = lambda _key, default: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.side_effect = [
-                RuntimeError("Connection timeout"),
-                ["tool1"],
-            ]
+            registrar = Mock()
+
+            def sync_servers(servers, **kwargs):
+                for server in servers:
+                    kwargs["on_server_start"](server)
+                return SyncBatchResult(
+                    [
+                        ServerSyncResult("failing-server", error="Connection timeout"),
+                        ServerSyncResult("working-server", tools_discovered=1, tools_registered=1),
+                    ],
+                    0,
+                    True,
+                )
+
+            registrar.sync_servers.side_effect = sync_servers
 
             # Run with verbose=True
-            _auto_discover_mcp_servers(ctx, verbose=True)
+            with patch("pflow.mcp.MCPRegistrar", return_value=registrar):
+                _auto_discover_mcp_servers(ctx, verbose=True)
 
             # Verify progress messages shown
             expected_calls = [
                 call("Discovering tools from MCP server 'failing-server'...", err=True),
-                call("  ⚠ Failed to connect to failing-server", err=True),
                 call("Discovering tools from MCP server 'working-server'...", err=True),
                 call("  ✓ Discovered 1 tool(s) from working-server", err=True),
-                call("⚠ Failed to connect to 1 server(s): failing-server", err=True),
+                call("⚠ Failed to connect to MCP server(s): failing-server", err=True),
             ]
             mock_echo.assert_has_calls(expected_calls)
 
-    def test_already_synced_nodes_still_rediscover(self, tmp_path, monkeypatch):
-        """Test that we always re-discover to catch updates, even with existing nodes."""
+    def test_unchanged_fingerprints_skip_rediscovery(self, tmp_path, monkeypatch):
+        """Unchanged per-server fingerprints avoid server startup and registry writes."""
         monkeypatch.setenv("HOME", str(tmp_path))
 
         ctx = Mock()
@@ -454,41 +458,24 @@ class TestAutoDiscovery:
             patch("pflow.mcp.MCPRegistrar") as mock_registrar_class,
         ):
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["github"]
+            configs = {"github": {"command": "github"}}
+            mock_manager.get_all_servers_if_configured.return_value = configs
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             mock_manager.config_path.touch()  # Create the config file
 
-            # Registry already has MCP nodes (previously synced)
             mock_registry = mock_registry_class.return_value
-            mock_registry.list_nodes.return_value = [
-                "mcp-github-create-issue",
-                "mcp-github-list-issues",
-                "regular-node",
-            ]
-            # Make it appear that sync is needed (old sync time)
-            mock_registry.get_metadata.side_effect = lambda key, default: {
-                "mcp_last_sync_time": 0,  # Very old sync
-                "mcp_servers_hash": "",  # No previous hash
-            }.get(key, default)
-            mock_registry.load.return_value = {
-                "mcp-github-create-issue": {},
-                "mcp-github-list-issues": {},
-            }  # Existing MCP entries to be cleaned
-
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.return_value = ["create-issue", "list-issues", "new-tool"]
-
-            mock_registrar = mock_registrar_class.return_value
+            mock_registry.get_metadata.side_effect = lambda key, default: (
+                fingerprint_server_configs(configs) if key == MCP_SERVER_FINGERPRINTS_KEY else default
+            )
+            mock_registry.load.return_value = {}
+            mock_registrar_class.full_reconciliation_removals.return_value = []
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
 
-            # Should still attempt discovery
-            mock_discovery.discover_tools.assert_called_with("github", verbose=False)
-
-            # Should register the discovered tools (including new ones)
-            mock_registrar.register_tools.assert_called_with("github", ["create-issue", "list-issues", "new-tool"])
+            mock_discovery_class.assert_not_called()
+            mock_registrar_class.assert_not_called()
 
 
 class TestAutoDiscoveryIntegration:
@@ -497,8 +484,8 @@ class TestAutoDiscoveryIntegration:
     These tests use less mocking to verify the interactions between components.
     """
 
-    def test_discovery_with_real_registry(self, tmp_path, monkeypatch):
-        """Test discovery with real Registry to verify registration works."""
+    def test_batch_coordinator_receives_real_registry(self, tmp_path, monkeypatch):
+        """Auto-sync passes its inspected registry to the batch coordinator."""
         from pflow.registry import Registry
 
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -522,24 +509,22 @@ class TestAutoDiscoveryIntegration:
             patch("pflow.mcp.MCPRegistrar") as mock_registrar_class,
         ):
             mock_manager = mock_manager_class.return_value
-            mock_manager.list_servers.return_value = ["test-server"]
+            mock_manager.get_all_servers_if_configured.return_value = {"test-server": {"command": "test"}}
             mock_manager.config_path = tmp_path / ".pflow" / "mcp-servers.json"
             mock_manager.config_path.parent.mkdir(parents=True, exist_ok=True)
             # Create a valid JSON config file
             mock_manager.config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
 
-            # Set up registry metadata to force sync
-            registry.set_metadata("mcp_last_sync_time", 0)
-            registry.set_metadata("mcp_servers_hash", "")
-
-            mock_discovery = mock_discovery_class.return_value
-            mock_discovery.discover_tools.return_value = ["tool1", "tool2"]
-
-            # Let registrar use the real registry
-            mock_registrar_class.return_value = Mock()
+            mock_registrar_class.return_value.sync_servers.return_value = SyncBatchResult(
+                [ServerSyncResult("test-server", tools_discovered=2, tools_registered=2)], 0, True
+            )
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
 
             # Verify registrar was initialized with real registry
-            mock_registrar_class.assert_called_with(registry=registry, manager=mock_manager)
+            mock_registrar_class.assert_called_with(
+                registry=registry,
+                manager=mock_manager,
+                discovery=mock_discovery_class.return_value,
+            )

--- a/tests/test_cli/test_mcp_auto_discovery.py
+++ b/tests/test_cli/test_mcp_auto_discovery.py
@@ -18,8 +18,8 @@ from pflow.mcp.sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server
 class TestAutoDiscovery:
     """Test automatic MCP server discovery at pflow startup."""
 
-    def test_no_servers_configured_does_nothing(self, tmp_path, monkeypatch):
-        """Test that auto-discovery exits early when no servers configured."""
+    def test_explicit_empty_config_reconciles_registry(self, tmp_path, monkeypatch):
+        """An explicit empty config reaches reconciliation for stale cleanup."""
         monkeypatch.setenv("HOME", str(tmp_path))
 
         # Create mock context
@@ -40,7 +40,7 @@ class TestAutoDiscovery:
             # Existing empty config is explicit reconciliation state.
             mock_manager = mock_manager_class.return_value
             mock_manager.get_all_servers_if_configured.return_value = {}
-            mock_registrar_class.return_value.sync_servers.return_value = SyncBatchResult([], 0, True)
+            mock_registrar_class.return_value.sync_servers.return_value = SyncBatchResult([])
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=True)
@@ -84,19 +84,15 @@ class TestAutoDiscovery:
             # Configure registry
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            mock_registry.get_metadata.side_effect = lambda _key, default: default
+            mock_registry.get_metadata.side_effect = lambda _key, default=None: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
             # Configure the shared batch coordinator result.
             mock_registrar = mock_registrar_class.return_value
-            mock_registrar.sync_servers.return_value = SyncBatchResult(
-                [
-                    ServerSyncResult("github", tools_discovered=2, tools_registered=2),
-                    ServerSyncResult("slack", tools_discovered=2, tools_registered=2),
-                ],
-                0,
-                True,
-            )
+            mock_registrar.sync_servers.return_value = SyncBatchResult([
+                ServerSyncResult("github", tools_discovered=2, tools_registered=2),
+                ServerSyncResult("slack", tools_discovered=2, tools_registered=2),
+            ])
 
             # Run auto-discovery with verbose=False (summary only)
             _auto_discover_mcp_servers(ctx, verbose=False)
@@ -143,18 +139,14 @@ class TestAutoDiscovery:
             # Configure registry
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            mock_registry.get_metadata.side_effect = lambda _key, default: default
+            mock_registry.get_metadata.side_effect = lambda _key, default=None: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
             mock_registrar = mock_registrar_class.return_value
-            mock_registrar.sync_servers.return_value = SyncBatchResult(
-                [
-                    ServerSyncResult("broken", error="Connection failed"),
-                    ServerSyncResult("working", tools_discovered=2, tools_registered=2),
-                ],
-                0,
-                True,
-            )
+            mock_registrar.sync_servers.return_value = SyncBatchResult([
+                ServerSyncResult("broken", error="Connection failed"),
+                ServerSyncResult("working", tools_discovered=2, tools_registered=2),
+            ])
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
@@ -192,16 +184,14 @@ class TestAutoDiscovery:
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            mock_registry.get_metadata.side_effect = lambda _key, default: default
+            mock_registry.get_metadata.side_effect = lambda _key, default=None: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
             registrar = Mock()
 
             def sync_servers(_servers, **kwargs):
                 kwargs["on_server_start"]("test-server")
-                return SyncBatchResult(
-                    [ServerSyncResult("test-server", tools_discovered=2, tools_registered=2)], 0, True
-                )
+                return SyncBatchResult([ServerSyncResult("test-server", tools_discovered=2, tools_registered=2)])
 
             registrar.sync_servers.side_effect = sync_servers
 
@@ -317,7 +307,7 @@ class TestAutoDiscovery:
             mock_registry.list_nodes.return_value = []
 
             mock_registrar = mock_registrar_class.return_value
-            mock_registrar.sync_servers.return_value = SyncBatchResult([ServerSyncResult("empty-server")], 0, True)
+            mock_registrar.sync_servers.return_value = SyncBatchResult([ServerSyncResult("empty-server")])
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
@@ -357,19 +347,15 @@ class TestAutoDiscovery:
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            mock_registry.get_metadata.side_effect = lambda _key, default: default
+            mock_registry.get_metadata.side_effect = lambda _key, default=None: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
             mock_registrar = mock_registrar_class.return_value
-            mock_registrar.sync_servers.return_value = SyncBatchResult(
-                [
-                    ServerSyncResult("empty"),
-                    ServerSyncResult("github", tools_discovered=2, tools_registered=2),
-                    ServerSyncResult("another-empty"),
-                ],
-                0,
-                True,
-            )
+            mock_registrar.sync_servers.return_value = SyncBatchResult([
+                ServerSyncResult("empty"),
+                ServerSyncResult("github", tools_discovered=2, tools_registered=2),
+                ServerSyncResult("another-empty"),
+            ])
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)
@@ -408,7 +394,7 @@ class TestAutoDiscovery:
 
             mock_registry = mock_registry_class.return_value
             mock_registry.list_nodes.return_value = []
-            mock_registry.get_metadata.side_effect = lambda _key, default: default
+            mock_registry.get_metadata.side_effect = lambda _key, default=None: default
             mock_registry.load.return_value = {}  # Empty registry for cleaning old entries
 
             registrar = Mock()
@@ -416,14 +402,10 @@ class TestAutoDiscovery:
             def sync_servers(servers, **kwargs):
                 for server in servers:
                     kwargs["on_server_start"](server)
-                return SyncBatchResult(
-                    [
-                        ServerSyncResult("failing-server", error="Connection timeout"),
-                        ServerSyncResult("working-server", tools_discovered=1, tools_registered=1),
-                    ],
-                    0,
-                    True,
-                )
+                return SyncBatchResult([
+                    ServerSyncResult("failing-server", error="Connection timeout"),
+                    ServerSyncResult("working-server", tools_discovered=1, tools_registered=1),
+                ])
 
             registrar.sync_servers.side_effect = sync_servers
 
@@ -465,7 +447,7 @@ class TestAutoDiscovery:
             mock_manager.config_path.touch()  # Create the config file
 
             mock_registry = mock_registry_class.return_value
-            mock_registry.get_metadata.side_effect = lambda key, default: (
+            mock_registry.get_metadata.side_effect = lambda key, default=None: (
                 fingerprint_server_configs(configs) if key == MCP_SERVER_FINGERPRINTS_KEY else default
             )
             mock_registry.load.return_value = {}
@@ -515,9 +497,9 @@ class TestAutoDiscoveryIntegration:
             # Create a valid JSON config file
             mock_manager.config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
 
-            mock_registrar_class.return_value.sync_servers.return_value = SyncBatchResult(
-                [ServerSyncResult("test-server", tools_discovered=2, tools_registered=2)], 0, True
-            )
+            mock_registrar_class.return_value.sync_servers.return_value = SyncBatchResult([
+                ServerSyncResult("test-server", tools_discovered=2, tools_registered=2)
+            ])
 
             # Run auto-discovery
             _auto_discover_mcp_servers(ctx, verbose=False)

--- a/tests/test_cli/test_mcp_auto_sync_state.py
+++ b/tests/test_cli/test_mcp_auto_sync_state.py
@@ -1,0 +1,242 @@
+"""Persistence-level tests for workflow-start MCP synchronization."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pflow.cli.mcp_sync import _auto_discover_mcp_servers
+from pflow.mcp import MCPRegistrar, MCPServerManager
+from pflow.mcp.sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_configs
+from pflow.registry import Registry
+
+
+def _tool(name: str) -> dict:
+    return {"name": name, "description": name}
+
+
+def _setup(tmp_path: Path, configs: dict[str, dict]) -> tuple[MCPServerManager, Registry, Mock]:
+    manager = MCPServerManager(config_path=tmp_path / "mcp-servers.json")
+    manager.save({"mcpServers": configs})
+    registry = Registry(registry_path=tmp_path / "registry.json")
+    registry._save_with_metadata({})
+    discovery = Mock()
+    discovery.convert_to_pflow_params.return_value = []
+    return manager, registry, discovery
+
+
+def _run(
+    manager: MCPServerManager,
+    registry: Registry,
+    discovery: Mock,
+    *,
+    interactive: bool = False,
+    verbose: bool = False,
+) -> None:
+    controller = Mock()
+    controller.is_interactive.return_value = interactive
+    ctx = Mock(obj={})
+    with (
+        patch("pflow.cli.mcp_sync._get_output_controller", return_value=controller),
+        patch("pflow.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.registry.Registry", return_value=registry),
+        patch("pflow.mcp.MCPDiscovery", return_value=discovery),
+    ):
+        _auto_discover_mcp_servers(ctx, verbose=verbose)
+
+
+def _entry(registry: Registry, server: str, tool: str) -> dict:
+    registrar = MCPRegistrar(registry=registry)
+    return registrar._create_registry_entry(server, _tool(tool))
+
+
+def test_bootstrap_adds_servers_and_unchanged_second_run_does_nothing(tmp_path: Path) -> None:
+    configs = {"one": {"command": "one"}, "two": {"command": "two"}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    discovery.discover_tools.side_effect = [[_tool("first")], [_tool("second")]]
+
+    _run(manager, registry, discovery)
+    with patch.object(registry, "save", wraps=registry.save) as save:
+        _run(manager, registry, discovery)
+
+    assert [call.args[0] for call in discovery.discover_tools.call_args_list] == ["one", "two"]
+    save.assert_not_called()
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == fingerprint_server_configs(configs)
+    assert set(registry.load(include_filtered=True)) == {"mcp-one-first", "mcp-two-second"}
+
+
+@pytest.mark.parametrize(
+    ("initial", "changed"),
+    [
+        ({"command": "old"}, {"command": "new"}),
+        ({"command": "cmd", "args": ["old"]}, {"command": "cmd", "args": ["new"]}),
+        ({"command": "cmd", "env": {"TOKEN": "${OLD}"}}, {"command": "cmd", "env": {"TOKEN": "${NEW}"}}),
+        ({"type": "http", "url": "https://old"}, {"type": "http", "url": "https://new"}),
+        (
+            {"type": "http", "url": "https://same", "headers": {"Authorization": "${OLD}"}},
+            {"type": "http", "url": "https://same", "headers": {"Authorization": "${NEW}"}},
+        ),
+    ],
+)
+def test_raw_config_value_change_contacts_only_changed_server(
+    tmp_path: Path,
+    initial: dict,
+    changed: dict,
+) -> None:
+    configs = {"target": initial, "peer": {"command": "peer"}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    target_attempts = 0
+
+    def discover(server_name, **_kwargs):
+        nonlocal target_attempts
+        if server_name == "peer":
+            return [_tool("peer")]
+        target_attempts += 1
+        return [_tool("old" if target_attempts == 1 else "new")]
+
+    discovery.discover_tools.side_effect = discover
+    _run(manager, registry, discovery)
+    manager.save({"mcpServers": {"target": changed, "peer": configs["peer"]}})
+
+    _run(manager, registry, discovery)
+
+    calls = [call.args[0] for call in discovery.discover_tools.call_args_list]
+    assert set(calls[:2]) == {"target", "peer"}
+    assert calls[2:] == ["target"]
+    assert "mcp-target-new" in registry.load(include_filtered=True)
+
+
+def test_formatting_and_key_order_only_rewrite_contacts_none_and_writes_nothing(tmp_path: Path) -> None:
+    configs = {"one": {"command": "cmd", "args": ["a"], "env": {"B": "2", "A": "1"}}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    discovery.discover_tools.return_value = [_tool("tool")]
+    _run(manager, registry, discovery)
+    discovery.reset_mock()
+    manager.config_path.write_text(
+        json.dumps({"mcpServers": {"one": {"env": {"A": "1", "B": "2"}, "args": ["a"], "command": "cmd"}}}),
+        encoding="utf-8",
+    )
+
+    with patch.object(registry, "save", wraps=registry.save) as save:
+        _run(manager, registry, discovery)
+
+    discovery.discover_tools.assert_not_called()
+    save.assert_not_called()
+
+
+def test_resolved_environment_change_does_not_change_raw_config_fingerprint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configs = {"one": {"command": "cmd", "env": {"TOKEN": "${TOKEN}"}}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    discovery.discover_tools.return_value = [_tool("tool")]
+    monkeypatch.setenv("TOKEN", "first-secret")
+    _run(manager, registry, discovery)
+    discovery.reset_mock()
+    monkeypatch.setenv("TOKEN", "rotated-secret")
+
+    with patch.object(registry, "save", wraps=registry.save) as save:
+        _run(manager, registry, discovery)
+
+    discovery.discover_tools.assert_not_called()
+    save.assert_not_called()
+
+
+def test_partial_failure_retries_only_failed_server(tmp_path: Path) -> None:
+    configs = {"good": {"command": "good"}, "bad": {"command": "bad"}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    registry.save({
+        "mcp-good-old": _entry(registry, "good", "old"),
+        "mcp-bad-old": _entry(registry, "bad", "old"),
+    })
+    bad_attempts = 0
+
+    def discover(server_name, **_kwargs):
+        nonlocal bad_attempts
+        if server_name == "good":
+            return [_tool("new")]
+        bad_attempts += 1
+        if bad_attempts == 1:
+            raise RuntimeError("down")
+        return [_tool("recovered")]
+
+    discovery.discover_tools.side_effect = discover
+
+    _run(manager, registry, discovery)
+    after_failure = registry.load(include_filtered=True)
+    _run(manager, registry, discovery)
+
+    assert set(after_failure) == {"mcp-good-new", "mcp-bad-old"}
+    calls = [call.args[0] for call in discovery.discover_tools.call_args_list]
+    assert set(calls[:2]) == {"good", "bad"}
+    assert calls[2:] == ["bad"]
+    assert set(registry.load(include_filtered=True)) == {"mcp-good-new", "mcp-bad-recovered"}
+
+
+def test_total_failure_preserves_state_and_retries_all(tmp_path: Path) -> None:
+    configs = {"one": {"command": "one"}, "two": {"command": "two"}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    old_nodes = {
+        "mcp-one-old": _entry(registry, "one", "old"),
+        "mcp-two-old": _entry(registry, "two", "old"),
+    }
+    registry.save(old_nodes)
+    discovery.discover_tools.side_effect = [
+        RuntimeError("one down"),
+        RuntimeError("two down"),
+        RuntimeError("one still down"),
+        RuntimeError("two still down"),
+    ]
+
+    _run(manager, registry, discovery)
+    _run(manager, registry, discovery)
+
+    assert registry.load(include_filtered=True) == old_nodes
+    assert [call.args[0] for call in discovery.discover_tools.call_args_list] == ["one", "two", "one", "two"]
+
+
+def test_empty_success_and_removed_overlapping_server_names(tmp_path: Path) -> None:
+    configs = {"foo": {"command": "foo"}, "foo-bar": {"command": "foo-bar"}}
+    manager, registry, discovery = _setup(tmp_path, configs)
+    discovery.discover_tools.side_effect = [[_tool("old")], [_tool("peer")], []]
+    _run(manager, registry, discovery)
+    manager.save({"mcpServers": {"foo": {"command": "changed"}}})
+
+    _run(manager, registry, discovery)
+
+    assert registry.load(include_filtered=True) == {}
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == fingerprint_server_configs({
+        "foo": {"command": "changed"}
+    })
+
+
+def test_explicit_empty_cleans_canonical_and_legacy_while_missing_file_preserves(tmp_path: Path) -> None:
+    manager, registry, discovery = _setup(tmp_path, {"one": {"command": "one"}})
+    registry.save({
+        "mcp-one-old": _entry(registry, "one", "old"),
+        "mcp-legacy": {"type": "mcp"},
+        "user-node": {"type": "user"},
+    })
+    manager.config_path.unlink()
+
+    _run(manager, registry, discovery)
+    assert set(registry.load(include_filtered=True)) == {"mcp-one-old", "mcp-legacy", "user-node"}
+
+    manager.save({"mcpServers": {}})
+    _run(manager, registry, discovery)
+    assert registry.load(include_filtered=True) == {"user-node": {"type": "user"}}
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {}
+
+
+def test_failure_warning_names_servers_only_in_interactive_mode(tmp_path: Path) -> None:
+    manager, registry, discovery = _setup(tmp_path, {"broken": {"command": "broken"}})
+    discovery.discover_tools.side_effect = RuntimeError("down")
+
+    with patch("pflow.cli.mcp_sync.click.echo") as echo:
+        _run(manager, registry, discovery, interactive=False)
+        echo.assert_not_called()
+        _run(manager, registry, discovery, interactive=True)
+
+    assert any("broken" in call.args[0] for call in echo.call_args_list)

--- a/tests/test_cli/test_mcp_commands.py
+++ b/tests/test_cli/test_mcp_commands.py
@@ -1,10 +1,14 @@
 """Tests for the reworked `pflow mcp` namespace."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import click.testing
 
 from pflow.cli.commands.mcp import mcp
+from pflow.mcp import MCPRegistrar, MCPServerManager
+from pflow.mcp.sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_config
+from pflow.registry import Registry
 from pflow.registry.discovery import ComponentSelection
 
 
@@ -322,3 +326,150 @@ def test_removed_mcp_tools_and_info_commands_fail() -> None:
     assert info_result.exit_code != 0
     assert "'mcp info' command was removed" in info_result.output
     assert "pflow mcp describe" in info_result.output
+
+
+def _manual_sync_components(tmp_path: Path, configs: dict[str, dict]):
+    manager = MCPServerManager(config_path=tmp_path / "mcp-servers.json")
+    manager.save({"mcpServers": configs})
+    registry = Registry(registry_path=tmp_path / "registry.json")
+    registry._save_with_metadata({})
+    discovery = MagicMock()
+    registrar = MCPRegistrar(registry=registry, manager=manager, discovery=discovery)
+    registrar._settings_manager = MagicMock()
+    registrar._settings_manager.should_include_node.return_value = True
+    return manager, registry, discovery, registrar
+
+
+def _mcp_entry(registrar: MCPRegistrar, server: str, tool: str) -> dict:
+    return registrar._create_registry_entry(server, {"name": tool})
+
+
+def test_manual_single_sync_replaces_tools_and_advances_fingerprint(tmp_path: Path) -> None:
+    configs = {"one": {"command": "one"}}
+    manager, registry, discovery, registrar = _manual_sync_components(tmp_path, configs)
+    registry.save({"mcp-one-old": _mcp_entry(registrar, "one", "old")})
+    discovery.discover_tools.return_value = [{"name": "new"}]
+
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "one"])
+
+    assert result.exit_code == 0
+    assert "mcp-one-new" in registry.load(include_filtered=True)
+    assert "mcp-one-old" not in registry.load(include_filtered=True)
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"one": fingerprint_server_config(configs["one"])}
+
+
+def test_manual_single_sync_failure_preserves_tools_and_fingerprint(tmp_path: Path) -> None:
+    configs = {"one": {"command": "one"}}
+    manager, registry, discovery, registrar = _manual_sync_components(tmp_path, configs)
+    old = {"mcp-one-old": _mcp_entry(registrar, "one", "old")}
+    registry.save(old, metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"one": "old"}})
+    discovery.discover_tools.side_effect = RuntimeError("temporarily unavailable")
+
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "one"])
+
+    assert result.exit_code == 1
+    assert registry.load(include_filtered=True) == old
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"one": "old"}
+
+
+def test_manual_sync_all_advances_success_and_preserves_failure(tmp_path: Path) -> None:
+    configs = {"good": {"command": "good"}, "bad": {"command": "bad"}}
+    manager, registry, discovery, registrar = _manual_sync_components(tmp_path, configs)
+    registry.save(
+        {
+            "mcp-good-old": _mcp_entry(registrar, "good", "old"),
+            "mcp-bad-old": _mcp_entry(registrar, "bad", "old"),
+        },
+        metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"good": "old-good", "bad": "old-bad"}},
+    )
+
+    def discover(server_name, **_kwargs):
+        if server_name == "bad":
+            raise RuntimeError("down")
+        return [{"name": "new"}]
+
+    discovery.discover_tools.side_effect = discover
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+        patch.object(manager, "list_servers", side_effect=AssertionError("forced all must use coordinator snapshot")),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "--all"])
+
+    assert result.exit_code == 0
+    assert set(registry.load(include_filtered=True)) == {"mcp-good-new", "mcp-bad-old"}
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {
+        "good": fingerprint_server_config(configs["good"]),
+        "bad": "old-bad",
+    }
+
+
+def test_manual_single_config_change_during_discovery_aborts_without_registry_write(tmp_path: Path) -> None:
+    configs = {"one": {"command": "old"}}
+    manager, registry, discovery, registrar = _manual_sync_components(tmp_path, configs)
+    old_nodes = {"mcp-one-old": _mcp_entry(registrar, "one", "old")}
+    registry.save(old_nodes, metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"one": "old"}})
+
+    def discover(*_args, **_kwargs):
+        manager.save({"mcpServers": {"one": {"command": "changed"}}})
+        return [{"name": "observed"}]
+
+    discovery.discover_tools.side_effect = discover
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+        patch.object(registry, "save", wraps=registry.save) as save,
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "one"])
+
+    assert result.exit_code == 1
+    save.assert_not_called()
+    assert registry.load(include_filtered=True) == old_nodes
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"one": "old"}
+
+
+def test_manual_sync_all_missing_config_preserves_registry(tmp_path: Path) -> None:
+    manager, registry, discovery, registrar = _manual_sync_components(tmp_path, {"old": {"command": "old"}})
+    old_nodes = {"mcp-old-tool": _mcp_entry(registrar, "old", "tool")}
+    registry.save(old_nodes, metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"old": "old"}})
+    manager.config_path.unlink()
+
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "--all"])
+
+    assert result.exit_code == 0
+    assert "No MCP server configuration found" in result.output
+    discovery.discover_tools.assert_not_called()
+    assert registry.load(include_filtered=True) == old_nodes
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"old": "old"}
+
+
+def test_remove_uses_exact_owner_and_removes_zero_tool_fingerprint(tmp_path: Path) -> None:
+    configs = {"foo": {"command": "foo"}, "foo-bar": {"command": "foo-bar"}}
+    manager, registry, _, registrar = _manual_sync_components(tmp_path, configs)
+    registry.save(
+        {"mcp-foo-bar-tool": _mcp_entry(registrar, "foo-bar", "tool")},
+        metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"foo": "foo", "foo-bar": "foo-bar"}},
+    )
+
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["remove", "foo", "--force"])
+
+    assert result.exit_code == 0
+    assert registrar.list_registered_tools("foo-bar", include_filtered=True) == ["mcp-foo-bar-tool"]
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"foo-bar": "foo-bar"}
+    assert manager.list_servers() == ["foo-bar"]

--- a/tests/test_cli/test_mcp_commands.py
+++ b/tests/test_cli/test_mcp_commands.py
@@ -436,6 +436,27 @@ def test_manual_single_config_change_during_discovery_aborts_without_registry_wr
     assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"one": "old"}
 
 
+def test_manual_single_config_disappears_before_discovery_reports_error(tmp_path: Path) -> None:
+    configs = {"one": {"command": "one"}}
+    manager, _, discovery, registrar = _manual_sync_components(tmp_path, configs)
+
+    def remove_after_read(name: str):
+        manager.config_path.unlink()
+        return configs[name]
+
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+        patch.object(manager, "get_server", side_effect=remove_after_read),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "one"])
+
+    assert result.exit_code == 1
+    assert "MCP configuration is no longer available" in result.output
+    assert "list index out of range" not in result.output
+    discovery.discover_tools.assert_not_called()
+
+
 def test_manual_sync_all_missing_config_preserves_registry(tmp_path: Path) -> None:
     manager, registry, discovery, registrar = _manual_sync_components(tmp_path, {"old": {"command": "old"}})
     old_nodes = {"mcp-old-tool": _mcp_entry(registrar, "old", "tool")}
@@ -453,6 +474,20 @@ def test_manual_sync_all_missing_config_preserves_registry(tmp_path: Path) -> No
     discovery.discover_tools.assert_not_called()
     assert registry.load(include_filtered=True) == old_nodes
     assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"old": "old"}
+
+
+def test_manual_sync_all_explicit_empty_config_reports_no_servers(tmp_path: Path) -> None:
+    manager, _, discovery, registrar = _manual_sync_components(tmp_path, {})
+
+    with (
+        patch("pflow.cli.commands.mcp.MCPServerManager", return_value=manager),
+        patch("pflow.cli.commands.mcp.MCPRegistrar", return_value=registrar),
+    ):
+        result = click.testing.CliRunner().invoke(mcp, ["sync", "--all"])
+
+    assert result.exit_code == 0
+    assert "No MCP servers configured" in result.output
+    discovery.discover_tools.assert_not_called()
 
 
 def test_remove_uses_exact_owner_and_removes_zero_tool_fingerprint(tmp_path: Path) -> None:

--- a/tests/test_mcp/test_config_management.py
+++ b/tests/test_mcp/test_config_management.py
@@ -16,6 +16,15 @@ import pytest
 from pflow.mcp import MCPServerManager
 
 
+def test_raw_server_snapshot_distinguishes_missing_from_explicit_empty(tmp_path: Path) -> None:
+    manager = MCPServerManager(config_path=tmp_path / "mcp-servers.json")
+
+    assert manager.get_all_servers_if_configured() is None
+
+    manager.save({"mcpServers": {}})
+    assert manager.get_all_servers_if_configured() == {}
+
+
 class TestAtomicWriteProtection:
     """Test that atomic writes ACTUALLY prevent corruption."""
 

--- a/tests/test_mcp/test_mcp_discovery_critical.py
+++ b/tests/test_mcp/test_mcp_discovery_critical.py
@@ -121,6 +121,24 @@ class TestMCPDiscoveryCritical:
                 server_config={"command": "hung", "timeout": 0.01},
             )
 
+    def test_discovery_default_accommodates_slow_server_startup(self):
+        """The bounded default leaves room for cold package-runner startup."""
+        discovery = MCPDiscovery()
+        observed_timeout = None
+
+        async def capture_timeout(awaitable, *, timeout):
+            nonlocal observed_timeout
+            observed_timeout = timeout
+            return await awaitable
+
+        with (
+            patch.object(discovery, "_discover_async", return_value=[]),
+            patch("pflow.mcp.discovery.asyncio.wait_for", side_effect=capture_timeout),
+        ):
+            assert discovery.discover_tools("cold", server_config={"command": "npx"}) == []
+
+        assert observed_timeout == 60
+
 
 class TestMCPRegistrarCritical:
     """Test the critical tool registration process."""

--- a/tests/test_mcp/test_mcp_discovery_critical.py
+++ b/tests/test_mcp/test_mcp_discovery_critical.py
@@ -186,7 +186,7 @@ class TestMCPRegistrarCritical:
             manager.add_server(name="test", transport="stdio", command="test-cmd", args=[])
 
             # Mock discovery to return tools
-            def mock_discover(server_name, verbose=False):
+            def mock_discover(server_name, verbose=False, *, server_config=None):
                 return [
                     {
                         "name": "tool1",
@@ -197,12 +197,12 @@ class TestMCPRegistrarCritical:
                 ]
 
             with patch.object(discovery, "discover_tools", side_effect=mock_discover):
-                result = registrar.sync_server("test")
+                result = registrar.sync_servers(["test"], reconcile_all=False).servers[0]
 
             # Verify sync results
-            assert result["server"] == "test"
-            assert result["tools_discovered"] == 2
-            assert result["tools_registered"] == 2
+            assert result.server == "test"
+            assert result.tools_discovered == 2
+            assert result.tools_registered == 2
 
             # Verify registry was updated
             nodes = registry.load()
@@ -225,9 +225,9 @@ class TestMCPRegistrarCritical:
 
             # Add some tools to registry
             nodes = {
-                "mcp-github-create-issue": {"class_name": "MCPNode"},
-                "mcp-github-list-issues": {"class_name": "MCPNode"},
-                "mcp-slack-send-message": {"class_name": "MCPNode"},
+                "mcp-github-create-issue": registrar._create_registry_entry("github", {"name": "create-issue"}),
+                "mcp-github-list-issues": registrar._create_registry_entry("github", {"name": "list-issues"}),
+                "mcp-slack-send-message": registrar._create_registry_entry("slack", {"name": "send-message"}),
                 "read-file": {"class_name": "ReadFileNode"},  # Non-MCP node
             }
             registry.save(nodes)
@@ -246,7 +246,7 @@ class TestMCPRegistrarCritical:
 
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="ExceptionGroup requires Python 3.11+")
     def test_sync_server_returns_diagnostic_with_suggestions_on_failure(self):
-        """When discovery fails, sync_server should return a Diagnostic with suggestions.
+        """When discovery fails, sync_servers should return a Diagnostic with suggestions.
 
         CRITICAL: Without this, the CLI falls back to raw ExceptionGroup text
         with no actionable guidance — the exact bug this refactor fixes.
@@ -268,16 +268,15 @@ class TestMCPRegistrarCritical:
             exc_group = _ExceptionGroup("unhandled errors in a TaskGroup", [inner_exc])
 
             with patch.object(discovery, "discover_tools", side_effect=exc_group):
-                result = registrar.sync_server("test")
+                result = registrar.sync_servers(["test"], reconcile_all=False).servers[0]
 
             # Must have structured error, not ExceptionGroup garbage
-            assert "error" in result
-            assert "unhandled errors" not in result["error"]
-            assert "Authentication failed" in result["error"]
+            assert result.error is not None
+            assert "unhandled errors" not in result.error
+            assert "Authentication failed" in result.error
 
             # Must have Diagnostic with suggestions for CLI rendering
-            assert "diagnostic" in result
-            diagnostic = result["diagnostic"]
+            diagnostic = result.diagnostic
             assert isinstance(diagnostic, Diagnostic)
             assert diagnostic.severity == Severity.ERROR
             assert diagnostic.suggestions is not None

--- a/tests/test_mcp/test_mcp_discovery_critical.py
+++ b/tests/test_mcp/test_mcp_discovery_critical.py
@@ -5,6 +5,7 @@ Without these components working, users cannot discover or use MCP tools at all.
 These tests prevent complete feature failure in production.
 """
 
+import asyncio
 import builtins
 import sys
 import tempfile
@@ -103,6 +104,22 @@ class TestMCPDiscoveryCritical:
         assert len(params) == 1
         assert params[0]["type"] == "str"  # Fallback to str (safe default)
         assert params[0]["key"] == "weird_field"
+
+    def test_discovery_times_out_a_hung_server(self):
+        """Discovery bounds the whole handshake/list operation, including stdio."""
+        discovery = MCPDiscovery()
+
+        async def hang(*_args, **_kwargs):
+            await asyncio.Event().wait()
+
+        with (
+            patch.object(discovery, "_discover_async", side_effect=hang),
+            pytest.raises(RuntimeError, match=r"Request timed out after 0\.01 seconds"),
+        ):
+            discovery.discover_tools(
+                "hung",
+                server_config={"command": "hung", "timeout": 0.01},
+            )
 
 
 class TestMCPRegistrarCritical:

--- a/tests/test_mcp/test_mcp_sync_state.py
+++ b/tests/test_mcp/test_mcp_sync_state.py
@@ -1,0 +1,202 @@
+"""Persistence-level tests for MCP per-server reconciliation."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from pflow.mcp import MCPRegistrar, MCPServerManager
+from pflow.mcp.sync_state import MCP_SERVER_FINGERPRINTS_KEY, fingerprint_server_config
+from pflow.registry import Registry
+
+
+def _tool(name: str) -> dict:
+    return {"name": name, "description": name}
+
+
+def _entry(registrar: MCPRegistrar, server: str, tool: str) -> dict:
+    return registrar._create_registry_entry(server, _tool(tool))
+
+
+def _build(tmp_path: Path, configs: dict[str, dict]) -> tuple[MCPServerManager, Registry, Mock, MCPRegistrar]:
+    manager = MCPServerManager(config_path=tmp_path / "mcp-servers.json")
+    manager.save({"mcpServers": configs})
+    registry = Registry(registry_path=tmp_path / "registry.json")
+    registry._save_with_metadata({})
+    discovery = Mock()
+    registrar = MCPRegistrar(registry=registry, manager=manager, discovery=discovery)
+    registrar._settings_manager = Mock()
+    registrar._settings_manager.should_include_node.return_value = True
+    return manager, registry, discovery, registrar
+
+
+def test_fingerprint_uses_canonical_raw_json_and_sha256() -> None:
+    config = {"env": {"TOKEN": "${TOKEN}"}, "command": "cmd", "args": ["x"]}
+
+    assert fingerprint_server_config(config) == "753d4b739030191da0cdd56a8859f1e0d2723f256b3cd84d0e20a84feb433b64"
+
+
+def test_partial_failure_replaces_success_preserves_failure_and_cleans_removed(tmp_path: Path) -> None:
+    configs = {"good": {"command": "good"}, "bad": {"command": "bad"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    nodes = {
+        "mcp-good-old": _entry(registrar, "good", "old"),
+        "mcp-bad-old": _entry(registrar, "bad", "old"),
+        "mcp-removed-old": _entry(registrar, "removed", "old"),
+        "mcp-legacy": {"type": "mcp"},
+        "user-node": {"type": "user"},
+    }
+    registry.save(
+        nodes,
+        metadata_updates={
+            MCP_SERVER_FINGERPRINTS_KEY: {
+                "good": "old-good",
+                "bad": "old-bad",
+                "removed": "old-removed",
+            }
+        },
+    )
+    discovery.discover_tools.side_effect = [[_tool("new")], RuntimeError("temporary outage")]
+
+    with patch.object(registry, "save", wraps=registry.save) as save:
+        batch = registrar.sync_servers(["good", "bad"], reconcile_all=True)
+
+    assert save.call_count == 1
+    assert [result.error for result in batch.servers] == [None, "temporary outage"]
+    persisted = registry.load(include_filtered=True)
+    assert set(persisted) == {"mcp-good-new", "mcp-bad-old", "user-node"}
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {
+        "good": fingerprint_server_config(configs["good"]),
+        "bad": "old-bad",
+    }
+
+
+def test_total_failure_preserves_tools_and_fingerprints(tmp_path: Path) -> None:
+    configs = {"one": {"command": "one"}, "two": {"command": "two"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    nodes = {
+        "mcp-one-old": _entry(registrar, "one", "old"),
+        "mcp-two-old": _entry(registrar, "two", "old"),
+    }
+    old_fingerprints = {"one": "old-one", "two": "old-two"}
+    registry.save(nodes, metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: old_fingerprints})
+    discovery.discover_tools.side_effect = [RuntimeError("one down"), RuntimeError("two down")]
+
+    batch = registrar.sync_servers(["one", "two"], reconcile_all=True)
+
+    assert all(result.error for result in batch.servers)
+    assert registry.load(include_filtered=True) == nodes
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == old_fingerprints
+
+
+def test_empty_success_removes_owned_tools_and_advances_fingerprint(tmp_path: Path) -> None:
+    configs = {"empty": {"command": "empty"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    registry.save({"mcp-empty-old": _entry(registrar, "empty", "old")})
+    discovery.discover_tools.return_value = []
+
+    batch = registrar.sync_servers(["empty"], reconcile_all=True)
+
+    assert batch.servers[0].tools_discovered == 0
+    assert registry.load(include_filtered=True) == {}
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"empty": fingerprint_server_config(configs["empty"])}
+
+
+def test_exact_owner_replacement_removal_and_listing_isolate_overlapping_names(tmp_path: Path) -> None:
+    configs = {"foo": {"command": "foo"}, "foo-bar": {"command": "foo-bar"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    nodes = {
+        "mcp-foo-old": _entry(registrar, "foo", "old"),
+        "mcp-foo-bar-old": _entry(registrar, "foo-bar", "old"),
+    }
+    registry.save(
+        nodes,
+        metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"foo": "old", "foo-bar": "peer"}},
+    )
+    discovery.discover_tools.return_value = [_tool("new")]
+
+    registrar.sync_servers(["foo"], reconcile_all=False)
+    assert registrar.list_registered_tools("foo") == ["mcp-foo-new"]
+    assert registrar.list_registered_tools("foo-bar") == ["mcp-foo-bar-old"]
+
+    assert registrar.remove_server_tools("foo") == 1
+    assert registrar.list_registered_tools("foo") == []
+    assert registrar.list_registered_tools("foo-bar") == ["mcp-foo-bar-old"]
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {"foo-bar": "peer"}
+
+
+def test_filtered_replacement_preserves_unrelated_filtered_entries(tmp_path: Path) -> None:
+    configs = {"target": {"command": "target"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    unrelated = _entry(registrar, "other", "denied")
+    registry.save({"mcp-target-old": _entry(registrar, "target", "old"), "mcp-other-denied": unrelated})
+    discovery.discover_tools.return_value = [_tool("allowed"), _tool("denied")]
+    registrar._settings_manager.should_include_node.side_effect = lambda name: not name.endswith("denied")
+
+    batch = registrar.sync_servers(["target"], reconcile_all=False)
+
+    persisted = registry.load(include_filtered=True)
+    assert set(persisted) == {"mcp-target-allowed", "mcp-other-denied"}
+    assert batch.servers[0].tools_filtered == 1
+
+
+def test_conversion_failure_preserves_server_while_valid_peer_advances(tmp_path: Path) -> None:
+    configs = {"bad": {"command": "bad"}, "good": {"command": "good"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    registry.save(
+        {
+            "mcp-bad-old": _entry(registrar, "bad", "old"),
+            "mcp-good-old": _entry(registrar, "good", "old"),
+        },
+        metadata_updates={MCP_SERVER_FINGERPRINTS_KEY: {"bad": "old-bad", "good": "old-good"}},
+    )
+    discovery.discover_tools.side_effect = [
+        [_tool("broken") | {"inputSchema": {"properties": []}}],
+        [_tool("new")],
+    ]
+    discovery.convert_to_pflow_params.side_effect = AttributeError("invalid properties")
+
+    batch = registrar.sync_servers(["bad", "good"], reconcile_all=True)
+
+    assert batch.servers[0].error == "invalid properties"
+    assert batch.servers[1].error is None
+    assert set(registry.load(include_filtered=True)) == {"mcp-bad-old", "mcp-good-new"}
+    assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {
+        "bad": "old-bad",
+        "good": fingerprint_server_config(configs["good"]),
+    }
+
+
+def test_registry_change_during_discovery_survives_late_snapshot(tmp_path: Path) -> None:
+    configs = {"target": {"command": "target"}}
+    _, registry, discovery, registrar = _build(tmp_path, configs)
+    registry.save({"existing": {"type": "user"}})
+
+    def discover(*_args, **_kwargs):
+        concurrent_registry = Registry(registry.registry_path)
+        current = concurrent_registry.load(include_filtered=True)
+        current["concurrent"] = {"type": "user"}
+        concurrent_registry.save(current)
+        return [_tool("new")]
+
+    discovery.discover_tools.side_effect = discover
+    registrar.sync_servers(["target"], reconcile_all=False)
+
+    assert set(registry.load(include_filtered=True)) == {"existing", "concurrent", "mcp-target-new"}
+
+
+def test_config_change_during_discovery_aborts_without_registry_write(tmp_path: Path) -> None:
+    configs = {"target": {"command": "old"}}
+    manager, registry, discovery, registrar = _build(tmp_path, configs)
+    registry.save({"mcp-target-old": _entry(registrar, "target", "old")})
+    before = registry.registry_path.read_text(encoding="utf-8")
+
+    def discover(*_args, **_kwargs):
+        manager.save({"mcpServers": {"target": {"command": "changed"}}})
+        return [_tool("observed")]
+
+    discovery.discover_tools.side_effect = discover
+    with patch.object(registry, "save", wraps=registry.save) as save:
+        batch = registrar.sync_servers(["target"], reconcile_all=True)
+
+    assert batch.aborted_reason is not None
+    save.assert_not_called()
+    assert registry.registry_path.read_text(encoding="utf-8") == before

--- a/tests/test_mcp/test_mcp_sync_state.py
+++ b/tests/test_mcp/test_mcp_sync_state.py
@@ -156,7 +156,7 @@ def test_conversion_failure_preserves_server_while_valid_peer_advances(tmp_path:
 
     batch = registrar.sync_servers(["bad", "good"], reconcile_all=True)
 
-    assert batch.servers[0].error == "invalid properties"
+    assert batch.servers[0].error == "Could not build registry entries for 'bad': invalid properties"
     assert batch.servers[1].error is None
     assert set(registry.load(include_filtered=True)) == {"mcp-bad-old", "mcp-good-new"}
     assert registry.get_metadata(MCP_SERVER_FINGERPRINTS_KEY) == {

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -1084,6 +1084,33 @@ class TestRegistryFormatConsistency:
             # Metadata must survive
             assert registry.get_metadata("mcp_config_hash") == "abc123"
 
+    def test_save_updates_nodes_and_metadata_in_one_atomic_write(self):
+        """save() can publish a coherent node and metadata snapshot."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry.json"
+            registry = Registry(registry_path)
+            registry._write_atomic({
+                "version": "stored-version",
+                "last_core_scan": "2000-01-01T00:00:00+00:00",
+                "metadata": {"unrelated": "preserved", "sync": "old"},
+                "nodes": {"old": {"module": "old"}},
+            })
+
+            with patch.object(registry, "_write_atomic", wraps=registry._write_atomic) as atomic_write:
+                registry.save(
+                    {"new": {"module": "new"}},
+                    metadata_updates={"sync": "new"},
+                )
+
+            atomic_write.assert_called_once()
+            written = json.loads(registry_path.read_text(encoding="utf-8"))
+            assert written == {
+                "version": "stored-version",
+                "last_core_scan": "2000-01-01T00:00:00+00:00",
+                "metadata": {"unrelated": "preserved", "sync": "new"},
+                "nodes": {"new": {"module": "new"}},
+            }
+
     def test_get_set_metadata_roundtrip(self):
         """get_metadata/set_metadata must work on structured format."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Replaces destructive global MCP auto-sync with per-server raw-configuration fingerprints and one coherent post-discovery reconciliation. Successful servers advance independently, failed servers retain their last-known-good tools and fingerprint for retry, and unchanged servers are never started.

Closes #612

## Evaluation verdict

The issue remained reproducible on the branch base (`81d2d56a`): an executed real-Registry/real-MCPRegistrar probe left only the successful server's new tool after a partial discovery failure and reported no retry due. The issue text was revised before implementation to replace its original all-or-nothing global-marker proposal with per-server fingerprints, exact canonical ownership, missing-versus-empty config semantics, and one nodes-plus-fingerprints write.

The final shape is the simplest coherent form found in the existing architecture: discovery uses captured raw server blocks, the registrar owns one batch state machine, and `Registry.save(..., metadata_updates=...)` publishes nodes and fingerprint metadata in the same atomic replacement. It deliberately does not add a generic transaction abstraction.

## Changes

- Fingerprint each raw persisted server config with canonical JSON plus SHA-256; formatting, key order, and resolved secret-value changes are inert.
- Discover only added/changed servers and use the captured config block that was fingerprinted.
- Preserve failed servers, replace successful servers exactly (including successful empty results), and retry only servers still due.
- Remove absent servers and unsupported metadata-less MCP entries only during full reconciliation, using exact `interface.mcp_metadata.server` ownership.
- Share the same batch coordinator across workflow-start auto-sync, manual single sync, and manual `--all`; explicit removal deletes exact owned tools and its fingerprint coherently.
- Preserve registry state for a missing config and reconcile an existing explicit-empty config to no MCP entries/fingerprints.
- Extend `Registry.save()` narrowly so node and metadata updates share one atomic wrapper write.
- Update internal CLI/MCP/registry guidance and replace mock-only coverage with persisted state-machine regressions.

Backward compatibility for metadata-less legacy MCP entries is intentionally not provided, per the user ruling; full reconciliation discards them rather than guessing ownership from ambiguous node names. Generic cross-process registry read-modify-write locking/CAS remains explicitly outside #612.

## Review gate and dispositions

The external Claude fan-out was sandbox-blocked before sending repository content, so the documented direct-agent fallback ran six read-only lenses: silent failures, concurrency safety, feature interactions, impact completeness, test fidelity, and simplicity. A separate executing falsifier exercised the state table through real registry persistence, real stdio MCP processes, manual commands, and the actual `pflow run` entry path. Targeted re-reviews found no remaining in-scope findings.

Fixed findings:

- Forced `sync --all` selected targets before the coordinator snapshot. Verified by reading `src/pflow/cli/commands/mcp.py` and an executed regression that makes `manager.list_servers()` fail; forced-all now derives targets inside `MCPRegistrar.sync_servers()`.
- Manual `sync --all` could treat a missing config as explicit empty and delete MCP state. Reproduced with CliRunner + real Registry; fixed and pinned by `test_manual_sync_all_missing_config_preserves_registry`.
- Missing-file detection used a separate `exists()` check and load. Verified by concurrency review at `src/pflow/mcp/manager.py`; fixed with one sentinel-preserving raw snapshot API and pinned by `test_raw_server_snapshot_distinguishes_missing_from_explicit_empty`.
- Post-discovery schema conversion could abort the whole batch silently. Reproduced with two servers; replacement construction is now per-server transactional, and `test_conversion_failure_preserves_server_while_valid_peer_advances` proves the failed server is preserved while its peer commits.
- Raw SHA-256/environment-reference and manual single config-race contracts were unpinned. Fixed by independent known-digest, resolved-env/no-write, and manual abort/no-save tests.
- Cleanup policy, fingerprint decoding, and a mock rendering test had drift/duplication. Verified by the simplicity/test-fidelity lenses; consolidated and re-reviewed clean.

Skipped with reason:

- Three lenses reproduced the pre-existing flat node-key collision (`server=a-b, tool=c` versus `server=a, tool=b-c`). The binding audited plan explicitly excludes registry node-ID redesign; exact metadata ownership fixes overbroad removal/replacement for overlapping server names without claiming to solve that separate identity collision. The current change does not widen it.

## Verification

- Focused persisted-state suite: 124 passed across registry, config manager, registrar state machine, auto-sync, and manual MCP commands.
- `make check`: passed (Ruff, formatting, pre-commit, mypy, deptry, reusable-asset sync).
- `make test`: 9,173 passed.
- `make test-all-local`: 9,217 passed, 2 skipped.
- Real surface: with isolated HOME, `pflow run examples/simple-workflow.pflow.md --no-trace` started a real local stdio `pflow mcp serve`, persisted 13 canonically owned tools plus its fingerprint, and completed the workflow. A second unchanged run completed without changing the registry mtime.
- Executing falsifier: all tested promises held, including partial/total failure retries, empty success, config-change abort, late registry load, manual single/all sync, exact non-colliding overlapping-name removal, missing/explicit-empty behavior, and non-interactive output silence.

Platform-sensitive registry/config atomic replacement remains covered by the existing blocking Windows CI gate; local verification ran on macOS.
